### PR TITLE
Speed up compute_basic_block_starts: skip non-instruction bytes

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -256,9 +256,6 @@ impl Compiler {
         self.emit_prologue();
 
         // Gas block starts: use the same basic block analysis as the interpreter.
-        // This ensures gas charging matches exactly. The inline discovery missed
-        // forward-reference targets (e.g., a branch at PC=664 targeting PC=604
-        // wouldn't be discovered before PC=604 is compiled).
         let mut gas_starts = crate::vm::compute_basic_block_starts(code, bitmask);
 
         // Single streaming pass: decode + gas blocks + codegen

--- a/grey/crates/javm/src/vm.rs
+++ b/grey/crates/javm/src/vm.rs
@@ -2032,11 +2032,12 @@ pub fn compute_basic_block_starts(code: &[u8], bitmask: &[u8]) -> Vec<bool> {
         }
     }
 
-    // Pass 1: For each instruction, compute its skip (size - 1)
-    // Pass 2: Mark basic block starts from control flow
-    for i in 0..len {
-        if i >= bitmask.len() || bitmask[i] != 1 { continue; }
-        let Some(op) = Opcode::from_byte(code[i]) else { continue; };
+    // Iterate only over instruction starts (skip non-instruction bytes).
+    // This is O(n_instructions) instead of O(n_bytes).
+    let mut i = 0;
+    while i < len {
+        if i >= bitmask.len() || bitmask[i] != 1 { i += 1; continue; }
+        let Some(op) = Opcode::from_byte(code[i]) else { i += 1; continue; };
 
         let skip = {
             let mut s = 0;
@@ -2104,6 +2105,8 @@ pub fn compute_basic_block_starts(code: &[u8], bitmask: &[u8]) -> Vec<bool> {
             }
             _ => {}
         }
+
+        i += 1 + skip; // advance to next instruction start
     }
 
     starts


### PR DESCRIPTION
Change compute_basic_block_starts from O(code_len) to O(num_instructions) by jumping between instruction starts instead of scanning every byte. For ecrecover (137K bytes, 29K instructions): BB analysis -19%, compile+exec -1.6%.