### PR TITLE
Fuse load_imm + 32-bit shift into shift immediate forms

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -1028,6 +1028,25 @@ impl TranslationContext {
                         return Ok(());
                     }
                 }
+                // 32-bit shifts with loaded shift count → shift immediate forms.
+                // SLLW/SRLW/SRAW rd, rs1, load_rd → shlo_l/shlo_r/shar_r_imm_32
+                if rs2 == load_rd && matches!((funct7, funct3), (0, 1) | (0, 5) | (0x20, 5)) {
+                    let pvm_imm_opcode = match (funct7, funct3) {
+                        (0, 1) => 138,    // SLLW → shlo_l_imm_32
+                        (0, 5) => 139,    // SRLW → shlo_r_imm_32
+                        (0x20, 5) => 140, // SRAW → shar_r_imm_32
+                        _ => unreachable!(),
+                    };
+                    self.code.truncate(undo_pos);
+                    self.bitmask.truncate(undo_pos);
+                    let pvm_rd = self.require_reg(rd)?;
+                    let pvm_rs1 = self.require_reg(rs1)?;
+                    self.emit_inst(pvm_imm_opcode);
+                    self.emit_data(pvm_rd | (pvm_rs1 << 4));
+                    self.emit_var_imm(imm);
+                    return Ok(());
+                }
+
                 // SUB with loaded rs2: SUBW rd, rs1, load_rd → add_imm_32 rd, rs1, -imm
                 if (funct7, funct3) == (0x20, 0) && rs2 == load_rd && rs1 != load_rd {
                     let neg_imm = (-(load_val as i32) as i64) as i32;


### PR DESCRIPTION
## Summary

Extend the `load_imm` fusion in `translate_op_32` to cover 32-bit shift operations (SLLW, SRLW, SRAW):

| Pattern | Fused to | PVM opcode |
|---------|----------|------------|
| SLLW rd, rs1, load_rd | shlo_l_imm_32 rd, rs1, imm | 138 |
| SRLW rd, rs1, load_rd | shlo_r_imm_32 rd, rs1, imm | 139 |
| SRAW rd, rs1, load_rd | shar_r_imm_32 rd, rs1, imm | 140 |

Complements PR #142 (64-bit shift fusion), completing shift fusion coverage for both 32-bit and 64-bit variants.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)