### PR TITLE
Use LEA for addresses, cmp_ri for set-comparisons

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -1202,42 +1202,30 @@ impl Compiler {
             }
             Opcode::SetLtUImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
-                    let rb_reg = REG_MAP[*rb];
-                    self.asm.mov_ri64(SCRATCH, *imm);
-                    self.asm.cmp_rr(rb_reg, SCRATCH);
+                    self.emit_cmp_imm(REG_MAP[*rb], *imm);
                     self.asm.setcc(Cc::B, REG_MAP[*ra]);
                     self.asm.movzx_8_64(REG_MAP[*ra], REG_MAP[*ra]);
-
                 }
             }
             Opcode::SetLtSImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
-                    let rb_reg = REG_MAP[*rb];
-                    self.asm.mov_ri64(SCRATCH, *imm);
-                    self.asm.cmp_rr(rb_reg, SCRATCH);
+                    self.emit_cmp_imm(REG_MAP[*rb], *imm);
                     self.asm.setcc(Cc::L, REG_MAP[*ra]);
                     self.asm.movzx_8_64(REG_MAP[*ra], REG_MAP[*ra]);
-
                 }
             }
             Opcode::SetGtUImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
-                    let rb_reg = REG_MAP[*rb];
-                    self.asm.mov_ri64(SCRATCH, *imm);
-                    self.asm.cmp_rr(rb_reg, SCRATCH);
+                    self.emit_cmp_imm(REG_MAP[*rb], *imm);
                     self.asm.setcc(Cc::A, REG_MAP[*ra]);
                     self.asm.movzx_8_64(REG_MAP[*ra], REG_MAP[*ra]);
-
                 }
             }
             Opcode::SetGtSImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
-                    let rb_reg = REG_MAP[*rb];
-                    self.asm.mov_ri64(SCRATCH, *imm);
-                    self.asm.cmp_rr(rb_reg, SCRATCH);
+                    self.emit_cmp_imm(REG_MAP[*rb], *imm);
                     self.asm.setcc(Cc::G, REG_MAP[*ra]);
                     self.asm.movzx_8_64(REG_MAP[*ra], REG_MAP[*ra]);
-
                 }
             }
             Opcode::ShloLImm32 => {
@@ -1905,6 +1893,17 @@ impl Compiler {
         self.asm.jmp_label(self.panic_label);
     }
 
+    /// Compare register against immediate, using cmp_ri for i32-range values.
+    fn emit_cmp_imm(&mut self, reg: Reg, imm: u64) {
+        let imm_i64 = imm as i64;
+        if imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64 {
+            self.asm.cmp_ri(reg, imm_i64 as i32);
+        } else {
+            self.asm.mov_ri64(SCRATCH, imm);
+            self.asm.cmp_rr(reg, SCRATCH);
+        }
+    }
+
     /// Emit a branch comparing register against immediate.
     fn emit_branch_imm(&mut self, reg: Reg, imm: u64, cc: Cc, target: u32, _fallthrough: u32, pc: u32) {
         if !self.is_basic_block_start(target) {
@@ -1915,14 +1914,7 @@ impl Compiler {
             self.asm.jcc_label(cc, self.panic_label);
             return;
         }
-        // Use cmp_ri for small immediates (avoids mov_ri64 + cmp_rr)
-        let imm_i64 = imm as i64;
-        if imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64 {
-            self.asm.cmp_ri(reg, imm_i64 as i32);
-        } else {
-            self.asm.mov_ri64(SCRATCH, imm);
-            self.asm.cmp_rr(reg, SCRATCH);
-        }
+        self.emit_cmp_imm(reg, imm);
         let label = self.label_for_pc(target);
         self.asm.jcc_label(cc, label);
     }


### PR DESCRIPTION
## Summary

- **Address computation**: Replace `movzx r32, base` + `add r32, offset` with single `lea r32, [base + offset]` for memory accesses with non-zero offsets. 32-bit LEA naturally computes `(base + disp) mod 2^32` with zero-extension — exact PVM semantics, ~2 bytes fewer per access
- **Set-comparison immediates**: `SetLtUImm`, `SetLtSImm`, `SetGtUImm`, `SetGtSImm` now use `cmp_ri` for i32-range immediates instead of `mov_ri64 + cmp_rr`, saving 1-6 bytes per comparison
- Extracted shared `emit_cmp_imm` helper (also used by `emit_branch_imm`)

**Measured impact:**
- ecrecover native code: 271,705 → 250,109 bytes (**-21,596, -7.9%**)
- ecrecover benchmark: **-2.3%** (2.387 → 2.332 ms)

Cumulative since PR #72: native code 278,955 → 250,109 bytes (**-10.3%**)

## Test plan

- [x] `cargo test -p javm` — 41 tests pass (interpreter)
- [x] `GREY_PVM=recompiler cargo test -p javm` — 41 tests pass (recompiler)
- [x] `cargo test -p grey-bench --features javm/signals test_grey_ecrecover_recompiler` — a0=1, exact gas match
- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] Criterion benchmarks: ecrecover -2.3%, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)