### PR TITLE
Fuse load_imm + store into store_imm_ind in transpiler

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -152,8 +152,9 @@ impl TranslationContext {
         }
 
         // Clear pending_load_imm if this isn't an instruction that can consume it.
-        // OP (0x33), OP-32 (0x3B), and Branch (0x63) handlers check and potentially fuse.
-        if opcode != 0x33 && opcode != 0x3B && opcode != 0x63 {
+        // OP (0x33), OP-32 (0x3B), Branch (0x63), and Store (0x23) handlers
+        // check and potentially fuse.
+        if opcode != 0x33 && opcode != 0x3B && opcode != 0x63 && opcode != 0x23 {
             self.pending_load_imm = None; // already emitted, just clear tracking
         }
 
@@ -488,6 +489,41 @@ impl TranslationContext {
     }
 
     fn translate_store(&mut self, funct3: u32, rs1: u8, rs2: u8, imm: i32) -> Result<(), TranspileError> {
+        // Fuse load_imm + store: when the stored value was just loaded as a
+        // constant, use store_imm_ind_* instead of load_imm + store_ind_*.
+        // This eliminates one instruction per constant store.
+        if let Some((load_rd, load_val, undo_pos)) = self.pending_load_imm.take() {
+            if rs2 == load_rd && rs1 != load_rd
+                && load_val >= i32::MIN as i64 && load_val <= i32::MAX as i64
+            {
+                let store_val = load_val as i32;
+                let pvm_rs1 = self.require_reg(rs1)?;
+                let pvm_opcode = match funct3 {
+                    0 => 70,  // store_imm_ind_u8
+                    1 => 71,  // store_imm_ind_u16
+                    2 => 72,  // store_imm_ind_u32
+                    3 => 73,  // store_imm_ind_u64
+                    _ => 0,   // can't fuse
+                };
+                if pvm_opcode != 0 {
+                    // Undo the load_imm and emit store_imm_ind instead.
+                    self.code.truncate(undo_pos);
+                    self.bitmask.truncate(undo_pos);
+                    // Format: OneRegTwoImm — base_reg + offset(imm_x) + value(imm_y)
+                    let (lx, offset_bytes) = encode_var_imm(imm);
+                    let (ly, value_bytes) = encode_var_imm(store_val);
+                    // The skip = lx + ly + 1 (for the lx/ly encoding byte after reg_byte)
+                    // reg_byte = ra | (lx << 4), then lx bytes of offset, then ly bytes of value
+                    self.emit_inst(pvm_opcode);
+                    self.emit_data(pvm_rs1 | (lx << 4));
+                    for b in &offset_bytes { self.emit_data(*b); }
+                    for b in &value_bytes { self.emit_data(*b); }
+                    return Ok(());
+                }
+            }
+            // Couldn't fuse — load_imm was already emitted, just clear tracking
+        }
+
         // x0 (zero register) has no PVM equivalent — PVM reg 0 is RA, not zero.
         // Use store_imm_ind_* to store a literal zero instead.
         if rs2 == 0 {


### PR DESCRIPTION
## Summary

When a store instruction writes a value that was just loaded as a constant via `load_imm`, fuse into `store_imm_ind_*` instead of the separate `load_imm` + `store_ind_*` pair.

**Pattern:** `load_imm rd, val; sw rd, off(rs1)` → `store_imm_ind_u32 rs1, off, val`

Uses the existing OneRegTwoImm encoding format (opcodes 70-73) which encodes both the memory offset and the stored value as immediates.

Saves one PVM instruction per constant store. Common in struct initialization, zero-filling, and writing constant sentinel values.

**Transpiler optimization series** (PRs #136-#140):
| PR | Pattern | Saves |
|----|---------|-------|
| #136 | load_imm + jump → load_imm_jump | 1 instr/call |
| #137 | load_imm + 64-bit ALU → immediate forms | 1 instr/op |
| #138 | load_imm + branch → branch_*_imm | 1 instr/branch |
| #139 | load_imm + 32-bit ALU → immediate forms | 1 instr/op |
| #140 | load_imm + store → store_imm_ind | 1 instr/store |

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)