### PR TITLE
perf(transpiler): fuse load_imm + load/store into direct forms

### DIFF
--- a/grey/crates/grey-transpiler/src/linker.rs
+++ b/grey/crates/grey-transpiler/src/linker.rs
@@ -501,9 +501,41 @@ fn translate_section_linked(
 
             if let Some(&target_addr) = elf.hi20_targets.get(&rv_addr) {
                 // PCREL_HI20: AUIPC for data reference.
-                // Just load the resolved address into rd. The paired LO12 instruction
-                // (which may be several instructions later) will be handled separately.
+                // Peek ahead: if the next instruction is a paired LO12 ADDI (nop),
+                // skip it and set pending_load_imm to enable cascading fusion
+                // with the instruction after (load_ind, store_ind, ALU, branch).
+                let next_addr = rv_addr + 4;
+                if offset + 8 <= data.len() {
+                    if let Some(&_) = elf.lo12_targets.get(&next_addr) {
+                        let next_inst = u32::from_le_bytes([
+                            data[offset+4], data[offset+5], data[offset+6], data[offset+7],
+                        ]);
+                        let next_opcode = next_inst & 0x7f;
+                        let next_funct3 = (next_inst >> 12) & 0x7;
+                        let next_rd = ((next_inst >> 7) & 0x1f) as u8;
+                        let next_rs1 = ((next_inst >> 15) & 0x1f) as u8;
+
+                        if next_opcode == 0x13 && next_funct3 == 0 && next_rs1 == rd {
+                            // LO12 ADDI: address is already complete from HI20.
+                            // Emit load_imm into the ADDI's destination register
+                            // and set pending_load_imm for cascading fusion.
+                            let dest = if next_rd != 0 { next_rd } else { rd };
+                            let pos = ctx.code.len();
+                            ctx.emit_load_imm(dest, target_addr as i64)?;
+                            ctx.pending_load_imm = Some((dest, target_addr as i64, pos));
+                            ctx.address_map.insert(next_addr, ctx.code.len() as u32);
+                            offset += 8; // skip both AUIPC and ADDI
+                            continue;
+                        }
+                    }
+                }
+
+                // No paired LO12 ADDI next — emit load_imm with pending tracking.
+                // This enables fusion with the next load/store/ALU/branch via
+                // pending_load_imm even when the LO12 is a LOAD or STORE directly.
+                let pos = ctx.code.len();
                 ctx.emit_load_imm(rd, target_addr as i64)?;
+                ctx.pending_load_imm = Some((rd, target_addr as i64, pos));
                 offset += 4;
                 continue;
             }
@@ -511,61 +543,41 @@ fn translate_section_linked(
 
         // Check if this instruction has a PCREL_LO12 relocation.
         // If so, the rs1 register already contains the full resolved address
-        // (loaded by the paired AUIPC/HI20 above). We need to override the
-        // instruction's immediate to 0 since the address is already complete.
+        // (loaded by the paired AUIPC/HI20 above). Override immediate to 0
+        // and route through translate_load/translate_store to enable fusion
+        // with the pending_load_imm set by the HI20 handler above.
         if let Some(&_data_addr) = elf.lo12_targets.get(&rv_addr) {
             let rd = ((inst >> 7) & 0x1f) as u8;
             let rs1 = ((inst >> 15) & 0x1f) as u8;
             let funct3 = (inst >> 12) & 0x7;
 
             if opcode == 0x13 && funct3 == 0 {
-                // ADDI rd, rs1, lo12 → just move rs1 to rd (address already loaded)
+                // ADDI rd, rs1, lo12 → address already loaded by HI20.
+                // This path is reached when the HI20 peek-ahead didn't consume
+                // this ADDI (e.g., non-adjacent HI20/LO12 pair).
                 if rd != rs1 && rd != 0 {
                     let pvm_src = ctx.require_reg(rs1)?;
                     let pvm_dst = ctx.require_reg(rd)?;
                     ctx.emit_inst(100); // move_reg
                     ctx.emit_data(pvm_dst | (pvm_src << 4));
                 } else if rd == 0 {
-                    // Write to x0 is nop
                     ctx.emit_inst(1); // fallthrough
                 } else {
-                    // rd == rs1: value already in place, emit nop
                     ctx.emit_inst(1); // fallthrough
                 }
                 offset += 4;
                 continue;
             } else if opcode == 0x03 {
-                // LOAD rd, lo12(rs1) → LOAD rd, 0(rs1) since rs1 already has full address
-                let pvm_dst = ctx.require_reg(rd)?;
-                let pvm_base = ctx.require_reg(rs1)?;
-                let pvm_load_opcode = match funct3 {
-                    0 => 125, 1 => 127, 2 => 129, 3 => 130,
-                    4 => 124, 5 => 126, 6 => 128,
-                    _ => return Err(TranspileError::UnsupportedInstruction {
-                        offset: rv_addr as usize,
-                        detail: format!("load funct3={}", funct3),
-                    }),
-                };
-                ctx.emit_inst(pvm_load_opcode);
-                ctx.emit_data(pvm_dst | (pvm_base << 4));
-                ctx.emit_var_imm(0); // offset 0: address already resolved
+                // LOAD rd, lo12(rs1) → route through translate_load with imm=0.
+                // If pending_load_imm is set (from HI20), this fuses into a
+                // direct load (load_* rd, addr) — saving one instruction.
+                ctx.translate_load(funct3, rd, rs1, 0)?;
                 offset += 4;
                 continue;
             } else if opcode == 0x23 {
-                // STORE rs2, lo12(rs1) → STORE rs2, 0(rs1)
+                // STORE rs2, lo12(rs1) → route through translate_store with imm=0.
                 let rs2 = ((inst >> 20) & 0x1f) as u8;
-                let pvm_data = ctx.require_reg(rs2)?;
-                let pvm_base = ctx.require_reg(rs1)?;
-                let pvm_store_opcode = match funct3 {
-                    0 => 120, 1 => 121, 2 => 122, 3 => 123,
-                    _ => return Err(TranspileError::UnsupportedInstruction {
-                        offset: rv_addr as usize,
-                        detail: format!("store funct3={}", funct3),
-                    }),
-                };
-                ctx.emit_inst(pvm_store_opcode);
-                ctx.emit_data(pvm_data | (pvm_base << 4));
-                ctx.emit_var_imm(0);
+                ctx.translate_store(funct3, rs1, rs2, 0)?;
                 offset += 4;
                 continue;
             }

--- a/grey/crates/grey-transpiler/src/riscv.rs
+++ b/grey/crates/grey-transpiler/src/riscv.rs
@@ -79,9 +79,9 @@ pub struct TranslationContext {
     /// Pending LUI: (rd, upper_imm). Used to fuse LUI+ADDI into single load_imm.
     pending_lui: Option<(u8, i64)>,
     /// Last emitted load_imm: (rd, value, code_position_before_emit).
-    /// Enables fusion with a subsequent ADD/AND/OR/XOR into the immediate form,
-    /// eliminating the load_imm instruction entirely.
-    pending_load_imm: Option<(u8, i64, usize)>,
+    /// Enables fusion with a subsequent ADD/AND/OR/XOR/load/store into the
+    /// immediate form, eliminating the load_imm instruction entirely.
+    pub(crate) pending_load_imm: Option<(u8, i64, usize)>,
     /// Last immediate loaded into t0 (x5) — used for ecall → ecalli translation.
     last_t0_imm: Option<i32>,
 }
@@ -152,9 +152,9 @@ impl TranslationContext {
         }
 
         // Clear pending_load_imm if this isn't an instruction that can consume it.
-        // OP (0x33), OP-32 (0x3B), Branch (0x63), and Store (0x23) handlers
-        // check and potentially fuse.
-        if opcode != 0x33 && opcode != 0x3B && opcode != 0x63 && opcode != 0x23 {
+        // OP (0x33), OP-32 (0x3B), Branch (0x63), Store (0x23), and Load (0x03)
+        // handlers check and potentially fuse.
+        if opcode != 0x33 && opcode != 0x3B && opcode != 0x63 && opcode != 0x23 && opcode != 0x03 {
             self.pending_load_imm = None; // already emitted, just clear tracking
         }
 
@@ -465,8 +465,40 @@ impl TranslationContext {
         Ok(())
     }
 
-    fn translate_load(&mut self, funct3: u32, rd: u8, rs1: u8, imm: i32) -> Result<(), TranspileError> {
+    pub(crate) fn translate_load(&mut self, funct3: u32, rd: u8, rs1: u8, imm: i32) -> Result<(), TranspileError> {
         if rd == 0 { return Ok(()); } // Write to x0 is a no-op
+
+        // Fuse load_imm + load_ind: if the base register was just loaded with
+        // a constant address, use the direct load form (OneRegOneImm) instead.
+        // Saves one PVM instruction per fused load.
+        if let Some((load_rd, load_val, undo_pos)) = self.pending_load_imm.take() {
+            if rs1 == load_rd {
+                let combined = load_val.wrapping_add(imm as i64);
+                if combined >= i32::MIN as i64 && combined <= i32::MAX as i64 {
+                    let direct_opcode = match funct3 {
+                        0 => Some(53),  // LB → load_i8
+                        1 => Some(55),  // LH → load_i16
+                        2 => Some(57),  // LW → load_i32
+                        3 => Some(58),  // LD → load_u64
+                        4 => Some(52),  // LBU → load_u8
+                        5 => Some(54),  // LHU → load_u16
+                        6 => Some(56),  // LWU → load_u32
+                        _ => None,
+                    };
+                    if let Some(opc) = direct_opcode {
+                        self.code.truncate(undo_pos);
+                        self.bitmask.truncate(undo_pos);
+                        let pvm_rd = self.require_reg(rd)?;
+                        self.emit_inst(opc);
+                        self.emit_data(pvm_rd);
+                        self.emit_var_imm(combined as i32);
+                        return Ok(());
+                    }
+                }
+            }
+            // Couldn't fuse — load_imm already emitted, just proceed
+        }
+
         let pvm_rd = self.require_reg(rd)?;
         let pvm_rs1 = self.require_reg(rs1)?;
 
@@ -491,37 +523,56 @@ impl TranslationContext {
         Ok(())
     }
 
-    fn translate_store(&mut self, funct3: u32, rs1: u8, rs2: u8, imm: i32) -> Result<(), TranspileError> {
-        // Fuse load_imm + store: when the stored value was just loaded as a
-        // constant, use store_imm_ind_* instead of load_imm + store_ind_*.
-        // This eliminates one instruction per constant store.
+    pub(crate) fn translate_store(&mut self, funct3: u32, rs1: u8, rs2: u8, imm: i32) -> Result<(), TranspileError> {
+        // Fuse load_imm + store: check if the base address or stored value was constant.
         if let Some((load_rd, load_val, undo_pos)) = self.pending_load_imm.take() {
-            if rs2 == load_rd && rs1 != load_rd
-                && load_val >= i32::MIN as i64 && load_val <= i32::MAX as i64
-            {
-                let store_val = load_val as i32;
-                let pvm_rs1 = self.require_reg(rs1)?;
-                let pvm_opcode = match funct3 {
-                    0 => 70,  // store_imm_ind_u8
-                    1 => 71,  // store_imm_ind_u16
-                    2 => 72,  // store_imm_ind_u32
-                    3 => 73,  // store_imm_ind_u64
-                    _ => 0,   // can't fuse
-                };
-                if pvm_opcode != 0 {
-                    // Undo the load_imm and emit store_imm_ind instead.
-                    self.code.truncate(undo_pos);
-                    self.bitmask.truncate(undo_pos);
-                    // Format: OneRegTwoImm — base_reg + offset(imm_x) + value(imm_y)
-                    let (lx, offset_bytes) = encode_var_imm(imm);
-                    let (ly, value_bytes) = encode_var_imm(store_val);
-                    // The skip = lx + ly + 1 (for the lx/ly encoding byte after reg_byte)
-                    // reg_byte = ra | (lx << 4), then lx bytes of offset, then ly bytes of value
-                    self.emit_inst(pvm_opcode);
-                    self.emit_data(pvm_rs1 | (lx << 4));
-                    for b in &offset_bytes { self.emit_data(*b); }
-                    for b in &value_bytes { self.emit_data(*b); }
-                    return Ok(());
+            if load_val >= i32::MIN as i64 && load_val <= i32::MAX as i64 {
+                // Case 1: Base register was loaded with constant address → direct store.
+                // store_ind_* data, base, offset  where base = constant addr
+                //   → store_* data, (addr + offset)
+                if rs1 == load_rd && rs2 != load_rd && rs2 != 0 {
+                    let combined = load_val.wrapping_add(imm as i64);
+                    if combined >= i32::MIN as i64 && combined <= i32::MAX as i64 {
+                        let direct_opcode = match funct3 {
+                            0 => Some(59),  // SB → store_u8
+                            1 => Some(60),  // SH → store_u16
+                            2 => Some(61),  // SW → store_u32
+                            3 => Some(62),  // SD → store_u64
+                            _ => None,
+                        };
+                        if let Some(opc) = direct_opcode {
+                            self.code.truncate(undo_pos);
+                            self.bitmask.truncate(undo_pos);
+                            let pvm_rs2 = self.require_reg(rs2)?;
+                            self.emit_inst(opc);
+                            self.emit_data(pvm_rs2);
+                            self.emit_var_imm(combined as i32);
+                            return Ok(());
+                        }
+                    }
+                }
+                // Case 2: Value register was loaded with constant → store_imm_ind (existing).
+                if rs2 == load_rd && rs1 != load_rd {
+                    let store_val = load_val as i32;
+                    let pvm_rs1 = self.require_reg(rs1)?;
+                    let pvm_opcode = match funct3 {
+                        0 => 70,  // store_imm_ind_u8
+                        1 => 71,  // store_imm_ind_u16
+                        2 => 72,  // store_imm_ind_u32
+                        3 => 73,  // store_imm_ind_u64
+                        _ => 0,   // can't fuse
+                    };
+                    if pvm_opcode != 0 {
+                        self.code.truncate(undo_pos);
+                        self.bitmask.truncate(undo_pos);
+                        let (lx, offset_bytes) = encode_var_imm(imm);
+                        let (ly, value_bytes) = encode_var_imm(store_val);
+                        self.emit_inst(pvm_opcode);
+                        self.emit_data(pvm_rs1 | (lx << 4));
+                        for b in &offset_bytes { self.emit_data(*b); }
+                        for b in &value_bytes { self.emit_data(*b); }
+                        return Ok(());
+                    }
                 }
             }
             // Couldn't fuse — load_imm was already emitted, just clear tracking

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -1173,7 +1173,7 @@ impl Compiler {
                 if let Args::RegImm { ra, imm } = args {
                     let addr = *imm as u32;
                     let fn_addr = self.read_fn_for(opcode);
-                    self.asm.mov_ri64(SCRATCH, addr as u64);
+                    self.asm.mov_ri32(SCRATCH, addr);
                     let ra_reg = REG_MAP[*ra];
                     self.emit_mem_read(ra_reg, SCRATCH, fn_addr, pc);
                     // Sign-extend for signed load variants
@@ -1190,7 +1190,7 @@ impl Compiler {
                     let addr = *imm as u32;
                     let ra_reg = REG_MAP[*ra];
                     let fn_addr = self.write_fn_for(opcode);
-                    self.asm.mov_ri64(SCRATCH, addr as u64);
+                    self.asm.mov_ri32(SCRATCH, addr);
                     self.emit_mem_write(true, ra_reg, fn_addr, pc);
                 }
             }


### PR DESCRIPTION
## Summary

- Fuse `load_imm` + `load_ind_*` → direct `load_*` when base address is a constant
- Fuse `load_imm` + `store_ind_*` → direct `store_*` when base address is a constant (extends existing constant-value fusion)
- Optimize PCREL HI20+LO12 pairs: skip ADDI nops, set `pending_load_imm` for cascading fusion, route LO12 loads/stores through `translate_load`/`translate_store`
- Use 5-byte `mov r32` instead of 10-byte `mov r64` for direct load/store address materialization in the recompiler

Ecrecover blob: 32,145 → 32,118 instructions (-27), 110,546 → 110,492 bytes (-54). Impact is small on ecrecover (arithmetic-heavy, few global data refs) but larger for workloads with many global/constant table accesses.

Addresses #84.

## Test plan

- `cargo test --workspace` — all 365 tests pass
- `cargo test -p grey-bench` — ecrecover correctness verified on both interpreter and recompiler
- `cargo bench -p grey-bench --features javm/signals -- 'grey-'` — compile and exec within noise