### PR TITLE
Genesis: Sybil-resistant ranking via 1/3 quantile reviewer selection

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -243,7 +243,8 @@ jobs:
               SIGNED_COMMITS=$(echo "$SIGNED_COMMITS" | jq --argjson c "$COMMIT_LINE" '. + [$c]')
             fi
           done
-          NEW_RANKING=$(echo "{\"signedCommits\":$SIGNED_COMMITS}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+          NEW_RANKING=$(jq -n --argjson sc "$SIGNED_COMMITS" --argjson idx "$UPDATED_CACHE" \
+            '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
           NEW_COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
 
           # Update ranking.json: add new entry keyed by the new commit hash

--- a/spec/Genesis/Cli/Ranking.lean
+++ b/spec/Genesis/Cli/Ranking.lean
@@ -1,10 +1,13 @@
 /-
   genesis_ranking CLI
 
-  Computes the global quality ranking from pairwise review evidence.
+  Computes the global quality ranking using 1/3 quantile reviewer selection
+  (Sybil-resistant: same model as score derivation).
 
-  Input:  {"signedCommits": [...]}
+  Input:  {"signedCommits": [...], "indices": [...]}
   Output: {"ranking": ["hash1", "hash2", ...]}  (best to worst)
+
+  Reviewer weights are reconstructed from indices at each step.
 -/
 
 import Genesis.Cli.Common
@@ -14,7 +17,15 @@ open Genesis.Cli
 
 def main : IO UInt32 := runJsonPipe fun j => do
   let signedCommits ← IO.ofExcept (j.getObjValAs? (List SignedCommit) "signedCommits")
-  -- Use v1 variant for designWeight (same across v1/v2)
+  let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
+  -- Build per-commit weight functions by reconstructing state incrementally
+  let (weightFns, _) := signedCommits.zip indices |>.foldl
+    (fun (fns, pastIndices) (commit, idx) =>
+      let state := reconstructState pastIndices
+      letI := activeVariant commit.prCreatedAt
+      let fn := (state.reviewerWeight ·)
+      (fns ++ [fn], pastIndices ++ [idx])
+    ) (([] : List (ContributorId → Nat)), ([] : List CommitIndex))
   letI := GenesisVariant.v1
-  let ranking := computeRanking signedCommits
+  let ranking := computeRanking signedCommits weightFns
   return Json.mkObj [("ranking", toJson ranking)]

--- a/spec/Genesis/Scoring.lean
+++ b/spec/Genesis/Scoring.lean
@@ -251,11 +251,11 @@ def extractPairwise [GenesisVariant] (review : EmbeddedReview) : List (CommitId 
     acc ++ (commits.drop (i + 1)).map (fun loser => (winner, loser))
   ) []
 
-/-- Accumulate pairwise wins from reviews into a map: commitId → set of commitIds it beats. -/
-def accumulatePairwise [GenesisVariant]
-    (reviews : List EmbeddedReview)
+/-- Accumulate pairwise wins from a single review into a map: commitId → set of commitIds it beats. -/
+def accumulatePairwiseFromReview [GenesisVariant]
+    (review : EmbeddedReview)
     (existing : List (CommitId × List CommitId)) : List (CommitId × List CommitId) :=
-  let pairs := reviews.foldl (fun acc r => acc ++ extractPairwise r) []
+  let pairs := extractPairwise review
   pairs.foldl (fun acc (winner, loser) =>
     match acc.find? (fun (c, _) => c == winner) with
     | some (_, losers) =>
@@ -263,6 +263,43 @@ def accumulatePairwise [GenesisVariant]
       else acc.map (fun (c, ls) => if c == winner then (c, ls ++ [loser]) else (c, ls))
     | none => acc ++ [(winner, [loser])]
   ) existing
+
+/-- Select the 1/3 quantile reviewer for a commit.
+    Mirrors the scoring system's Sybil resistance: sort reviewers by how
+    conservatively they ranked the current commit (worst position first),
+    walk from most conservative accumulating weight, pick the reviewer
+    whose cumulative weight crosses the 1/3 threshold.
+
+    With a single reviewer, always picks that reviewer.
+    With 2/3 Sybil inflating, picks an honest conservative reviewer. -/
+def selectQuantileReviewer [gv : GenesisVariant]
+    (reviews : List EmbeddedReview)
+    (getWeight : ContributorId → Nat)
+    (commitId : CommitId) : Option EmbeddedReview :=
+  -- Filter to weighted reviewers
+  let weighted := reviews.filterMap fun r =>
+    let w := getWeight r.reviewer
+    if w == 0 then none else some (r, w)
+  if weighted.isEmpty then none
+  else
+    -- For each reviewer, find currentPR's position in their aggregate ranking
+    -- Higher position = more conservative (ranked it worse)
+    let withPos := weighted.map fun (r, w) =>
+      let ranked := aggregateReviewRanking r
+      let arr := ranked.toArray.qsort (fun a b => a.2 < b.2)
+      let commits : List CommitId := arr.toList.map Prod.fst
+      let pos := commits.findIdx? (· == commitId) |>.getD commits.length
+      (r, w, pos)
+    -- Sort by position descending (most conservative first = highest position)
+    let sorted := withPos.toArray.qsort (fun (_, _, p1) (_, _, p2) => p1 > p2) |>.toList
+    let totalWeight := sorted.foldl (fun acc (_, w, _) => acc + w) 0
+    let target := totalWeight * gv.quantileNum / gv.quantileDen
+    -- Walk from most conservative, pick at 1/3 threshold
+    let (_, result) := sorted.foldl (fun (cumWeight, best) (r, w, _) =>
+      let newCum := cumWeight + w
+      if cumWeight ≤ target then (newCum, some r) else (newCum, best)
+    ) (0, none)
+    result
 
 /-- Compute net-wins for each commit: |commits beaten| - |commits lost to|. -/
 def computeNetWins (commits : List CommitId)
@@ -278,14 +315,20 @@ def computeNetWins (commits : List CommitId)
     ) 0
     (c, (beaten : Int) - (lostTo : Int))
 
