### PR TITLE
feat(rpc): add /health and /ready HTTP endpoints

### DIFF
--- a/grey/crates/grey-rpc/Cargo.toml
+++ b/grey/crates/grey-rpc/Cargo.toml
@@ -13,6 +13,7 @@ grey-store = { workspace = true }
 jsonrpsee = { version = "0.24", features = ["server", "macros"] }
 tower-http = { version = "0.5", features = ["cors"] }
 tower = "0.4"
+http = "1"
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
@@ -21,5 +22,6 @@ hex = { workspace = true }
 
 [dev-dependencies]
 jsonrpsee = { version = "0.24", features = ["client"] }
+reqwest = { version = "0.12", default-features = false }
 tempfile = "3"
 grey-consensus = { workspace = true }

--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -275,6 +275,95 @@ impl JamRpcServer for RpcImpl {
     }
 }
 
+// ── Health / readiness HTTP endpoints ─────────────────────────────────
+
+/// Tower layer that intercepts GET `/health` and `/ready` before they
+/// reach the JSON-RPC handler.
+///
+/// - `GET /health` — always 200 `{"status":"ok"}` (process is alive)
+/// - `GET /ready`  — 200 `{"status":"ready","head_slot":N}` if head is set,
+///   503 `{"status":"syncing"}` otherwise
+#[derive(Clone)]
+struct HealthLayer {
+    state: Arc<RpcState>,
+}
+
+impl<S> tower::Layer<S> for HealthLayer {
+    type Service = HealthService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        HealthService {
+            inner,
+            state: self.state.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct HealthService<S> {
+    inner: S,
+    state: Arc<RpcState>,
+}
+
+type HttpBody = jsonrpsee::server::HttpBody;
+
+fn json_response(status: u16, body: String) -> http::Response<HttpBody> {
+    http::Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(HttpBody::from(body))
+        .unwrap()
+}
+
+impl<S, ReqBody> tower::Service<http::Request<ReqBody>> for HealthService<S>
+where
+    S: tower::Service<http::Request<ReqBody>, Response = http::Response<HttpBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+{
+    type Response = http::Response<HttpBody>;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let is_get = req.method() == http::Method::GET;
+        let path = req.uri().path().to_owned();
+
+        if is_get && path == "/health" {
+            let body = serde_json::json!({"status": "ok"}).to_string();
+            Box::pin(async move { Ok(json_response(200, body)) })
+        } else if is_get && path == "/ready" {
+            let state = self.state.clone();
+            Box::pin(async move {
+                match state.store.get_head() {
+                    Ok((_, slot)) => Ok(json_response(
+                        200,
+                        serde_json::json!({"status": "ready", "head_slot": slot}).to_string(),
+                    )),
+                    Err(_) => Ok(json_response(
+                        503,
+                        serde_json::json!({"status": "syncing"}).to_string(),
+                    )),
+                }
+            })
+        } else {
+            let fut = self.inner.call(req);
+            Box::pin(fut)
+        }
+    }
+}
+
 /// Start the JSON-RPC server. Returns the command receiver for the node event loop.
 pub async fn start_rpc_server(
     port: u16,
@@ -288,7 +377,12 @@ pub async fn start_rpc_server(
     } else {
         tower_http::cors::CorsLayer::new()
     };
-    let middleware = tower::ServiceBuilder::new().layer(cors_layer);
+    let health_layer = HealthLayer {
+        state: state.clone(),
+    };
+    let middleware = tower::ServiceBuilder::new()
+        .layer(cors_layer)
+        .layer(health_layer);
     let server = Server::builder()
         .set_http_middleware(middleware)
         .build(&addr)
@@ -552,5 +646,46 @@ mod tests {
             .request("jam_submitWorkPackage", rpc_params![""])
             .await;
         assert!(result.is_err());
+    }
+
+    // ── Health / readiness endpoint tests ──
+
+    async fn http_get(url: &str) -> (u16, String) {
+        let resp = reqwest::get(url).await.unwrap();
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let (url, _state, _rx, _store, _dir) = setup().await;
+        let (status, body) = http_get(&format!("{}/health", url)).await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_ready_not_synced() {
+        let (url, _state, _rx, _store, _dir) = setup().await;
+        let (status, body) = http_get(&format!("{}/ready", url)).await;
+        assert_eq!(status, 503);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["status"], "syncing");
+    }
+
+    #[tokio::test]
+    async fn test_ready_with_head() {
+        let (url, _state, _rx, store, _dir) = setup().await;
+        let block = test_block(42);
+        let hash = store.put_block(&block).unwrap();
+        store.set_head(&hash, 42).unwrap();
+
+        let (status, body) = http_get(&format!("{}/ready", url)).await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["status"], "ready");
+        assert_eq!(json["head_slot"], 42);
     }
 }


### PR DESCRIPTION
## Summary

- Add `GET /health` — always 200 `{"status":"ok"}` (liveness probe for k8s/Docker)
- Add `GET /ready` — 200 `{"status":"ready","head_slot":N}` if head block is set, 503 `{"status":"syncing"}` if not yet synced (readiness probe)
- Implemented as a tower middleware layer that intercepts these paths before the JSON-RPC handler
- 3 new tests covering health, ready-not-synced, and ready-with-head

Addresses #179.

## Test plan

- `cargo test -p grey-rpc` — all 16 tests pass (13 existing + 3 new)
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes
- Manual: `curl http://localhost:PORT/health` returns `{"status":"ok"}`