### PR TITLE
Prove weightDelta is bounded 0-100

### DIFF
--- a/Genesis/Scoring.lean
+++ b/Genesis/Scoring.lean
@@ -147,6 +147,22 @@ def percentileFromRanking
     | none => 0
     | some pos => (n - 1 - pos) * 100 / (n - 1)
 
+/-- percentileFromRanking always returns a value ≤ 100. -/
+theorem percentileFromRanking_le_100 (ranking : Ranking) (pr : CommitId) :
+    percentileFromRanking ranking pr ≤ 100 := by
+  simp only [percentileFromRanking]
+  split <;> rename_i h
+  · -- n ≤ 1: returns 100
+    omega
+  · -- n > 1: match on findIdx?
+    split
+    · -- none: returns 0
+      omega
+    · -- some pos: (n - 1 - pos) * 100 / (n - 1) ≤ 100
+      rename_i pos _
+      apply Nat.div_le_of_le_mul
+      exact Nat.mul_le_mul_right 100 (Nat.sub_le ..)
+
 /-- Derive a score for the current PR from one reviewer's rankings.
     Each dimension is a percentile rank (0-100). -/
 def scoreFromReview

--- a/Genesis/Types.lean
+++ b/Genesis/Types.lean
@@ -141,6 +141,13 @@ def CommitScore.numWeightedDimensions : Nat := 5  -- 1 + 1 + 3
 def CommitScore.weighted (s : CommitScore) : Nat :=
   (s.difficulty + s.novelty + 3 * s.designQuality) / CommitScore.numWeightedDimensions
 
+/-- weightDelta is at most 100 when all dimension scores are at most 100. -/
+theorem CommitScore.weighted_le_100 (s : CommitScore)
+    (hd : s.difficulty ≤ 100) (hn : s.novelty ≤ 100) (hq : s.designQuality ≤ 100) :
+    s.weighted ≤ 100 := by
+  unfold weighted numWeightedDimensions
+  omega
+
 /-- A signed commit and the data needed to compute its rewards. -/
 structure SignedCommit where
   id : CommitId


### PR DESCRIPTION
## Summary

Two machine-checked proofs that weightDelta is always in [0, 100]:

1. **`percentileFromRanking_le_100`** — each dimension score is ≤ 100
   - `n ≤ 1`: returns 100 ✓
   - `none`: returns 0 ✓
   - `some pos`: `(n-1-pos) * 100 / (n-1) ≤ 100` by `Nat.div_le_of_le_mul` + `Nat.sub_le`

2. **`CommitScore.weighted_le_100`** — combined score ≤ 100 when fields ≤ 100
   - `(d + n + 3q) / 5 ≤ (100 + 100 + 300) / 5 = 100` by `omega`

No `sorry` — both proofs are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)