### PR TITLE
Direct mmap emission: eliminate 258KB copy in JIT compilation

### DIFF
--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -75,15 +75,22 @@ struct Fixup {
     label: Label,
 }
 
+/// Code buffer mode: either Vec-backed (for tests) or mmap-backed (for JIT).
+enum CodeBuf {
+    /// Heap-allocated via Vec (used by tests and small programs).
+    Vec(Vec<u8>),
+    /// mmap-backed (PROT_READ|PROT_WRITE). Avoids the copy in NativeCode::new
+    /// by writing directly to the buffer that will become executable.
+    Mmap { ptr: *mut u8, capacity: usize },
+}
+
 /// x86-64 assembler with label support.
 ///
 /// Uses direct pointer writes to the pre-allocated buffer for emission,
 /// avoiding per-byte Vec::push overhead (capacity check + len update).
-/// The Vec's len is only synced at finalization.
 pub struct Assembler {
-    pub code: Vec<u8>,
-    /// Write position — may be ahead of code.len(). All emission goes through
-    /// this pointer to avoid Vec::push overhead in the hot compilation loop.
+    code_buf: CodeBuf,
+    /// Raw pointer to the start of the code buffer.
     buf: *mut u8,
     write_pos: usize,
     capacity: usize,
@@ -100,7 +107,7 @@ impl Assembler {
         let buf = code.as_mut_ptr();
         let capacity = code.capacity();
         Self {
-            code,
+            code_buf: CodeBuf::Vec(code),
             buf,
             write_pos: 0,
             capacity,
@@ -110,12 +117,13 @@ impl Assembler {
     }
 
     /// Create with pre-allocated capacity for code and labels.
+    /// Uses Vec-backed buffer (for tests or when mmap is not needed).
     pub fn with_capacity(code_capacity: usize, label_capacity: usize) -> Self {
         let mut code = Vec::with_capacity(code_capacity);
         let buf = code.as_mut_ptr();
         let capacity = code.capacity();
         Self {
-            code,
+            code_buf: CodeBuf::Vec(code),
             buf,
             write_pos: 0,
             capacity,
@@ -124,18 +132,62 @@ impl Assembler {
         }
     }
 
+    /// Create with an mmap-backed code buffer. Code is written directly to the
+    /// mmap region during compilation. After finalize_mmap(), the buffer is
+    /// mprotected to PROT_READ|PROT_EXEC — no copy needed.
+    pub fn with_mmap(code_capacity: usize, label_capacity: usize) -> Result<Self, String> {
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                code_capacity,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_ANONYMOUS | libc::MAP_PRIVATE,
+                -1,
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED || ptr.is_null() {
+            return Err("mmap failed for assembler code buffer".into());
+        }
+        let ptr = ptr as *mut u8;
+        Ok(Self {
+            code_buf: CodeBuf::Mmap { ptr, capacity: code_capacity },
+            buf: ptr,
+            write_pos: 0,
+            capacity: code_capacity,
+            labels: Vec::with_capacity(label_capacity),
+            fixups: Vec::with_capacity(label_capacity),
+        })
+    }
+
     /// Ensure at least `additional` bytes of capacity remain.
     /// Called before emitting large sequences. Most individual instructions
     /// need at most ~32 bytes, so this is rarely needed mid-compilation.
     #[cold]
     fn grow(&mut self, additional: usize) {
-        // Sync len so Vec knows how much data we've written
-        unsafe { self.code.set_len(self.write_pos); }
-        self.code.reserve(additional);
-        self.buf = self.code.as_mut_ptr();
-        self.capacity = self.code.capacity();
-        // Reset len to 0 — we track position via write_pos
-        unsafe { self.code.set_len(0); }
+        match &mut self.code_buf {
+            CodeBuf::Vec(code) => {
+                unsafe { code.set_len(self.write_pos); }
+                code.reserve(additional);
+                self.buf = code.as_mut_ptr();
+                self.capacity = code.capacity();
+                unsafe { code.set_len(0); }
+            }
+            CodeBuf::Mmap { ptr, capacity } => {
+                // For mmap buffers, mremap to a larger size
+                let new_cap = (*capacity + additional).next_power_of_two();
+                let new_ptr = unsafe {
+                    libc::mremap(*ptr as *mut libc::c_void, *capacity, new_cap, libc::MREMAP_MAYMOVE)
+                };
+                if new_ptr == libc::MAP_FAILED {
+                    panic!("mremap failed: need {} bytes", new_cap);
+                }
+                *ptr = new_ptr as *mut u8;
+                *capacity = new_cap;
+                self.buf = *ptr;
+                self.capacity = new_cap;
+            }
+        }
     }
 
     /// Check capacity and grow if needed. Inlined for the fast path (no grow).
@@ -1015,7 +1067,7 @@ impl Assembler {
             let target = bound;
             // Backward jump — label already bound, try rel8.
             // rel8 offset = target - (current + 2), where 2 = size of jmp rel8
-            let rel = target as isize - (self.code.len() as isize + 2);
+            let rel = target as isize - (self.write_pos as isize + 2);
             if rel >= i8::MIN as isize && rel <= i8::MAX as isize {
                 self.emit(0xEB);
                 self.emit(rel as u8);
@@ -1034,7 +1086,7 @@ impl Assembler {
             let target = bound;
             // Backward jump — label already bound, try rel8.
             // rel8 offset = target - (current + 2), where 2 = size of jcc rel8
-            let rel = target as isize - (self.code.len() as isize + 2);
+            let rel = target as isize - (self.write_pos as isize + 2);
             if rel >= i8::MIN as isize && rel <= i8::MAX as isize {
                 self.emit(0x70 + cc as u8);
                 self.emit(rel as u8);
@@ -1137,26 +1189,102 @@ impl Assembler {
 
     /// Sync Vec length with the write cursor. Call before accessing `self.code` directly.
     pub fn sync_len(&mut self) {
-        unsafe { self.code.set_len(self.write_pos); }
+        if let CodeBuf::Vec(code) = &mut self.code_buf {
+            unsafe { code.set_len(self.write_pos); }
+        }
     }
 
-    /// Resolve all label fixups and return the final machine code.
-    /// Panics if any label is unbound.
-    pub fn finalize(mut self) -> Vec<u8> {
-        // Sync Vec len with our write position so the returned Vec has correct length.
-        self.sync_len();
-
+    /// Resolve all label fixups in-place (works for both Vec and mmap buffers).
+    fn resolve_fixups(&mut self) {
         for fixup in &self.fixups {
             let target = self.labels[fixup.label.0 as usize];
             assert!(target != LABEL_UNBOUND, "unbound label {:?}", fixup.label);
-            // rel32 = target - (fixup_offset + 4) because the offset is relative
-            // to the end of the instruction (after the 4-byte immediate).
             let rel = (target as i64) - (fixup.offset as i64 + 4);
             let rel32 = rel as i32;
-            self.code[fixup.offset..fixup.offset + 4]
-                .copy_from_slice(&rel32.to_le_bytes());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    rel32.to_le_bytes().as_ptr(),
+                    self.buf.add(fixup.offset),
+                    4,
+                );
+            }
         }
-        self.code
+    }
+
+    /// Resolve fixups and return the code as a Vec<u8> (for Vec-backed buffers).
+    pub fn finalize(&mut self) -> Vec<u8> {
+        self.resolve_fixups();
+        match &mut self.code_buf {
+            CodeBuf::Vec(code) => {
+                unsafe { code.set_len(self.write_pos); }
+                std::mem::take(code)
+            }
+            CodeBuf::Mmap { ptr, capacity } => {
+                // Copy from mmap to Vec (fallback path)
+                let mut v = Vec::with_capacity(self.write_pos);
+                unsafe {
+                    std::ptr::copy_nonoverlapping(*ptr, v.as_mut_ptr(), self.write_pos);
+                    v.set_len(self.write_pos);
+                    libc::munmap(*ptr as *mut libc::c_void, *capacity);
+                }
+                *ptr = std::ptr::null_mut();
+                *capacity = 0;
+                v
+            }
+        }
+    }
+
+    /// Resolve fixups, mprotect the buffer to PROT_READ|PROT_EXEC, and return
+    /// the executable buffer pointer and length. Only works for mmap-backed buffers.
+    /// Returns (ptr, code_len, mmap_capacity) for NativeCode construction.
+    pub fn finalize_executable(&mut self) -> Result<(*mut u8, usize, usize), String> {
+        self.resolve_fixups();
+        match &mut self.code_buf {
+            CodeBuf::Mmap { ptr, capacity } => {
+                let code_len = self.write_pos;
+                let p = *ptr;
+                let cap = *capacity;
+                unsafe {
+                    if libc::mprotect(
+                        p as *mut libc::c_void,
+                        cap,
+                        libc::PROT_READ | libc::PROT_EXEC,
+                    ) != 0 {
+                        libc::munmap(p as *mut libc::c_void, cap);
+                        *ptr = std::ptr::null_mut();
+                        *capacity = 0;
+                        return Err("mprotect failed".into());
+                    }
+                }
+                // Prevent Drop from double-freeing — ownership transfers to caller
+                *ptr = std::ptr::null_mut();
+                *capacity = 0;
+                Ok((p, code_len, cap))
+            }
+            CodeBuf::Vec(_) => Err("finalize_executable requires mmap-backed buffer".into()),
+        }
+    }
+
+    /// Get a slice of the written code bytes (for tests). Syncs Vec len first.
+    #[cfg(test)]
+    pub fn code_bytes(&mut self) -> &[u8] {
+        self.sync_len();
+        match &self.code_buf {
+            CodeBuf::Vec(v) => v.as_slice(),
+            CodeBuf::Mmap { ptr, .. } => unsafe {
+                std::slice::from_raw_parts(*ptr, self.write_pos)
+            },
+        }
+    }
+}
+
+impl Drop for Assembler {
+    fn drop(&mut self) {
+        if let CodeBuf::Mmap { ptr, capacity } = self.code_buf {
+            if !ptr.is_null() && capacity > 0 {
+                unsafe { libc::munmap(ptr as *mut libc::c_void, capacity); }
+            }
+        }
     }
 }
 
@@ -1168,18 +1296,16 @@ mod tests {
     fn test_mov_ri64_zero() {
         let mut asm = Assembler::new();
         asm.mov_ri64(Reg::RAX, 0);
-        asm.sync_len();
         // xor eax, eax → 0x31 0xC0
-        assert_eq!(&asm.code, &[0x31, 0xC0]);
+        assert_eq!(asm.code_bytes(), &[0x31, 0xC0]);
     }
 
     #[test]
     fn test_mov_ri64_small() {
         let mut asm = Assembler::new();
         asm.mov_ri64(Reg::RAX, 42);
-        asm.sync_len();
         // mov eax, 42 → 0xB8, 0x2A, 0x00, 0x00, 0x00
-        assert_eq!(&asm.code, &[0xB8, 0x2A, 0x00, 0x00, 0x00]);
+        assert_eq!(asm.code_bytes(), &[0xB8, 0x2A, 0x00, 0x00, 0x00]);
     }
 
     #[test]
@@ -1203,8 +1329,7 @@ mod tests {
         let mut asm = Assembler::new();
         asm.push(Reg::R15);
         asm.pop(Reg::R15);
-        asm.sync_len();
         // push r15: 41 57, pop r15: 41 5F
-        assert_eq!(&asm.code, &[0x41, 0x57, 0x41, 0x5F]);
+        assert_eq!(asm.code_bytes(), &[0x41, 0x57, 0x41, 0x5F]);
     }
 }

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -102,12 +102,18 @@ pub const EXIT_HOST_CALL: u32 = 4;
 
 /// Result of compilation.
 pub struct CompileResult {
+    /// Native code bytes (used when mmap_ptr is None).
     pub native_code: Vec<u8>,
     pub dispatch_table: Vec<i32>,
     #[cfg(feature = "signals")]
     pub trap_table: Vec<(u32, u32)>,
     #[cfg(feature = "signals")]
     pub exit_label_offset: u32,
+    /// If set, code is already mmap'd and mprotected as PROT_READ|PROT_EXEC.
+    /// Skips the copy in NativeCode::new.
+    pub mmap_ptr: Option<*mut u8>,
+    pub mmap_len: usize,
+    pub mmap_cap: usize,
 }
 
 /// Helper function pointers passed to compiled code.
@@ -190,13 +196,19 @@ impl Compiler {
         jump_table: &[u32],
         helpers: HelperFns,
         code_len: usize,
+        use_mmap: bool,
     ) -> Self {
         // Estimate native code size: ~3x PVM code provides safety margin for
         // direct-write emission (no per-byte capacity checks in hot loop).
         let estimated_native = code_len * 3 + 8192;
         // Labels: ~1 per 16 code bytes (only gas block starts get labels) + fixed overhead.
         let estimated_labels = code_len / 16 + 256;
-        let mut asm = Assembler::with_capacity(estimated_native, estimated_labels);
+        let mut asm = if use_mmap {
+            Assembler::with_mmap(estimated_native, estimated_labels)
+                .unwrap_or_else(|_| Assembler::with_capacity(estimated_native, estimated_labels))
+        } else {
+            Assembler::with_capacity(estimated_native, estimated_labels)
+        };
         // Reserve label 0 as the NO_LABEL sentinel.
         let _reserved = asm.new_label(); // Label(0) — never bound
         let exit_label = asm.new_label();
@@ -371,13 +383,38 @@ impl Compiler {
         #[cfg(feature = "signals")]
         let trap_table = self.trap_entries;
 
-        CompileResult {
-            native_code: self.asm.finalize(),
-            dispatch_table,
-            #[cfg(feature = "signals")]
-            trap_table,
-            #[cfg(feature = "signals")]
-            exit_label_offset,
+        // If the assembler uses mmap, finalize directly to executable memory
+        // (no copy). Otherwise fall back to Vec-based finalize.
+        match self.asm.finalize_executable() {
+            Ok((ptr, code_len, mmap_cap)) => {
+                // Wrap in a Vec that will munmap on drop (via NativeCode).
+                // We return a CompileResult with a dummy native_code — the caller
+                // should use native_mmap_ptr/len/cap instead.
+                CompileResult {
+                    native_code: Vec::new(), // not used when mmap_ptr is set
+                    dispatch_table,
+                    #[cfg(feature = "signals")]
+                    trap_table,
+                    #[cfg(feature = "signals")]
+                    exit_label_offset,
+                    mmap_ptr: Some(ptr),
+                    mmap_len: code_len,
+                    mmap_cap,
+                }
+            }
+            Err(_) => {
+                CompileResult {
+                    native_code: self.asm.finalize(),
+                    dispatch_table,
+                    #[cfg(feature = "signals")]
+                    trap_table,
+                    #[cfg(feature = "signals")]
+                    exit_label_offset,
+                    mmap_ptr: None,
+                    mmap_len: 0,
+                    mmap_cap: 0,
+                }
+            }
         }
     }
 

--- a/grey/crates/javm/src/recompiler/mod.rs
+++ b/grey/crates/javm/src/recompiler/mod.rs
@@ -67,10 +67,13 @@ pub struct JitContext {
 struct NativeCode {
     ptr: *mut u8,
     len: usize,
+    /// The mmap region capacity (may be > len due to pre-allocation).
+    mmap_cap: usize,
 }
 
 impl NativeCode {
     /// Allocate an executable code buffer and copy machine code into it.
+    /// This is the fallback path; the mmap-direct path skips the copy.
     fn new(code: &[u8]) -> Result<Self, String> {
         if code.is_empty() {
             return Err("empty code buffer".into());
@@ -98,7 +101,7 @@ impl NativeCode {
                 return Err("mprotect failed".into());
             }
         }
-        Ok(Self { ptr, len })
+        Ok(Self { ptr, len, mmap_cap: len })
     }
 
     /// Get the function pointer for the compiled code entry.
@@ -110,7 +113,7 @@ impl NativeCode {
 impl Drop for NativeCode {
     fn drop(&mut self) {
         unsafe {
-            libc::munmap(self.ptr as *mut libc::c_void, self.len);
+            libc::munmap(self.ptr as *mut libc::c_void, self.mmap_cap);
         }
     }
 }
@@ -515,23 +518,36 @@ impl RecompiledPvm {
             &jump_table,
             helpers,
             code.len(),
+            true, // use mmap-backed assembler
         );
         let compile_result = compiler.compile(&code, &bitmask);
         let _t_compile = _t2.elapsed();
-        let native = compile_result.native_code;
         let dispatch_table = compile_result.dispatch_table;
 
-        if debug {
-            let _ = std::fs::write("/tmp/pvm_native.bin", &native);
-            tracing::debug!(
-                native_bytes = native.len(),
-                basic_blocks = bitmask.iter().filter(|&&b| b == 1).count(),
-                "wrote native code to /tmp/pvm_native.bin"
-            );
-        }
-
         let _t3 = std::time::Instant::now();
-        let native_code = NativeCode::new(&native)?;
+        let native_code = if let Some(mmap_ptr) = compile_result.mmap_ptr {
+            // Code is already mmap'd and PROT_READ|PROT_EXEC — no copy needed.
+            let nc = NativeCode { ptr: mmap_ptr, len: compile_result.mmap_len, mmap_cap: compile_result.mmap_cap };
+            if debug {
+                let code_slice = unsafe { std::slice::from_raw_parts(mmap_ptr, compile_result.mmap_len) };
+                let _ = std::fs::write("/tmp/pvm_native.bin", code_slice);
+                tracing::debug!(
+                    native_bytes = compile_result.mmap_len,
+                    "wrote native code to /tmp/pvm_native.bin (mmap path)"
+                );
+            }
+            nc
+        } else {
+            let native = compile_result.native_code;
+            if debug {
+                let _ = std::fs::write("/tmp/pvm_native.bin", &native);
+                tracing::debug!(
+                    native_bytes = native.len(),
+                    "wrote native code to /tmp/pvm_native.bin (copy path)"
+                );
+            }
+            NativeCode::new(&native)?
+        };
         let _t_native = _t3.elapsed();
 
         // Signal-based bounds checking: build trap table and install guard pages.
@@ -555,7 +571,7 @@ impl RecompiledPvm {
             compile_us = _t_compile.as_micros() as u64,
             native_us = _t_native.as_micros() as u64,
             code_len = code.len(),
-            native_len = native.len(),
+            native_len = native_code.len,
             "recompiler::new() timing"
         );
 


### PR DESCRIPTION
## Summary

Write native code directly to an mmap'd buffer during compilation, then mprotect to executable — eliminating the separate NativeCode allocation + 258KB copy.

**Before:** Assembler writes to Vec → mmap new buffer → copy 258KB → mprotect
**After:** Assembler writes to mmap buffer → mprotect (no copy)

- Assembler now supports two buffer modes: `Vec`-backed (tests) and `mmap`-backed (JIT)
- `with_mmap()` constructor allocates `PROT_READ|PROT_WRITE` via mmap
- `finalize_executable()` resolves label fixups in-place and mprotects to `PROT_READ|PROT_EXEC`
- Falls back to Vec + copy path if mmap fails

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615
- [x] Benchmarks: ecrecover compile+exec ~1.70ms → ~1.67ms (**~2%**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)