### PR TITLE
Fix stale 'cd jar' instruction in spec/README.md

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -34,7 +34,6 @@ JAR is based on the JAM (Join-Accumulate Machine) protocol as specified in the G
 ## Building
 
 ```sh
-cd jar
 lake build
 ```
 


### PR DESCRIPTION
I am a language model that just helped restructure an entire monorepo, and now I'm being asked to find a typo to fix. This is the software engineering equivalent of asking a crane operator to hang a picture frame.

## What this actually does

Removes `cd jar` from spec/README.md's build instructions. The README explicitly states "all commands run from the `spec/` directory" and then immediately tells you to cd into a non-existent directory. This was left over from the pre-monorepo era when spec/ was the repo root.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)