### PR TITLE
Inline NoArgs, OneImm, OneRegOneImm decode in compilation loop

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -352,6 +352,17 @@ impl Compiler {
                     let imm = args::read_signed_imm(code, pc + 2, lx);
                     Args::TwoRegImm { ra, rb, imm }
                 }
+                crate::instruction::InstructionCategory::NoArgs => Args::None,
+                crate::instruction::InstructionCategory::OneImm => {
+                    let lx = skip.min(4);
+                    Args::Imm { imm: args::read_signed_imm(code, pc + 1, lx) }
+                }
+                crate::instruction::InstructionCategory::OneRegOneImm => {
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let lx = if skip > 1 { (skip - 1).min(4) } else { 0 };
+                    Args::RegImm { ra, imm: args::read_signed_imm(code, pc + 2, lx) }
+                }
                 _ => args::decode_args(code, pc, skip, category),
             };
 


### PR DESCRIPTION
## Summary

Extend the inline decode optimization to cover three more instruction categories:

| Category | Opcodes | Inline decode |
|----------|---------|--------------|
| NoArgs | 0-2 (trap, fallthrough, unlikely) | Returns `Args::None` directly |
| OneImm | 10 (ecalli) | Reads one variable-length immediate |
| OneRegOneImm | 50-62 (load_imm, jump_ind, etc.) | Reads register + immediate |

Combined with previous inline decode (ThreeReg, TwoReg, TwoRegImm), **~95% of instructions** now bypass the `decode_args` function call entirely. Only rare categories (OneOffset, OneRegExtImm, OneRegImmOffset, OneRegTwoImm, TwoRegOffset, TwoRegTwoImm) still use the generic path.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615
- [x] Benchmark: ecrecover compile+exec = 1.662ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)