### PR TITLE
feat(grey): add queue depth monitoring for bounded channels

### DIFF
--- a/grey/crates/grey-network/src/service.rs
+++ b/grey/crates/grey-network/src/service.rs
@@ -242,22 +242,30 @@ impl request_response::Codec for JamProtocol {
 /// Channel capacity for network events (network → node).
 /// Sized for bursts: a full validator set can each send a block + vote + assurance
 /// in a single slot. 1024 provides headroom without unbounded growth.
-const EVENT_CHANNEL_CAPACITY: usize = 1024;
+pub const EVENT_CHANNEL_CAPACITY: usize = 1024;
 
 /// Channel capacity for network commands (node → network).
 /// Node sends at a controlled rate (one broadcast per event processed).
-const COMMAND_CHANNEL_CAPACITY: usize = 256;
+pub const COMMAND_CHANNEL_CAPACITY: usize = 256;
 
 /// Create and run the network service.
 ///
-/// Returns channels for communication with the network service.
+/// Returns:
+/// - `event_rx`: receiver for network events (network → node)
+/// - `cmd_tx`: sender for network commands (node → network)
+/// - `event_tx_monitor`: clone of the event sender for queue depth monitoring
 pub async fn start_network(
     config: NetworkConfig,
 ) -> Result<
-    (mpsc::Receiver<NetworkEvent>, mpsc::Sender<NetworkCommand>),
+    (
+        mpsc::Receiver<NetworkEvent>,
+        mpsc::Sender<NetworkCommand>,
+        mpsc::Sender<NetworkEvent>,
+    ),
     Box<dyn std::error::Error + Send + Sync>,
 > {
     let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+    let event_tx_monitor = event_tx.clone();
     let (cmd_tx, cmd_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
 
     // Build the swarm
@@ -346,7 +354,7 @@ pub async fn start_network(
         run_network_loop(swarm, event_tx, cmd_rx, topics, validator_index).await;
     });
 
-    Ok((event_rx, cmd_tx))
+    Ok((event_rx, cmd_tx, event_tx_monitor))
 }
 
 /// Behaviour combining gossipsub, identify, and request-response protocols.

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -15,13 +15,19 @@ use crate::tickets::{self, TicketState};
 use grey_codec::header_codec::compute_header_hash;
 use grey_consensus::authoring;
 
-use grey_network::service::{NetworkCommand, NetworkConfig, NetworkEvent};
+use grey_network::service::{
+    COMMAND_CHANNEL_CAPACITY, EVENT_CHANNEL_CAPACITY, NetworkCommand, NetworkConfig, NetworkEvent,
+};
 use grey_store::Store;
 use grey_types::config::Config;
 use grey_types::header::{Assurance, Block};
 use grey_types::state::State;
 use grey_types::{BandersnatchPublicKey, Hash, Timeslot};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Maximum number of out-of-order blocks to buffer. Prevents memory
+/// exhaustion from peers sending blocks far ahead of our current state.
+const MAX_PENDING_BLOCKS: usize = 100;
 
 /// Node configuration.
 pub struct NodeConfig {
@@ -90,13 +96,14 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
         .filter_map(|s| s.parse().ok())
         .collect();
 
-    let (mut net_events, net_commands) = grey_network::service::start_network(NetworkConfig {
-        listen_addr: config.listen_addr.clone(),
-        listen_port: config.listen_port,
-        boot_peers,
-        validator_index: config.validator_index,
-    })
-    .await?;
+    let (mut net_events, net_commands, net_event_monitor) =
+        grey_network::service::start_network(NetworkConfig {
+            listen_addr: config.listen_addr.clone(),
+            listen_port: config.listen_port,
+            boot_peers,
+            validator_index: config.validator_index,
+        })
+        .await?;
 
     // Start RPC server
     let store = std::sync::Arc::new(store_raw);
@@ -139,9 +146,6 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     // to apply it after the missing ones arrive.
     let mut pending_blocks: std::collections::BTreeMap<Timeslot, (Block, Hash)> =
         std::collections::BTreeMap::new();
-    /// Maximum number of out-of-order blocks to buffer. Prevents memory
-    /// exhaustion from peers sending blocks far ahead of our current state.
-    const MAX_PENDING_BLOCKS: usize = 100;
 
     tracing::info!(
         "Validator {} node started, genesis_time={}",
@@ -157,6 +161,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     let mut interval = tokio::time::interval(Duration::from_millis(500));
     let mut last_authored_slot: Timeslot = 0;
     let mut last_assurance_slot: Timeslot = 0;
+    let mut monitor_tick: u64 = 0;
 
     loop {
         tokio::select! {
@@ -189,6 +194,18 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                     .as_secs();
                 // slot = (now - genesis_time) / slot_period
                 let current_slot = ((now - genesis_time) / 6) as Timeslot + 1; // +1 because genesis is slot 0
+
+                // Queue depth monitoring: check every 12 ticks (~6 seconds, once per slot).
+                monitor_tick += 1;
+                if monitor_tick.is_multiple_of(12) {
+                    check_queue_depths(
+                        config.validator_index,
+                        &net_event_monitor,
+                        &net_commands,
+                        rpc_state.as_ref(),
+                        pending_blocks.len(),
+                    );
+                }
 
                 // Only attempt authoring if this is a new slot we haven't authored yet
                 if current_slot > state.timeslot && current_slot > last_authored_slot {
@@ -1142,5 +1159,72 @@ fn create_demo_work_package(
             imports: vec![],
             extrinsics: vec![],
         }],
+    }
+}
+
+/// Check queue depths for all inter-component channels and the pending blocks buffer.
+/// Logs at debug level normally, warns when any queue exceeds 80% capacity.
+fn check_queue_depths(
+    validator_index: u16,
+    net_event_tx: &tokio::sync::mpsc::Sender<NetworkEvent>,
+    net_cmd_tx: &tokio::sync::mpsc::Sender<NetworkCommand>,
+    rpc_state: Option<&std::sync::Arc<grey_rpc::RpcState>>,
+    pending_blocks_len: usize,
+) {
+    const WARN_THRESHOLD: f64 = 0.8;
+
+    let event_depth = EVENT_CHANNEL_CAPACITY - net_event_tx.capacity();
+    let cmd_depth = COMMAND_CHANNEL_CAPACITY - net_cmd_tx.capacity();
+    let rpc_depth = rpc_state.map(|s| 256 - s.commands.capacity()).unwrap_or(0);
+    let rpc_capacity: usize = 256;
+
+    tracing::debug!(
+        "Validator {} queue depths: events={}/{}, commands={}/{}, rpc={}/{}, pending_blocks={}/{}",
+        validator_index,
+        event_depth,
+        EVENT_CHANNEL_CAPACITY,
+        cmd_depth,
+        COMMAND_CHANNEL_CAPACITY,
+        rpc_depth,
+        rpc_capacity,
+        pending_blocks_len,
+        MAX_PENDING_BLOCKS,
+    );
+
+    if event_depth as f64 > EVENT_CHANNEL_CAPACITY as f64 * WARN_THRESHOLD {
+        tracing::warn!(
+            "Validator {} network event queue at {:.0}% capacity ({}/{})",
+            validator_index,
+            event_depth as f64 / EVENT_CHANNEL_CAPACITY as f64 * 100.0,
+            event_depth,
+            EVENT_CHANNEL_CAPACITY,
+        );
+    }
+    if cmd_depth as f64 > COMMAND_CHANNEL_CAPACITY as f64 * WARN_THRESHOLD {
+        tracing::warn!(
+            "Validator {} network command queue at {:.0}% capacity ({}/{})",
+            validator_index,
+            cmd_depth as f64 / COMMAND_CHANNEL_CAPACITY as f64 * 100.0,
+            cmd_depth,
+            COMMAND_CHANNEL_CAPACITY,
+        );
+    }
+    if rpc_state.is_some() && rpc_depth as f64 > rpc_capacity as f64 * WARN_THRESHOLD {
+        tracing::warn!(
+            "Validator {} RPC command queue at {:.0}% capacity ({}/{})",
+            validator_index,
+            rpc_depth as f64 / rpc_capacity as f64 * 100.0,
+            rpc_depth,
+            rpc_capacity,
+        );
+    }
+    if pending_blocks_len as f64 > MAX_PENDING_BLOCKS as f64 * WARN_THRESHOLD {
+        tracing::warn!(
+            "Validator {} pending blocks buffer at {:.0}% capacity ({}/{})",
+            validator_index,
+            pending_blocks_len as f64 / MAX_PENDING_BLOCKS as f64 * 100.0,
+            pending_blocks_len,
+            MAX_PENDING_BLOCKS,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add periodic queue depth monitoring (~every 6 seconds) for all inter-component bounded channels: network events (1024), network commands (256), RPC commands (256), and pending blocks buffer (100)
- Log queue depths at `debug` level every slot; emit `warn` when any queue exceeds 80% capacity
- Export `EVENT_CHANNEL_CAPACITY` and `COMMAND_CHANNEL_CAPACITY` constants from `grey-network` and return a monitoring sender clone from `start_network` so node.rs can observe all channel depths centrally

Addresses #178.

## Scope

This PR addresses: queue depth monitoring and 80% capacity warnings.

Remaining sub-tasks in #178:
- Alert on persistent queue saturation (sustained high watermark tracking)
- Graceful degradation (message priority under backpressure)

## Test plan

- `cargo test --workspace` — all existing tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- `cargo fmt --all` — clean
- Manual verification: run a multi-validator network and observe `debug`-level queue depth logs in each slot tick