### PR TITLE
Track shift-left-immediate in reg_defs for scaled index peephole

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -900,6 +900,22 @@ impl Compiler {
                     self.invalidate_dependents(*ra);
                 }
             }
+            // Track shift-left-immediate as Shifted for LEA-based scaled indexing.
+            // sll_imm_64 rd, rb, shift → Shifted{src:rb, shift} if shift ∈ 1..=3.
+            // This enables the peephole: sll + add + load → LEA + load with SIB scaling.
+            Opcode::ShloLImm64 => {
+                if let Args::TwoRegImm { ra, rb, imm } = args {
+                    let shift = (*imm as u32 % 64) as u8;
+                    if shift >= 1 && shift <= 3 {
+                        self.reg_defs[*ra] = RegDef::Shifted { src: *rb, shift };
+                        self.reg_defs_active |= 1u16 << *ra;
+                    } else {
+                        self.reg_defs[*ra] = RegDef::Unknown;
+                        self.reg_defs_active &= !(1u16 << *ra);
+                    }
+                    self.invalidate_dependents(*ra);
+                }
+            }
             Opcode::MoveReg => {
                 if let Args::TwoReg { rd, ra } = args {
                     if *rd != *ra {


### PR DESCRIPTION
## Summary

Add `ShloLImm64` (opcode 151) to the recompiler's register definition tracker, producing `RegDef::Shifted{src, shift}` when the shift amount is 1-3.

This enables the existing scaled-index peephole optimization to fire on patterns like:
```
sll_imm_64 idx, src, 2    → Shifted{src, shift:2}
add64 addr, base, idx     → ScaledAdd{base, idx:src, shift:2}
load result, [addr]       → LEA [base + src*4] + load (single x86 SIB byte)
```

Previously, only the `add+add` doubling pattern (`add64 D,A,A` → Shifted) was tracked. Explicit shift-left-immediate instructions now also participate, catching cases where LLVM emits `slli` instead of an add-chain.

This is a **recompiler optimization** (issue #56): improves execution speed by using x86 SIB-encoded scaled addressing instead of separate shift+add+load.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)