### PR TITLE
Use compact move_reg for ADDI rd, rs, 0 (mv pseudo-instruction)

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -438,6 +438,21 @@ impl TranslationContext {
 
         if rd == 0 { return Ok(()); } // Write to x0 is a no-op in RISC-V
 
+        // ADDI rd, rs, 0 is the RISC-V `mv rd, rs` pseudo-instruction.
+        // Use compact move_reg (2 bytes) instead of add_imm (6 bytes).
+        if funct3 == 0 && imm == 0 && rs1 != 0 {
+            if rd == rs1 {
+                // ADDI rd, rd, 0 is a NOP
+                self.emit_inst(1); // fallthrough
+                return Ok(());
+            }
+            let pvm_rd = self.require_reg(rd)?;
+            let pvm_rs1 = self.require_reg(rs1)?;
+            self.emit_inst(100); // move_reg
+            self.emit_data(pvm_rd | (pvm_rs1 << 4));
+            return Ok(());
+        }
+
         // When rs1 = x0 (zero register), treat as loading immediate directly
         // because PVM has no zero register — x0 maps to RA which is NOT zero.
         if rs1 == 0 {


### PR DESCRIPTION
## Summary

- Detect `ADDI rd, rs, 0` (the RISC-V `mv rd, rs` pseudo-instruction) in the transpiler and emit compact PVM `move_reg` (2 bytes) instead of `add_imm_64` with zero immediate (6 bytes)
- Detect `ADDI rd, rd, 0` (NOP) and emit PVM `fallthrough` (1 byte) instead of 6-byte `add_imm`
- Saves 4 bytes per register-to-register move, 5 bytes per NOP

The existing `translate_op` already optimizes `ADD rd, rs, x0` to `move_reg`, but the immediate form `ADDI rd, rs, 0` was not optimized. Since LLVM generates `mv` as `ADDI` (not `ADD`), this covers the common case.

**Benchmark results** (ecrecover, `--features javm/signals`):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Code bytes | 157,727 | 155,155 | **-2,572 (-1.6%)** |
| Instructions | 33,242 | 33,242 | unchanged |
| compile+exec | 1.855 ms | 1.842 ms | **-0.7%** (p < 0.05) |
| exec only | ~620 µs | ~609 µs | **-1.7%** (p < 0.05) |

Relates to #84 (transpiler optimization) and #56 (PVM performance).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] `cargo test -p grey-bench test_grey_ecrecover_recompiler` — correctness verified
- [x] `cargo bench -p grey-bench --features javm/signals` — statistically significant improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)