### PR TITLE
Resolve backward label fixups immediately during emission

### DIFF
--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -290,11 +290,22 @@ impl Assembler {
         self.write_pos += 4;
     }
 
-    /// Emit a 4-byte placeholder for a label fixup, recording the fixup.
+    /// Emit a label reference (4-byte rel32). For backward references (label
+    /// already bound), resolves immediately without creating a fixup entry.
+    /// For forward references, emits a placeholder and records a fixup.
     fn emit_label_fixup(&mut self, label: Label) {
-        let offset = self.write_pos;
-        self.fixups.push(Fixup { offset, label });
-        self.emit_u32(0); // placeholder
+        let bound = self.labels[label.0 as usize];
+        if bound != LABEL_UNBOUND {
+            // Backward reference — resolve immediately, no fixup needed.
+            // rel32 = target - (current_offset + 4)
+            let rel = bound as i64 - (self.write_pos as i64 + 4);
+            self.emit_i32(rel as i32);
+        } else {
+            // Forward reference — defer to finalization.
+            let offset = self.write_pos;
+            self.fixups.push(Fixup { offset, label });
+            self.emit_u32(0); // placeholder
+        }
     }
 
     // === REX prefix helpers ===


### PR DESCRIPTION
## Summary

When `emit_label_fixup` encounters a backward reference (label already bound), resolve the `rel32` offset immediately instead of creating a fixup entry for deferred resolution at finalization.

**Before:** All label references create fixup entries → finalization loop processes ~20K entries.
**After:** Backward references (OOG stub jumps, loop back-edges, etc.) resolve immediately → finalization loop processes only forward references (~10K entries).

This reduces:
- Fixup list allocations and memory usage
- Finalization loop iterations (roughly halved)
- Vec::push calls for fixup entries

## Test plan

- [x] `cargo test -p javm --features javm/signals` — all 41 pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all pass
- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)