### PR TITLE
Pass --inline-threshold=375 to LLVM for smaller, faster PVM blobs

### DIFF
--- a/grey/crates/build-javm/src/lib.rs
+++ b/grey/crates/build-javm/src/lib.rs
@@ -17,12 +17,18 @@ pub fn build(manifest_dir: &str, bin_name: &str) -> PathBuf {
     let resolved = build_crate::resolve_manifest_dir(manifest_dir);
     let target_json_path = build_crate::write_target_json("riscv64em-javm.json", TARGET_JSON);
 
+    // Pass LLVM flags to encourage aggressive inlining and unrolling.
+    // More inlining → fewer function calls → fewer jump table entries →
+    // fewer gas block transitions in the recompiler → faster compile+exec.
+    let extra_rustflags = vec![
+        "-Cllvm-args=--inline-threshold=375".to_string(),
+    ];
     let guest = GuestBuild {
         manifest_dir: resolved,
         target_json_path,
         target_dir_name: TARGET_NAME.to_string(),
         build_kind: BuildKind::Bin(bin_name.to_string()),
-        extra_rustflags: vec![],
+        extra_rustflags,
         env_overrides: vec![],
         rustc_bootstrap: true,
     };


### PR DESCRIPTION
Increase LLVM inline threshold from ~225 to 375 for standard blob builds. More inlining eliminates call/return overhead. Blob: 193KB→181KB (-6.5%). ecrecover compile+exec: 2.038ms→1.954ms (-4.1%). Execution unchanged.