### PR TITLE
Direct-write assembler: bypass Vec::push in JIT compilation

### DIFF
--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -76,8 +76,17 @@ struct Fixup {
 }
 
 /// x86-64 assembler with label support.
+///
+/// Uses direct pointer writes to the pre-allocated buffer for emission,
+/// avoiding per-byte Vec::push overhead (capacity check + len update).
+/// The Vec's len is only synced at finalization.
 pub struct Assembler {
     pub code: Vec<u8>,
+    /// Write position — may be ahead of code.len(). All emission goes through
+    /// this pointer to avoid Vec::push overhead in the hot compilation loop.
+    buf: *mut u8,
+    write_pos: usize,
+    capacity: usize,
     /// Label ID → bound offset (usize::MAX = unbound).
     labels: Vec<usize>,
     fixups: Vec<Fixup>,
@@ -87,8 +96,14 @@ const LABEL_UNBOUND: usize = usize::MAX;
 
 impl Assembler {
     pub fn new() -> Self {
+        let mut code = Vec::with_capacity(4096);
+        let buf = code.as_mut_ptr();
+        let capacity = code.capacity();
         Self {
-            code: Vec::with_capacity(4096),
+            code,
+            buf,
+            write_pos: 0,
+            capacity,
             labels: Vec::new(),
             fixups: Vec::new(),
         }
@@ -96,10 +111,38 @@ impl Assembler {
 
     /// Create with pre-allocated capacity for code and labels.
     pub fn with_capacity(code_capacity: usize, label_capacity: usize) -> Self {
+        let mut code = Vec::with_capacity(code_capacity);
+        let buf = code.as_mut_ptr();
+        let capacity = code.capacity();
         Self {
-            code: Vec::with_capacity(code_capacity),
+            code,
+            buf,
+            write_pos: 0,
+            capacity,
             labels: Vec::with_capacity(label_capacity),
             fixups: Vec::with_capacity(label_capacity),
+        }
+    }
+
+    /// Ensure at least `additional` bytes of capacity remain.
+    /// Called before emitting large sequences. Most individual instructions
+    /// need at most ~32 bytes, so this is rarely needed mid-compilation.
+    #[cold]
+    fn grow(&mut self, additional: usize) {
+        // Sync len so Vec knows how much data we've written
+        unsafe { self.code.set_len(self.write_pos); }
+        self.code.reserve(additional);
+        self.buf = self.code.as_mut_ptr();
+        self.capacity = self.code.capacity();
+        // Reset len to 0 — we track position via write_pos
+        unsafe { self.code.set_len(0); }
+    }
+
+    /// Check capacity and grow if needed. Inlined for the fast path (no grow).
+    #[inline(always)]
+    pub fn ensure_capacity(&mut self, n: usize) {
+        if self.write_pos + n > self.capacity {
+            self.grow(n);
         }
     }
 
@@ -110,49 +153,94 @@ impl Assembler {
         Label(id)
     }
 
-    /// Bind a label to the current code position.
+    /// Bind a label to the current write position.
     pub fn bind_label(&mut self, label: Label) {
-        self.labels[label.0 as usize] = self.code.len();
+        self.labels[label.0 as usize] = self.write_pos;
     }
 
-    /// Current code offset.
+    /// Current code offset (write position).
     pub fn offset(&self) -> usize {
-        self.code.len()
+        self.write_pos
     }
 
     /// Patch an i32 value at a previously recorded offset.
     pub fn patch_i32(&mut self, offset: usize, value: i32) {
-        self.code[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+        debug_assert!(offset + 4 <= self.write_pos);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                value.to_le_bytes().as_ptr(),
+                self.buf.add(offset),
+                4,
+            );
+        }
     }
 
     // === Raw byte emission ===
+    // All emission writes directly to the buffer via raw pointer,
+    // bypassing Vec::push's capacity check and len update.
 
     #[inline(always)]
     fn emit(&mut self, b: u8) {
-        self.code.push(b);
+        debug_assert!(self.write_pos < self.capacity);
+        unsafe { *self.buf.add(self.write_pos) = b; }
+        self.write_pos += 1;
     }
 
-/// Emit 3 bytes at once.
+    /// Emit 3 bytes at once.
     #[inline(always)]
     fn emit3(&mut self, a: u8, b: u8, c: u8) {
-        self.code.extend_from_slice(&[a, b, c]);
+        debug_assert!(self.write_pos + 3 <= self.capacity);
+        unsafe {
+            let p = self.buf.add(self.write_pos);
+            *p = a;
+            *p.add(1) = b;
+            *p.add(2) = c;
+        }
+        self.write_pos += 3;
     }
 
+    #[inline(always)]
     fn emit_u32(&mut self, v: u32) {
-        self.code.extend_from_slice(&v.to_le_bytes());
+        debug_assert!(self.write_pos + 4 <= self.capacity);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                v.to_le_bytes().as_ptr(),
+                self.buf.add(self.write_pos),
+                4,
+            );
+        }
+        self.write_pos += 4;
     }
 
+    #[inline(always)]
     fn emit_u64(&mut self, v: u64) {
-        self.code.extend_from_slice(&v.to_le_bytes());
+        debug_assert!(self.write_pos + 8 <= self.capacity);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                v.to_le_bytes().as_ptr(),
+                self.buf.add(self.write_pos),
+                8,
+            );
+        }
+        self.write_pos += 8;
     }
 
