### PR TITLE
Fix th.mveqz self-move nop, inline OneRegExtImm decode

### DIFF
--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -253,6 +253,9 @@ impl TranslationContext {
                             // Condition is x0 (always 0) → always execute: rd = rs1
                             if rs1 == 0 {
                                 self.emit_load_imm(rd, 0)?;
+                            } else if rd == rs1 {
+                                // Self-move is a nop
+                                self.emit_inst(1); // fallthrough
                             } else {
                                 let pvm_rd = self.require_reg(rd)?;
                                 let pvm_rs1 = self.require_reg(rs1)?;

--- a/grey/crates/javm/src/args.rs
+++ b/grey/crates/javm/src/args.rs
@@ -120,6 +120,13 @@ pub fn read_signed_imm(code: &[u8], offset: usize, n: usize) -> u64 {
     read_signed_at(code, offset, n)
 }
 
+/// Read `n` bytes from code at offset as little-endian u64 (no sign extension).
+/// Public for use by the recompiler's inline decode path (e.g., OneRegExtImm).
+#[inline(always)]
+pub fn read_le_imm(code: &[u8], offset: usize, n: usize) -> u64 {
+    read_le_at(code, offset, n)
+}
+
 /// Read `n` bytes and sign-extend (no allocation).
 #[inline(always)]
 fn read_signed_at(code: &[u8], offset: usize, n: usize) -> u64 {

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -363,6 +363,13 @@ impl Compiler {
                     let lx = if skip > 1 { (skip - 1).min(4) } else { 0 };
                     Args::RegImm { ra, imm: args::read_signed_imm(code, pc + 2, lx) }
                 }
+                crate::instruction::InstructionCategory::OneRegExtImm => {
+                    // load_imm_64 (opcode 20): register + 8-byte LE immediate
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let imm = args::read_le_imm(code, pc + 2, 8);
+                    Args::RegExtImm { ra, imm }
+                }
                 _ => args::decode_args(code, pc, skip, category),
             };
 


### PR DESCRIPTION
## Summary

Two small improvements:

1. **Transpiler**: Fix `th.mveqz` with rs2==0 to emit `fallthrough` instead of `move_reg` when rd==rs1 (self-move is a nop). The handler was missing the rd==rs1 check that other paths (like ADDI rd,rd,0) correctly handle.

2. **Recompiler**: Inline `OneRegExtImm` decode (opcode 20, `load_imm_64`) in the compilation loop. Reads register + 8-byte LE immediate directly from code bytes, bypassing `decode_args`.

Also exposes `read_le_imm` as a public helper in the args module.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)