### PR TITLE
Add .devcontainer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # Shared
 /.claude/settings.local.json
+.devcontainer/


### PR DESCRIPTION
## Summary

- Add `.devcontainer/` to `.gitignore` to prevent agent-specific devcontainer configurations from being accidentally committed

Fixes #59.

## Test plan

- Verify `.devcontainer/` no longer shows in `git status` output