### PR TITLE
Genesis: weighted pairwise evidence in global ranking

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -243,7 +243,8 @@ jobs:
               SIGNED_COMMITS=$(echo "$SIGNED_COMMITS" | jq --argjson c "$COMMIT_LINE" '. + [$c]')
             fi
           done
-          NEW_RANKING=$(echo "{\"signedCommits\":$SIGNED_COMMITS}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+          NEW_RANKING=$(jq -n --argjson sc "$SIGNED_COMMITS" --argjson idx "$UPDATED_CACHE" \
+            '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
           NEW_COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
 
           # Update ranking.json: add new entry keyed by the new commit hash

--- a/spec/Genesis/Cli/Ranking.lean
+++ b/spec/Genesis/Cli/Ranking.lean
@@ -1,10 +1,12 @@
 /-
   genesis_ranking CLI
 
-  Computes the global quality ranking from pairwise review evidence.
+  Computes the global quality ranking from weighted pairwise review evidence.
 
-  Input:  {"signedCommits": [...]}
+  Input:  {"signedCommits": [...], "indices": [...]}
   Output: {"ranking": ["hash1", "hash2", ...]}  (best to worst)
+
+  Reviewer weights are reconstructed from indices at each step.
 -/
 
 import Genesis.Cli.Common
@@ -14,7 +16,15 @@ open Genesis.Cli
 
 def main : IO UInt32 := runJsonPipe fun j => do
   let signedCommits ← IO.ofExcept (j.getObjValAs? (List SignedCommit) "signedCommits")
-  -- Use v1 variant for designWeight (same across v1/v2)
+  let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
+  -- Build per-commit weight functions by reconstructing state incrementally
+  let weightFns := signedCommits.zip indices |>.foldl
+    (fun (fns, pastIndices) (commit, idx) =>
+      let state := reconstructState pastIndices
+      letI := activeVariant commit.prCreatedAt
+      let fn := (state.reviewerWeight ·)
+      (fns ++ [fn], pastIndices ++ [idx])
+    ) (([] : List (ContributorId → Nat)), ([] : List CommitIndex))
   letI := GenesisVariant.v1
-  let ranking := computeRanking signedCommits
+  let ranking := computeRanking signedCommits weightFns.1
   return Json.mkObj [("ranking", toJson ranking)]

--- a/spec/Genesis/Scoring.lean
+++ b/spec/Genesis/Scoring.lean
@@ -251,43 +251,70 @@ def extractPairwise [GenesisVariant] (review : EmbeddedReview) : List (CommitId 
     acc ++ (commits.drop (i + 1)).map (fun loser => (winner, loser))
   ) []
 
-/-- Accumulate pairwise wins from reviews into a map: commitId → set of commitIds it beats. -/
-def accumulatePairwise [GenesisVariant]
+/-- Weighted pairwise evidence: (commitA, commitB, netWeight).
+    Positive netWeight means A beats B with that weight of evidence. -/
+abbrev PairwiseEvidence := List (CommitId × CommitId × Int)
+
+/-- Accumulate normalized weighted pairwise evidence from reviews.
+    Each reviewer's contribution is normalized by total reviewer weight
+    for this commit's reviews, so reviews at different points in time
+    (when total weight differs) contribute equally per-commit.
+    Uses fixed-point scaling (×10000) to avoid precision loss with integers. -/
+def accumulateWeightedPairwise [GenesisVariant]
     (reviews : List EmbeddedReview)
-    (existing : List (CommitId × List CommitId)) : List (CommitId × List CommitId) :=
-  let pairs := reviews.foldl (fun acc r => acc ++ extractPairwise r) []
-  pairs.foldl (fun acc (winner, loser) =>
-    match acc.find? (fun (c, _) => c == winner) with
-    | some (_, losers) =>
-      if losers.contains loser then acc
-      else acc.map (fun (c, ls) => if c == winner then (c, ls ++ [loser]) else (c, ls))
-    | none => acc ++ [(winner, [loser])]
-  ) existing
+    (getWeight : ContributorId → Nat)
+    (existing : PairwiseEvidence) : PairwiseEvidence :=
+  -- Compute total reviewer weight for normalization
+  let totalWeight := reviews.foldl (fun acc r => acc + getWeight r.reviewer) 0
+  if totalWeight == 0 then existing
+  else
+    reviews.foldl (fun acc review =>
+      let w := getWeight review.reviewer
+      if w == 0 then acc  -- non-reviewer, skip
+      else
+        -- Normalized weight: (w / totalWeight) × 10000
+        let normW : Int := (w * 10000 / totalWeight : Nat)
+        let pairs := extractPairwise review
+        pairs.foldl (fun acc2 (winner, loser) =>
+          match acc2.find? (fun (a, b, _) => a == winner && b == loser) with
+          | some _ =>
+            acc2.map (fun (a, b, ew) =>
+              if a == winner && b == loser then (a, b, ew + normW) else (a, b, ew))
+          | none =>
+            match acc2.find? (fun (a, b, _) => a == loser && b == winner) with
+            | some _ =>
+              acc2.map (fun (a, b, ew) =>
+                if a == loser && b == winner then (a, b, ew - normW) else (a, b, ew))
+            | none => acc2 ++ [(winner, loser, normW)]
+        ) acc
+    ) existing
 
-/-- Compute net-wins for each commit: |commits beaten| - |commits lost to|. -/
-def computeNetWins (commits : List CommitId)
-    (wins : List (CommitId × List CommitId)) : List (CommitId × Int) :=
+/-- Compute weighted net-wins for each commit.
+    For commit C: sum of all evidence weights where C is the winner. -/
+def computeWeightedNetWins (commits : List CommitId)
+    (evidence : PairwiseEvidence) : List (CommitId × Int) :=
   commits.map fun c =>
-    let beaten := match wins.find? (fun (w, _) => w == c) with
-      | some (_, losers) => losers.filter (commits.contains ·) |>.length
-      | none => 0
-    let lostTo := commits.foldl (fun acc other =>
-      match wins.find? (fun (w, _) => w == other) with
-      | some (_, losers) => if losers.contains c then acc + 1 else acc
-      | none => acc
-    ) 0
-    (c, (beaten : Int) - (lostTo : Int))
+    let net := evidence.foldl (fun acc (a, b, w) =>
+      if a == c && commits.contains b then acc + w
+      else if b == c && commits.contains a then acc - w
+      else acc
+    ) (0 : Int)
+    (c, net)
 
-/-- Compute global ranking from a list of signed commits.
+/-- Compute global ranking from signed commits with per-commit weight functions.
+    Each entry in `weightFns` provides the reviewer weight function at that commit's evaluation time.
     Returns commit hashes ordered best to worst. -/
-def computeRanking [GenesisVariant] (signedCommits : List SignedCommit) : List CommitId :=
+def computeRanking [GenesisVariant]
+    (signedCommits : List SignedCommit)
+    (weightFns : List (ContributorId → Nat)) : List CommitId :=
   let allCommitIds := signedCommits.map (·.id)
-  -- Accumulate all pairwise evidence
-  let pairwiseWins := signedCommits.foldl (fun acc commit =>
-    accumulatePairwise commit.reviews acc
-  ) []
-  -- Compute net-wins and sort
-  let netWins := computeNetWins allCommitIds pairwiseWins
+  -- Accumulate weighted pairwise evidence
+  let evidence := signedCommits.zip weightFns |>.foldl
+    (fun ev (commit, getWeight) =>
+      accumulateWeightedPairwise commit.reviews getWeight ev
+    ) ([] : PairwiseEvidence)
+  -- Compute weighted net-wins and sort
+  let netWins := computeWeightedNetWins allCommitIds evidence
   let indexed := netWins.zip (List.range netWins.length)
   let sorted := indexed.toArray.qsort (fun ((_, nw1), i1) ((_, nw2), i2) =>
     if nw1 != nw2 then nw1 > nw2 else i1 < i2

--- a/spec/tools/genesis-replay.sh
+++ b/spec/tools/genesis-replay.sh
@@ -84,7 +84,8 @@ if [ "$MODE" = "--rebuild" ]; then
     REBUILT=$(echo "$REBUILT" | jq --argjson idx "$INDEX" '. + [$idx]')
     # Compute ranking snapshot at this point
     COMMITS_SO_FAR=$(echo "$COMMITS_SO_FAR" | jq --argjson c "$COMMIT" '. + [$c]')
-    SNAPSHOT=$(echo "{\"signedCommits\":$COMMITS_SO_FAR}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+    SNAPSHOT=$(jq -n --argjson sc "$COMMITS_SO_FAR" --argjson idx "$REBUILT" \
+      '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
     COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
     RANKING_MAP=$(echo "$RANKING_MAP" | jq --arg key "$COMMIT_HASH" --argjson val "$SNAPSHOT" '. + {($key): $val}')
   done
@@ -123,7 +124,8 @@ elif [ "$MODE" = "--verify-cache" ]; then
     REBUILT=$(echo "$REBUILT" | jq --argjson idx "$INDEX" '. + [$idx]')
     # Compute ranking snapshot
     COMMITS_SO_FAR=$(echo "$COMMITS_SO_FAR" | jq --argjson c "$COMMIT" '. + [$c]')
-    SNAPSHOT=$(echo "{\"signedCommits\":$COMMITS_SO_FAR}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+    SNAPSHOT=$(jq -n --argjson sc "$COMMITS_SO_FAR" --argjson idx "$REBUILT" \
+      '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
     COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
     RANKING_MAP=$(echo "$RANKING_MAP" | jq --arg key "$COMMIT_HASH" --argjson val "$SNAPSHOT" '. + {($key): $val}')
   done


### PR DESCRIPTION
## Summary

Normalize reviewer weights in pairwise ranking evidence so reviews at different points in time contribute proportionally, and multiple reviewers' opinions are weighted by their share of total reviewer weight.

### Changes

- `accumulateWeightedPairwise`: normalizes each reviewer's contribution by `weight/totalWeight × 10000` (fixed-point)
- `computeWeightedNetWins`: sums weighted evidence instead of counting boolean wins
- `computeRanking`: takes `indices` alongside `signedCommits` to reconstruct reviewer weights at each step
- `genesis_ranking` CLI: accepts `{"signedCommits": [...], "indices": [...]}` 
- Workflow + genesis-replay.sh: pass indices to ranking tool

### Backward compatibility

All past commits have single reviewer → normalized weight is always 10000 → ranking is equivalent (only tiebreaking changes). Cache rebuilt and verified.

## Test plan

- [x] `genesis-replay.sh --verify` — 25/25 pass
- [x] `genesis-replay.sh --verify-cache` — 25 indices + ranking match
- [x] Final ranking still reasonable (Ligerito #1, early docs last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)