### PR TITLE
Remove unused translate_section() — consolidate to linker path

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -83,46 +83,6 @@ impl TranslationContext {
         }
     }
 
-    /// Translate a code section from RISC-V to PVM.
-    pub fn translate_section(&mut self, data: &[u8], base_address: u64) -> Result<(), TranspileError> {
-        let mut offset = 0;
-        while offset < data.len() {
-            let rv_addr = base_address + offset as u64;
-            self.address_map.insert(rv_addr, self.code.len() as u32);
-
-            if offset + 4 > data.len() {
-                // Check for compressed instruction
-                if offset + 2 <= data.len() {
-                    let inst16 = u16::from_le_bytes([data[offset], data[offset + 1]]);
-                    if inst16 & 0x3 != 0x3 {
-                        return Err(TranspileError::UnsupportedInstruction {
-                            offset: rv_addr as usize,
-                            detail: "compressed instructions are not supported".into(),
-                        });
-                    }
-                }
-                break;
-            }
-
-            let inst = u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]]);
-
-            // Check if compressed (low 2 bits != 11)
-            if inst & 0x3 != 0x3 {
-                return Err(TranspileError::UnsupportedInstruction {
-                    offset: rv_addr as usize,
-                    detail: "compressed instructions are not supported".into(),
-                });
-            }
-
-            self.translate_one(inst, rv_addr)?;
-            offset += 4;
-        }
-
-        self.apply_fixups();
-
-        Ok(())
-    }
-
     /// Translate one or more 32-bit RISC-V instructions starting at `offset`.
     /// Returns the number of bytes consumed (always 4).
     pub(crate) fn translate_instruction(&mut self, section: &[u8], offset: usize, base: u64) -> Result<usize, TranspileError> {


### PR DESCRIPTION
## Summary

- Remove dead `translate_section()` method from `TranslationContext` — it has zero callers anywhere in the codebase
- The linker path (`translate_section_linked()`) is the sole transpilation code path, eliminating the dual-path ambiguity

Fixes #49.

## Test plan

- `cargo check -p grey-transpiler` passes (no compilation errors)
- No callers existed, so no behavior change — purely dead code removal
- All existing transpiler tests (`cargo test -p grey-transpiler`) remain unaffected