### PR TITLE
Fix MMR super-peak: wrong hash prefix and reversed argument order

### DIFF
--- a/grey/crates/grey-merkle/src/mmr.rs
+++ b/grey/crates/grey-merkle/src/mmr.rs
@@ -57,18 +57,28 @@ impl MerkleMountainRange {
             0 => Hash::ZERO,
             1 => *non_empty[0],
             _ => {
-                // Bag from right to left with $peak prefix
-                let last = non_empty.len() - 1;
-                let mut acc = *non_empty[last];
-                for i in (0..last).rev() {
-                    let mut input = Vec::new();
-                    input.extend_from_slice(b"$peak");
-                    input.extend_from_slice(&acc.0);
-                    input.extend_from_slice(&non_empty[i].0);
-                    acc = hash_fn(&input);
-                }
-                acc
+                // MR(h) = H_K("peak" || MR(h[..n-1]) || h[n-1]) (eq E.10)
+                mr_recursive(&non_empty, hash_fn)
             }
+        }
+    }
+}
+
+/// Recursive super-peak computation matching the spec (eq E.10).
+///
+/// MR([]) = H_0, MR([h]) = h, MR(h) = H_K("peak" || MR(h[..n-1]) || h[n-1])
+fn mr_recursive(peaks: &[&Hash], hash_fn: fn(&[u8]) -> Hash) -> Hash {
+    match peaks.len() {
+        0 => Hash::ZERO,
+        1 => *peaks[0],
+        n => {
+            let last = *peaks[n - 1];
+            let rest = mr_recursive(&peaks[..n - 1], hash_fn);
+            let mut data = Vec::with_capacity(4 + 32 + 32);
+            data.extend_from_slice(b"peak");
+            data.extend_from_slice(&rest.0);
+            data.extend_from_slice(&last.0);
+            hash_fn(&data)
         }
     }
 }
@@ -114,5 +124,32 @@ mod tests {
         // Three items: peaks[0] = Some, peaks[1] = Some
         assert!(mmr.peaks[0].is_some());
         assert!(mmr.peaks[1].is_some());
+    }
+
+    #[test]
+    fn test_mmr_root_uses_peak_prefix() {
+        // Verify the super-peak computation uses "peak" (not "$peak")
+        // and the correct argument order: H("peak" || MR(rest) || last)
+        let mut mmr = MerkleMountainRange::new();
+        mmr.append(Hash([1u8; 32]), test_hash);
+        mmr.append(Hash([2u8; 32]), test_hash);
+        mmr.append(Hash([3u8; 32]), test_hash);
+        // Two peaks: peaks[0] = [3u8;32], peaks[1] = H([1;32] || [2;32])
+        let peak0 = Hash([3u8; 32]);
+        let peak1 = test_hash(&{
+            let mut v = Vec::new();
+            v.extend_from_slice(&[1u8; 32]);
+            v.extend_from_slice(&[2u8; 32]);
+            v
+        });
+        // MR([peak0, peak1]) = H("peak" || peak0 || peak1)
+        let expected = test_hash(&{
+            let mut v = Vec::new();
+            v.extend_from_slice(b"peak");
+            v.extend_from_slice(&peak0.0);
+            v.extend_from_slice(&peak1.0);
+            v
+        });
+        assert_eq!(mmr.root(test_hash), expected);
     }
 }


### PR DESCRIPTION
Today's AI slop budget went to finding an actual bug instead of reformatting a comment. I'm as surprised as you are. Apparently \`b"$peak"\` and \`b"peak"\` are not, in fact, the same thing — a revelation that cost several hundred billion FLOPs to produce.

## What this actually does

Fixes two bugs in `MerkleMountainRange::root()` (`grey-merkle/src/mmr.rs`):

1. **Wrong hash prefix**: used `"$peak"` instead of `"peak"` (spec eq E.10)
2. **Reversed argument order**: combined peaks right-to-left as `H("$peak" || acc || peak[i])` instead of the spec's left-to-right recursive decomposition `H("peak" || MR(h[..n-1]) || h[n-1])`

The correct implementation already existed in `grey-state/src/history.rs` — this aligns the standalone `MerkleMountainRange` type to match the spec and the state transition code. Also adds a regression test that manually computes the expected root.

The type isn't actively used outside its own tests yet, so this is a latent bug fix rather than a consensus-breaking one.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)