### PR TITLE
Genesis variant system for non-retroactive parameter changes

### DIFF
--- a/Genesis/Cli/SelectTargets.lean
+++ b/Genesis/Cli/SelectTargets.lean
@@ -15,6 +15,8 @@ def main : IO UInt32 := runJsonPipe fun j => do
   let prCreatedAt ← IO.ofExcept (j.getObjValAs? Nat "prCreatedAt")
   let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
   let scoredCommits := indices.map (fun idx => (idx.commitHash, idx.epoch))
+  let v := activeVariant prCreatedAt
+  letI := v
   let eligible := scoredCommits.filter (fun (_, epoch) => epoch < prCreatedAt)
-  let targets := selectComparisonTargets scoredCommits (min rankingSize eligible.length) prId prCreatedAt
+  let targets := selectComparisonTargets scoredCommits (min v.rankingSize eligible.length) prId prCreatedAt
   return Json.mkObj [("targets", toJson targets)]

--- a/Genesis/Json.lean
+++ b/Genesis/Json.lean
@@ -190,20 +190,4 @@ instance : FromJson CommitIndex where
     return { commitHash, epoch, score, contributor, weightDelta, reviewers,
              metaReviews, mergeVotes, rejectVotes, founderOverride }
 
--- ============================================================================
--- EvalParams
--- ============================================================================
-
-instance : ToJson EvalParams where
-  toJson ep := Json.mkObj [
-    ("reviewerThreshold", toJson ep.reviewerThreshold),
-    ("minReviews", toJson ep.minReviews)
-  ]
-
-instance : FromJson EvalParams where
-  fromJson? j := do
-    let reviewerThreshold ← j.getObjValAs? Nat "reviewerThreshold"
-    let minReviews ← j.getObjValAs? Nat "minReviews"
-    return { reviewerThreshold, minReviews }
-
 end Genesis.Json

--- a/Genesis/Scoring.lean
+++ b/Genesis/Scoring.lean
@@ -18,45 +18,6 @@
 
 import Genesis.Types
 
-/-! ### Configurable Parameters
-
-  These are Lean constants, easy to adjust for experimentation.
--/
-
-/-- Number of past commits a reviewer must rank alongside the current PR.
-    Total items ranked = rankingSize + 1 (targets + current PR).
-    Higher = more context for scoring, more effort per review.
-    Lower = faster reviews, less context. -/
-def rankingSize : Nat := 7
-
-/-- Quantile for the weighted quantile scoring function, as num/den.
-    The score is the value at this quantile of the weighted distribution.
-
-    - 1/2 (median): safe up to 50% honest. Symmetric.
-    - 1/3 (lower third): safe up to 66% honest for inflation.
-      Meta-review covers deflation below 50%.
-    - 2/5 (lower two-fifths): safe up to 60% honest for inflation.
-
-    Lower quantile = more conservative scoring, higher Sybil resistance. -/
-def quantileNum : Nat := 1
-def quantileDen : Nat := 3
-
-/-! ### Evaluation Parameters -/
-
-/-- Parameters for the evaluation path (scoring + state reconstruction).
-    Reward parameters (emission, caps, splits) are deferred to finalization
-    and documented in Design.lean. -/
-structure EvalParams where
-  /-- Minimum weight to activate as a reviewer. -/
-  reviewerThreshold : Nat
-  /-- Minimum number of approved reviews required for scoring. -/
-  minReviews : Nat
-  deriving Repr
-
-def EvalParams.default : EvalParams where
-  reviewerThreshold := 500
-  minReviews := 1
-
 /-! ### Comparison Target Selection -/
 
 /-- Maps a PR ID to a pseudo-random natural number for target selection. -/
@@ -90,14 +51,14 @@ def selectComparisonTargets
         pastCommitIds[idx]!
 
 /-- Validate comparison targets in a signed commit. -/
-def validateComparisonTargets
+def validateComparisonTargets [gv : GenesisVariant]
     (commit : SignedCommit)
     (scoredCommits : List (CommitId × Epoch)) : Bool :=
   let eligible := scoredCommits.filter (fun (_, epoch) => epoch < commit.prCreatedAt)
   if eligible.isEmpty then commit.comparisonTargets.isEmpty
   else
     let expected := selectComparisonTargets scoredCommits
