### PR TITLE
Coarsen gas blocks: skip post-Fallthrough/Unlikely gas block starts

### DIFF
--- a/grey/crates/javm/src/vm.rs
+++ b/grey/crates/javm/src/vm.rs
@@ -2110,7 +2110,12 @@ pub fn compute_basic_block_starts_bitset(code: &[u8], bitmask: &[u8]) -> (BitSet
         };
         skip_table[i] = skip as u8;
 
-        if op.is_terminator() {
+        // Mark post-terminator PCs as gas block starts, EXCEPT after
+        // Fallthrough/Unlikely which don't change control flow. Post-fallthrough
+        // blocks are only reachable by sequential execution and will already be
+        // marked if they're branch targets. This coarsens gas blocks for
+        // straight-line code, reducing gas check overhead.
+        if op.is_terminator() && !matches!(op, Opcode::Fallthrough | Opcode::Unlikely) {
             let next = i + 1 + skip;
             if next < len && next < bitmask.len() && bitmask[next] == 1 {
                 starts.set(next);


### PR DESCRIPTION
## Summary

Don't mark post-`Fallthrough`/post-`Unlikely` PCs as gas block starts. These terminators don't change control flow — the next instruction is only reachable by sequential fallthrough. If the next PC is also a branch target, it's marked as a gas block start by the branch-target scan independently.

This merges consecutive blocks separated only by Fallthrough/Unlikely into larger gas blocks, reducing:
- Gas checks at runtime
- OOG stubs emitted during compilation
- Labels allocated
- Native code size

The total gas charged is unchanged — the GasSimulator's pipeline model produces the same total cost whether blocks are split or merged at fallthrough boundaries.

Addresses the "Reduce gas block overhead (currently one per basic block start — could coarsen for straight-line code)" item from issue #56.

## Test plan

- [x] `cargo test -p grey-bench --features javm/signals` — all 7 tests pass
- [x] `GREY_PVM=recompiler cargo test -p javm --features javm/signals` — all 41 pass
- [x] ecrecover gas matches exactly: interpreter=7206615, recompiler=7206615

🤖 Generated with [Claude Code](https://claude.com/claude-code)