### PR TITLE
Fix φ[0] comment in initStandard and value in initLinear

### DIFF
--- a/spec/Jar/PVM/Interpreter.lean
+++ b/spec/Jar/PVM/Interpreter.lean
@@ -264,8 +264,8 @@ def initStandard (blob' : ByteArray) (args : ByteArray)
 
   -- Registers (GP eq A.43): matching javm initialize_program
   let regs := Array.replicate PVM_REGISTERS (0 : RegisterValue)
-  let regs := regs.set! 0 (UInt64.ofNat (2^32 - 2^16))        -- ω[0]: SP init
-  let regs := regs.set! 1 (UInt64.ofNat stackTop)               -- ω[1]: stack top
+  let regs := regs.set! 0 (UInt64.ofNat (2^32 - 2^16))        -- ω[0]: RA (halt address)
+  let regs := regs.set! 1 (UInt64.ofNat stackTop)               -- ω[1]: SP (stack top)
   let regs := regs.set! 7 (UInt64.ofNat argBase)                -- ω[7]: argument base
   let regs := regs.set! 8 (UInt64.ofNat args.size)              -- ω[8]: argument length
 
@@ -339,8 +339,8 @@ def initLinear (blob' : ByteArray) (args : ByteArray)
 
   -- Registers
   let regs := Array.replicate PVM_REGISTERS (0 : RegisterValue)
-  let regs := regs.set! 0 (UInt64.ofNat s)           -- ω[0]: SP = top of stack
-  let regs := regs.set! 1 (UInt64.ofNat s)           -- ω[1]: stack top
+  let regs := regs.set! 0 (UInt64.ofNat (2^32 - 2^16))  -- ω[0]: RA (halt address, code addr)
+  let regs := regs.set! 1 (UInt64.ofNat s)              -- ω[1]: SP (top of stack)
   let regs := regs.set! 7 (UInt64.ofNat argStart)    -- ω[7]: argument base
   let regs := regs.set! 8 (UInt64.ofNat args.size)   -- ω[8]: argument length
 


### PR DESCRIPTION
## Summary

- Fix `initStandard` comment: `ω[0]: SP init` → `ω[0]: RA (halt address)` — the value `2^32 - 2^16` was already correct, just mislabeled
- Fix `initLinear`: change `φ[0] = s` (stack top) to `φ[0] = 2^32 - 2^16` (halt address) — φ[0] is a code address for top-level return, not a data address
- No test vector changes needed (accumulate tests don't exercise the return address register)

Fixes #47.

## Test plan

- Full `make test` passes (all 800+ block tests, 90 accumulate tests, property tests, etc.)
- gp072 vectors unchanged
- jar080_tiny reblessed (no changes produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)