-      (min rankingSize eligible.length) commit.prId commit.prCreatedAt
+      (min gv.rankingSize eligible.length) commit.prId commit.prCreatedAt
     commit.comparisonTargets == expected
 
 /-! ### Meta-Review Filtering
@@ -188,8 +149,8 @@ def scoreFromReview
 /-- Weighted quantile of a list of (weight, value) pairs.
     Returns the value at the point where `quantileNum/quantileDen`
     of the total weight has been accumulated (walking from low to high). -/
-def weightedQuantile (entries : List (Nat × Nat))
-    (qNum : Nat := quantileNum) (qDen : Nat := quantileDen) : Nat :=
+def weightedQuantile [gv : GenesisVariant] (entries : List (Nat × Nat))
+    (qNum : Nat := gv.quantileNum) (qDen : Nat := gv.quantileDen) : Nat :=
   if entries.isEmpty then 0
   else
     let sorted := entries.toArray.qsort (fun a b => a.2 < b.2) |>.toList
@@ -210,7 +171,7 @@ def weightedQuantile (entries : List (Nat × Nat))
     Then take the weighted quantile across all reviewers per dimension.
 
     Reviews from non-reviewers (weight = 0) are silently ignored. -/
-def deriveScore
+def deriveScore [GenesisVariant]
     (reviews : List EmbeddedReview)
     (currentPR : CommitId)
     (getWeight : ContributorId → Nat) : CommitScore :=
@@ -239,8 +200,7 @@ def deriveScore
 
     Returns the CommitScore (percentile-based, 0-100 per dimension).
     Reward computation is deferred to finalization (see Design.lean). -/
-def commitScore
-    (ep : EvalParams)
+def commitScore [gv : GenesisVariant]
     (commit : SignedCommit)
     (scoredCommits : List (CommitId × Epoch))
     (getWeight : ContributorId → Nat)
@@ -255,7 +215,7 @@ def commitScore
     -- Step 3: Check minimum approved reviews from weighted reviewers
     let weightedReviews := approvedReviews.filter fun (r : EmbeddedReview) =>
       getWeight r.reviewer > 0
-    if weightedReviews.length < ep.minReviews then
+    if weightedReviews.length < gv.minReviews then
       zeroScore
     else
       -- Step 4: Derive score (percentile-based)

--- a/Genesis/State.lean
+++ b/Genesis/State.lean
@@ -1,21 +1,20 @@
 /-
   Genesis Protocol — Execution Model & State
 
-  ## Execution
+  ## Variant System
 
-  For commit N, any spec version ≥ the spec at commit N-1 must produce
-  the same CommitIndex. The spec is backward compatible (new handles old)
-  but not necessarily forward compatible (old may not handle new).
+  Protocol parameters are grouped in GenesisConfig/GenesisVariant.
+  The active variant is selected by epoch via genesisSchedule, following
+  the blockchain hard-fork pattern. Parameter changes are non-retroactive:
+  each past index is processed under the variant active at its epoch,
+  and each commit is scored under the variant active at its prCreatedAt.
 
-  The current spec on master is always a valid evaluator for all past
-  commits. This is enforced by CI (`genesis-replay.sh --verify`).
+  ## Spec Consistency Rule
 
-  Evaluation order:
-  1. Gather all signed commits from git history (merge commit trailers).
-  2. Evaluate the first signed commit with empty state → produces index_0.
-  3. Evaluate the second with [index_0] as past state → produces index_1.
-  4. Continue: each step receives all prior indices as input.
-  5. Finalization (future work): compute end balances from all indices.
+  The current spec on master evaluates ALL past commits correctly.
+  Spec changes (algorithms) must remain backward compatible.
+  Parameter changes use the variant schedule — no backward compat needed.
+  CI enforces via `genesis-replay.sh --verify`.
 -/
 
 import Genesis.Types
@@ -36,6 +35,27 @@ def genesisCommit : CommitId := "4cc102a03d715c6bb2b119d8a3a1c49e4694751f"
 
 /-- Initial weight for the founder. -/
 def founderWeight : Nat := 1
