### PR TITLE
Use variable-length offset encoding for store_imm_ind

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -462,11 +462,12 @@ impl TranslationContext {
                 }),
             };
             // Format: OneRegTwoImm — reg_byte encodes ra + imm_x length
-            // reg_byte = ra | (lx << 4), lx=4 for 4-byte imm_x (offset)
+            // reg_byte = ra | (lx << 4)
             // imm_y has length 0, which decodes as 0 (the value we want to store)
+            let (lx, imm_bytes) = encode_var_imm(imm);
             self.emit_inst(pvm_opcode);
-            self.emit_data(pvm_rs1 | (4 << 4));
-            self.emit_imm32(imm);
+            self.emit_data(pvm_rs1 | (lx << 4));
+            for b in &imm_bytes { self.emit_data(*b); }
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary

The `store_imm_ind` handler (storing x0/zero to memory) always used `lx=4` in the OneRegTwoImm encoding, emitting a full 4-byte offset even for small values. Now uses `encode_var_imm` to select minimum encoding (0/1/2/4 bytes).

This completes the var-imm encoding work: all PVM instruction categories that support variable-length immediates now use minimum encoding.

**Results** (ecrecover):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Code bytes | 110,620 | 110,538 | **-82** |

Compile+exec within noise.

Relates to #84 (transpiler optimization).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)