### PR TITLE
Swap φ[0]↔φ[1] register mapping to avoid RBP encoding penalty

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -5,8 +5,8 @@
 //! mapped to x86-64 registers for the duration of execution.
 //!
 //! Register mapping (PVM φ[i] → x86-64):
-//!   φ[0]  → RBX   (callee-saved)
-//!   φ[1]  → RBP   (callee-saved)
+//!   φ[0]  → RBP   (callee-saved) — RA, rarely used as memory base
+//!   φ[1]  → RBX   (callee-saved) — SP, avoids RBP encoding penalty
 //!   φ[2]  → R12   (callee-saved)
 //!   φ[3]  → R13   (callee-saved)
 //!   φ[4]  → R14   (callee-saved)
@@ -51,8 +51,8 @@ fn compute_skip(pc: usize, bitmask: &[u8]) -> usize {
 /// Map PVM register index (0..12) to x86-64 register.
 /// All 13 PVM registers live in x86 registers.
 const REG_MAP: [Reg; 13] = [
-    Reg::RBX,  // φ[0]
-    Reg::RBP,  // φ[1]
+    Reg::RBP,  // φ[0] — RA (rarely used as memory base, so RBP encoding penalty is acceptable)
+    Reg::RBX,  // φ[1] — SP (frequently used as memory base, RBX avoids RBP disp8 penalty)
     Reg::R12,  // φ[2]
     Reg::R13,  // φ[3]
     Reg::R14,  // φ[4]


### PR DESCRIPTION
## Summary

- Swap φ[0]→RBP and φ[1]→RBX in the recompiler's x86-64 register mapping
- After PR #45 (φ[0]=RA, φ[1]=SP), SP is frequently used as a memory base register. RBP has an x86-64 encoding penalty: `[RBP]` always requires a `disp8` byte even for offset 0. Giving SP the compact RBX encoding saves 1 byte per load/store through SP.

Fixes #48.

## Test plan

- All workspace tests pass
- Sort benchmark improved ~3% (472µs → 460µs)
- No regressions on fib, hostcall, or ecrecover

🤖 Generated with [Claude Code](https://claude.com/claude-code)