### PR TITLE
Inline TwoRegImm decode in compilation hot loop

### DIFF
--- a/grey/crates/javm/src/args.rs
+++ b/grey/crates/javm/src/args.rs
@@ -113,6 +113,13 @@ fn read_le_at(code: &[u8], offset: usize, n: usize) -> u64 {
     }
 }
 
+/// Read `n` bytes from code at offset, sign-extend, and return as u64.
+/// Public for use by the recompiler's inline decode path.
+#[inline(always)]
+pub fn read_signed_imm(code: &[u8], offset: usize, n: usize) -> u64 {
+    read_signed_at(code, offset, n)
+}
+
 /// Read `n` bytes and sign-extend (no allocation).
 #[inline(always)]
 fn read_signed_at(code: &[u8], offset: usize, n: usize) -> u64 {

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -341,6 +341,17 @@ impl Compiler {
                         ra: (reg_byte >> 4).min(12) as usize,
                     }
                 }
+                crate::instruction::InstructionCategory::TwoRegOneImm => {
+                    // Inline decode for the ~30% of instructions that are TwoRegImm
+                    // (load/store indirect, immediate ALU ops). Avoids the decode_args
+                    // function call and its 13-arm category match.
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let rb = (reg_byte >> 4).min(12) as usize;
+                    let lx = if skip > 1 { (skip - 1).min(4) } else { 0 };
+                    let imm = args::read_signed_imm(code, pc + 2, lx);
+                    Args::TwoRegImm { ra, rb, imm }
+                }
                 _ => args::decode_args(code, pc, skip, category),
             };
 


### PR DESCRIPTION
## Summary

Extend the inline decode optimization (PR #132) to also cover **TwoRegOneImm** (opcodes 120-161): load/store indirect and immediate ALU operations (~30% of instructions in crypto code).

The inline decode reads registers + variable-length immediate directly from code bytes, avoiding the `decode_args` function call and its 13-arm category match dispatch.

With this PR, **~80% of instructions** (ThreeReg + TwoReg + TwoRegImm) now bypass `decode_args` entirely.

Also exposes `read_signed_imm` as a public helper in the args module.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)