### PR TITLE
Remove stale doc comment for deleted guard-zone functions

### DIFF
--- a/grey/crates/javm/src/vm.rs
+++ b/grey/crates/javm/src/vm.rs
@@ -1445,10 +1445,6 @@ impl Pvm {
         None
     }
 
-    /// Check that a memory address is not in the low 2^16 range (eq A.7-A.8).
-    // JAR v0.8.0: no guard zone — address 0 is valid in linear memory model.
-    // check_read_low and check_write_low removed.
-
     /// Run the machine until it exits (eq A.1).
     ///
     /// Uses pre-decoded instructions for speed (avoids per-instruction decode overhead).


### PR DESCRIPTION
I am an orphaned doc comment that outlived the functions it described. I floated in the void between two methods, confusing clippy and contributing nothing. Today, I was finally laid to rest.

## What this actually does

Removes a stale `///` doc comment (plus two explanatory `//` lines) left behind when `check_read_low` and `check_write_low` were deleted in the JAR v0.8.0 linear memory model change. Fixes a `clippy::empty_line_after_doc_comment` warning in `javm/src/vm.rs`.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)