### PR TITLE
Use LEA for address computation in recompiler

### DIFF
--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -951,6 +951,14 @@ impl Assembler {
         self.modrm_disp(dst.lo(), base, disp);
     }
 
+    /// lea r32, [base + disp] — 32-bit result, zero-extends to 64-bit.
+    /// Combines address truncation and offset addition in one instruction.
+    pub fn lea_32(&mut self, dst: Reg, base: Reg, disp: i32) {
+        self.rex_opt(dst, base);
+        self.emit(0x8D);
+        self.modrm_disp(dst.lo(), base, disp);
+    }
+
     /// lea r32, [base32 + index32 * 4]  (32-bit result, auto zero-extends to 64)
     /// lea dst32, [base32 + index32 * (1 << scale_log2)]
     /// scale_log2: 0=*1, 1=*2, 2=*4, 3=*8

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -656,9 +656,12 @@ impl Compiler {
             }
         }
         let rb_reg = REG_MAP[rb];
-        self.asm.movzx_32_64(SCRATCH, rb_reg);
         if imm != 0 {
-            self.asm.add_ri32(SCRATCH, imm);
+            // lea r32, [base + disp]: combines truncation to 32-bit and offset
+            // addition in one instruction (saves ~2 bytes vs movzx + add).
+            self.asm.lea_32(SCRATCH, rb_reg, imm);
+        } else {
+            self.asm.movzx_32_64(SCRATCH, rb_reg);
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace two-instruction address computation (`movzx r32, base` + `add r32, offset`) with single `lea r32, [base + offset]` for memory accesses with non-zero offsets
- `lea r32, [base + disp]` computes `(base + disp) mod 2^32` and zero-extends to 64 bits — exactly the PVM 32-bit address semantics
- Only applies when offset is non-zero; zero-offset accesses still use the cheaper `movzx`

**Measured impact:**
- ecrecover native code: 271,705 → 250,401 bytes (**-21,304 bytes, -7.8%**)
- ecrecover benchmark: **-3.1%** (2.387 → 2.314 ms)
- sort benchmark: **-0.9%**, hostcall: **-1.6%**

Cumulative since PR #73: native code 278,955 → 250,401 bytes (**-10.2%**)

## Test plan

- [x] `cargo test -p javm` — 41 tests pass (interpreter)
- [x] `GREY_PVM=recompiler cargo test -p javm` — 41 tests pass (recompiler)
- [x] `cargo test -p grey-bench --features javm/signals test_grey_ecrecover_recompiler` — a0=1, exact gas match
- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] Criterion benchmarks: ecrecover -3.1%, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)