+
+/-! ### Activation Schedule -/
+
+/-- Activation schedule. Each entry: (activationEpoch, variant).
+    For a given epoch, the active variant is the last entry where
+    activationEpoch ≤ epoch. Uses idx.epoch for state reconstruction,
+    commit.prCreatedAt for scoring.
+
+    To change a parameter:
+    1. PR A: add new GenesisConfig + GenesisVariant instance. Safe (inactive).
+    2. PR B: add entry here with a future activation epoch. Must merge before that date. -/
+def genesisSchedule : List (Epoch × GenesisVariant) :=
+  [ (0, GenesisVariant.v1)
+  ]
+
+/-- Resolve the active variant for a given epoch. -/
+def activeVariant (epoch : Epoch) : GenesisVariant :=
+  let applicable := genesisSchedule.filter (fun (e, _) => e ≤ epoch)
+  match applicable.getLast? with
+  | some (_, v) => v
+  | none => GenesisVariant.v1
 
 /-! ### CommitIndex — Output of evaluating one signed commit -/
 
@@ -71,12 +91,7 @@ structure CommitIndex where
   founderOverride : Bool
   deriving Repr
 
-/-! ### Intermediate State
-
-  Reconstructed from past CommitIndices for evaluating the next commit.
-  This is NOT the final balance — it's the working state needed to
-  run the scoring algorithm (reviewer weights, past commit IDs).
--/
+/-! ### Intermediate State -/
 
 /-- Intermediate state reconstructed from past indices. -/
 structure EvalState where
@@ -92,29 +107,31 @@ private def upsertContributor (cs : List Contributor) (updated : Contributor) : 
   else
     cs ++ [updated]
 
-/-- Reconstruct the evaluation state from genesis + past indices.
-    Only needs weight and reviewer status — not balances (those are
-    computed during finalization). -/
-def reconstructState (pastIndices : List CommitIndex) (ep : EvalParams := .default) : EvalState :=
-  let init : EvalState := {
-    contributors := [⟨founder, 0, founderWeight, true⟩],
-    scoredCommits := []
-  }
-  pastIndices.foldl (fun state (idx : CommitIndex) =>
-    -- Apply weight change to the contributor (author)
-    let contributors :=
-      if idx.weightDelta == 0 then state.contributors
-      else
-        let existing := state.contributors.find? (fun (c : Contributor) => c.id == idx.contributor)
-        let c := existing.getD ⟨idx.contributor, 0, 0, false⟩
-        let newWeight := c.weight + idx.weightDelta
-        let meetsThreshold := newWeight ≥ ep.reviewerThreshold
-        let updated : Contributor := ⟨c.id, c.balance, newWeight, c.isReviewer || meetsThreshold⟩
-        upsertContributor state.contributors updated
-    -- Record scored commit with epoch for target selection
-    let scoredCommits := state.scoredCommits ++ [(idx.commitHash, idx.epoch)]
-    { contributors := contributors, scoredCommits := scoredCommits }
-  ) init
+/-- Initial evaluation state: founder with initial weight, no scored commits. -/
+def initEvalState : EvalState := {
+  contributors := [⟨founder, 0, founderWeight, true⟩],
+  scoredCommits := []
+}
+
+/-! ### Inner functions (use [GenesisVariant] typeclass) -/
+
+section VariantScoped
+variable [gv : GenesisVariant]
+
+/-- Process one past index under the current variant's parameters.
+    Updates contributor weights and reviewer status. -/
+def stepState (state : EvalState) (idx : CommitIndex) : EvalState :=
+  let contributors :=
+    if idx.weightDelta == 0 then state.contributors
+    else
+      let existing := state.contributors.find? (fun (c : Contributor) => c.id == idx.contributor)
+      let c := existing.getD ⟨idx.contributor, 0, 0, false⟩
+      let newWeight := c.weight + idx.weightDelta
+      let meetsThreshold := newWeight ≥ gv.reviewerThreshold
+      let updated : Contributor := ⟨c.id, c.balance, newWeight, c.isReviewer || meetsThreshold⟩
+      upsertContributor state.contributors updated
+  let scoredCommits := state.scoredCommits ++ [(idx.commitHash, idx.epoch)]
+  { contributors := contributors, scoredCommits := scoredCommits }
 
 /-- Get reviewer weight from an EvalState. -/
 def EvalState.reviewerWeight (s : EvalState) (id : ContributorId) : Nat :=
@@ -122,22 +139,10 @@ def EvalState.reviewerWeight (s : EvalState) (id : ContributorId) : Nat :=
   | some c => if c.isReviewer then c.weight else 0
   | none => 0
 
