### PR TITLE
Add +xtheadcondmov to RISC-V target spec and transpiler

### DIFF
--- a/grey/crates/build-javm/src/riscv64em-javm.json
+++ b/grey/crates/build-javm/src/riscv64em-javm.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S64",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m",
+  "features": "+e,+m,+xtheadcondmov",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64e",

--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -250,6 +250,62 @@ impl TranslationContext {
             0x0F => { // FENCE
                 self.emit_inst(1); // → fallthrough (nop)
             }
+            0x0B => { // CUSTOM-0 — T-Head extensions
+                match (funct7, funct3) {
+                    (0x20, 1) => { // th.mveqz rd, rs1, rs2: if rs2 == 0 then rd = rs1
+                        if rd == 0 { /* nop */ } else if rs2 == 0 {
+                            // Condition is x0 (always 0) → always execute: rd = rs1
+                            if rs1 == 0 {
+                                self.emit_load_imm(rd, 0)?;
+                            } else {
+                                let pvm_rd = self.require_reg(rd)?;
+                                let pvm_rs1 = self.require_reg(rs1)?;
+                                self.emit_inst(100); // move_reg
+                                self.emit_data(pvm_rd | (pvm_rs1 << 4));
+                            }
+                        } else if rs1 == 0 {
+                            // Source is x0 (always 0): if rs2 == 0 then rd = 0
+                            let pvm_rd = self.require_reg(rd)?;
+                            let pvm_rs2 = self.require_reg(rs2)?;
+                            self.emit_inst(147); // CmovIzImm
+                            self.emit_data(pvm_rd | (pvm_rs2 << 4));
+                            self.emit_var_imm(0);
+                        } else {
+                            let pvm_rd = self.require_reg(rd)?;
+                            let pvm_rs1 = self.require_reg(rs1)?;
+                            let pvm_rs2 = self.require_reg(rs2)?;
+                            self.emit_inst(218); // CmovIz
+                            self.emit_data(pvm_rs1 | (pvm_rs2 << 4));
+                            self.emit_data(pvm_rd);
+                        }
+                    }
+                    (0x21, 1) => { // th.mvnez rd, rs1, rs2: if rs2 != 0 then rd = rs1
+                        if rd == 0 || rs2 == 0 {
+                            // rd==0: nop. rs2==x0: condition "x0 != 0" is always false → nop
+                            self.emit_inst(1); // fallthrough
+                        } else if rs1 == 0 {
+                            let pvm_rd = self.require_reg(rd)?;
+                            let pvm_rs2 = self.require_reg(rs2)?;
+                            self.emit_inst(148); // CmovNzImm
+                            self.emit_data(pvm_rd | (pvm_rs2 << 4));
+                            self.emit_var_imm(0);
+                        } else {
+                            let pvm_rd = self.require_reg(rd)?;
+                            let pvm_rs1 = self.require_reg(rs1)?;
+                            let pvm_rs2 = self.require_reg(rs2)?;
+                            self.emit_inst(219); // CmovNz
+                            self.emit_data(pvm_rs1 | (pvm_rs2 << 4));
+                            self.emit_data(pvm_rd);
+                        }
+                    }
+                    _ => {
+                        return Err(TranspileError::UnsupportedInstruction {
+                            offset: _addr as usize,
+                            detail: format!("custom-0 funct7={:#x} funct3={}", funct7, funct3),
+                        });
+                    }
+                }
+            }
             _ => {
                 return Err(TranspileError::UnsupportedInstruction {
                     offset: _addr as usize,


### PR DESCRIPTION
## Summary

- Add `+xtheadcondmov` to the RISC-V target features (matching PolkaVM's target spec)
- Handle T-Head conditional move instructions (th.mveqz, th.mvnez) in the transpiler
- Map to PVM's existing CmovIz/CmovNz opcodes (218/219)
- Handle edge cases: x0 as source (use CmovIzImm/CmovNzImm with immediate 0), x0 as condition (unconditional move or nop)

This is the **RISC-V target spec change** that enables LLVM to generate conditional moves instead of branch+move sequences for conditional assignments. Conditional moves eliminate branches, reducing branch mispredictions and gas block transitions.

**Results** (ecrecover, `--features javm/signals`):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Instructions | 32,473 | 32,474 | +1 |
| Code bytes | 115,786 | 115,774 | -12 |
| compile+exec | ~1.805 ms | ~1.807 ms | within noise |
| exec only | ~616 µs | ~616 µs | within noise |

The ecrecover workload (secp256k1 field arithmetic) has few conditional patterns, so the benefit is minimal here. Services with more conditional logic (branchy code, lookups, validation) will benefit more from this feature.

Relates to #84 (RISC-V target spec) and #56 (PVM performance).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] `cargo test -p grey-bench` — ecrecover correctness verified (both interpreter and recompiler)
- [x] Edge cases tested: x0 as source, x0 as condition, x0 as destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)