### PR TITLE
fix: change memory layout to [stack|ro|rw|args|heap]

### DIFF
--- a/grey/crates/javm/src/program.rs
+++ b/grey/crates/javm/src/program.rs
@@ -154,12 +154,12 @@ pub fn initialize_program(program_blob: &[u8], arguments: &[u8], gas: Gas) -> Op
 
     let page_round = |x: u32| -> u32 { x.div_ceil(PVM_PAGE_SIZE) * PVM_PAGE_SIZE };
 
-    // Linear layout: stack | args | roData | rwData | heap
+    // Linear layout: stack | roData | rwData | args | heap
     let s = page_round(stack_size); // stack: [0, s)
-    let arg_start = s; // args:  [s, s + P(|a|))
-    let ro_start = arg_start + page_round(arguments.len() as u32);
+    let ro_start = s;
     let rw_start = ro_start + page_round(ro_size);
-    let heap_start = rw_start + page_round(rw_size);
+    let arg_start = rw_start + page_round(rw_size);
+    let heap_start = arg_start + page_round(arguments.len() as u32);
     let heap_end = heap_start + heap_pages * PVM_PAGE_SIZE;
     let mem_size = heap_end;
 
@@ -170,15 +170,15 @@ pub fn initialize_program(program_blob: &[u8], arguments: &[u8], gas: Gas) -> Op
 
     // Build flat memory buffer
     let mut flat_mem = vec![0u8; mem_size as usize];
-    if !arguments.is_empty() {
-        flat_mem[arg_start as usize..arg_start as usize + arguments.len()]
-            .copy_from_slice(arguments);
-    }
     if !ro_data.is_empty() {
         flat_mem[ro_start as usize..ro_start as usize + ro_data.len()].copy_from_slice(ro_data);
     }
     if !rw_data.is_empty() {
         flat_mem[rw_start as usize..rw_start as usize + rw_data.len()].copy_from_slice(rw_data);
+    }
+    if !arguments.is_empty() {
+        flat_mem[arg_start as usize..arg_start as usize + arguments.len()]
+            .copy_from_slice(arguments);
     }
 
     // Registers (JAR v0.8.0 linear)
@@ -281,11 +281,12 @@ pub fn parse_program_blob<'a>(
 
     let page_round = |x: u32| -> u32 { x.div_ceil(PVM_PAGE_SIZE) * PVM_PAGE_SIZE };
 
+    // Linear layout: stack | roData | rwData | args | heap
     let s = page_round(stack_size);
-    let arg_start = s;
-    let ro_start = arg_start + page_round(arguments.len() as u32);
+    let ro_start = s;
     let rw_start = ro_start + page_round(ro_size);
-    let heap_start = rw_start + page_round(rw_size);
+    let arg_start = rw_start + page_round(rw_size);
+    let heap_start = arg_start + page_round(arguments.len() as u32);
     let heap_end = heap_start + heap_pages * PVM_PAGE_SIZE;
     let mem_size = heap_end;
 
