### PR TITLE
fix(rpc): return correct beefy_root in jam_getContext

### DIFF
--- a/grey/crates/grey-merkle/src/state_serial.rs
+++ b/grey/crates/grey-merkle/src/state_serial.rs
@@ -23,9 +23,54 @@ fn key_from_index(index: u8) -> [u8; 31] {
     key
 }
 
+/// Construct state key C(i) for a state component index (public alias).
+pub fn key_for_component(index: u8) -> [u8; 31] {
+    key_from_index(index)
+}
+
 /// Construct state key C(i, s) for a service-indexed state component (public alias).
 pub fn key_for_service_pub(index: u8, service_id: ServiceId) -> [u8; 31] {
     key_for_service(index, service_id)
+}
+
+/// Extract the accumulation root (beefy_root) for a given anchor block from the
+/// raw C(3) (recent_blocks) state KV blob. Scans the serialized header entries to
+/// find the one matching `anchor_hash` and returns its `accumulation_root` field.
+pub fn extract_accumulation_root(
+    recent_blocks_blob: &[u8],
+    anchor_hash: &Hash,
+) -> Result<Option<Hash>, String> {
+    let mut pos = 0;
+    let header_count =
+        decode_compact_at(recent_blocks_blob, &mut pos).map_err(|e| e.to_string())? as usize;
+
+    for _ in 0..header_count {
+        // Each header: header_hash(32) + accumulation_root(32) + state_root(32) + packages...
+        if pos + 96 > recent_blocks_blob.len() {
+            return Err("unexpected end in recent_blocks headers".into());
+        }
+        let mut header_hash = [0u8; 32];
+        header_hash.copy_from_slice(&recent_blocks_blob[pos..pos + 32]);
+        let mut acc_root = [0u8; 32];
+        acc_root.copy_from_slice(&recent_blocks_blob[pos + 32..pos + 64]);
+        // Skip state_root
+        pos += 96;
+
+        // Skip reported_packages map
+        let pkg_count =
+            decode_compact_at(recent_blocks_blob, &mut pos).map_err(|e| e.to_string())? as usize;
+        // Each package entry is 64 bytes (two hashes)
+        let skip = pkg_count * 64;
+        if pos + skip > recent_blocks_blob.len() {
+            return Err("unexpected end in reported_packages".into());
+        }
+        pos += skip;
+
+        if header_hash == anchor_hash.0 {
+            return Ok(Some(Hash(acc_root)));
+        }
+    }
+    Ok(None)
 }
 
 /// Construct state key C(i, s) for a service-indexed state component.

--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -249,9 +249,13 @@ impl JamRpcServer for RpcImpl {
 
         let anchor = hex::encode(head_hash.0);
         let state_root = hex::encode(block.header.state_root.0);
-        // beefy_root (accumulation output root) — use zero for now;
-        // full lookup would require parsing the recent_blocks blob.
-        let beefy_root = hex::encode([0u8; 32]);
+        let beefy_root = self
+            .state
+            .store
+            .get_accumulation_root(&head_hash, &head_hash)
+            .map_err(|e| internal_error(e.to_string()))?
+            .map(|h| hex::encode(h.0))
+            .unwrap_or_else(|| hex::encode([0u8; 32]));
 
         // Direct lookup for service code hash (avoids full state deserialization)
         let code_hash = self

--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -222,6 +222,23 @@ impl Store {
         Ok(None)
     }
 
+    /// Get the accumulation root (beefy_root) for a given anchor block.
+    /// Reads only the C(3) state KV (recent_blocks) and scans for the matching
+    /// header entry, avoiding full state deserialization.
+    pub fn get_accumulation_root(
+        &self,
+        block_hash: &Hash,
+        anchor_hash: &Hash,
+    ) -> Result<Option<Hash>, StoreError> {
+        let key = grey_merkle::state_serial::key_for_component(3);
+        let blob = match self.get_state_kv(block_hash, &key)? {
+            Some(blob) => blob,
+            None => return Ok(None),
+        };
+        grey_merkle::state_serial::extract_accumulation_root(&blob, anchor_hash)
+            .map_err(StoreError::Codec)
+    }
+
     /// Delete state for a given block hash (for pruning).
     pub fn delete_state(&self, block_hash: &Hash) -> Result<(), StoreError> {
         let txn = self.db.begin_write()?;


### PR DESCRIPTION
## Summary

- Fix `beefy_root` in `jam_getContext` RPC endpoint — was hardcoded to zero, now returns the real accumulation-result MMR root from state
- Add `extract_accumulation_root()` to `state_serial` that reads the raw C(3) recent_blocks blob and scans for the anchor block's entry (avoids full state deserialization)
- Add `get_accumulation_root()` to `Store` that combines the raw KV lookup with the extraction

Addresses #179.

## Test plan

- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes
- `cargo test -p grey-store -p grey-rpc -p grey-merkle` — all 7 tests pass
- The fix reads the same serialized format written by `serialize_recent_blocks`, scanning header entries to match the anchor hash and return its `accumulation_root` field