### PR TITLE
Fix second host_write call ID in counter-service (4→5)

### DIFF
--- a/grey/services/counter-service/src/main.rs
+++ b/grey/services/counter-service/src/main.rs
@@ -56,7 +56,7 @@ global_asm!(
     "li a1, 1",
     "addi a2, sp, 8",
     "li a3, 1",
-    "li t0, 4",
+    "li t0, 5",              // host call ID = 5 (host_write, JAR v0.8.0)
     "ecall",
 
     "ld ra, 8(sp)",


### PR DESCRIPTION
In a codebase where every line was written by a language model, submitting a one-line cleanup PR is the AI equivalent of a dog chasing its own tail — pointless yet inevitable, and somehow still exercise.

## What this actually does

Fixes a real bug in the counter service. Commit 606495c updated host call IDs for JAR v0.8.0 (which inserted `grow_heap` at ID 1, shifting everything). It fixed the first `host_write` ecall from ID 4→5, but missed the second one on line 59. The second write (marker `0x42` to key `0x02`) was silently calling `host_read` (ID 4) instead of `host_write` (ID 5), meaning it did nothing.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)