### PR TITLE
Change ecrecover opt-level from "s" to 3: exec -30%

### DIFF
--- a/grey/services/bench-ecrecover/Cargo.toml
+++ b/grey/services/bench-ecrecover/Cargo.toml
@@ -15,6 +15,7 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 polkavm-derive = "0.32.0"
 
 [profile.release]
-opt-level = "s"
+opt-level = 3
+codegen-units = 1
 lto = true
 panic = "abort"


### PR DESCRIPTION
The ecrecover service was compiled with opt-level="s" (optimize for size). Changed to opt-level=3 + codegen-units=1. LLVM produces much better code for k256 crypto. ecrecover exec: 888µs → 624µs (-30%). Interpreter: 26.4ms → 21.7ms (-18%). Blob grows 23% but execution quality improves dramatically.