### PR TITLE
fix(network): switch gossipsub from Permissive to Strict validation

### DIFF
--- a/grey/crates/grey-network/src/service.rs
+++ b/grey/crates/grey-network/src/service.rs
@@ -376,7 +376,7 @@ fn build_swarm() -> Result<Swarm<JamBehaviour>, Box<dyn std::error::Error + Send
 
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
-                .validation_mode(gossipsub::ValidationMode::Permissive)
+                .validation_mode(gossipsub::ValidationMode::Strict)
                 .message_id_fn(message_id_fn)
                 .build()
                 .expect("Valid gossipsub config");


### PR DESCRIPTION
## Summary

- Switch gossipsub `ValidationMode::Permissive` → `ValidationMode::Strict`
- Messages are already signed (`MessageAuthenticity::Signed`), so this adds verification of those signatures at the network layer
- Unsigned or incorrectly signed messages are now rejected before reaching the node event loop, preventing spam and eclipse attacks

Addresses #176.

## Test plan

- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes
- `cargo test -p grey-network` — 2 tests pass
- Behavioral: gossipsub now rejects messages with invalid/missing signatures at the transport layer instead of accepting everything