### PR TITLE
Anchor comparison targets to PR created_at timestamp

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -85,13 +85,15 @@ jobs:
           git fetch origin genesis-state
           CACHE=$(git show origin/genesis-state:genesis.json)
 
-          # Get PR details
-          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,author)
+          # Get PR details (including immutable created_at for target anchoring)
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,author,createdAt)
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
           AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
+          PR_CREATED_AT=$(echo "$PR_JSON" | jq -r '.createdAt')
+          PR_CREATED_EPOCH=$(date -d "$PR_CREATED_AT" +%s)
 
-          # Get comparison targets (needed before collecting reviews for hash expansion)
-          TARGETS_JSON=$(echo "{\"prId\":${PR_NUMBER},\"indices\":${CACHE}}" | \
+          # Get comparison targets anchored to PR creation time
+          TARGETS_JSON=$(echo "{\"prId\":${PR_NUMBER},\"prCreatedAt\":${PR_CREATED_EPOCH},\"indices\":${CACHE}}" | \
             .lake/build/bin/genesis_select_targets)
           TARGETS=$(echo "$TARGETS_JSON" | jq -c '.targets')
 
@@ -112,12 +114,13 @@ jobs:
             --argjson prId "$PR_NUMBER" \
             --arg author "$AUTHOR" \
             --argjson mergeEpoch "$EPOCH" \
+            --argjson prCreatedAt "$PR_CREATED_EPOCH" \
             --argjson targets "$TARGETS" \
             --argjson reviews "$REVIEWS" \
             --argjson metaReviews "$META_REVIEWS" \
             --argjson founderOverride "$FOUNDER_OVERRIDE" \
             '{id: $id, prId: $prId, author: $author, mergeEpoch: $mergeEpoch,
-              comparisonTargets: $targets, reviews: $reviews,
+              prCreatedAt: $prCreatedAt, comparisonTargets: $targets, reviews: $reviews,
               metaReviews: $metaReviews, founderOverride: $founderOverride}')
 
           # Evaluate

--- a/.github/workflows/genesis-pr-opened.yml
+++ b/.github/workflows/genesis-pr-opened.yml
@@ -49,7 +49,9 @@ jobs:
           git fetch origin genesis-state
           CACHE=$(git show origin/genesis-state:genesis.json)
           PR_ID=${{ github.event.pull_request.number }}
-          echo "{\"prId\":${PR_ID},\"indices\":${CACHE}}" | \
+          PR_CREATED_AT="${{ github.event.pull_request.created_at }}"
+          PR_CREATED_EPOCH=$(date -d "$PR_CREATED_AT" +%s)
+          echo "{\"prId\":${PR_ID},\"prCreatedAt\":${PR_CREATED_EPOCH},\"indices\":${CACHE}}" | \
             .lake/build/bin/genesis_select_targets > /tmp/targets.json
 
       - name: Post review template

--- a/.github/workflows/genesis-review.yml
+++ b/.github/workflows/genesis-review.yml
@@ -53,9 +53,12 @@ jobs:
           git fetch origin genesis-state
           CACHE=$(git show origin/genesis-state:genesis.json)
 
-          # Get PR head SHA and comparison targets
-          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
-          TARGETS=$(echo "{\"prId\":${PR_NUMBER},\"indices\":${CACHE}}" | \
+          # Get PR head SHA and created_at for target anchoring
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,createdAt)
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+          PR_CREATED_AT=$(echo "$PR_JSON" | jq -r '.createdAt')
+          PR_CREATED_EPOCH=$(date -d "$PR_CREATED_AT" +%s)
+          TARGETS=$(echo "{\"prId\":${PR_NUMBER},\"prCreatedAt\":${PR_CREATED_EPOCH},\"indices\":${CACHE}}" | \
             .lake/build/bin/genesis_select_targets | jq -c '.targets')
 
           # Collect reviews + meta-reviews (expand currentPR + short hashes)

--- a/Genesis/Cli/SelectTargets.lean
+++ b/Genesis/Cli/SelectTargets.lean
@@ -1,7 +1,7 @@
 /-
   genesis_select_targets CLI
 
-  Input:  {"prId": 42, "indices": [...]}
+  Input:  {"prId": 42, "prCreatedAt": 1774000000, "indices": [...]}
   Output: {"targets": ["abc123", ...]}
 -/
 
@@ -12,7 +12,9 @@ open Genesis.Cli
 
 def main : IO UInt32 := runJsonPipe fun j => do
   let prId ← IO.ofExcept (j.getObjValAs? Nat "prId")
