### PR TITLE
Genesis: rank-based comparison target selection (v2)

### DIFF
--- a/spec/Genesis/Cli/CheckMerge.lean
+++ b/spec/Genesis/Cli/CheckMerge.lean
@@ -13,7 +13,7 @@ open Genesis.Cli
 def main : IO UInt32 := runJsonPipe fun j => do
   let reviews ← IO.ofExcept (j.getObjValAs? (List EmbeddedReview) "reviews")
   let metaReviews ← IO.ofExcept (j.getObjValAs? (List MetaReview) "metaReviews")
-  let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
+  let indices ← IO.ofExcept (j.getObjValAs? (List CachedCommitIndex) "indices")
   let state := reconstructState indices
   -- Filter reviews by meta-review
   let approved := filterReviews reviews metaReviews (state.reviewerWeight ·)

--- a/spec/Genesis/Cli/Evaluate.lean
+++ b/spec/Genesis/Cli/Evaluate.lean
@@ -2,7 +2,7 @@
   genesis_evaluate CLI
 
   Input:  {"commit": {...}, "pastIndices": [...]}
-  Output: CommitIndex JSON
+  Output: CachedCommitIndex JSON (includes globalRank)
 -/
 
 import Genesis.Cli.Common
@@ -12,6 +12,6 @@ open Genesis.Cli
 
 def main : IO UInt32 := runJsonPipe fun j => do
   let commit ← IO.ofExcept (j.getObjValAs? SignedCommit "commit")
-  let pastIndices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "pastIndices")
+  let pastIndices ← IO.ofExcept (j.getObjValAs? (List CachedCommitIndex) "pastIndices")
   let idx := evaluate pastIndices commit
   return toJson idx

--- a/spec/Genesis/Cli/Finalize.lean
+++ b/spec/Genesis/Cli/Finalize.lean
@@ -15,7 +15,7 @@ open Lean (Json ToJson toJson fromJson? FromJson)
 open Genesis.Cli
 
 def main : IO UInt32 := runJsonPipe fun j => do
-  let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
+  let indices ← IO.ofExcept (j.getObjValAs? (List CachedCommitIndex) "indices")
   let weights := finalWeights indices
   let weightsJson := weights.map fun (id, weight) =>
     Json.mkObj [("id", toJson id), ("weight", toJson weight)]

--- a/spec/Genesis/Cli/SelectTargets.lean
+++ b/spec/Genesis/Cli/SelectTargets.lean
@@ -13,10 +13,16 @@ open Genesis.Cli
 def main : IO UInt32 := runJsonPipe fun j => do
   let prId ← IO.ofExcept (j.getObjValAs? Nat "prId")
   let prCreatedAt ← IO.ofExcept (j.getObjValAs? Nat "prCreatedAt")
-  let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
-  let scoredCommits := indices.map (fun idx => (idx.commitHash, idx.epoch))
+  let indices ← IO.ofExcept (j.getObjValAs? (List CachedCommitIndex) "indices")
   let v := activeVariant prCreatedAt
   letI := v
-  let eligible := scoredCommits.filter (fun (_, epoch) => epoch < prCreatedAt)
-  let targets := selectComparisonTargets scoredCommits (min v.rankingSize eligible.length) prId prCreatedAt
+  let targets :=
+    if v.useRankedTargets then
+      let scoredCommits := indices.map (fun idx => (idx.commitHash, idx.epoch, idx.globalRank))
+      let eligible := scoredCommits.filter (fun (_, epoch, _) => epoch < prCreatedAt)
+      selectComparisonTargetsRanked scoredCommits (min v.rankingSize eligible.length) prId prCreatedAt
+    else
+      let scoredCommits := indices.map (fun idx => (idx.commitHash, idx.epoch))
+      let eligible := scoredCommits.filter (fun (_, epoch) => epoch < prCreatedAt)
+      selectComparisonTargets scoredCommits (min v.rankingSize eligible.length) prId prCreatedAt
   return Json.mkObj [("targets", toJson targets)]

--- a/spec/Genesis/Cli/Validate.lean
+++ b/spec/Genesis/Cli/Validate.lean
@@ -22,9 +22,9 @@ def main : IO UInt32 := runJsonPipe fun j => do
       ("errors", Json.arr #[Json.str s!"index count ({indices.length}) != commit count ({signedCommits.length})"])
     ]
   let mut errors : Array Json := #[]