-/-- Compute global ranking from a list of signed commits.
-    Returns commit hashes ordered best to worst. -/
-def computeRanking [GenesisVariant] (signedCommits : List SignedCommit) : List CommitId :=
+/-- Compute global ranking from signed commits with per-commit weight functions.
+    For each commit, selects the 1/3 quantile reviewer (Sybil-resistant) and
+    uses only their pairwise evidence. Returns commit hashes best to worst. -/
+def computeRanking [GenesisVariant]
+    (signedCommits : List SignedCommit)
+    (weightFns : List (ContributorId → Nat)) : List CommitId :=
   let allCommitIds := signedCommits.map (·.id)
-  -- Accumulate all pairwise evidence
-  let pairwiseWins := signedCommits.foldl (fun acc commit =>
-    accumulatePairwise commit.reviews acc
-  ) []
+  -- Accumulate pairwise evidence using quantile-selected reviewer per commit
+  let pairwiseWins := signedCommits.zip weightFns |>.foldl
+    (fun acc (commit, getWeight) =>
+      match selectQuantileReviewer commit.reviews getWeight commit.id with
+      | some review => accumulatePairwiseFromReview review acc
+      | none => acc  -- no weighted reviewers
+    ) ([] : List (CommitId × List CommitId))
   -- Compute net-wins and sort
   let netWins := computeNetWins allCommitIds pairwiseWins
   let indexed := netWins.zip (List.range netWins.length)

--- a/spec/tools/genesis-replay.sh
+++ b/spec/tools/genesis-replay.sh
@@ -84,7 +84,8 @@ if [ "$MODE" = "--rebuild" ]; then
     REBUILT=$(echo "$REBUILT" | jq --argjson idx "$INDEX" '. + [$idx]')
     # Compute ranking snapshot at this point
     COMMITS_SO_FAR=$(echo "$COMMITS_SO_FAR" | jq --argjson c "$COMMIT" '. + [$c]')
-    SNAPSHOT=$(echo "{\"signedCommits\":$COMMITS_SO_FAR}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+    SNAPSHOT=$(jq -n --argjson sc "$COMMITS_SO_FAR" --argjson idx "$REBUILT" \
+      '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
     COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
     RANKING_MAP=$(echo "$RANKING_MAP" | jq --arg key "$COMMIT_HASH" --argjson val "$SNAPSHOT" '. + {($key): $val}')
   done
@@ -123,7 +124,8 @@ elif [ "$MODE" = "--verify-cache" ]; then
     REBUILT=$(echo "$REBUILT" | jq --argjson idx "$INDEX" '. + [$idx]')
     # Compute ranking snapshot
     COMMITS_SO_FAR=$(echo "$COMMITS_SO_FAR" | jq --argjson c "$COMMIT" '. + [$c]')
-    SNAPSHOT=$(echo "{\"signedCommits\":$COMMITS_SO_FAR}" | .lake/build/bin/genesis_ranking | jq -c '.ranking')
+    SNAPSHOT=$(jq -n --argjson sc "$COMMITS_SO_FAR" --argjson idx "$REBUILT" \
+      '{signedCommits: $sc, indices: $idx}' | .lake/build/bin/genesis_ranking | jq -c '.ranking')
     COMMIT_HASH=$(echo "$INDEX" | jq -r '.commitHash')
     RANKING_MAP=$(echo "$RANKING_MAP" | jq --arg key "$COMMIT_HASH" --argjson val "$SNAPSHOT" '. + {($key): $val}')
   done


### PR DESCRIPTION
## Summary

Select the 1/3 quantile reviewer per commit for ranking evidence, matching the scoring system's Sybil resistance model.

### How it works

For each commit with reviews:
1. Compute each reviewer's aggregate ordering (1×diff + 1×nov + 3×design)
2. Sort reviewers by how conservatively they ranked the commit (worst first)
3. Walk from most conservative, accumulate weight, pick reviewer at 1/3 threshold
4. Use only that reviewer's pairwise evidence

With 2/3 Sybil weight inflating rankings, the honest 1/3 reviewer determines the pairwise outcomes. Same guarantee as the scoring system.

### Backward compatibility

All past commits have single reviewer → quantile always picks that reviewer → ranking identical to unweighted. Cache verified: 25/25 match.

## Test plan

- [x] `genesis-replay.sh --verify` — 25/25 pass
- [x] `genesis-replay.sh --verify-cache` — 25 indices + ranking match (identical to unweighted)
- [x] All genesis CLI tools build

🤖 Generated with [Claude Code](https://claude.com/claude-code)