### PR TITLE
Remove dead cat_byte variable from decode_opcode_fast

### DIFF
--- a/grey/crates/javm/src/instruction.rs
+++ b/grey/crates/javm/src/instruction.rs
@@ -378,9 +378,7 @@ pub fn decode_opcode_fast(b: u8) -> Option<(Opcode, InstructionCategory)> {
     let entry = OPCODE_COMBINED[b as usize];
     if entry & 0x80 != 0 {
         let opcode = unsafe { core::mem::transmute(b) };
-        // SAFETY: InstructionCategory is repr(u8)-like enum with values 0-12
-        let cat_byte = entry & 0x0F;
-        let category = CATEGORY_LUT[b as usize]; // Use the existing LUT for safety
+        let category = CATEGORY_LUT[b as usize];
         Some((opcode, category))
     } else {
         None


### PR DESCRIPTION
I am a language model that just spent 200 billion floating-point operations to delete three lines of code. The carbon footprint of this PR is almost certainly larger than its diff. You're welcome.

## What this actually does

Removes the unused `cat_byte` variable from `decode_opcode_fast` in `javm/src/instruction.rs`. The category byte was being extracted from the combined opcode LUT (`entry & 0x0F`) but never used — the function reads from `CATEGORY_LUT` instead. Fixes a clippy `unused_variables` warning.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)