@@ -797,13 +798,14 @@ pub fn strip_corevm_wrapper(data: &[u8]) -> Option<&[u8]> {
 pub fn initialize_from_polkavm(prog: &PolkaVMProgram, arguments: &[u8], gas: Gas) -> Option<Pvm> {
     let page_round = |x: u32| -> u32 { x.div_ceil(PVM_PAGE_SIZE) * PVM_PAGE_SIZE };
 
+    // Linear layout: stack | roData | rwData | args | heap
     let s = page_round(prog.stack_size);
-    let arg_start = s;
-    let ro_start = arg_start + page_round(arguments.len() as u32);
+    let ro_start = s;
     let rw_start = ro_start + page_round(prog.ro_data.len() as u32);
     // rw_data_size may be larger than rw_data payload (zero-filled)
     let rw_region = core::cmp::max(prog.rw_data_size, prog.rw_data.len() as u32);
-    let heap_start = rw_start + page_round(rw_region);
+    let arg_start = rw_start + page_round(rw_region);
+    let heap_start = arg_start + page_round(arguments.len() as u32);
     // Heap size is not stored in the blob (upstream computes it as leftover
     // address space).  Default to 32 MB — matches the prototype and gives
     // enough headroom for realistic guests like doom.corevm.
@@ -816,10 +818,6 @@ pub fn initialize_from_polkavm(prog: &PolkaVMProgram, arguments: &[u8], gas: Gas
     }
 
     let mut flat_mem = vec![0u8; mem_size as usize];
-    if !arguments.is_empty() {
-        flat_mem[arg_start as usize..arg_start as usize + arguments.len()]
-            .copy_from_slice(arguments);
-    }
     if !prog.ro_data.is_empty() {
         flat_mem[ro_start as usize..ro_start as usize + prog.ro_data.len()]
             .copy_from_slice(&prog.ro_data);
@@ -827,6 +825,10 @@ pub fn initialize_from_polkavm(prog: &PolkaVMProgram, arguments: &[u8], gas: Gas
     if !prog.rw_data.is_empty() {
         flat_mem[rw_start as usize..rw_start as usize + prog.rw_data.len()]
             .copy_from_slice(&prog.rw_data);
+    }
+    if !arguments.is_empty() {
+        flat_mem[arg_start as usize..arg_start as usize + arguments.len()]
+            .copy_from_slice(arguments);
     }
 
     let mut registers = [0u64; 13];

--- a/grey/services/javm-guest-tests/tests/guest.rs
+++ b/grey/services/javm-guest-tests/tests/guest.rs
@@ -17,16 +17,9 @@ fn run_test(test_id: u32, args: &[u8]) {
     let host_output = unsafe { javm_guest_tests::read_output(host_len) }.to_vec();
 
     // --- Interpreter ---
-    // Initialize with empty args to keep rodata at the correct PVM address.
-    // Write input to the heap region (writable in both interpreter and recompiler).
-    // Parse blob header to find heap_start: stack + page_round(ro) + page_round(rw).
     let gas = 100_000_000_000u64;
-    let mut interp = javm::program::initialize_program(GUEST_TESTS_BLOB, &[], gas)
+    let mut interp = javm::program::initialize_program(GUEST_TESTS_BLOB, &input, gas)
         .expect("blob should be loadable");
-    let arg_addr = interp.heap_base as usize;
-    interp.flat_mem[arg_addr..arg_addr + input.len()].copy_from_slice(&input);
-    interp.registers[7] = arg_addr as u64;
-    interp.registers[8] = input.len() as u64;
     loop {
         match interp.run().0 {
             javm::ExitReason::Halt => break,
@@ -53,13 +46,8 @@ fn run_test(test_id: u32, args: &[u8]) {
     );
 
     // --- Recompiler ---
-    let mut recomp = javm::recompiler::initialize_program_recompiled(GUEST_TESTS_BLOB, &[], gas)
+    let mut recomp = javm::recompiler::initialize_program_recompiled(GUEST_TESTS_BLOB, &input, gas)
         .expect("recompiler should initialize");
-    let arg_addr = interp.heap_base;
-    recomp.write_bytes(arg_addr, &input);
-
-    recomp.registers_mut()[7] = arg_addr as u64;
-    recomp.registers_mut()[8] = input.len() as u64;
     loop {
         match recomp.run() {
             javm::ExitReason::Halt => break,

--- a/spec/Jar/PVM/Interpreter.lean
+++ b/spec/Jar/PVM/Interpreter.lean
@@ -275,11 +275,14 @@ def initStandard (blob' : ByteArray) (args : ByteArray)
     Same blob format as initStandard, but all data is packed into a single
     contiguous read-write region starting at address 0:
       [0, s)                     stack (SP = s, grows toward 0)
-      [s, s + |a|)               arguments
-      [s + |a|, s + |a| + |o|)  RO data
-      [s + |a| + |o|, ... + |w|) RW data
-      [... + |w|, heap_top)      heap (z pages)
-    No guard zone, no read-only pages, no zone alignment. -/
+      [s, s + P(|o|))            RO data
+      [s + P(|o|), ... + P(|w|)) RW data
+      [... + P(|w|), ... + P(|a|)) arguments
+      [... + P(|a|), heap_top)   heap (z pages)
+    No guard zone, no read-only pages, no zone alignment.
+    Arguments are placed after RW data so that RO/RW addresses are
+    independent of argument size (the transpiler bakes absolute data
+    addresses at compile time). -/
 def initLinear (blob' : ByteArray) (args : ByteArray)
     : Option (ProgramBlob × Registers × Memory) := do
   let blob := skipMetadata blob'
@@ -314,12 +317,12 @@ def initLinear (blob' : ByteArray) (args : ByteArray)
   -- v0.8.0: validate basic block structure
   if !validateBasicBlocks prog then none
 
-  -- Linear layout: stack | args | roData | rwData | heap
+  -- Linear layout: stack | roData | rwData | args | heap
   let s := pageRound stackSize         -- stack occupies [0, s)
-  let argStart := s
-  let roStart := argStart + pageRound args.size
+  let roStart := s
   let rwStart := roStart + pageRound roSize
-  let heapStart := rwStart + pageRound rwSize
+  let argStart := rwStart + pageRound rwSize
+  let heapStart := argStart + pageRound args.size
   let heapEnd := heapStart + heapPages * Z_P
   let memSize := heapEnd
 
@@ -333,9 +336,9 @@ def initLinear (blob' : ByteArray) (args : ByteArray)
 
   -- Build memory with guardZone = 0 (address 0 is valid)
   let mem : Memory := { pages := Dict.empty, access, heapTop := heapEnd, guardZone := 0 }
-  let mem := copyToMem mem argStart args
   let mem := copyToMem mem roStart roData
   let mem := copyToMem mem rwStart rwData
+  let mem := copyToMem mem argStart args
 
   -- Registers
   let regs := Array.replicate PVM_REGISTERS (0 : RegisterValue)


### PR DESCRIPTION
## Summary

Move arguments after rw_data in the PVM linear memory layout, fixing a bug where non-empty arguments shifted rodata/rwdata addresses and broke transpiled programs.

**Before:** `[stack | args | ro | rw | heap]` — args shift ro/rw by `page_round(args.len())`
**After:** `[stack | ro | rw | args | heap]` — ro/rw addresses fixed at compile time

### Changes
- `spec/Jar/PVM/Interpreter.lean`: reorder `initLinear` layout (jar080 only; gp072 `initStandard` unchanged)
- `grey/crates/javm/src/program.rs`: reorder in `initialize_program`, `parse_program_blob`, `initialize_from_polkavm`
- `grey/services/javm-guest-tests/tests/guest.rs`: remove heap-area workaround, pass args normally

See `docs/javm-memory-arch.md` for full rationale.

Closes #195

## Test plan
- [x] All Lean spec tests pass (gp072_tiny, gp072_full, jar080_tiny — zero changes to test vectors)
- [x] `cargo test --workspace` — all pass
- [x] `cargo test --workspace --features javm/signals` — all pass
- [x] `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)