-  let mut pastIndices : List CommitIndex := []
+  let mut pastCached : List CachedCommitIndex := []
   for (idx, commit) in indices.zip signedCommits do
-    let expected := evaluate pastIndices commit
+    let expected := evaluate pastCached commit
     -- Compare key fields
     if expected.commitHash != idx.commitHash then
       errors := errors.push (Json.str s!"commit {idx.commitHash}: hash mismatch")
@@ -34,7 +34,11 @@ def main : IO UInt32 := runJsonPipe fun j => do
       errors := errors.push (Json.str s!"commit {idx.commitHash}: weightDelta mismatch (expected {expected.weightDelta}, got {idx.weightDelta})")
     if expected.contributor != idx.contributor then
       errors := errors.push (Json.str s!"commit {idx.commitHash}: contributor mismatch")
-    pastIndices := pastIndices ++ [idx]
+    -- Only check globalRank if the trailer includes it
+    if let some trailerRank := idx.globalRank then
+      if expected.globalRank != trailerRank then
+        errors := errors.push (Json.str s!"commit {idx.commitHash}: globalRank mismatch (expected {expected.globalRank}, got {trailerRank})")
+    pastCached := pastCached ++ [expected]
   return Json.mkObj [
     ("valid", toJson errors.isEmpty),
     ("errors", Json.arr errors)

--- a/spec/Genesis/Json.lean
+++ b/spec/Genesis/Json.lean
@@ -161,19 +161,25 @@ instance : FromJson Contributor where
 -- CommitIndex
 -- ============================================================================
 
+-- CommitIndex: for trailers. globalRank is Option Nat (old trailers lack it).
 instance : ToJson CommitIndex where
-  toJson idx := Json.mkObj [
-    ("commitHash", toJson idx.commitHash),
-    ("epoch", toJson idx.epoch),
-    ("score", toJson idx.score),
-    ("contributor", toJson idx.contributor),
-    ("weightDelta", toJson idx.weightDelta),
-    ("reviewers", toJson idx.reviewers),
-    ("metaReviews", toJson idx.metaReviews),
-    ("mergeVotes", toJson idx.mergeVotes),
-    ("rejectVotes", toJson idx.rejectVotes),
-    ("founderOverride", toJson idx.founderOverride)
-  ]
+  toJson idx :=
+    let fields := [
+      ("commitHash", toJson idx.commitHash),
+      ("epoch", toJson idx.epoch),
+      ("score", toJson idx.score),
+      ("contributor", toJson idx.contributor),
+      ("weightDelta", toJson idx.weightDelta),
+      ("reviewers", toJson idx.reviewers),
+      ("metaReviews", toJson idx.metaReviews),
+      ("mergeVotes", toJson idx.mergeVotes),
+      ("rejectVotes", toJson idx.rejectVotes),
+      ("founderOverride", toJson idx.founderOverride)
+    ]
+    let fields := match idx.globalRank with
+      | some r => fields ++ [("globalRank", toJson r)]
+      | none => fields
+    Json.mkObj fields
 
 instance : FromJson CommitIndex where
   fromJson? j := do
@@ -187,7 +193,45 @@ instance : FromJson CommitIndex where
     let mergeVotes ← j.getObjValAs? (List String) "mergeVotes"
     let rejectVotes ← j.getObjValAs? (List String) "rejectVotes"
     let founderOverride ← j.getObjValAs? Bool "founderOverride"
+    let globalRank := (j.getObjValAs? Nat "globalRank").toOption
     return { commitHash, epoch, score, contributor, weightDelta, reviewers,
-             metaReviews, mergeVotes, rejectVotes, founderOverride }
+             metaReviews, mergeVotes, rejectVotes, founderOverride, globalRank }
+
+-- ============================================================================
+-- CachedCommitIndex
+-- ============================================================================
+
+-- CachedCommitIndex: for cache. globalRank is always Nat.
+instance : ToJson CachedCommitIndex where
+  toJson idx := Json.mkObj [
+    ("commitHash", toJson idx.commitHash),
+    ("epoch", toJson idx.epoch),
+    ("score", toJson idx.score),
+    ("contributor", toJson idx.contributor),
+    ("weightDelta", toJson idx.weightDelta),
+    ("reviewers", toJson idx.reviewers),
+    ("metaReviews", toJson idx.metaReviews),
+    ("mergeVotes", toJson idx.mergeVotes),
+    ("rejectVotes", toJson idx.rejectVotes),
+    ("founderOverride", toJson idx.founderOverride),
+    ("globalRank", toJson idx.globalRank)
+  ]
+
+instance : FromJson CachedCommitIndex where
+  fromJson? j := do
+    let commitHash ← j.getObjValAs? String "commitHash"
+    let epoch ← j.getObjValAs? Nat "epoch"
+    let score ← j.getObjValAs? CommitScore "score"
+    let contributor ← j.getObjValAs? String "contributor"
+    let weightDelta ← j.getObjValAs? Nat "weightDelta"
+    let reviewers ← j.getObjValAs? (List String) "reviewers"
+    let metaReviews ← j.getObjValAs? (List MetaReview) "metaReviews"
+    let mergeVotes ← j.getObjValAs? (List String) "mergeVotes"
+    let rejectVotes ← j.getObjValAs? (List String) "rejectVotes"
+    let founderOverride ← j.getObjValAs? Bool "founderOverride"
+    -- Tolerate missing globalRank for backward compat (default 0)
+    let globalRank ← (j.getObjValAs? Nat "globalRank") <|> pure 0
+    return { commitHash, epoch, score, contributor, weightDelta, reviewers,
+             metaReviews, mergeVotes, rejectVotes, founderOverride, globalRank }
 
 end Genesis.Json

