### PR TITLE
Fix genesis-merge: retry merge state check for API propagation

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -202,8 +202,13 @@ jobs:
           Genesis-PR: #${PR_NUMBER}
           Genesis-Author: ${AUTHOR}"
 
-          # Confirm merge actually happened
-          STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+          # Confirm merge actually happened (retry up to 10s for API propagation)
+          for i in 1 2 3 4 5; do
+            STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+            if [ "$STATE" = "MERGED" ]; then break; fi
+            echo "Waiting for merge state propagation (attempt $i, state: $STATE)..."
+            sleep 2
+          done
           if [ "$STATE" != "MERGED" ]; then
             echo "ERROR: PR #$PR_NUMBER not merged (state: $STATE)" >&2
             gh pr comment "$PR_NUMBER" --body \


### PR DESCRIPTION
## Summary

`gh pr merge` returns before GitHub's API propagates the MERGED state. The immediate `gh pr view` reads stale state (OPEN), causing the workflow to report failure and skip cache update — even though the merge succeeded.

Adds a retry loop (5 attempts, 2s apart) before declaring failure. This fixes the race condition that caused PR #43's cache to need manual update.

## Test plan

- [ ] Next PR merge: bot should successfully detect MERGED state and update cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)