### PR TITLE
Genesis: add Set-Genesis-Author PR description flag

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -88,11 +88,24 @@ jobs:
           CACHE=$(git show origin/genesis-state:genesis.json)
 
           # Get PR details (including immutable created_at for target anchoring)
-          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,author,createdAt)
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,author,createdAt,body)
           HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
           AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
           PR_CREATED_AT=$(echo "$PR_JSON" | jq -r '.createdAt')
           PR_CREATED_EPOCH=$(date -d "$PR_CREATED_AT" +%s)
+          PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+
+          # Parse accepted flags from leading lines of PR body (before first blank line).
+          # To add new flags, add a new parse_flag call below.
+          parse_flag() {
+            local flag="$1"
+            echo "$PR_BODY" | awk '/^$/{exit} /^'"$flag"':/{print; exit}' | sed "s/^${flag}: *@\\{0,1\\}//"
+          }
+
+          GENESIS_AUTHOR=$(parse_flag "Set-Genesis-Author")
+          if [ -n "$GENESIS_AUTHOR" ]; then
+            AUTHOR="$GENESIS_AUTHOR"
+          fi
 
           # Get comparison targets anchored to PR creation time
           TARGETS_JSON=$(echo "{\"prId\":${PR_NUMBER},\"prCreatedAt\":${PR_CREATED_EPOCH},\"indices\":${CACHE}}" | \

--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -194,6 +194,23 @@ CACHE=$(git show origin/genesis-state:genesis.json)
 echo "{\"indices\":${CACHE}}" | .lake/build/bin/genesis_finalize
 ```
 
+## PR Description Flags
+
+Structured flags in the leading lines of the PR description (before the first blank line) configure Genesis behavior.
+
+| Flag | Effect |
+|------|--------|
+| `Set-Genesis-Author: @username` | Override the Genesis author (tokens go to `username` instead of PR author) |
+
+Example PR description:
+```
+Set-Genesis-Author: @alice
+
+This PR implements feature X on behalf of alice.
+```
+
+To add new flags: edit `genesis-merge.yml`, add a `parse_flag "Set-Flag-Name"` call.
+
 ## Contributing (Proof of Intelligence)
 
 Every merged PR earns a genesis allocation scored on difficulty, novelty, and design quality. To contribute:


### PR DESCRIPTION
## Summary

- PR authors can override the Genesis author by adding `Set-Genesis-Author: @username` in the leading lines of the PR description
- Uses a `parse_flag` function that scans lines before the first blank line — easy to extend with new flags
- Only affects `genesis-merge.yml` (the only workflow where author matters for scoring)

## Example

```
Set-Genesis-Author: @alice

This PR implements feature X on behalf of alice.
```

## Test plan

- [x] Smoke tested `parse_flag` locally: 5/5 cases pass (with @, without @, absent, after blank line, multiple flags)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)