--- a/spec/Genesis/Scoring.lean
+++ b/spec/Genesis/Scoring.lean
@@ -220,3 +220,135 @@ def commitScore [gv : GenesisVariant]
     else
       -- Step 4: Derive score (percentile-based)
       deriveScore weightedReviews commit.id getWeight
+
+/-! ### Global Ranking (v2 target selection)
+
+  Build a global quality ordering from pairwise review evidence.
+  Each review's 3 dimension rankings are aggregated into one ordering
+  (1×diff + 1×nov + 3×design position). Pairwise wins are accumulated
+  across all reviews. Net-wins determines the global rank.
+-/
+
+/-- Compute aggregate position for each commit in a review.
+    Lower = better. Uses weighted positions: diff + nov + 3×design. -/
+def aggregateReviewRanking [gv : GenesisVariant]
+    (review : EmbeddedReview) : List (CommitId × Nat) :=
+  let commits := review.designQualityRanking
+  commits.map fun c =>
+    let dPos := review.difficultyRanking.findIdx? (· == c) |>.getD review.difficultyRanking.length
+    let nPos := review.noveltyRanking.findIdx? (· == c) |>.getD review.noveltyRanking.length
+    let qPos := review.designQualityRanking.findIdx? (· == c) |>.getD review.designQualityRanking.length
+    (c, dPos + nPos + gv.designWeight * qPos)
+
+/-- Extract pairwise outcomes from a single review.
+    Returns list of (winner, loser) pairs. -/
+def extractPairwise [GenesisVariant] (review : EmbeddedReview) : List (CommitId × CommitId) :=
+  let ranked := aggregateReviewRanking review
+  let sorted := ranked.toArray.qsort (fun a b => a.2 < b.2) |>.toList
+  let commits := sorted.map (·.1)
+  -- Each commit beats all those below it in the aggregate ordering
+  let indexed := commits.zip (List.range commits.length)
+  indexed.foldl (fun acc (winner, i) =>
+    acc ++ (commits.drop (i + 1)).map (fun loser => (winner, loser))
+  ) []
+
+/-- Accumulate pairwise wins from a list of reviews into a map.
+    Map: commitId → set of commitIds it beats. -/
+def accumulatePairwise [GenesisVariant]
+    (reviews : List EmbeddedReview)
+    (existing : List (CommitId × List CommitId)) : List (CommitId × List CommitId) :=
+  let pairs := reviews.foldl (fun acc r => acc ++ extractPairwise r) []
+  pairs.foldl (fun acc (winner, loser) =>
+    match acc.find? (fun (c, _) => c == winner) with
+    | some (_, losers) =>
+      if losers.contains loser then acc
+      else acc.map (fun (c, ls) => if c == winner then (c, ls ++ [loser]) else (c, ls))
+    | none => acc ++ [(winner, [loser])]
+  ) existing
+
+/-- Compute net-wins for each commit: |commits beaten| - |commits lost to|. -/
+def computeNetWins (commits : List CommitId)
+    (wins : List (CommitId × List CommitId)) : List (CommitId × Int) :=
+  let commitSet := commits
+  commits.map fun c =>
+    let beaten := match wins.find? (fun (w, _) => w == c) with
+      | some (_, losers) => losers.filter (commitSet.contains ·) |>.length
+      | none => 0
+    let lostTo := commits.foldl (fun acc other =>
+      match wins.find? (fun (w, _) => w == other) with
+      | some (_, losers) => if losers.contains c then acc + 1 else acc
+      | none => acc
+    ) 0
+    (c, (beaten : Int) - (lostTo : Int))
+
+/-- Compute globalRank for a new commit by insertion into existing ranking.
+    Uses the new commit's reviews to determine pairwise outcomes against targets,
+    then finds the insertion position based on targets' existing globalRanks.
+
+    The rank is the median of the valid range:
+    - Must be above (higher rank number than) all targets that beat it
+    - Must be below (lower rank number than) all targets it beats
+    Returns 0 (best) when the commit beats all its targets. -/
+def computeGlobalRank [GenesisVariant]
+    (pastRanking : List (CommitId × Nat))
+    (newCommitId : CommitId)
+    (reviews : List EmbeddedReview) : Nat :=
+  if pastRanking.isEmpty then 0
+  else
+    -- Extract pairwise outcomes from ALL reviews (not just approved ones —
+    -- pairwise evidence is structural, not weighted)
+    let allPairs := reviews.foldl (fun acc r => acc ++ extractPairwise r) []
+    -- Which targets does the new commit beat / lose to?
+    let beats := allPairs.filterMap fun (w, l) =>
+      if w == newCommitId then some l else none
+    let losesTo := allPairs.filterMap fun (w, l) =>
+      if l == newCommitId then some w else none
+    -- Find the globalRank bounds from targets in the existing ranking
+    -- bestBeaten: lowest globalRank (best) among targets we beat
+    -- worstLostTo: highest globalRank (worst) among targets that beat us
+    let n := pastRanking.length
+    let bestBeaten := pastRanking.foldl (fun acc (c, r) =>
+      if beats.contains c then min acc r else acc
+    ) n
+    let worstLostTo := pastRanking.foldl (fun acc (c, r) =>
+      if losesTo.contains c then max acc r else acc
+    ) 0
+    -- Insert: above all beaten (lower rank number), below all that beat us
+    -- If we beat everything: rank 0. If everything beats us: rank n.
+    -- Otherwise: midpoint of the valid range.
+    if beats.isEmpty && losesTo.isEmpty then n  -- no evidence: worst
+    else if losesTo.isEmpty then
+      -- Beat some targets, lost to none: go above the best we beat
+      if bestBeaten > 0 then bestBeaten / 2 else 0
+    else if beats.isEmpty then
+      -- Lost to some, beat none: go below the worst that beat us
+      (worstLostTo + n) / 2
+    else
+      -- Have both beats and losses: insert between them
+      (worstLostTo + bestBeaten) / 2
+
+/-- Select comparison targets using globalRank ordering (v2).
+    Sorts eligible commits by globalRank, then bucket-selects with hash jitter. -/
+def selectComparisonTargetsRanked
+    (scoredCommits : List (CommitId × Epoch × Nat))  -- (hash, epoch, globalRank)
+    (numTargets : Nat)
+    (prId : PRId)
+    (prCreatedAt : Epoch) : List CommitId :=
+  let eligible := scoredCommits.filter (fun (_, epoch, _) => epoch < prCreatedAt)
+  -- Sort by globalRank ascending (best first)
+  let sorted := eligible.toArray.qsort (fun a b => a.2.2 < b.2.2) |>.toList
+  let pastCommitIds := sorted.map (·.1)
+  let n := pastCommitIds.length
+  if n == 0 then []
+  else
+    let k := min numTargets n
+    let hash := prIdHash prId
+    List.range k |>.map fun i =>
+      let bucketStart := n * i / k
+      let bucketEnd := n * (i + 1) / k
+      let bucketSize := bucketEnd - bucketStart
+      if bucketSize == 0 then
+        pastCommitIds[bucketStart]!
+      else
+        let idx := bucketStart + (hash + i * 7) % bucketSize
+        pastCommitIds[idx]!

