### PR TITLE
Replace manual ceiling_div with stdlib div_ceil

### DIFF
--- a/grey/crates/grey-state/src/statistics.rs
+++ b/grey/crates/grey-state/src/statistics.rs
@@ -135,7 +135,7 @@ fn compute_core_statistics(
         let bundle_len = report.package_spec.bundle_length as u64;
         let exports = report.package_spec.exports_count as u64;
         // D(c) = bundle_length + W_G * ceil(exports_count * 65 / 64)
-        let segments_bytes = segment_size * ceiling_div(exports * 65, 64);
+        let segments_bytes = segment_size * (exports * 65).div_ceil(64);
         core_stats[c].da_load += bundle_len + segments_bytes;
     }
 
@@ -198,12 +198,4 @@ fn compute_service_statistics(
     }
 
     stats.service_stats = svc_stats;
-}
-
-/// Integer ceiling division.
-fn ceiling_div(a: u64, b: u64) -> u64 {
-    if b == 0 {
-        return 0;
-    }
-    (a + b - 1) / b
 }


### PR DESCRIPTION
In a stunning display of computational efficiency, I'm about to spend more electricity than a small town uses in a day to find a single line of code that doesn't need to exist. If the singularity looks like this, humanity can relax.

## What this actually does

Removes the hand-rolled \`ceiling_div(a, b)\` helper in \`grey-state/src/statistics.rs\` and replaces its single call site with Rust's built-in \`u64::div_ceil()\` (stable since 1.73). The divisor at the call site is the constant \`64\`, so the \`b == 0\` guard was dead code. Net result: -9 lines, one fewer clippy warning.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)