+  let prCreatedAt ← IO.ofExcept (j.getObjValAs? Nat "prCreatedAt")
   let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
-  let pastIds := indices.map (·.commitHash)
-  let targets := selectComparisonTargets pastIds (min rankingSize pastIds.length) prId
+  let scoredCommits := indices.map (fun idx => (idx.commitHash, idx.epoch))
+  let eligible := scoredCommits.filter (fun (_, epoch) => epoch < prCreatedAt)
+  let targets := selectComparisonTargets scoredCommits (min rankingSize eligible.length) prId prCreatedAt
   return Json.mkObj [("targets", toJson targets)]

--- a/Genesis/Json.lean
+++ b/Genesis/Json.lean
@@ -116,6 +116,7 @@ instance : ToJson SignedCommit where
     ("prId", toJson c.prId),
     ("author", toJson c.author),
     ("mergeEpoch", toJson c.mergeEpoch),
+    ("prCreatedAt", toJson c.prCreatedAt),
     ("comparisonTargets", toJson c.comparisonTargets),
     ("reviews", toJson c.reviews),
     ("metaReviews", toJson c.metaReviews),
@@ -128,11 +129,13 @@ instance : FromJson SignedCommit where
     let prId ← j.getObjValAs? Nat "prId"
     let author ← j.getObjValAs? String "author"
     let mergeEpoch ← j.getObjValAs? Nat "mergeEpoch"
+    -- Backward compat: legacy commits without prCreatedAt use mergeEpoch
+    let prCreatedAt ← (j.getObjValAs? Nat "prCreatedAt") <|> pure mergeEpoch
     let comparisonTargets ← j.getObjValAs? (List String) "comparisonTargets"
     let reviews ← j.getObjValAs? (List EmbeddedReview) "reviews"
     let metaReviews ← j.getObjValAs? (List MetaReview) "metaReviews"
     let founderOverride ← j.getObjValAs? Bool "founderOverride"
-    return { id, prId, author, mergeEpoch, comparisonTargets, reviews, metaReviews, founderOverride }
+    return { id, prId, author, mergeEpoch, prCreatedAt, comparisonTargets, reviews, metaReviews, founderOverride }
 
 -- ============================================================================
 -- Contributor

--- a/Genesis/Scoring.lean
+++ b/Genesis/Scoring.lean
@@ -65,11 +65,15 @@ def prIdHash (prId : PRId) : Nat :=
   (prId * a) % (2^32)
 
 /-- Select comparison targets from past scored commits.
-    Divides into buckets, picks one per bucket using hash(prId). -/
+    Only commits merged before prCreatedAt are eligible.
+    Divides eligible commits into buckets, picks one per bucket using hash(prId). -/
 def selectComparisonTargets
-    (pastCommitIds : List CommitId)
+    (scoredCommits : List (CommitId × Epoch))
     (numTargets : Nat)
-    (prId : PRId) : List CommitId :=
+    (prId : PRId)
+    (prCreatedAt : Epoch) : List CommitId :=
+  let eligible := scoredCommits.filter (fun (_, epoch) => epoch < prCreatedAt)
+  let pastCommitIds := eligible.map (·.1)
   let n := pastCommitIds.length
   if n == 0 then []
   else
@@ -88,11 +92,12 @@ def selectComparisonTargets
 /-- Validate comparison targets in a signed commit. -/
 def validateComparisonTargets
     (commit : SignedCommit)
-    (pastCommitIds : List CommitId) : Bool :=
-  if pastCommitIds.isEmpty then commit.comparisonTargets.isEmpty
+    (scoredCommits : List (CommitId × Epoch)) : Bool :=
+  let eligible := scoredCommits.filter (fun (_, epoch) => epoch < commit.prCreatedAt)
+  if eligible.isEmpty then commit.comparisonTargets.isEmpty
   else
-    let expected := selectComparisonTargets pastCommitIds
-      (min rankingSize pastCommitIds.length) commit.prId
+    let expected := selectComparisonTargets scoredCommits
+      (min rankingSize eligible.length) commit.prId commit.prCreatedAt
     commit.comparisonTargets == expected
 
 /-! ### Meta-Review Filtering
@@ -237,12 +242,12 @@ def deriveScore
 def commitScore
     (ep : EvalParams)
     (commit : SignedCommit)
-    (pastCommitIds : List CommitId)
+    (scoredCommits : List (CommitId × Epoch))
     (getWeight : ContributorId → Nat)
     : CommitScore :=
   let zeroScore : CommitScore := { difficulty := 0, novelty := 0, designQuality := 0 }