+    #[inline(always)]
     fn emit_i32(&mut self, v: i32) {
-        self.code.extend_from_slice(&v.to_le_bytes());
+        debug_assert!(self.write_pos + 4 <= self.capacity);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                v.to_le_bytes().as_ptr(),
+                self.buf.add(self.write_pos),
+                4,
+            );
+        }
+        self.write_pos += 4;
     }
 
     /// Emit a 4-byte placeholder for a label fixup, recording the fixup.
     fn emit_label_fixup(&mut self, label: Label) {
-        let offset = self.code.len();
+        let offset = self.write_pos;
         self.fixups.push(Fixup { offset, label });
         self.emit_u32(0); // placeholder
     }
@@ -1047,9 +1135,17 @@ impl Assembler {
         if off == LABEL_UNBOUND { None } else { Some(off) }
     }
 
+    /// Sync Vec length with the write cursor. Call before accessing `self.code` directly.
+    pub fn sync_len(&mut self) {
+        unsafe { self.code.set_len(self.write_pos); }
+    }
+
     /// Resolve all label fixups and return the final machine code.
     /// Panics if any label is unbound.
     pub fn finalize(mut self) -> Vec<u8> {
+        // Sync Vec len with our write position so the returned Vec has correct length.
+        self.sync_len();
+
         for fixup in &self.fixups {
             let target = self.labels[fixup.label.0 as usize];
             assert!(target != LABEL_UNBOUND, "unbound label {:?}", fixup.label);
@@ -1072,6 +1168,7 @@ mod tests {
     fn test_mov_ri64_zero() {
         let mut asm = Assembler::new();
         asm.mov_ri64(Reg::RAX, 0);
+        asm.sync_len();
         // xor eax, eax → 0x31 0xC0
         assert_eq!(&asm.code, &[0x31, 0xC0]);
     }
@@ -1080,6 +1177,7 @@ mod tests {
     fn test_mov_ri64_small() {
         let mut asm = Assembler::new();
         asm.mov_ri64(Reg::RAX, 42);
+        asm.sync_len();
         // mov eax, 42 → 0xB8, 0x2A, 0x00, 0x00, 0x00
         assert_eq!(&asm.code, &[0xB8, 0x2A, 0x00, 0x00, 0x00]);
     }
@@ -1105,6 +1203,7 @@ mod tests {
         let mut asm = Assembler::new();
         asm.push(Reg::R15);
         asm.pop(Reg::R15);
+        asm.sync_len();
         // push r15: 41 57, pop r15: 41 5F
         assert_eq!(&asm.code, &[0x41, 0x57, 0x41, 0x5F]);
     }

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -163,8 +163,9 @@ pub struct Compiler {
     fault_stubs: Vec<(Label, u32)>,
     /// Helper function addresses.
     helpers: HelperFns,
-    /// Jump table.
-    jump_table: Vec<u32>,
+    /// Jump table (borrowed, read-only during compilation).
+    jump_table_ptr: *const u32,
+    jump_table_len: usize,
     /// Bitmask reference (1 = instruction start). Stored as raw pointer for self-referential use.
     bitmask_ptr: *const u8,
     bitmask_len: usize,
@@ -186,12 +187,13 @@ const NO_LABEL: Label = Label(0);
 impl Compiler {
     pub fn new(
         bitmask: &[u8],
-        jump_table: Vec<u32>,
+        jump_table: &[u32],
         helpers: HelperFns,
         code_len: usize,
     ) -> Self {
-        // Estimate native code size: ~2x PVM code (empirically ~1.8x after encoding optimizations).
-        let estimated_native = code_len * 2 + 4096;
+        // Estimate native code size: ~3x PVM code provides safety margin for
+        // direct-write emission (no per-byte capacity checks in hot loop).
+        let estimated_native = code_len * 3 + 8192;
         // Labels: ~1 per 16 code bytes (only gas block starts get labels) + fixed overhead.
         let estimated_labels = code_len / 16 + 256;
         let mut asm = Assembler::with_capacity(estimated_native, estimated_labels);
@@ -216,7 +218,8 @@ impl Compiler {
             reg_defs: [RegDef::Unknown; 13],
             reg_defs_active: 0,
             helpers,
-            jump_table,
+            jump_table_ptr: jump_table.as_ptr(),
+            jump_table_len: jump_table.len(),
             bitmask_ptr: bitmask.as_ptr(),
             bitmask_len: bitmask.len(),
             #[cfg(feature = "signals")]
@@ -259,8 +262,9 @@ impl Compiler {
         // Ensure jump table target PCs are marked as gas block starts.
         // Dynamic jumps (jump_ind) dispatch through the dispatch table,
         // so these PCs need labels and dispatch table entries.
-        for i in 0..self.jump_table.len() {
-            let target_pc = self.jump_table[i] as usize;
+        let jt_len = self.jump_table_len;
+        for i in 0..jt_len {
+            let target_pc = unsafe { *self.jump_table_ptr.add(i) } as usize;
             if target_pc < code_len {
                 gas_starts.set(target_pc);
             }
@@ -289,16 +293,6 @@ impl Compiler {
             let skip = skip_table[pc] as usize;
             let next_pc = (pc + 1 + skip) as u32;
 
-            // Only create and bind labels for PCs that need dispatch table entries:
-            // gas block starts (branch targets, post-terminators, post-ecalli,
-            // jump table targets) for OOG/ecalli re-entry and branch dispatch.
-            // Other instruction PCs don't need labels — they're only reached by
-            // native code fallthrough, never by dispatch table lookup.
-            if gas_starts.get(pc) {
-                let label = self.label_for_pc(pc as u32);
-                self.asm.bind_label(label);
-            }
-
             // Full decode — done once, reused for both gas cost and codegen.
             let category = opcode.category();
             let decoded_args = args::decode_args(code, pc, skip, category);
@@ -309,15 +303,13 @@ impl Compiler {
                 gas_starts.set(next_pc as usize);
             }
 
-            // At basic block boundaries (branch targets, post-terminators),
-            // invalidate all reg_defs since registers may have different values
-            // when entered from different paths (e.g., loop back-edges).
+            // Gas block boundary: consolidated check (was 3 separate checks).
+            // Handles label binding, reg invalidation, and gas metering in one branch.
             if gas_starts.get(pc) {
+                let label = self.label_for_pc(pc as u32);
+                self.asm.bind_label(label);
                 self.invalidate_all_regs();
-            }
 
-            // Gas block boundary check
-            if gas_starts.get(pc) {
                 if let Some((stub_label, block_pc, patch_offset)) = pending_gas.take() {
                     let cost = gas_sim.flush_and_get_cost();
                     self.asm.patch_i32(patch_offset, cost as i32);
@@ -860,6 +852,10 @@ impl Compiler {
 
     /// Compile a single PVM instruction.
     fn compile_instruction(&mut self, opcode: Opcode, args: &Args, pc: u32, next_pc: u32) {
+        // Ensure capacity for this instruction's native code emission.
+        // Most PVM instructions emit at most ~64 bytes of x86. Memory access
+        // with helper calls can emit ~128. This avoids per-byte capacity checks.
+        self.asm.ensure_capacity(256);
         match opcode {
             // === A.5.1: No arguments ===
             Opcode::Trap => {
@@ -2370,6 +2366,7 @@ impl Compiler {
     /// Emit prologue: save callee-saved, load PVM registers from context,
     /// then dispatch to the correct basic block based on entry_pc.
     fn emit_prologue(&mut self) {
+        self.asm.ensure_capacity(512); // prologue needs ~200 bytes
         // Save callee-saved registers
         self.asm.push(Reg::RBX);
         self.asm.push(Reg::RBP);
@@ -2410,6 +2407,10 @@ impl Compiler {
 
     /// Emit exit sequences and epilogue.
     fn emit_exit_sequences(&mut self) {
+        // Reserve capacity for exit sequences + all OOG/fault stubs.
+        // Each OOG stub is ~12 bytes, each fault stub is ~10 bytes.
+        let needed = 512 + self.oog_stubs.len() * 16 + self.fault_stubs.len() * 16;
+        self.asm.ensure_capacity(needed);
         // Shared OOG handler that reads PC from SCRATCH — emitted BEFORE OOG
         // stubs so backward jumps from stubs can use jmp rel8 (2 bytes).
         self.asm.bind_label(self.oog_pc_label);

--- a/grey/crates/javm/src/recompiler/mod.rs
+++ b/grey/crates/javm/src/recompiler/mod.rs
@@ -512,7 +512,7 @@ impl RecompiledPvm {
         let _t2 = std::time::Instant::now();
         let compiler = Compiler::new(
             &bitmask,
-            jump_table.clone(),
+            &jump_table,
             helpers,
             code.len(),
         );


### PR DESCRIPTION
## Summary

- **Direct pointer writes in assembler**: Replace `Vec::push`/`extend_from_slice` byte emission with direct writes through a raw pointer to the pre-allocated buffer. Eliminates per-byte capacity checks and `Vec::len` updates across ~240K emit calls (ecrecover blob). Vec length is synced only at finalization.

- **Consolidate gas_starts checks**: Merge 3 separate `gas_starts.get(pc)` calls per instruction (label binding, reg invalidation, gas metering) into a single check. Eliminates 2 redundant bitset lookups per instruction (~32K instructions).

- **Avoid jump_table clone**: Pass `&[u32]` reference instead of `Vec<u32>` to `Compiler::new`, eliminating an unnecessary allocation.

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all 41 tests pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615
- [x] Benchmarks: ecrecover compile+exec 1.78ms → 1.71ms (**-3.7%**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)