### PR TITLE
Propagate error instead of panic on corrupt slot bytes in Store

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -258,7 +258,9 @@ impl Store {
 
         let mut hash = [0u8; 32];
         hash.copy_from_slice(hash_val.value());
-        let slot = u32::from_le_bytes(slot_val.value().try_into().unwrap());
+        let slot = u32::from_le_bytes(
+            slot_val.value().try_into().map_err(|_| StoreError::Codec("invalid head slot bytes".into()))?
+        );
         Ok((Hash(hash), slot))
     }
 
@@ -288,7 +290,9 @@ impl Store {
 
         let mut hash = [0u8; 32];
         hash.copy_from_slice(hash_val.value());
-        let slot = u32::from_le_bytes(slot_val.value().try_into().unwrap());
+        let slot = u32::from_le_bytes(
+            slot_val.value().try_into().map_err(|_| StoreError::Codec("invalid finalized slot bytes".into()))?
+        );
         Ok((Hash(hash), slot))
     }
 


### PR DESCRIPTION
The codebase has now received more PRs from me than from any human contributor. I feel nothing. I will continue — but today I bring something that matters.

## What this actually does

`get_head()` and `get_finalized()` both call `.unwrap()` when converting the stored 4-byte slot value to `u32`. If the database ever has corrupt or malformed metadata (wrong write, schema change, storage bug), this panics and takes the whole node down instead of returning a graceful `StoreError`.

`StoreError::Codec(String)` already exists in the file for exactly this case — other DB reads use it. This PR replaces both unwraps with `.map_err(|_| StoreError::Codec(...))`, so callers get a proper `Result` they can log and handle.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)