### PR TITLE
Category lookup table + immutable gas_starts during compilation

### DIFF
--- a/grey/crates/javm/src/instruction.rs
+++ b/grey/crates/javm/src/instruction.rs
@@ -306,6 +306,56 @@ pub enum InstructionCategory {
     ThreeReg,
 }
 
+/// Pre-computed lookup table: opcode byte → InstructionCategory.
+/// Eliminates the match in `Opcode::category()` from the hot compilation loop.
+/// Invalid opcodes map to NoArgs (same as the fallback in category()).
+static CATEGORY_LUT: [InstructionCategory; 256] = {
+    let mut t = [InstructionCategory::NoArgs; 256];
+    // OneImm
+    t[10] = InstructionCategory::OneImm;
+    // OneRegExtImm
+    t[20] = InstructionCategory::OneRegExtImm;
+    // TwoImm
+    t[30] = InstructionCategory::TwoImm;
+    t[31] = InstructionCategory::TwoImm;
+    t[32] = InstructionCategory::TwoImm;
+    t[33] = InstructionCategory::TwoImm;
+    // OneOffset
+    t[40] = InstructionCategory::OneOffset;
+    // OneRegOneImm
+    let mut i = 50;
+    while i <= 62 { t[i] = InstructionCategory::OneRegOneImm; i += 1; }
+    // OneRegTwoImm
+    i = 70;
+    while i <= 73 { t[i] = InstructionCategory::OneRegTwoImm; i += 1; }
+    // OneRegImmOffset
+    i = 80;
+    while i <= 90 { t[i] = InstructionCategory::OneRegImmOffset; i += 1; }
+    // TwoReg
+    i = 100;
+    while i <= 111 { t[i] = InstructionCategory::TwoReg; i += 1; }
+    // TwoRegOneImm
+    i = 120;
+    while i <= 161 { t[i] = InstructionCategory::TwoRegOneImm; i += 1; }
+    // TwoRegOneOffset
+    i = 170;
+    while i <= 175 { t[i] = InstructionCategory::TwoRegOneOffset; i += 1; }
+    // TwoRegTwoImm
+    t[180] = InstructionCategory::TwoRegTwoImm;
+    // ThreeReg
+    i = 190;
+    while i <= 230 { t[i] = InstructionCategory::ThreeReg; i += 1; }
+    t
+};
+
+impl InstructionCategory {
+    /// Look up category from raw opcode byte via static table (O(1), no branching).
+    #[inline(always)]
+    pub fn from_opcode_byte(b: u8) -> Self {
+        CATEGORY_LUT[b as usize]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -254,21 +254,20 @@ impl Compiler {
         // Emit prologue
         self.emit_prologue();
 
-        // Gas block starts as compact bitset (1.75KB vs 112KB Vec<bool>)
-        // + precomputed skip table (avoids repeated bitmask scanning).
-        let (mut gas_starts, skip_table) =
-            crate::vm::compute_basic_block_starts_bitset(code, bitmask);
-
-        // Ensure jump table target PCs are marked as gas block starts.
-        // Dynamic jumps (jump_ind) dispatch through the dispatch table,
-        // so these PCs need labels and dispatch table entries.
-        let jt_len = self.jump_table_len;
-        for i in 0..jt_len {
-            let target_pc = unsafe { *self.jump_table_ptr.add(i) } as usize;
-            if target_pc < code_len {
-                gas_starts.set(target_pc);
+        // Gas block starts as compact bitset (1.75KB). Ecalli post-PCs are
+        // included from the pre-pass so gas_starts is immutable during compilation.
+        let (gas_starts, skip_table) = {
+            let (mut gs, st) = crate::vm::compute_basic_block_starts_bitset(code, bitmask);
+            // Ensure jump table target PCs are marked as gas block starts.
+            let jt_len = self.jump_table_len;
+            for i in 0..jt_len {
+                let target_pc = unsafe { *self.jump_table_ptr.add(i) } as usize;
+                if target_pc < code_len {
+                    gs.set(target_pc);
+                }
             }
-        }
+            (gs, st) // gas_starts is now immutable
+        };
 
         // Single streaming pass: decode + gas blocks + codegen
         let mut gas_sim = GasSimulator::new();
@@ -294,14 +293,9 @@ impl Compiler {
             let next_pc = (pc + 1 + skip) as u32;
 
             // Full decode — done once, reused for both gas cost and codegen.
-            let category = opcode.category();
+            // Use static lookup table for category (eliminates match dispatch).
+            let category = crate::instruction::InstructionCategory::from_opcode_byte(code[pc]);
             let decoded_args = args::decode_args(code, pc, skip, category);
-
-            // Post-ecalli boundaries need to be added here since they're not
-            // basic block boundaries per se but must be gas block boundaries.
-            if matches!(opcode, Opcode::Ecalli) && (next_pc as usize) < code_len {
-                gas_starts.set(next_pc as usize);
-            }
 
             // Gas block boundary: consolidated check (was 3 separate checks).
             // Handles label binding, reg invalidation, and gas metering in one branch.

--- a/grey/crates/javm/src/vm.rs
+++ b/grey/crates/javm/src/vm.rs
@@ -2084,6 +2084,15 @@ pub fn compute_basic_block_starts_bitset(code: &[u8], bitmask: &[u8]) -> (BitSet
             }
         }
 
+        // Mark post-ecalli PCs as gas block starts (so gas_starts is
+        // complete after the pre-pass and immutable during compilation).
+        if matches!(op, Opcode::Ecalli) {
+            let next = i + 1 + skip;
+            if next < len && next < bitmask.len() && bitmask[next] == 1 {
+                starts.set(next);
+            }
+        }
+
         let cat = op.category();
         match cat {
             crate::instruction::InstructionCategory::OneOffset => {


### PR DESCRIPTION
## Summary

- **Static `CATEGORY_LUT[256]`**: Replace `Opcode::category()` match dispatch with a direct array lookup from opcode byte. Eliminates one match/branch level per instruction in the hot compilation loop (~32K instructions for ecrecover).

- **Immutable `gas_starts`**: Move ecalli post-PC detection into the pre-pass (`compute_basic_block_starts_bitset`), so `gas_starts` is complete before the main compilation loop begins. The bitset is never mutated during compilation, enabling better compiler optimization (no aliasing between reads and writes in the hot loop).

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615
- [x] Benchmarks: ecrecover compile+exec ~1.71ms → ~1.70ms (**~1%**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)