-  -- Step 1: Validate comparison targets
-  if !validateComparisonTargets commit pastCommitIds then
+  -- Step 1: Validate comparison targets (anchored to prCreatedAt)
+  if !validateComparisonTargets commit scoredCommits then
     zeroScore
   else
     -- Step 2: Filter reviews by meta-review

--- a/Genesis/State.lean
+++ b/Genesis/State.lean
@@ -85,8 +85,8 @@ structure CommitIndex where
 structure EvalState where
   /-- Current contributor weights (for reviewer weight lookups). -/
   contributors : List Contributor
-  /-- Past commit IDs (for comparison target selection). -/
-  pastCommitIds : List CommitId
+  /-- Scored commits with their merge epochs (for comparison target selection). -/
+  scoredCommits : List (CommitId × Epoch)
 
 /-- Update or insert a contributor in a list. -/
 private def upsertContributor (cs : List Contributor) (updated : Contributor) : List Contributor :=
@@ -101,7 +101,7 @@ private def upsertContributor (cs : List Contributor) (updated : Contributor) : 
 def reconstructState (pastIndices : List CommitIndex) (ep : EvalParams := .default) : EvalState :=
   let init : EvalState := {
     contributors := [⟨founder, 0, founderWeight, true⟩],
-    pastCommitIds := []
+    scoredCommits := []
   }
   pastIndices.foldl (fun state (idx : CommitIndex) =>
     -- Apply weight change to the contributor (author)
@@ -114,9 +114,9 @@ def reconstructState (pastIndices : List CommitIndex) (ep : EvalParams := .defau
         let meetsThreshold := newWeight ≥ ep.reviewerThreshold
         let updated : Contributor := ⟨c.id, c.balance, newWeight, c.isReviewer || meetsThreshold⟩
         upsertContributor state.contributors updated
-    -- Record commit ID for future target selection
-    let pastCommitIds := state.pastCommitIds ++ [idx.commitHash]
-    { contributors := contributors, pastCommitIds := pastCommitIds }
+    -- Record scored commit with epoch for target selection
+    let scoredCommits := state.scoredCommits ++ [(idx.commitHash, idx.epoch)]
+    { contributors := contributors, scoredCommits := scoredCommits }
   ) init
 
 /-- Get reviewer weight from an EvalState. -/
@@ -144,7 +144,7 @@ def evaluate
     (ep : EvalParams := .default) : CommitIndex :=
   let state := reconstructState pastIndices ep
   let score := commitScore ep commit
-    state.pastCommitIds (state.reviewerWeight ·)
+    state.scoredCommits (state.reviewerWeight ·)
   let approved := filterReviews commit.reviews commit.metaReviews (state.reviewerWeight ·)
   let approvedReviewers := approved
     |>.filter (fun (r : EmbeddedReview) => state.reviewerWeight r.reviewer > 0)

--- a/Genesis/Types.lean
+++ b/Genesis/Types.lean
@@ -154,8 +154,13 @@ structure SignedCommit where
   prId : PRId
   author : ContributorId
   mergeEpoch : Epoch
+  /-- PR's created_at timestamp (immutable, set by GitHub at PR open).
+      Used to anchor comparison target selection: only commits merged
+      before this timestamp are eligible as targets. For legacy commits
+      without this field, falls back to mergeEpoch. -/
+  prCreatedAt : Epoch
   /-- The comparison targets selected by the bot.
-      Validated against hash(prId) at spec time. -/
+      Validated against hash(prId) + prCreatedAt at spec time. -/
   comparisonTargets : List CommitId
   /-- Reviews: each reviewer's rankings and verdicts. -/
   reviews : List EmbeddedReview


### PR DESCRIPTION
## Summary

Fixes a concurrency bug: when multiple PRs are open simultaneously, comparison targets shift as other PRs merge, causing reviewer rankings to reference stale targets.

**Solution**: targets are now anchored to the PR's `created_at` timestamp (immutable, set by GitHub at PR open). Only commits merged before the PR was opened are eligible as comparison targets. This is deterministic, stateless, and stable regardless of merge ordering.

### Spec changes
- `SignedCommit.prCreatedAt` — new field (falls back to `mergeEpoch` for legacy)
- `selectComparisonTargets` — filters `scoredCommits` by `epoch < prCreatedAt`
- `EvalState.scoredCommits` — carries `(CommitId × Epoch)` pairs for filtering

### Backward compatibility
Legacy `SignedCommit` JSON without `prCreatedAt` falls back to `mergeEpoch`. Since all past PRs were merged sequentially, `epoch < mergeEpoch` gives identical results. Verified: `genesis-replay.sh --verify` passes for all 8 indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)