### PR TITLE
fix(rpc): add request body size and connection limits

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -383,7 +383,13 @@ pub async fn start_rpc_server(
     let middleware = tower::ServiceBuilder::new()
         .layer(cors_layer)
         .layer(health_layer);
+    // Work packages can be up to ~14MB (MAX_WORK_PACKAGE_BLOB_SIZE), and hex
+    // encoding doubles the size. Allow 30MB to accommodate the largest valid
+    // request with JSON-RPC overhead.
     let server = Server::builder()
+        .max_request_body_size(30 * 1024 * 1024)
+        .max_response_body_size(30 * 1024 * 1024)
+        .max_connections(100)
         .set_http_middleware(middleware)
         .build(&addr)
         .await?;


### PR DESCRIPTION
## Summary

- Set `max_request_body_size` and `max_response_body_size` to 30MB (work packages hex-encode to ~28MB max; the default 10MB was too small)
- Set `max_connections` to 100 to prevent connection exhaustion attacks (default was unlimited)

Addresses #179.

## Test plan

- `cargo test -p grey-rpc` — all 16 tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes