### PR TITLE
fix(genesis): use fetch+origin/master instead of pull in merge workflow

### DIFF
--- a/tools/jar-genesis/src/git.rs
+++ b/tools/jar-genesis/src/git.rs
@@ -47,7 +47,15 @@ pub fn git_cmd_in(dir: &str, args: &[&str]) -> Result<String, GitError> {
 /// Get merge commits from genesis_commit..HEAD, oldest first.
 /// Returns (hash, full commit message) pairs.
 pub fn log_merge_commits(genesis_commit: &str) -> Result<Vec<(String, String)>, GitError> {
-    let range = format!("{genesis_commit}..HEAD");
+    log_merge_commits_ref(genesis_commit, "HEAD")
+}
+
+/// Walk merge commits between `genesis_commit` and `end_ref` (e.g. "origin/master").
+pub fn log_merge_commits_ref(
+    genesis_commit: &str,
+    end_ref: &str,
+) -> Result<Vec<(String, String)>, GitError> {
+    let range = format!("{genesis_commit}..{end_ref}");
     let hashes = git(&["log", "--merges", "--reverse", "--format=%H", &range])?;
     let mut result = Vec::new();
     for hash in hashes.lines() {

--- a/tools/jar-genesis/src/replay.rs
+++ b/tools/jar-genesis/src/replay.rs
@@ -11,11 +11,12 @@ struct GenesisCommitEntry {
     stored_index: serde_json::Value,
 }
 
-/// Walk merge commits and collect genesis entries.
-fn collect_entries(
+/// Walk merge commits up to `end_ref` and collect genesis entries.
+fn collect_entries_ref(
     genesis_commit: &str,
+    end_ref: &str,
 ) -> Result<Vec<GenesisCommitEntry>, Box<dyn std::error::Error>> {
-    let merge_commits = git::log_merge_commits(genesis_commit)?;
+    let merge_commits = git::log_merge_commits_ref(genesis_commit, end_ref)?;
     let mut entries = Vec::new();
 
     for (hash, message) in &merge_commits {
@@ -183,7 +184,9 @@ pub fn verify() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let entries = collect_entries(&genesis_commit)?;
+    // Use origin/master to ensure we see all merge commits.
+    git::git_cmd(&["fetch", "origin", "master"])?;
+    let entries = collect_entries_ref(&genesis_commit, "origin/master")?;
     let signed_commits: Vec<serde_json::Value> =
         entries.iter().map(|e| e.signed_commit.clone()).collect();
     let stored_indices: Vec<serde_json::Value> =
@@ -239,7 +242,10 @@ pub fn verify_cache() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let entries = collect_entries(&genesis_commit)?;
+    // Use origin/master to read trailers — the working tree may be behind
+    // (e.g., during merge workflow where cargo build dirtied Cargo.lock).
+    git::git_cmd(&["fetch", "origin", "master"])?;
+    let entries = collect_entries_ref(&genesis_commit, "origin/master")?;
     let signed_commits: Vec<serde_json::Value> =
         entries.iter().map(|e| e.signed_commit.clone()).collect();
 
@@ -339,7 +345,10 @@ pub fn rebuild() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let entries = collect_entries(&genesis_commit)?;
+    // Use origin/master to ensure we see all merge commits, even if
+    // the working tree HEAD is behind (e.g., Cargo.lock dirty from cargo build).
+    git::git_cmd(&["fetch", "origin", "master"])?;
+    let entries = collect_entries_ref(&genesis_commit, "origin/master")?;
     let signed_commits: Vec<serde_json::Value> =
         entries.iter().map(|e| e.signed_commit.clone()).collect();
 

--- a/tools/jar-genesis/src/workflow/merge.rs
+++ b/tools/jar-genesis/src/workflow/merge.rs
@@ -213,8 +213,8 @@ pub fn run(pr: u64, founder_override: bool) -> Result<(), Box<dyn std::error::Er
     )?;
 
     // --- Step 11: Verify cache integrity ---
-    // Pull latest master (now includes the merge), then verify
-    git::git_cmd(&["pull", "origin", "master", "--ff-only"])?;
+    // Fetch latest master (includes our merge) without touching the working tree.
+    git::git_cmd(&["fetch", "origin", "master"])?;
     replay::verify_cache()?;
 
     Ok(())
@@ -232,11 +232,13 @@ fn update_cache(
     let mut updated_indices = cache_indices.to_vec();
     updated_indices.push(new_index.clone());
 
-    // Compute updated ranking from all SignedCommits in git history
+    // Compute updated ranking from all SignedCommits in git history.
+    // Use `git fetch` + `origin/master` ref instead of `git pull` to avoid
+    // working tree conflicts (cargo build dirties Cargo.lock).
     let genesis_commit = git::read_genesis_commit_hash(spec_dir)?;
-    git::git_cmd(&["pull", "origin", "master", "--ff-only"])?;
+    git::git_cmd(&["fetch", "origin", "master"])?;
 
-    let merge_commits = git::log_merge_commits(&genesis_commit)?;
+    let merge_commits = git::log_merge_commits_ref(&genesis_commit, "origin/master")?;
     let mut signed_commits = Vec::new();
     for (_, message) in &merge_commits {
         if let Some(commit_line) = git::parse_trailer(message, "Genesis-Commit")


### PR DESCRIPTION
## Summary

- Replace `git pull origin master --ff-only` with `git fetch origin master` in the merge workflow and all replay commands
- Read merge trailers from `origin/master` ref instead of `HEAD`, avoiding working tree modifications entirely
- Add `log_merge_commits_ref()` to accept a configurable end ref

### Root cause

The merge workflow runs `cargo build` (which dirties `Cargo.lock`) before git operations. When a concurrent PR merges and changes `Cargo.lock` on master, `git pull --ff-only` fails because the dirty working tree conflicts with the incoming changes. This caused the cache to fall 9 entries behind (#199, #200, and others).

The same HEAD-behind-origin/master issue affected `replay --mode verify`, `verify-cache`, and `rebuild` — all used `genesis_commit..HEAD` which missed commits not yet in the local checkout.

## Test plan

- [x] `cargo run -p jar-genesis -- replay --mode verify` → 149/149 match
- [x] `cargo run -p jar-genesis -- replay --mode verify-cache` → 149 indices match
- [x] Clean build, no warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)