-/-! ### Evaluate — Produce a CommitIndex from a signed commit -/
-
-/-- Evaluate a single signed commit, producing a CommitIndex.
-
-    This is THE core function. It takes:
-    - All past indices (from prior evaluations)
-    - The current signed commit to evaluate
-
-    It reconstructs the evaluation state from past indices, then
-    runs the scoring algorithm to produce the new index. -/
-def evaluate
-    (pastIndices : List CommitIndex)
-    (commit : SignedCommit)
-    (ep : EvalParams := .default) : CommitIndex :=
-  let state := reconstructState pastIndices ep
-  let score := commitScore ep commit
+/-- Evaluate a single signed commit given pre-built state.
+    Uses the current [GenesisVariant] for scoring parameters. -/
+def evaluateWithState (state : EvalState) (commit : SignedCommit) : CommitIndex :=
+  let score := commitScore commit
     state.scoredCommits (state.reviewerWeight ·)
   let approved := filterReviews commit.reviews commit.metaReviews (state.reviewerWeight ·)
   let approvedReviewers := approved
@@ -160,13 +165,30 @@ def evaluate
     rejectVotes := rejectVoters,
     founderOverride := commit.founderOverride }
 
-/-- Evaluate a full sequence of signed commits, producing all indices.
-    Each commit is evaluated with all prior indices as context. -/
-def evaluateAll
-    (signedCommits : List SignedCommit)
-    (ep : EvalParams := .default) : List CommitIndex :=
+end VariantScoped
+
+/-! ### Outer dispatch (resolves variant per-commit via schedule) -/
+
+/-- Reconstruct state from past indices. Each index is processed under
+    the variant active at its epoch (idx.epoch). -/
+def reconstructState (pastIndices : List CommitIndex) : EvalState :=
+  pastIndices.foldl (fun state idx =>
+    letI := activeVariant idx.epoch
+    stepState state idx
+  ) initEvalState
+
+/-- Evaluate a single signed commit.
+    State reconstruction uses per-index variants.
+    Scoring uses the variant active at commit.prCreatedAt. -/
+def evaluate (pastIndices : List CommitIndex) (commit : SignedCommit) : CommitIndex :=
+  let state := reconstructState pastIndices
+  letI := activeVariant commit.prCreatedAt
+  evaluateWithState state commit
+
+/-- Evaluate a full sequence of signed commits. -/
+def evaluateAll (signedCommits : List SignedCommit) : List CommitIndex :=
   signedCommits.foldl (fun indices commit =>
-    indices ++ [evaluate indices commit ep]
+    indices ++ [evaluate indices commit]
   ) []
 
 /-- Final weight for each contributor, computed from all indices.

--- a/Genesis/Types.lean
+++ b/Genesis/Types.lean
@@ -41,7 +41,57 @@
   - Reviewer reward per commit is capped.
   - Worst-case damage from a malicious spec = one commit's capped rewards.
   - Comparison targets are validated at spec time — forged targets → zero reward.
+
+  ## Variant System
+
+  Protocol parameters are grouped in GenesisConfig. The active config is
+  selected by epoch via a schedule (genesisSchedule), following the
+  blockchain hard-fork pattern. Parameter changes are non-retroactive:
+  PRs opened before the activation use the old config.
+
+  GenesisVariant extends GenesisConfig with variant-specific functions
+  (like JamVariant extends JamConfig in the JAR spec).
 -/
+
+/-! ### Genesis Config & Variant -/
+
+/-- Protocol parameters. Mirrors JamConfig's role in the JAR spec.
+    All configurable constants that affect scoring and state reconstruction
+    are defined here. Changes take effect via the activation schedule. -/
+structure GenesisConfig where
+  name : String
+  reviewerThreshold : Nat
+  minReviews : Nat
+  rankingSize : Nat
+  quantileNum : Nat
+  quantileDen : Nat
+  designWeight : Nat
+  numWeightedDimensions : Nat
+  deriving Repr
+
+/-- Protocol configuration typeclass. All configurable constants are
+    direct fields, accessed as GenesisVariant.reviewerThreshold etc.
+    Mirrors JamConfig in the JAR spec.
+    Future variant-specific functions can be added as fields here
+    (like JamVariant.pvmRun extends JamConfig). -/
+class GenesisVariant extends GenesisConfig
+
+/-! ### Standard Variants -/
+
+def GenesisConfig.v1 : GenesisConfig where
+  name := "genesis_v1"
+  reviewerThreshold := 500
+  minReviews := 1
+  rankingSize := 7
+  quantileNum := 1
+  quantileDen := 3
+  designWeight := 3
+  numWeightedDimensions := 5
+
+instance GenesisVariant.v1 : GenesisVariant where
+  toGenesisConfig := .v1
+
+/-! ### Core Types -/
 
 /-- GitHub username. -/
 abbrev ContributorId := String
