### PR TITLE
Genesis: activate v2 ranked target selection

### DIFF
--- a/.github/workflows/ci-spec.yml
+++ b/.github/workflows/ci-spec.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Smoke test CLI tools
         working-directory: spec
         run: |
-          echo '{"prId":1,"prCreatedAt":9999999999,"indices":[]}' | .lake/build/bin/genesis_select_targets | jq -e '.targets == []'
+          echo '{"prId":1,"prCreatedAt":9999999999,"indices":[],"ranking":[]}' | .lake/build/bin/genesis_select_targets | jq -e '.targets == []'
           echo '{"indices":[]}' | .lake/build/bin/genesis_finalize | jq -e '.weights[0].id == "sorpaas"'
           echo '{"reviews":[],"metaReviews":[],"indices":[]}' | .lake/build/bin/genesis_check_merge | jq -e '.ready == false'
 

--- a/spec/Genesis/State.lean
+++ b/spec/Genesis/State.lean
@@ -48,6 +48,7 @@ def founderWeight : Nat := 1
     2. PR B: add entry here with a future activation epoch. Must merge before that date. -/
 def genesisSchedule : List (Epoch × GenesisVariant) :=
   [ (0, GenesisVariant.v1)
+  , (1774188000, GenesisVariant.v2)  -- 2026-03-22 14:00 UTC: rank-based target selection
   ]
 
 /-- Resolve the active variant for a given epoch. -/


### PR DESCRIPTION
## Summary

Activate v2 comparison target selection at epoch 1774188000 (2026-03-22 14:00 UTC).

PRs created after this time will have comparison targets selected by global quality ranking (pairwise net-wins from review evidence) instead of time-based buckets.

One-line change: add `(1774188000, GenesisVariant.v2)` to `genesisSchedule`.

## Test plan

- [x] `lake build` passes
- [x] `genesis-replay.sh --verify` — 22/22 pass (existing commits unaffected)
- [x] `ranking.json` already bootstrapped on genesis-state (22 entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)