--- a/spec/Genesis/State.lean
+++ b/spec/Genesis/State.lean
@@ -59,13 +59,12 @@ def activeVariant (epoch : Epoch) : GenesisVariant :=
 
 /-! ### CommitIndex — Output of evaluating one signed commit -/
 
-/-- The output of evaluating a single signed commit.
+/-- CommitIndex as stored in Genesis-Index: trailers.
+    `globalRank` is `Option Nat` because old trailers predate this field.
 
     Contains only the raw facts needed for state reconstruction and
     future finalization. Token amounts are NOT stored here — they are
-    computed during finalization using the current spec's parameters.
-    This allows changing reward splits (e.g., 70/30 → 80/20) without
-    re-evaluating history. -/
+    computed during finalization using the current spec's parameters. -/
 structure CommitIndex where
   /-- Hash of the signed commit that was evaluated. -/
   commitHash : CommitId
@@ -89,7 +88,34 @@ structure CommitIndex where
   rejectVotes : List ContributorId
   /-- Whether the founder used the escape hatch to force this merge. -/
   founderOverride : Bool
+  /-- Position in the global quality ordering (0 = best).
+      `none` for old trailers that predate this field. -/
+  globalRank : Option Nat := none
   deriving Repr
+
+/-- CachedCommitIndex as stored in genesis.json cache.
+    `globalRank` is always present (computed during evaluate/rebuild). -/
+structure CachedCommitIndex where
+  commitHash : CommitId
+  epoch : Epoch
+  score : CommitScore
+  contributor : ContributorId
+  weightDelta : Nat
+  reviewers : List ContributorId
+  metaReviews : List MetaReview
+  mergeVotes : List ContributorId
+  rejectVotes : List ContributorId
+  founderOverride : Bool
+  globalRank : Nat
+  deriving Repr
+
+/-- Convert CachedCommitIndex to CommitIndex. -/
+def CachedCommitIndex.toCommitIndex (c : CachedCommitIndex) : CommitIndex :=
+  { commitHash := c.commitHash, epoch := c.epoch, score := c.score,
+    contributor := c.contributor, weightDelta := c.weightDelta,
+    reviewers := c.reviewers, metaReviews := c.metaReviews,
+    mergeVotes := c.mergeVotes, rejectVotes := c.rejectVotes,
+    founderOverride := c.founderOverride, globalRank := some c.globalRank }
 
 /-! ### Intermediate State -/
 
