### PR TITLE
Fix genesis bot commenting on fork PRs

### DIFF
--- a/.github/workflows/genesis-pr-opened.yml
+++ b/.github/workflows/genesis-pr-opened.yml
@@ -1,7 +1,7 @@
 name: "Genesis: PR Opened"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches: [master]
 


### PR DESCRIPTION
## Summary

Change `genesis-pr-opened.yml` trigger from `pull_request` to `pull_request_target`.

The `pull_request` trigger gives `GITHUB_TOKEN` read-only permissions on fork PRs, causing `gh pr comment` to fail with "Resource not accessible by integration." This broke the comparison targets comment on PR #17 (from rotkonetworks).

`pull_request_target` runs from the base branch with the base repo's full permissions. This is safe because our workflow only runs our own code from master (reads cache, runs `genesis_select_targets`, posts a comment) — it never checks out or executes fork code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)