### PR TITLE
Fuse load_imm + shift into shift immediate forms

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -732,6 +732,26 @@ impl TranslationContext {
                     }
                 }
 
+                // Special case: shifts with loaded shift count → shift immediate forms.
+                // SLL/SRL/SRA rd, rs1, load_rd → shlo_l/shlo_r/shar_r_imm rd, rs1, imm
+                if rs2 == load_rd && matches!((funct7, funct3), (0, 1) | (0, 5) | (0x20, 5)) {
+                    let pvm_imm_opcode = match (funct7, funct3) {
+                        (0, 1) => if self.is_64bit { 151 } else { 138 }, // SLL → shlo_l_imm
+                        (0, 5) => if self.is_64bit { 152 } else { 139 }, // SRL → shlo_r_imm
+                        (0x20, 5) => if self.is_64bit { 153 } else { 140 }, // SRA → shar_r_imm
+                        _ => unreachable!(),
+                    };
+                    self.code.truncate(undo_pos);
+                    self.bitmask.truncate(undo_pos);
+                    self.address_map.insert(addr, undo_pos as u32);
+                    let pvm_rd = self.require_reg(rd)?;
+                    let pvm_rs1 = self.require_reg(rs1)?;
+                    self.emit_inst(pvm_imm_opcode);
+                    self.emit_data(pvm_rd | (pvm_rs1 << 4));
+                    self.emit_var_imm(imm);
+                    return Ok(());
+                }
+
                 // Special case: SUB rd, rs1, load_rd → neg_add_imm rd, rs1, -imm
                 // SUB is not commutative, but if rs2 is the loaded register:
                 // rd = rs1 - imm = rs1 + (-imm)


### PR DESCRIPTION
## Summary

Extend the `load_imm + ALU` fusion to cover shift operations where the shift count was loaded as a constant:

| Pattern | Fused to | PVM opcode |
|---------|----------|------------|
| SLL rd, rs1, load_rd | shlo_l_imm rd, rs1, imm | 151 (64-bit) / 138 (32-bit) |
| SRL rd, rs1, load_rd | shlo_r_imm rd, rs1, imm | 152 (64-bit) / 139 (32-bit) |
| SRA rd, rs1, load_rd | shar_r_imm rd, rs1, imm | 153 (64-bit) / 140 (32-bit) |

Eliminates one `load_imm` instruction per constant-count shift. Common in bit manipulation and crypto code.

**Transpiler optimization series** (PRs #136-#142):
| PR | Pattern | Saves |
|----|---------|-------|
| #136 | load_imm + jump → load_imm_jump | 1 instr/call |
| #137 | load_imm + 64-bit ALU → immediate forms | 1 instr/op |
| #138 | load_imm + branch → branch_*_imm | 1 instr/branch |
| #139 | load_imm + 32-bit ALU → immediate forms | 1 instr/op |
| #140 | load_imm + store → store_imm_ind | 1 instr/store |
| #142 | load_imm + shift → shift_imm forms | 1 instr/shift |

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)