### PR TITLE
ci(grey): add RUSTFLAGS="-D warnings" to test jobs

### DIFF
--- a/.github/workflows/ci-grey.yml
+++ b/.github/workflows/ci-grey.yml
@@ -66,16 +66,20 @@ jobs:
 
       - name: Workspace tests (interpreter)
         run: cargo test --locked --workspace
+        env:
+          RUSTFLAGS: "-D warnings"
 
       - name: Workspace tests (recompiler)
         run: cargo test --locked --workspace
         env:
           GREY_PVM: recompiler
+          RUSTFLAGS: "-D warnings"
 
       - name: Workspace tests (recompiler + signals)
         run: cargo test --locked --workspace --features javm/signals
         env:
           GREY_PVM: recompiler
+          RUSTFLAGS: "-D warnings"
 
   harness:
     name: Integration harness

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -1020,17 +1020,20 @@ impl Compiler {
         ra: usize,
         imm_x: i32,
         imm_y: u64,
-        pvm_pc: u32,
+        _pvm_pc: u32,
     ) {
         // Compute address into SCRATCH
         self.emit_addr_to_scratch(ra, imm_x);
 
-        let imm_i64 = imm_y as i64;
-        let fits_i32 = imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64;
+        #[cfg(feature = "signals")]
+        let fits_i32 = {
+            let imm_i64 = imm_y as i64;
+            imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64
+        };
 
         #[cfg(feature = "signals")]
         {
-            self.trap_entries.push((self.asm.offset() as u32, pvm_pc));
+            self.trap_entries.push((self.asm.offset() as u32, _pvm_pc));
 
             match opcode {
                 Opcode::StoreImmIndU8 => {
@@ -1298,8 +1301,12 @@ impl Compiler {
                     let addr = *imm_x as u32;
                     self.asm.mov_ri32(SCRATCH, addr);
                     let imm_val = *imm_y;
-                    let imm_i64 = imm_val as i64;
-                    let fits_i32 = imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64;
+
+                    #[cfg(feature = "signals")]
+                    let fits_i32 = {
+                        let imm_i64 = imm_val as i64;
+                        imm_i64 >= i32::MIN as i64 && imm_i64 <= i32::MAX as i64
+                    };
 
                     #[cfg(feature = "signals")]
                     {


### PR DESCRIPTION
## Summary

- Add `RUSTFLAGS="-D warnings"` to all 3 CI test jobs (interpreter, recompiler, recompiler+signals) to catch compiler warnings before merge
- Fix 3 existing unused variable warnings in `codegen.rs`: gate `fits_i32` and `pvm_pc` with `#[cfg(feature = "signals")]` since they are only used in the signals code path

Addresses #180.

## Test plan

- `RUSTFLAGS="-D warnings" cargo check --workspace` passes (both with and without `signals` feature)
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes
- `cargo test -p javm` — all 79 tests pass