@@ -99,6 +125,8 @@ structure EvalState where
   contributors : List Contributor
   /-- Scored commits with their merge epochs (for comparison target selection). -/
   scoredCommits : List (CommitId × Epoch)
+  /-- Accumulated pairwise wins: (winner, list of losers). -/
+  pairwiseWins : List (CommitId × List CommitId) := []
 
 /-- Update or insert a contributor in a list. -/
 private def upsertContributor (cs : List Contributor) (updated : Contributor) : List Contributor :=
@@ -118,9 +146,9 @@ def initEvalState : EvalState := {
 section VariantScoped
 variable [gv : GenesisVariant]
 
-/-- Process one past index under the current variant's parameters.
-    Updates contributor weights and reviewer status. -/
-def stepState (state : EvalState) (idx : CommitIndex) : EvalState :=
+/-- Process one past cached index under the current variant's parameters.
+    Updates contributor weights, reviewer status, and ranking state. -/
+def stepState (state : EvalState) (idx : CachedCommitIndex) : EvalState :=
   let contributors :=
     if idx.weightDelta == 0 then state.contributors
     else
@@ -131,7 +159,8 @@ def stepState (state : EvalState) (idx : CommitIndex) : EvalState :=
       let updated : Contributor := ⟨c.id, c.balance, newWeight, c.isReviewer || meetsThreshold⟩
       upsertContributor state.contributors updated
   let scoredCommits := state.scoredCommits ++ [(idx.commitHash, idx.epoch)]
-  { contributors := contributors, scoredCommits := scoredCommits }
+  { contributors := contributors, scoredCommits := scoredCommits,
+    pairwiseWins := state.pairwiseWins }
 
 /-- Get reviewer weight from an EvalState. -/
 def EvalState.reviewerWeight (s : EvalState) (id : ContributorId) : Nat :=
@@ -140,8 +169,10 @@ def EvalState.reviewerWeight (s : EvalState) (id : ContributorId) : Nat :=
   | none => 0
 
 /-- Evaluate a single signed commit given pre-built state.
-    Uses the current [GenesisVariant] for scoring parameters. -/
-def evaluateWithState (state : EvalState) (commit : SignedCommit) : CommitIndex :=
+    Uses the current [GenesisVariant] for scoring parameters.
+    Returns CachedCommitIndex with computed globalRank, and updated EvalState
+    (with accumulated pairwise evidence). -/
+def evaluateWithState (state : EvalState) (commit : SignedCommit) : CachedCommitIndex × EvalState :=
   let score := commitScore commit
     state.scoredCommits (state.reviewerWeight ·)
   let approved := filterReviews commit.reviews commit.metaReviews (state.reviewerWeight ·)
@@ -154,24 +185,38 @@ def evaluateWithState (state : EvalState) (commit : SignedCommit) : CommitIndex 
   let rejectVoters := commit.reviews
     |>.filter (fun (r : EmbeddedReview) => r.verdict == .notMerge)
     |>.map (fun (r : EmbeddedReview) => r.reviewer)
-  { commitHash := commit.id,
-    epoch := commit.mergeEpoch,
-    score := score,
-    contributor := commit.author,
-    weightDelta := score.weighted,
-    reviewers := approvedReviewers,
-    metaReviews := commit.metaReviews,
-    mergeVotes := mergeVoters,
-    rejectVotes := rejectVoters,
-    founderOverride := commit.founderOverride }
+  -- Compute globalRank via full net-wins recomputation
+  let updatedWins := accumulatePairwise commit.reviews state.pairwiseWins
+  let pastCommitIds := state.scoredCommits.map (·.1)
+  let allCommits := pastCommitIds ++ [commit.id]
+  let netWins := computeNetWins allCommits updatedWins
+  let indexed := netWins.zip (List.range netWins.length)
+  let sorted := indexed.toArray.qsort (fun ((_, nw1), i1) ((_, nw2), i2) =>
+    if nw1 != nw2 then nw1 > nw2 else i1 < i2
+  ) |>.toList
+  let globalRank := sorted.findIdx? (fun ((c, _), _) => c == commit.id) |>.getD allCommits.length
+  let idx : CachedCommitIndex :=
+    { commitHash := commit.id,
+      epoch := commit.mergeEpoch,
+      score := score,
+      contributor := commit.author,
+      weightDelta := score.weighted,
+      reviewers := approvedReviewers,
+      metaReviews := commit.metaReviews,
+      mergeVotes := mergeVoters,
+      rejectVotes := rejectVoters,
+      founderOverride := commit.founderOverride,
+      globalRank := globalRank }
+  let newState := stepState state idx
+  (idx, { newState with pairwiseWins := updatedWins })
 
 end VariantScoped
 
 /-! ### Outer dispatch (resolves variant per-commit via schedule) -/
 
-/-- Reconstruct state from past indices. Each index is processed under
+/-- Reconstruct state from past cached indices. Each index is processed under
     the variant active at its epoch (idx.epoch). -/
-def reconstructState (pastIndices : List CommitIndex) : EvalState :=
+def reconstructState (pastIndices : List CachedCommitIndex) : EvalState :=
   pastIndices.foldl (fun state idx =>
     letI := activeVariant idx.epoch
     stepState state idx
@@ -180,20 +225,20 @@ def reconstructState (pastIndices : List CommitIndex) : EvalState :=
 /-- Evaluate a single signed commit.
     State reconstruction uses per-index variants.
     Scoring uses the variant active at commit.prCreatedAt. -/
-def evaluate (pastIndices : List CommitIndex) (commit : SignedCommit) : CommitIndex :=
+def evaluate (pastIndices : List CachedCommitIndex) (commit : SignedCommit) : CachedCommitIndex :=
   let state := reconstructState pastIndices
   letI := activeVariant commit.prCreatedAt
-  evaluateWithState state commit
+  (evaluateWithState state commit).1
 
 /-- Evaluate a full sequence of signed commits. -/
-def evaluateAll (signedCommits : List SignedCommit) : List CommitIndex :=
+def evaluateAll (signedCommits : List SignedCommit) : List CachedCommitIndex :=
   signedCommits.foldl (fun indices commit =>
     indices ++ [evaluate indices commit]
   ) []
 
 /-- Final weight for each contributor, computed from all indices.
     Weight = founderWeight + Σ weightDelta for authored commits. -/
-def finalWeights (indices : List CommitIndex) : List (ContributorId × Nat) :=
+def finalWeights (indices : List CachedCommitIndex) : List (ContributorId × Nat) :=
   let addToWeight (acc : List (ContributorId × Nat))
       (id : ContributorId) (amount : Nat) : List (ContributorId × Nat) :=
     if amount == 0 then acc
@@ -202,7 +247,7 @@ def finalWeights (indices : List CommitIndex) : List (ContributorId × Nat) :=
       | some _ => acc.map (fun (cid, w) => if cid == id then (cid, w + amount) else (cid, w))
       | none => acc ++ [(id, amount)]
   let init := [(founder, founderWeight)]
-  indices.foldl (fun acc (idx : CommitIndex) =>
+  indices.foldl (fun acc (idx : CachedCommitIndex) =>
     if idx.weightDelta == 0 then acc
     else addToWeight acc idx.contributor idx.weightDelta
   ) init

--- a/spec/Genesis/Types.lean
+++ b/spec/Genesis/Types.lean
@@ -67,6 +67,9 @@ structure GenesisConfig where
   quantileDen : Nat
   designWeight : Nat
   numWeightedDimensions : Nat
+  /-- When true, comparison targets are selected by globalRank (v2)
+      instead of time-based buckets (v1). -/
+  useRankedTargets : Bool
   deriving Repr
 
 /-- Protocol configuration typeclass. All configurable constants are
@@ -87,9 +90,24 @@ def GenesisConfig.v1 : GenesisConfig where
   quantileDen := 3
   designWeight := 3
   numWeightedDimensions := 5
+  useRankedTargets := false
 
 instance GenesisVariant.v1 : GenesisVariant where
   toGenesisConfig := .v1
+
+def GenesisConfig.v2 : GenesisConfig where
+  name := "genesis_v2"
+  reviewerThreshold := 500
+  minReviews := 1
+  rankingSize := 7
+  quantileNum := 1
+  quantileDen := 3
+  designWeight := 3
+  numWeightedDimensions := 5
+  useRankedTargets := true
+
+instance GenesisVariant.v2 : GenesisVariant where
+  toGenesisConfig := .v2
 
 /-! ### Core Types -/
 


### PR DESCRIPTION
## Summary

Add a global quality ordering for comparison target selection, built from pairwise review evidence.

**Current (v1):** Targets selected from time-based buckets — can cluster around whatever merged recently, making scores context-dependent.

**New (v2):** Targets selected evenly across a global ranking built from pairwise wins/losses. Each review's 3 dimension rankings are aggregated (1×diff + 1×nov + 3×design) to produce pairwise outcomes. Net-wins determines the global ordering. Every PR gets compared against a representative cross-section from best to worst.

### Changes

- `CommitIndex`: add `globalRank : Option Nat` (old trailers lack it → `none`)
- `CachedCommitIndex`: new type with `globalRank : Nat` (always computed)
- `evaluate` returns `CachedCommitIndex`; all CLI tools updated
- `GenesisConfig.v2` with `useRankedTargets := true` (NOT activated in schedule)
- Pairwise extraction, net-wins computation, ranked bucket selection in Scoring.lean

### Backward compatibility

- v2 defined but NOT activated — `genesisSchedule` stays `[(0, v1)]`
- Old trailers without globalRank tolerated (verification skipped)
- `genesis-replay.sh --verify`: 21/21 indices pass

## Test plan

- [x] `lake build` — all 5 genesis CLI tools compile
- [x] `genesis-replay.sh --verify` — 21/21 pass
- [x] Smoke tests pass (select_targets, finalize, check_merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)