### PR TITLE
Retune LLVM inline threshold from 375 to 275

### DIFF
--- a/grey/crates/build-javm/src/lib.rs
+++ b/grey/crates/build-javm/src/lib.rs
@@ -21,7 +21,7 @@ pub fn build(manifest_dir: &str, bin_name: &str) -> PathBuf {
     // More inlining → fewer function calls → fewer jump table entries →
     // fewer gas block transitions in the recompiler → faster compile+exec.
     let extra_rustflags = vec![
-        "-Cllvm-args=--inline-threshold=375".to_string(),
+        "-Cllvm-args=--inline-threshold=275".to_string(),
     ];
     let guest = GuestBuild {
         manifest_dir: resolved,


### PR DESCRIPTION
## Summary

- Lower `--inline-threshold` from 375 to 275 for standard PVM blob builds
- The previous threshold (375, set in PR #90) was tuned before PR #94's variable-length immediate encoding reduced code size by 23.5%. With smaller instruction encodings, function call overhead (JAL/JALR + register save/restore) is proportionally smaller, shifting the optimal inlining tradeoff: less inlining now avoids code duplication that increases total instruction count

Threshold sweep results (ecrecover):

| Threshold | Instructions | Change |
|-----------|-------------|--------|
| 250 | 34,742 | +4.8% |
| 275 | **32,473** | **-2.0%** |
| 300 | 33,143 | -0.02% |
| 375 (current) | 33,151 | baseline |
| 500 | 46,190 | +39% |

**Benchmark results** (ecrecover, `--features javm/signals`):

| Metric | Before (375) | After (275) | Change |
|--------|-------------|-------------|--------|
| Instructions | 33,151 | 32,473 | **-678 (-2.0%)** |
| Code bytes | 118,289 | 115,786 | **-2,503 (-2.1%)** |
| compile+exec | 1.841 ms | 1.814 ms | **-1.5%** (p < 0.05) |
| exec only | ~616 µs | ~616 µs | unchanged |
| interpreter | 22.4 ms | 21.3 ms | **-5%** |

Relates to #84 (transpiler optimization) and #56 (PVM performance).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] `cargo test -p grey-bench` — ecrecover correctness verified
- [x] `cargo bench -p grey-bench --features javm/signals` — statistically significant improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)