### PR TITLE
Require PR state OPEN in genesis merge and review workflows

### DIFF
--- a/tools/jar-genesis/src/workflow/merge.rs
+++ b/tools/jar-genesis/src/workflow/merge.rs
@@ -10,12 +10,11 @@ use crate::types::{MergeReadiness, SelectTargetsOutput};
 
 /// Run the merge workflow for a PR.
 pub fn run(pr: u64, founder_override: bool) -> Result<(), Box<dyn std::error::Error>> {
-    // --- Step 0: Guard against already-merged PRs ---
+    // --- Step 0: Guard against non-open PRs ---
     let state_json = github::pr_view(pr, "state")?;
     let state = state_json["state"].as_str().unwrap_or("");
-    if state == "MERGED" {
-        eprintln!("PR #{pr} is already merged — skipping.");
-        return Ok(());
+    if state != "OPEN" {
+        return Err(format!("PR #{pr} is not open (state: {state})").into());
     }
 
     let repo_root = git::repo_root()?;

--- a/tools/jar-genesis/src/workflow/review.rs
+++ b/tools/jar-genesis/src/workflow/review.rs
@@ -13,12 +13,12 @@ pub fn run(
     comment_author: &str,
     _comment_body: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Guard against already-merged PRs
+    // Guard against non-open PRs
     let state_json = github::pr_view(pr, "state")?;
     let state = state_json["state"].as_str().unwrap_or("");
-    if state == "MERGED" {
-        github::pr_comment(pr, "**JAR Bot:** PR is already merged — ignoring `/review`.")?;
-        return Ok(());
+    if state != "OPEN" {
+        github::pr_comment(pr, &format!("**JAR Bot:** PR is not open (state: {state}) — ignoring `/review`."))?;
+        return Err(format!("PR #{pr} is not open (state: {state})").into());
     }
 
     let repo_root = git::repo_root()?;


### PR DESCRIPTION
## Summary

- Change the PR state guard in `merge.rs` and `review.rs` from checking `== MERGED` to requiring `== OPEN`
- Previously only MERGED PRs were rejected; CLOSED (unmerged) PRs would slip through
- Both workflows now error on any non-OPEN state (MERGED or CLOSED)

## Test plan

- [x] `cargo check -p jar-genesis` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)