### PR TITLE
Inline ALL remaining decode categories — fully eliminate decode_args

### DIFF
--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -364,13 +364,65 @@ impl Compiler {
                     Args::RegImm { ra, imm: args::read_signed_imm(code, pc + 2, lx) }
                 }
                 crate::instruction::InstructionCategory::OneRegExtImm => {
-                    // load_imm_64 (opcode 20): register + 8-byte LE immediate
                     let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
                     let ra = (reg_byte & 0x0F).min(12) as usize;
-                    let imm = args::read_le_imm(code, pc + 2, 8);
-                    Args::RegExtImm { ra, imm }
+                    Args::RegExtImm { ra, imm: args::read_le_imm(code, pc + 2, 8) }
                 }
-                _ => args::decode_args(code, pc, skip, category),
+                crate::instruction::InstructionCategory::TwoImm => {
+                    let first = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let lx = (first as usize % 8).min(4);
+                    let ly = if skip > lx + 1 { (skip - lx - 1).min(4) } else { 0 };
+                    Args::TwoImm {
+                        imm_x: args::read_signed_imm(code, pc + 2, lx),
+                        imm_y: args::read_signed_imm(code, pc + 2 + lx, ly),
+                    }
+                }
+                crate::instruction::InstructionCategory::OneOffset => {
+                    let lx = skip.min(4);
+                    let signed_off = args::read_signed_imm(code, pc + 1, lx) as i64;
+                    Args::Offset { offset: (pc as i64).wrapping_add(signed_off) as u64 }
+                }
+                crate::instruction::InstructionCategory::OneRegTwoImm => {
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let lx = ((reg_byte as usize / 16) % 8).min(4);
+                    let ly = if skip > lx + 1 { (skip - lx - 1).min(4) } else { 0 };
+                    Args::RegTwoImm {
+                        ra,
+                        imm_x: args::read_signed_imm(code, pc + 2, lx),
+                        imm_y: args::read_signed_imm(code, pc + 2 + lx, ly),
+                    }
+                }
+                crate::instruction::InstructionCategory::OneRegImmOffset => {
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let lx = ((reg_byte as usize / 16) % 8).min(4);
+                    let ly = if skip > lx + 1 { (skip - lx - 1).min(4) } else { 0 };
+                    let imm = args::read_signed_imm(code, pc + 2, lx);
+                    let signed_off = args::read_signed_imm(code, pc + 2 + lx, ly) as i64;
+                    Args::RegImmOffset { ra, imm, offset: (pc as i64).wrapping_add(signed_off) as u64 }
+                }
+                crate::instruction::InstructionCategory::TwoRegOneOffset => {
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let rb = (reg_byte >> 4).min(12) as usize;
+                    let lx = if skip > 1 { (skip - 1).min(4) } else { 0 };
+                    let signed_off = args::read_signed_imm(code, pc + 2, lx) as i64;
+                    Args::TwoRegOffset { ra, rb, offset: (pc as i64).wrapping_add(signed_off) as u64 }
+                }
+                crate::instruction::InstructionCategory::TwoRegTwoImm => {
+                    let reg_byte = if pc + 1 < code.len() { code[pc + 1] } else { 0 };
+                    let ra = (reg_byte & 0x0F).min(12) as usize;
+                    let rb = (reg_byte >> 4).min(12) as usize;
+                    let lx_byte = if pc + 2 < code.len() { code[pc + 2] } else { 0 };
+                    let lx = (lx_byte as usize % 8).min(4);
+                    let ly = if skip > lx + 2 { (skip - lx - 2).min(4) } else { 0 };
+                    Args::TwoRegTwoImm {
+                        ra, rb,
+                        imm_x: args::read_signed_imm(code, pc + 3, lx),
+                        imm_y: args::read_signed_imm(code, pc + 3 + lx, ly),
+                    }
+                }
             };
 
             // Gas block boundary: consolidated check.


### PR DESCRIPTION
## Summary

Inline the last 6 instruction categories in the compilation loop:

| Category | Opcodes | Description |
|----------|---------|-------------|
| TwoImm | 30-33 | store_imm_* |
| OneOffset | 40 | jump |
| OneRegTwoImm | 70-73 | store_imm_ind_* |
| OneRegImmOffset | 80-90 | branch_*_imm, load_imm_jump |
| TwoRegOneOffset | 170-175 | branch_eq/ne/lt/ge |
| TwoRegTwoImm | 180 | load_imm_jump_ind |

Combined with previous inline decode PRs (#132, #145, #146, #147), **ALL 13 instruction categories** are now decoded inline. The `decode_args` function is never called from the hot compilation loop, completely eliminating its 13-arm match dispatch.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)