### PR TITLE
Gas cost lookup table: replace 256-arm match with array lookup

### DIFF
--- a/grey/crates/javm/src/gas_cost.rs
+++ b/grey/crates/javm/src/gas_cost.rs
@@ -1154,6 +1154,215 @@ pub fn fast_cost_from_decoded(opcode_byte: u8, args: &crate::args::Args, pc: u32
     }
 }
 
+// === Gas cost lookup table ===
+// Replaces the 256-arm match in fast_cost_from_decoded with a single array
+// lookup + lightweight mask computation. Eliminates branch-heavy dispatch.
+
+/// Register pattern encoding for the lookup table.
+/// Describes which raw register fields contribute to src_mask and dst_mask.
+#[derive(Clone, Copy)]
+struct GasCostEntry {
+    cycles: u8,
+    /// Base decode_slots (before overlap adjustment).
+    decode_slots: u8,
+    exec_unit: u8,
+    /// Source mask pattern: 0=none, 1=ra, 2=rb, 3=ra|rb, 4=rb|rd, 5=ra(store-imm)
+    src_pat: u8,
+    /// Destination mask pattern: 0=none, 1=ra, 2=rd
+    dst_pat: u8,
+    flags: u8, // bit0=terminator, bit1=move_reg, bit2=needs_branch_cost, bit3=overlap_adjust
+    /// For overlap_adjust: decode_slots_if_overlap (lower) and decode_slots_no_overlap (upper nibble)
+    overlap_slots: u8,
+}
+
+const F_TERM: u8 = 1;
+const F_MOVE: u8 = 2;
+const F_BRANCH: u8 = 4;
+const F_OVERLAP: u8 = 8;
+const F_BRANCH2: u8 = 16; // two-reg branch (src=ra|rb)
+const F_SHIFT_OVERLAP: u8 = 32; // shift: overlap is rb==ra, not dst_src_overlap
+
+const fn gc(cycles: u8, decode_slots: u8, exec_unit: u8, src_pat: u8, dst_pat: u8, flags: u8) -> GasCostEntry {
+    GasCostEntry { cycles, decode_slots, exec_unit, src_pat, dst_pat, flags, overlap_slots: 0 }
+}
+const fn gc_ov(cycles: u8, overlap_if: u8, overlap_no: u8, exec_unit: u8, src_pat: u8, dst_pat: u8, flags: u8) -> GasCostEntry {
+    GasCostEntry { cycles, decode_slots: 0, exec_unit, src_pat, dst_pat, flags: flags | F_OVERLAP, overlap_slots: overlap_if | (overlap_no << 4) }
+}
+
+static GAS_COST_LUT: [GasCostEntry; 256] = {
+    let d = gc(1, 1, EU_NONE, 0, 0, 0); // default
+    let mut t = [d; 256];
+    // No-arg terminators
+    t[0] = gc(2, 1, EU_NONE, 0, 0, F_TERM);
+    t[1] = gc(2, 1, EU_NONE, 0, 0, F_TERM);
+    t[2] = gc(40, 1, EU_NONE, 0, 0, F_TERM);
+    t[10] = gc(100, 4, EU_ALU, 0, 0, F_TERM);
+    // Control flow
+    t[40] = gc(15, 1, EU_ALU, 0, 0, F_TERM);
+    t[80] = gc(15, 1, EU_ALU, 0, 1, F_TERM); // dst=ra
+    t[50] = gc(22, 1, EU_ALU, 0, 0, F_TERM);
+    t[180] = gc(22, 1, EU_ALU, 2, 1, F_TERM); // src=rb, dst=ra
+    // Loads (src=rb, dst=ra)
+    let mut i = 52; while i <= 58 { t[i] = gc(25, 1, EU_LOAD, 2, 1, 0); i += 1; }
+    i = 124; while i <= 130 { t[i] = gc(25, 1, EU_LOAD, 2, 1, 0); i += 1; }
+    // Stores (src=ra|rb, dst=none)
+    i = 59; while i <= 62 { t[i] = gc(25, 1, EU_STORE, 3, 0, 0); i += 1; }
+    i = 120; while i <= 123 { t[i] = gc(25, 1, EU_STORE, 3, 0, 0); i += 1; }
+    i = 30; while i <= 33 { t[i] = gc(25, 1, EU_STORE, 0, 0, 0); i += 1; }
+    i = 70; while i <= 73 { t[i] = gc(25, 1, EU_STORE, 1, 0, 0); i += 1; } // src=ra
+    // Load immediates
+    t[51] = gc(1, 1, EU_NONE, 0, 1, 0);
+    t[20] = gc(1, 2, EU_NONE, 0, 1, 0);
+    // move_reg
+    t[100] = gc(0, 1, EU_NONE, 2, 1, F_MOVE); // src=rb, dst=ra
+    t[101] = gc(2, 1, EU_NONE, 0, 0, 0); // nop
+    // Branches (reg+imm+offset) — needs branch_cost
+    i = 81; while i <= 90 { t[i] = gc(0, 1, EU_ALU, 1, 0, F_TERM | F_BRANCH); i += 1; } // src=ra
+    // Branches (two-reg+offset)
+    i = 170; while i <= 175 { t[i] = gc(0, 1, EU_ALU, 3, 0, F_TERM | F_BRANCH2); i += 1; } // src=ra|rb
+    // ALU 64-bit 3-reg (src=rb|rd, dst=ra, overlap adjust)
+    t[200] = gc_ov(1, 1, 2, EU_ALU, 4, 1, 0);
+    t[201] = gc_ov(1, 1, 2, EU_ALU, 4, 1, 0);
+    t[210] = gc_ov(1, 1, 2, EU_ALU, 4, 1, 0);
+    t[211] = gc_ov(1, 1, 2, EU_ALU, 4, 1, 0);
+    t[212] = gc_ov(1, 1, 2, EU_ALU, 4, 1, 0);
+    // ALU 32-bit 3-reg
+    t[190] = gc_ov(2, 2, 3, EU_ALU, 4, 1, 0);
+    t[191] = gc_ov(2, 2, 3, EU_ALU, 4, 1, 0);
+    // ALU 2-op imm 64-bit (src=rb, dst=ra, overlap adjust)
+    { let e = gc_ov(1, 1, 2, EU_ALU, 2, 1, 0);
+      t[132]=e; t[133]=e; t[134]=e; t[149]=e; t[151]=e; t[152]=e; t[153]=e; t[158]=e; t[110]=e; }
+    // ALU 2-op imm 32-bit
+    { let e = gc_ov(2, 2, 3, EU_ALU, 2, 1, 0);
+      t[131]=e; t[138]=e; t[139]=e; t[140]=e; t[160]=e; }
+    // Trivial 2-op (src=rb, dst=ra)
+    { let e = gc(1, 1, EU_ALU, 2, 1, 0);
+      t[102]=e; t[103]=e; t[104]=e; t[105]=e; t[108]=e; t[109]=e; t[111]=e; }
+    // ctz
+    t[106] = gc(2, 1, EU_ALU, 2, 1, 0);
+    t[107] = gc(2, 1, EU_ALU, 2, 1, 0);
+    // Shifts 64-bit 3-reg (src=rb|rd, dst=ra, shift overlap: rb==ra)
+    { let e = gc_ov(1, 2, 3, EU_ALU, 4, 1, F_SHIFT_OVERLAP);
+      t[207]=e; t[208]=e; t[209]=e; t[220]=e; t[222]=e; }
+    // Shifts 32-bit 3-reg
+    { let e = gc_ov(2, 3, 4, EU_ALU, 4, 1, F_SHIFT_OVERLAP);
+      t[197]=e; t[198]=e; t[199]=e; t[221]=e; t[223]=e; }
+    // Shift alt 64-bit
+    { let e = gc(1, 3, EU_ALU, 2, 1, 0);
+      t[155]=e; t[156]=e; t[157]=e; t[159]=e; }
+    // Shift alt 32-bit
+    { let e = gc(2, 4, EU_ALU, 2, 1, 0);
+      t[144]=e; t[145]=e; t[146]=e; t[161]=e; }
+    // Comparisons 3-reg (src=rb|rd, dst=ra)
+    t[216] = gc(3, 3, EU_ALU, 4, 1, 0);
+    t[217] = gc(3, 3, EU_ALU, 4, 1, 0);
+    // Comparisons imm (src=rb, dst=ra)
+    { let e = gc(3, 3, EU_ALU, 2, 1, 0);
+      t[136]=e; t[137]=e; t[142]=e; t[143]=e; }
+    // Conditional moves 3-reg
+    t[218] = gc(2, 2, EU_ALU, 4, 1, 0);
+    t[219] = gc(2, 2, EU_ALU, 4, 1, 0);
+    // Conditional moves imm
+    t[147] = gc(2, 3, EU_ALU, 2, 1, 0);
+    t[148] = gc(2, 3, EU_ALU, 2, 1, 0);
+    // Min/Max (src=rb|rd, dst=ra, overlap adjust)
+    { let e = gc_ov(3, 2, 3, EU_ALU, 4, 1, 0);
+      t[227]=e; t[228]=e; t[229]=e; t[230]=e; }
+    // and_inv, or_inv
+    t[224] = gc(2, 3, EU_ALU, 4, 1, 0);
+    t[225] = gc(2, 3, EU_ALU, 4, 1, 0);
+    // xnor (overlap adjust)
+    t[226] = gc_ov(2, 2, 3, EU_ALU, 4, 1, 0);
+    // neg_add_imm
+    t[154] = gc(2, 3, EU_ALU, 2, 1, 0);
+    t[141] = gc(3, 4, EU_ALU, 2, 1, 0);
+    // Multiply 64-bit 3-reg (overlap adjust)
+    t[202] = gc_ov(3, 1, 2, EU_MUL, 4, 1, 0);
+    // mul_imm_64
+    t[150] = gc_ov(3, 1, 2, EU_MUL, 2, 1, 0);
+    // Multiply 32-bit 3-reg
+    t[192] = gc_ov(4, 2, 3, EU_MUL, 4, 1, 0);
+    // mul_imm_32
+    t[135] = gc_ov(4, 2, 3, EU_MUL, 2, 1, 0);
+    // Multiply upper
+    t[213] = gc(4, 4, EU_MUL, 4, 1, 0);
+    t[214] = gc(4, 4, EU_MUL, 4, 1, 0);
+    t[215] = gc(6, 4, EU_MUL, 4, 1, 0);
+    // Divide (src=rb|rd, dst=ra)
+    { let e = gc(60, 4, EU_DIV, 4, 1, 0);
+      t[193]=e; t[194]=e; t[195]=e; t[196]=e; t[203]=e; t[204]=e; t[205]=e; t[206]=e; }
+    t
+};
+
+/// Compute FastCost via lookup table — replaces the 256-arm match dispatch
+/// with a single array access + lightweight mask computation.
+#[inline(always)]
+pub fn fast_cost_lut(opcode_byte: u8, args: &crate::args::Args, pc: u32, code: &[u8], bitmask: &[u8]) -> FastCost {
+    use crate::args::Args;
+
+    let pcu = pc as usize;
+    let ra = if pcu + 1 < code.len() { code[pcu + 1] & 0x0F } else { 0xFF };
+    let rb = if pcu + 1 < code.len() { (code[pcu + 1] >> 4) & 0x0F } else { 0xFF };
+    let rd = if pcu + 2 < code.len() { code[pcu + 2] & 0x0F } else { 0xFF };
+
+    let entry = &GAS_COST_LUT[opcode_byte as usize];
+
+    // Compute source mask from pattern
+    let src_mask: u16 = match entry.src_pat {
+        0 => 0,
+        1 => reg_bit(ra),
+        2 => reg_bit(rb),
+        3 => reg_bit(ra) | reg_bit(rb),
+        4 => reg_bit(rb) | reg_bit(rd),
+        _ => 0,
+    };
+    // Compute destination mask from pattern
+    let dst_mask: u16 = match entry.dst_pat {
+        0 => 0,
+        1 => reg_bit(ra),
+        _ => 0,
+    };
+
+    // Handle branch cost (dynamic cycles based on target)
+    let cycles = if entry.flags & (F_BRANCH | F_BRANCH2) != 0 {
+        let branch_target = match args {
+            Args::RegImmOffset { offset, .. } => *offset as usize,
+            Args::TwoRegOffset { offset, .. } => *offset as usize,
+            Args::Offset { offset } => *offset as usize,
+            _ => pcu,
+        };
+        branch_cost(code, bitmask, branch_target) as u8
+    } else {
+        entry.cycles
+    };
+
+    // Compute decode_slots with optional overlap adjustment
+    let decode_slots = if entry.flags & F_OVERLAP != 0 {
+        let overlap = if entry.flags & F_SHIFT_OVERLAP != 0 {
+            rb == ra // shift overlap: check if rb==ra (raw byte comparison)
+        } else {
+            (dst_mask & src_mask) != 0 // general overlap: dst ∩ src
+        };
+        if overlap {
+            entry.overlap_slots & 0x0F
+        } else {
+            entry.overlap_slots >> 4
+        }
+    } else {
+        entry.decode_slots
+    };
+
+    FastCost {
+        cycles,
+        decode_slots,
+        exec_unit: entry.exec_unit,
+        src_mask,
+        dst_mask,
+        is_terminator: entry.flags & F_TERM != 0,
+        is_move_reg: entry.flags & F_MOVE != 0,
+    }
+}
+
 /// Check if execution unit is available.
 #[inline(always)]
 fn eu_available(avail: &[u8; 5], eu: u8) -> bool {

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -330,10 +330,9 @@ impl Compiler {
                 pending_gas = Some((stub_label, pc as u32, patch_offset));
             }
 
-            // Feed gas simulator — uses decoded args directly, avoiding:
-            // 1. Redundant raw register byte extraction
-            // 2. Redundant args re-decoding for branch target extraction
-            let fc = crate::gas_cost::fast_cost_from_decoded(
+            // Feed gas simulator via lookup table (single array access + mask
+            // computation, replaces the 256-arm match in fast_cost_from_decoded).
+            let fc = crate::gas_cost::fast_cost_lut(
                 opcode as u8, &decoded_args, pc as u32, code, bitmask,
             );
             gas_sim.feed(&fc);


### PR DESCRIPTION
## Summary

Replace the branch-heavy 256-arm match in `fast_cost_from_decoded` with a static `GAS_COST_LUT[256]` array. Each entry encodes the instruction's gas cost parameters as a compact struct. At runtime, `FastCost` is computed via a single array access + lightweight mask computation instead of branching through ~200 lines of match arms.

- **Register patterns** encoded as small integers (0=none, 1=ra, 2=rb, 3=ra|rb, 4=rb|rd), expanded to bitmasks at runtime
- **Overlap-adjusted decode_slots** use pre-computed if/else values packed in a byte
- **Branch instructions** still compute dynamic `branch_cost` (~6% of instructions), rest use pre-computed cycles from table

This reduces per-instruction gas cost computation from a branch-heavy match to a table lookup + 5-7 arithmetic operations. The benefit is more pronounced on bare metal where branch prediction pressure from the 256-arm match is real.

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)