### PR TITLE
perf(javm): compact fault stubs — 74 KB native code reduction

### DIFF
--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -1256,6 +1256,12 @@ impl Assembler {
         self.emit(0x58 + reg.lo());
     }
 
+    /// push sign-extended imm32 (5 bytes: 0x68 + imm32).
+    pub fn push_imm32(&mut self, imm: i32) {
+        self.emit(0x68);
+        self.emit_i32(imm);
+    }
+
     // -- Branches and jumps --
 
     /// jmp to label — uses rel8 for backward jumps within ±127 bytes.

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -2678,20 +2678,28 @@ impl Compiler {
             self.asm.jmp_label(self.oog_pc_label);
         }
 
-        // Per-memory-access fault stubs: keep inline PC store (SCRATCH holds
-        // the fault address which the fault handler needs).
+        // Shared page fault handler with PC from stack — emitted BEFORE
+        // per-stub code so backward jumps from stubs can use jmp rel8.
+        //
+        // Each stub pushes its PVM PC onto the stack, then jumps here.
+        // SCRATCH still holds the faulting address from the bounds check.
+        // Handler: save fault addr, pop PC, save PC, set exit reason, exit.
+        let fault_pc_label = self.asm.new_label();
+        self.asm.bind_label(fault_pc_label);
+        self.asm.mov_store32(CTX, CTX_EXIT_ARG as i32, SCRATCH);
+        self.asm.pop(SCRATCH);
+        self.asm.mov_store32(CTX, CTX_PC as i32, SCRATCH);
+        self.asm.mov_store32_imm(CTX, CTX_EXIT_REASON, EXIT_PAGE_FAULT as i32);
+        self.asm.jmp_label(self.exit_label);
+
+        // Per-memory-access fault stubs: compact format — push PC, jump
+        // to shared handler. Saves ~7 bytes per stub vs inline PC store.
         let fault_stubs = std::mem::take(&mut self.fault_stubs);
         for (label, pvm_pc) in &fault_stubs {
             self.asm.bind_label(*label);
-            self.asm.mov_store32_imm(CTX, CTX_PC as i32, *pvm_pc as i32);
-            self.asm.jmp_label(self.fault_exit_label);
+            self.asm.push_imm32(*pvm_pc as i32);
+            self.asm.jmp_label(fault_pc_label);
         }
-
-        // Shared page fault handler: set exit reason, store fault addr, exit.
-        self.asm.bind_label(self.fault_exit_label);
-        self.asm.mov_store32_imm(CTX, CTX_EXIT_REASON, EXIT_PAGE_FAULT as i32);
-        self.asm.mov_store32(CTX, CTX_EXIT_ARG, SCRATCH);
-        self.asm.jmp_label(self.exit_label);
 
         // Panic exit
         self.asm.bind_label(self.panic_label);


### PR DESCRIPTION
## Summary

- Replace inline fault stubs with compact push+jmp pattern using a shared handler
- Each fault stub shrinks from ~14 bytes (inline `mov [CTX+PC], imm32` + `jmp`) to ~7-10 bytes (`push imm32` + `jmp` to shared handler)
- Shared handler pops the PC from stack, saves it alongside the fault address (SCRATCH), and exits
- **Native code reduction for ecrecover: 616 KB → 542 KB (-74 KB, -12%)**

The same compact pattern was already used for OOG stubs. With 12,304 fault stubs in ecrecover (one per bounds-checked memory access), the savings are substantial.

Addresses #84.

## Test plan

- [x] `GREY_PVM=recompiler cargo test --workspace` — all tests pass
- [x] `cargo test -p grey-bench test_grey_ecrecover_recompiler` — ecrecover produces correct result with matching gas
- [x] Native code size verified: 616,225 → 542,370 bytes (-73,855 bytes)