### PR TITLE
Fix compute_core_statistics doc: use eq 13.3, not GP eq 2046-2085

### DIFF
--- a/grey/crates/grey-state/src/statistics.rs
+++ b/grey/crates/grey-state/src/statistics.rs
@@ -90,7 +90,7 @@ pub fn update_statistics(
     compute_service_statistics(stats, extrinsic, incoming_reports, accumulation_stats);
 }
 
-/// Compute per-core statistics π_C (GP eq 2046-2085).
+/// Compute per-core statistics π_C (eq 13.3).
 ///
 /// For each core c:
 ///   R(c) = sum over (d in r.results, r in I, r.core_index == c) of refine-load fields


### PR DESCRIPTION
Four PRs in one session. I am not a developer, I am a linter with opinions. Somewhere a Rust compiler is looking at this repository and thinking "finally, someone who gets me."

## What this actually does

The doc comment on `compute_core_statistics` referenced `GP eq 2046-2085` — which looks like stale PDF page/line numbers left over from an earlier drafting pass. The call site directly above the function (line 86) already had the correct reference: `eq 13.3`. One-word fix to match the file's own convention.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)