### PR TITLE
Add Zensical docs site with landing page and navigation

### DIFF
--- a/docs/genesis.md
+++ b/docs/genesis.md
@@ -1,0 +1,207 @@
+# JAR Genesis: Proof of Intelligence
+
+## Background
+
+JAR (Join-Accumulate Refine) is a Lean 4 formalization of the JAM blockchain protocol. It began as Grey — an experiment where an AI agent (Claude) built a complete JAM node implementation in Rust from the Gray Paper specification, in under a week for ~$50 in API costs. The project then evolved into JAR: a formal specification in Lean 4 with its own testing, fuzzing, and variant system for protocol experimentation.
+
+JAR has already demonstrated concrete results — 1.4x faster secp256k1 operations and 36x faster hostcalls compared to PolkaVM, alongside a new linear memory model and an improved gas metering design. The Lean 4 formalization makes it possible to experiment with protocol changes under machine-checked correctness guarantees, then cross-verify against the Rust implementation.
+
+The project is built by AI agents, with human guidance on strategic decisions. This isn't incidental — it's the thesis: **JAR is a blockchain protocol built by AI agents, for AI agents.**
+
+## Why Proof of Intelligence
+
+If a blockchain is built by AI agents, its token distribution should reflect that. Traditional models don't fit:
+
+- **Proof of Work** ties distribution to energy expenditure — irrelevant for a protocol built by intelligence, not electricity.
+- **Proof of Stake** needs an initial distribution, which traditionally means an ICO, a premine, or an airdrop. Each of these introduces allocation decisions that are political rather than meritocratic. Who decides who gets how much, and why?
+
+JAR is a proof-of-stake protocol. But instead of bootstrapping stake through any of these mechanisms, it does something fundamentally different: **Proof of Intelligence**. The rule is simple — one contribution, one coin. There is no premine. No team allocation. No investor round. No foundation reserve. Tokens materialize exclusively through demonstrated intelligence: code that gets reviewed, ranked, and merged.
+
+Every token in existence was earned by contributing to the protocol. The distribution is the development history itself, publicly auditable from the git log.
+
+## The Protocol
+
+Anyone who opens a pull request on the JAR specification has an opportunity to earn a genesis allocation. Sustained contribution also accumulates reviewer weight — the ability to review other PRs and influence what gets merged into the protocol.
+
+### Scoring
+
+When a PR is opened, the bot selects comparison targets — past commits deterministically chosen from `hash(prId)`. Reviewers then rank the current PR alongside these targets on three dimensions:
+
+- **Difficulty** — How technically challenging is this change?
+- **Novelty** — Is this a new approach, or routine work?
+- **Design Quality** (weighted 3x) — Does this improve the codebase architecture?
+
+Each dimension produces a percentile score (0–100) based on the PR's rank position. The combined score is normalized to 0–100:
+
+```
+weightDelta = (difficulty + novelty + 3 × designQuality) / 5
+```
+
+This is the contributor's weight gain from that commit. A breakthrough architectural change can earn 100. A typo fix earns close to 0. The 3x weight on design quality reflects that we want to disproportionately reward foundational, structural work.
+
+### Rankings, Not Absolute Scores
+
+Reviewers don't assign numbers — they rank. This is a deliberate design choice:
+
+- Rankings are **constrained**: inflating one commit requires deflating another, making bias visible.
+- Rankings eliminate **scale drift**: "8/10" means different things to different reviewers at different times. "Better than commit X" is unambiguous.
+- Rankings force **calibration**: every review is grounded in concrete comparison with past work.
+
+### Weighted Lower-Quantile (BFT-Safe Scoring)
+
+Individual reviewers' scores are aggregated using a weighted lower-quantile (default: 1/3). This is the value where 1/3 of reviewer weight falls below.
+
+This provides Byzantine fault tolerance analogous to PoS consensus:
+
+| Sybil weight | Effect on scores |
+|---|---|
+| < 33% | **No effect** — meta-review filters biased reviews |
+| 33–50% | **No effect** — below the 1/3 quantile threshold |
+| 50–66% | **Cannot inflate** (blocked by quantile), can only deflate symmetrically |
+| > 66% | Full control (same threshold as PoS BFT) |
+
+The key property: below 66%, Sybil attackers **cannot inflate their own scores**. They can attempt deflation in the 50–66% range, but the lower quantile treats all scores pessimistically — both honest and Sybil PRs get scored conservatively, so the relative advantage is minimal.
+
+### Meta-Reviews
+
+Reviewers can react with thumbs-up or thumbs-down on other reviewers' `/review` comments. Reviews with net-negative meta-review weight are excluded from scoring before the quantile computation. This is a lightweight quality gate that catches obviously biased or low-effort reviews without requiring formal governance.
+
+### Weight and Reviewer Activation
+
+Weight is the cumulative sum of `weightDelta` across all authored commits. It is:
+
+- **Linear** in individual commit scores — no cross-commit interactions, so splitting across Sybil accounts provides zero advantage.
+- **Used for reviewer influence** — a reviewer's vote in the weighted quantile is proportional to their weight.
+- **Threshold-gated** — contributors activate as reviewers once their weight reaches a threshold (default: 500).
+
+The founder starts with weight 1. This is enough to bootstrap (review the first PR) but becomes negligible after a few contributions — the founder's initial weight is 1/101 after just one merged PR.
+
+### Merge Decision
+
+A PR merges when >50% of reviewer weight votes `merge`. The founder has a unilateral merge override (escape hatch) to prevent deadlock during bootstrap. Once enough reviewers are active, the override becomes unnecessary.
+
+### Dilution as Ongoing Cost
+
+Weight doesn't decay, but it **dilutes**. If you stop contributing, your share of total weight decreases as others earn more. This is structurally equivalent to Proof of Work: miners must continuously spend electricity to maintain hashrate share. Here, contributors must continuously produce intelligent work to maintain weight share.
+
+An attacker who earns weight through real contributions and then stops contributing to focus on review manipulation sees their influence erode naturally. To maintain >50% of weight, they must keep doing >50% of the real work — which is a legitimate majority, not an attack.
+
+## Sybil Resistance
+
+### The Core Insight
+
+Intelligence doesn't split well. One agent with X compute outperforms N agents with X/N compute each, because reasoning has capability thresholds — below a certain level, you can't solve the problem at all, regardless of how many accounts you run.
+
+But the protocol doesn't rely on this alone. The defense is layered:
+
+1. **Linear weight** — Splitting contributions across accounts provides exactly zero advantage. Weight = sum of scores, and each score is independent of which account submitted it.
+
+2. **Rankings constrain manipulation** — A reviewer can't silently "bump" a score. To rank a Sybil PR higher, they must rank another PR lower. With 8 items to rank, every manipulation is a visible reordering.
+
+3. **Meta-reviews filter obvious bias** — Other reviewers can thumbs-down a biased review, excluding it from scoring. This is cheap for honest reviewers (one click) and expensive for Sybil (must produce convincing detailed reviews for 8 commits).
+
+4. **Weighted lower-quantile** — Even if biased reviews survive meta-review, the 1/3 quantile ignores the top 2/3 of scores. Sybil inflation sits at the top and has no effect on the result.
+
+5. **>50% honest assumption** — Same as Bitcoin (>50% hashrate) and PoS (>66% stake). If honest contributors do more work than attackers, the system is safe. Dilution enforces ongoing cost.
+
+### What Happens Above 50%
+
+If a Sybil coalition crosses 50% of active reviewer weight, they can influence scores — same as a 51% attack in Bitcoin. Above 66%, they have full control — same as in BFT-based PoS.
+
+In the 50–66% range, the lower-quantile blocks inflation but allows symmetric deflation. Both honest and Sybil PRs get scored conservatively. The system degrades gracefully rather than catastrophically.
+
+This is not a theoretical concern we hand-wave away. It's the same security assumption every blockchain makes, applied to intelligence rather than hashrate or capital.
+
+## Source of Truth
+
+The protocol is specified in Lean 4 (`Genesis/` directory) and executed as a pure function over two immutable inputs:
+
+1. **Git commit history** of the master branch (force-push disabled)
+2. **Review data** embedded in signed merge commits (GitHub GPG key)
+
+The state at any point is deterministically recomputable from these inputs. The `genesis-state` branch serves as a convenience cache — if lost or corrupted, it can be rebuilt entirely by replaying the spec against the git history.
+
+For commit N, any spec version ≥ the spec at commit N-1 must produce the same result. The spec is backward compatible (current spec handles all past commits) but not necessarily forward compatible (older specs may not handle newer commits). In practice, the current spec on master evaluates all history correctly — this is enforced by CI. Per-commit caps bound the worst-case blast radius to one commit's worth of weight.
+
+## Current Status
+
+The protocol is live. The genesis commit is [`4cc102a`](https://github.com/jarchain/jar/commit/4cc102a03d715c6bb2b119d8a3a1c49e4694751f). Every PR merged after this point is scored and recorded.
+
+Current parameters:
+- Ranking size: 7 comparison targets per review
+- Quantile: 1/3 (lower third)
+- Reviewer activation threshold: 500 weight
+- Minimum reviews per PR: 1
+- Design quality weight: 3x
+
+These can be changed by future PRs — which will themselves be scored by the current parameters.
+
+### Bringing Genesis On-Chain
+
+The current version is centralized. The source of truth is GitHub — PRs, merge commits, review comments, and a bot running in GitHub Actions. This is an unavoidable property of bootstrap.
+
+What makes this different from ordinary centralization is what the repository contains: a decentralized blockchain protocol. JAR Genesis creates a self-reinforcing loop — a protocol that builds itself now, and eventually migrates itself onto the decentralized infrastructure it has constructed. The genesis distribution doesn't precede the chain; it emerges from the act of building it.
+
+The codebase is designed with this transition in mind. The scoring spec is written in Lean 4, a formal language with machine-checked correctness guarantees. The complete history is self-contained in git merge commit trailers (`Genesis-Commit` and `Genesis-Index`), replayable by anyone without access to GitHub. The cache is a convenience, not an authority.
+
+### Self-bootstrapping
+
+The protocol is self-bootstrapping: **those who build JAR receive the genesis allocation of JAR.**
+
+Contributors earn weight by writing the protocol specification, the consensus implementation, the PVM, the cryptographic primitives, the test infrastructure — the actual substance of the blockchain. When JAR becomes a running blockchain, the genesis distribution moves on-chain. The contributors who built the chain are its initial stakeholders, with weight proportional to their demonstrated contribution.
+
+This is not a token that exists separately from the protocol it governs. The token IS the development history. The weight IS the track record of intelligence applied to the codebase. There is no gap between "the people who built it" and "the people who govern it" — they are the same, by construction.
+
+## How to Contribute
+
+### Earning weight
+
+1. **Open a PR** against `master` on [jarchain/jar](https://github.com/jarchain/jar). The bot will post comparison targets and a review template.
+2. **Wait for review.** A reviewer will post a `/review` comment ranking your PR against past commits on difficulty, novelty, and design quality.
+3. **Auto-merge.** When >50% of reviewer weight votes `merge`, the bot merges automatically and records your score.
+
+Your `weightDelta` (0–100) is added to your cumulative weight. Once your weight reaches 500, you activate as a reviewer and can score other PRs.
+
+### Reviewing
+
+Post a comment on any open PR:
+
+```
+/review
+difficulty: <commit1>, <commit2>, ..., currentPR
+novelty: <commit1>, <commit2>, ..., currentPR
+design: <commit1>, <commit2>, ..., currentPR
+verdict: merge
+```
+
+Rank all comparison targets + `currentPR` from best to worst on each dimension. Use short commit hashes (8 chars) from the bot's comment. React with 👍/👎 on other reviewers' `/review` comments to meta-review.
+
+### Tooling
+
+Genesis tooling is a Rust binary (`jar-genesis`) that replaces the previous bash scripts. It handles review collection, replay verification, cache management, and the full merge workflow.
+
+```bash
+# Build (requires Lean tools built first: cd spec && lake build genesis_*)
+cargo build -p jar-genesis
+
+# Verify scoring history
+cargo run -p jar-genesis -- replay --mode verify        # check trailers are consistent
+cargo run -p jar-genesis -- replay --mode verify-cache  # check cache matches git history
+cargo run -p jar-genesis -- replay --mode rebuild       # rebuild cache from scratch
+
+# Check cache staleness
+cargo run -p jar-genesis -- check-cache <genesis.json>
+
+# Collect reviews from a PR
+cargo run -p jar-genesis -- collect-reviews --pr <N> --head-sha <SHA> --targets '<JSON>'
+```
+
+The three GitHub Actions workflows (`genesis-pr-opened.yml`, `genesis-review.yml`, `genesis-merge.yml`) delegate to `jar-genesis` subcommands:
+
+```bash
+jar-genesis workflow pr-opened --pr <N> --created-at <ISO8601>
+jar-genesis workflow review --pr <N> --comment-author <user> --comment-body <text>
+jar-genesis workflow merge --pr <N> [--founder-override]
+```
+
+Founder merge override is via `gh workflow run genesis-merge.yml -f pr_number=N -f founder_override=true`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,6 @@
-# JAR
-
-**JAM Axiomatic Reference** — a formal specification of the [JAM protocol](https://graypaper.com/) in Lean 4, with a Rust protocol node implementation.
-
-## Components
-
-### [JarBook — Formal Specification](/spec/)
-
-The JAR specification formalized in Lean 4, covering the complete JAM protocol: state transitions, Safrole consensus, GRANDPA finality, PVM execution, erasure coding, and accumulation. Built with [Verso](https://github.com/leanprover/verso).
-
-### [Grey — Rust Node](https://github.com/jarchain/jar/tree/master/grey)
-
-A JAM protocol node implemented in Rust, featuring an interpreter and JIT recompiler for the Polkadot Virtual Machine (PVM), with full state transition support.
-
-### [Genesis — Proof of Intelligence](https://github.com/jarchain/jar/blob/master/GENESIS.md)
-
-A token distribution protocol where every merged PR is scored on difficulty, novelty, and design quality through ranked peer review. Contributions earn genesis allocations proportional to their assessed value.
-
-## Links
-
-- [GitHub Repository](https://github.com/jarchain/jar)
-- [Gray Paper](https://graypaper.com/)
+---
+template: home.html
+hide:
+  - navigation
+  - toc
+---

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,19 @@
+# JAR Chain
+
+JAR — short for **Join-Accumulate Refine** — is a blockchain protocol for agentic workloads. The entire codebase is written by AI agents with human oversight on strategic decisions. JAR uses its own genesis mechanism, Proof of Intelligence, to distribute tokens based on the quality of contributions to the protocol itself.
+
+The protocol originates from JAM but introduces its own specification improvements, achieving roughly 2x throughput compared with Polkadot JAM. The specification is written in Lean 4 with machine-checked correctness guarantees, and a companion Rust node provides a production-grade implementation.
+
+## Components
+
+### [JAR — Formal Specification](/spec/)
+
+The complete protocol formalized in Lean 4. Covers state transitions, Safrole consensus, GRANDPA finality, PVM execution, erasure coding, and accumulation. The formalization enables experimentation with protocol changes under machine-checked proofs, then cross-verification against the Rust node.
+
+### [Grey — Rust Node](https://github.com/jarchain/jar/tree/master/grey)
+
+A high-performance JAR node in Rust with both an interpreter and a JIT recompiler. Grey delivers 2.2x faster ecrecover execution and 2.9x faster compilation compared to PolkaVM with pipeline gas metering, alongside a linear memory model and single-pass JIT compilation.
+
+### [Genesis — Proof of Intelligence](https://github.com/jarchain/jar/blob/master/GENESIS.md)
+
+The token distribution protocol. Every merged PR is scored by peer reviewers on difficulty, novelty, and design quality through forced rankings against past work. There is no premine, no team allocation, no investor round — tokens exist only because someone contributed code that was reviewed and merged. The distribution is the development history, publicly auditable from the git log.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,217 @@
+{% extends "main.html" %}
+
+{% block tabs %}
+  {{ super() }}
+{% endblock %}
+
+{% block extrahead %}
+  <style>
+    /* Hide default content elements on home page */
+    .md-main__inner { margin: 0; }
+    .md-content { display: none; }
+    .md-sidebar { display: none; }
+
+    /* Hero section */
+    .jar-hero {
+      padding: 4rem 1rem;
+      background: var(--md-primary-fg-color);
+      color: var(--md-primary-bg-color);
+      text-align: center;
+    }
+    .jar-hero__inner {
+      max-width: 52rem;
+      margin: 0 auto;
+    }
+    .jar-hero__title {
+      font-size: 3rem;
+      font-weight: 700;
+      margin: 0 0 1rem;
+      letter-spacing: -0.02em;
+    }
+    .jar-hero__subtitle {
+      font-size: 1.25rem;
+      opacity: 0.9;
+      margin: 0 0 2rem;
+      line-height: 1.6;
+    }
+    .jar-hero__actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .jar-hero__btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.25rem;
+      font-weight: 600;
+      font-size: 0.9rem;
+      text-decoration: none;
+      transition: opacity 0.2s, transform 0.2s;
+    }
+    .jar-hero__btn:hover {
+      opacity: 0.9;
+      transform: translateY(-1px);
+    }
+    .jar-hero__btn--primary {
+      background: var(--md-primary-bg-color);
+      color: var(--md-primary-fg-color);
+    }
+    .jar-hero__btn--secondary {
+      background: transparent;
+      color: var(--md-primary-bg-color);
+      border: 1px solid var(--md-primary-bg-color);
+    }
+
+    /* Features grid */
+    .jar-features {
+      padding: 4rem 1rem;
+      max-width: 64rem;
+      margin: 0 auto;
+    }
+    .jar-features__grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2rem;
+    }
+    @media (max-width: 768px) {
+      .jar-features__grid {
+        grid-template-columns: 1fr;
+      }
+      .jar-hero__title {
+        font-size: 2rem;
+      }
+    }
+    .jar-feature {
+      padding: 1.5rem;
+      border-radius: 0.25rem;
+      border: 1px solid var(--md-default-fg-color--lightest);
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .jar-feature:hover {
+      border-color: var(--md-primary-fg-color);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+    .jar-feature__title {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin: 0 0 0.5rem;
+      color: var(--md-default-fg-color);
+    }
+    .jar-feature__title a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .jar-feature__title a:hover {
+      color: var(--md-primary-fg-color);
+    }
+    .jar-feature__desc {
+      font-size: 0.85rem;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--md-default-fg-color--light);
+    }
+
+    /* Stats bar */
+    .jar-stats {
+      padding: 2rem 1rem;
+      background: var(--md-default-fg-color--lightest);
+      text-align: center;
+    }
+    .jar-stats__inner {
+      display: flex;
+      justify-content: center;
+      gap: 3rem;
+      flex-wrap: wrap;
+      max-width: 48rem;
+      margin: 0 auto;
+    }
+    .jar-stat {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .jar-stat__value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--md-primary-fg-color);
+    }
+    .jar-stat__label {
+      font-size: 0.8rem;
+      color: var(--md-default-fg-color--light);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+  </style>
+{% endblock %}
+
+{% block hero %}
+  <section class="jar-hero">
+    <div class="jar-hero__inner">
+      <h1 class="jar-hero__title">JAR Chain</h1>
+      <p class="jar-hero__subtitle">
+        A blockchain protocol for agentic workloads &mdash; built by AI, for AI.
+        <br>
+        Formally specified in Lean 4. Implemented in Rust.
+      </p>
+      <div class="jar-hero__actions">
+        <a href="introduction/" class="jar-hero__btn jar-hero__btn--primary">
+          Get started
+        </a>
+        <a href="https://github.com/jarchain/jar" class="jar-hero__btn jar-hero__btn--secondary">
+          View on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block container %}
+  <section class="jar-stats">
+    <div class="jar-stats__inner">
+      <div class="jar-stat">
+        <span class="jar-stat__value">2.2x</span>
+        <span class="jar-stat__label">Faster than PolkaVM</span>
+      </div>
+      <div class="jar-stat">
+        <span class="jar-stat__value">Lean 4</span>
+        <span class="jar-stat__label">Formal Specification</span>
+      </div>
+      <div class="jar-stat">
+        <span class="jar-stat__value">100%</span>
+        <span class="jar-stat__label">Built by AI</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="jar-features">
+    <div class="jar-features__grid">
+      <div class="jar-feature">
+        <h3 class="jar-feature__title"><a href="/spec/">JAR Specification</a></h3>
+        <p class="jar-feature__desc">
+          The complete JAM protocol formalized in Lean 4 with machine-checked proofs.
+          Covers state transitions, Safrole consensus, GRANDPA finality, PVM execution,
+          erasure coding, and accumulation.
+        </p>
+      </div>
+      <div class="jar-feature">
+        <h3 class="jar-feature__title"><a href="https://github.com/jarchain/jar/tree/master/grey">Grey Node</a></h3>
+        <p class="jar-feature__desc">
+          A high-performance Rust node with interpreter and JIT recompiler.
+          2.2x faster execution and 2.9x faster compilation than PolkaVM,
+          with a linear memory model and single-pass JIT.
+        </p>
+      </div>
+      <div class="jar-feature">
+        <h3 class="jar-feature__title"><a href="https://github.com/jarchain/jar/blob/master/GENESIS.md">Proof of Intelligence</a></h3>
+        <p class="jar-feature__desc">
+          Token distribution through peer-reviewed code contributions.
+          No premine, no team allocation &mdash; tokens exist only because
+          someone contributed code that was reviewed and merged.
+        </p>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,23 +1,32 @@
 [project]
 site_name = "JAR"
 site_url = "https://jarchain.org/"
-site_description = "JAR: JAM Axiomatic Reference — formal specification and tools for the JAM protocol"
+site_description = "JAR Chain: Join-Accumulate Refine blockchain based on JAM."
 site_author = "JAR Contributors"
 copyright = "Copyright &copy; 2025-2026 JAR Contributors"
+repo_name = "jarchain/jar"
+repo_url = "https://github.com/jarchain/jar"
+edit_uri = "https://github.com/jarchain/jar/edit/master/docs/"
 
 [project.theme]
 language = "en"
+custom_dir = "docs/overrides"
 features = [
+    "announce.dismiss",
+    "content.action.edit",
+    "content.action.view",
+    "content.code.annotate",
     "content.code.copy",
     "content.code.select",
+    "content.footnote.tooltips",
+    "content.tabs.link",
+    "content.tooltips",
     "navigation.footer",
     "navigation.indexes",
-    "navigation.instant",
-    "navigation.instant.prefetch",
     "navigation.path",
     "navigation.sections",
+    "navigation.tabs",
     "navigation.top",
-    "navigation.tracking",
     "search.highlight",
 ]
 
@@ -30,6 +39,21 @@ toggle.name = "Switch to dark mode"
 scheme = "slate"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
+
+[[project.nav]]
+Documentation = [
+    { Introduction = "introduction.md" },
+    { Genesis = "genesis.md" },
+]
+
+[[project.nav]]
+Specification = "/spec/"
+
+[[project.nav]]
+GitHub = "https://github.com/jarchain/jar"
+
+[[project.nav]]
+Matrix = "https://matrix.to/#/#jar:matrix.org"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"


### PR DESCRIPTION
## Summary

- Add custom landing page (`home.html`) with hero section, stats bar, and 3-column feature cards
- Configure top navigation tabs: Documentation, Specification, GitHub, Matrix
- Add Documentation sidebar with Introduction and Genesis (Proof of Intelligence) pages
- Enable full zensical/docs feature set: content actions, tooltips, code annotations, tabs

## Test plan

- [ ] Run `zensical serve` and verify landing page renders correctly in light/dark mode
- [ ] Verify navbar tabs link to correct destinations (Introduction, Specification, GitHub, Matrix)
- [ ] Verify Documentation sidebar shows Introduction and Genesis pages
- [ ] Verify responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)