@@ -141,19 +191,17 @@ structure CommitScore where
   designQuality : Nat
   deriving Repr, BEq
 
-/-- Number of scoring dimensions. Used to normalize the weighted total. -/
-def CommitScore.numWeightedDimensions : Nat := 5  -- 1 + 1 + 3
+/-- Combined weighted score from CommitScore.
+    designWeight and numWeightedDimensions come from the active variant.
+    Result is 0-100 (normalized). -/
+def CommitScore.weighted [gv : GenesisVariant] (s : CommitScore) : Nat :=
+  (s.difficulty + s.novelty + gv.designWeight * s.designQuality) / gv.numWeightedDimensions
 
-/-- Combined weighted score from CommitScore. designQuality is 3x.
-    Result is 0-100 (normalized by number of weighted dimensions). -/
-def CommitScore.weighted (s : CommitScore) : Nat :=
-  (s.difficulty + s.novelty + 3 * s.designQuality) / CommitScore.numWeightedDimensions
-
-/-- weightDelta is at most 100 when all dimension scores are at most 100. -/
-theorem CommitScore.weighted_le_100 (s : CommitScore)
+/-- weightDelta is at most 100 when all dimension scores are at most 100 (for v1). -/
+theorem CommitScore.weighted_le_100_v1 (s : CommitScore)
     (hd : s.difficulty ≤ 100) (hn : s.novelty ≤ 100) (hq : s.designQuality ≤ 100) :
-    s.weighted ≤ 100 := by
-  unfold weighted numWeightedDimensions
+    (letI := GenesisVariant.v1; s.weighted) ≤ 100 := by
+  simp only [weighted, GenesisVariant.v1, GenesisConfig.v1]
   omega
 
 /-- A signed commit and the data needed to compute its rewards. -/


### PR DESCRIPTION
## Summary

Adds a variant system to the Genesis spec, modeled after JAR's `JamConfig`/`JamVariant` typeclasses. Protocol parameters are now part of `GenesisConfig`, and the active config is resolved per-commit via an activation schedule.

### The problem

All Genesis parameters (reviewerThreshold, quantile, rankingSize, etc.) were global constants. Changing any of them retroactively affected `reconstructState`, which replays all history with the new values. Even changing the reviewer threshold would break past scores.

### The solution

**Blockchain hard-fork pattern:**
- `GenesisConfig` — structure holding all parameters (like `JamConfig`)
- `GenesisVariant extends GenesisConfig` — typeclass (like `JamVariant`)
- `genesisSchedule` — list of `(activationEpoch, variant)` pairs
- `activeVariant(epoch)` — resolves which variant to use

**Per-commit variant resolution:**
- `reconstructState`: each past index processed under `activeVariant(idx.epoch)`
- `evaluate`/scoring: uses `activeVariant(commit.prCreatedAt)`

**To change a parameter:**
1. PR A: add new `GenesisConfig.v2` + `GenesisVariant.v2` instance (safe, inactive)
2. PR B: add schedule entry with a future activation epoch (must merge before that date)
3. After activation: PRs opened after that epoch use v2. Old PRs keep v1. No retroactive effects.

### What changed
- `EvalParams` removed — replaced by `GenesisVariant` typeclass
- All parameter globals (`rankingSize`, `quantileNum/Den`, etc.) → `GenesisConfig` fields
- Inner functions (`stepState`, `evaluateWithState`, `commitScore`) use `[GenesisVariant]`
- Outer functions (`reconstructState`, `evaluate`) resolve variant from schedule
- `genesisSchedule` starts with single entry `(0, v1)` — identical to current behavior

### Backward compatibility

Verified: `genesis-replay.sh --verify` passes for all 15 indices. The schedule has one entry (v1 from epoch 0), so all past commits resolve to v1 with the same parameter values as the old globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)