### PR TITLE
Use emit_var_imm for PCREL_LO12 zero-offset loads/stores in linker

### DIFF
--- a/grey/crates/grey-transpiler/src/linker.rs
+++ b/grey/crates/grey-transpiler/src/linker.rs
@@ -541,7 +541,7 @@ fn translate_section_linked(
                 };
                 ctx.emit_inst(pvm_load_opcode);
                 ctx.emit_data(pvm_dst | (pvm_base << 4));
-                ctx.emit_imm32(0); // offset 0: address already resolved
+                ctx.emit_var_imm(0); // offset 0: address already resolved
                 offset += 4;
                 continue;
             } else if opcode == 0x23 {
@@ -558,7 +558,7 @@ fn translate_section_linked(
                 };
                 ctx.emit_inst(pvm_store_opcode);
                 ctx.emit_data(pvm_data | (pvm_base << 4));
-                ctx.emit_imm32(0);
+                ctx.emit_var_imm(0);
                 offset += 4;
                 continue;
             }


### PR DESCRIPTION
## Summary

Fix missed conversion from PR #102: the linker's PCREL_LO12 relocation handler emits loads/stores with zero offset (address already resolved by paired PCREL_HI20). These used `emit_imm32(0)` (4 bytes) instead of `emit_var_imm(0)` (0 bytes).

PR #102 converted `emit_imm32` → `emit_var_imm` in `riscv.rs` but missed the two occurrences in `linker.rs`.

**Results** (ecrecover):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Code bytes | 110,784 | 110,620 | **-164** |
| compile+exec | ~1.782 ms | ~1.782 ms | within noise |

Relates to #84 (transpiler optimization).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] `cargo bench` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)