### PR TITLE
Hoist ensure_capacity from compile_instruction to main loop

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -290,6 +290,10 @@ impl Compiler {
         while pc < code.len() && (pc >= bitmask.len() || bitmask[pc] != 1) { pc += 1; }
 
         while pc < code.len() {
+            // Ensure assembler capacity for this instruction + gas block overhead.
+            // Batched: capacity is generously pre-allocated (code_len*3+8192), so
+            // this check is almost always false (no branch misprediction).
+            self.asm.ensure_capacity(512);
 
             // Decode instruction inline
             let opcode = match Opcode::from_byte(code[pc]) {
@@ -900,11 +904,8 @@ impl Compiler {
     }
 
     /// Compile a single PVM instruction.
+    /// Caller must ensure the assembler has sufficient capacity (at least 256 bytes).
     fn compile_instruction(&mut self, opcode: Opcode, args: &Args, pc: u32, next_pc: u32) {
-        // Ensure capacity for this instruction's native code emission.
-        // Most PVM instructions emit at most ~64 bytes of x86. Memory access
-        // with helper calls can emit ~128. This avoids per-byte capacity checks.
-        self.asm.ensure_capacity(256);
         match opcode {
             // === A.5.1: No arguments ===
             Opcode::Trap => {


### PR DESCRIPTION
## Summary

Move the per-instruction `ensure_capacity(256)` call from inside `compile_instruction` to the main compilation loop. This keeps the capacity check in one place alongside gas block emission (which also needs buffer space), and removes a function-call-boundary capacity check from the critical code generation path.

The assembler buffer is generously pre-allocated (`code_len*3+8192`), so the capacity check is almost always false. Moving it to the loop level makes the control flow clearer and allows LLVM to better optimize `compile_instruction` (no early-exit path for capacity growth).

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all 41 pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)