### PR TITLE
Fix address_map corruption in pending_load_imm undo

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -638,9 +638,12 @@ impl TranslationContext {
                     };
 
                     if let Some(pvm_opcode) = pvm_imm_opcode {
-                        // Undo the load_imm and emit immediate form instead
+                        // Undo the load_imm and emit immediate form instead.
+                        // Must update address_map for this RISC-V instruction since
+                        // its PVM offset shifted when the previous load_imm was removed.
                         self.code.truncate(undo_pos);
                         self.bitmask.truncate(undo_pos);
+                        self.address_map.insert(addr, undo_pos as u32);
                         let pvm_rd = self.require_reg(rd)?;
                         let pvm_base = self.require_reg(base)?;
                         self.emit_inst(pvm_opcode);


### PR DESCRIPTION
## Summary

Fix a latent correctness bug in the `load_imm + ALU` fusion (PR #97). When the fusion fires, it truncates the code buffer to undo the previously-emitted `load_imm`, then emits the fused `add_imm`/`and_imm`/etc. But the `address_map` entry for the current RISC-V instruction was set **before** the truncation and now points to a stale (too-high) PVM offset.

If any branch targets this instruction, the fixup would resolve to the wrong PVM address, causing incorrect execution.

**Fix**: update `address_map` for the current instruction after the undo.

This bug was discovered while investigating `+lui-addi-fusion` support — the scheduling hint changes instruction ordering enough to trigger the stale address_map, causing ecrecover to return wrong results.

No benchmark impact (the fix adds one HashMap insert on the fusion hot path, which is rare — ~91 occurrences in ecrecover).

Relates to #84 (transpiler correctness).

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all pass
- [x] Bug was discovered via `+lui-addi-fusion` which exposes the stale address_map

🤖 Generated with [Claude Code](https://claude.com/claude-code)