### PR TITLE
feat(grey-rpc): add jam_getServiceAccount endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -86,6 +86,13 @@ pub trait JamRpc {
     /// Clients need this to build valid work packages.
     #[method(name = "jam_getContext")]
     async fn get_context(&self, service_id: u32) -> Result<serde_json::Value, ErrorObjectOwned>;
+
+    /// Get a service account's metadata (balance, gas limits, code hash, etc.).
+    #[method(name = "jam_getServiceAccount")]
+    async fn get_service_account(
+        &self,
+        service_id: u32,
+    ) -> Result<serde_json::Value, ErrorObjectOwned>;
 }
 
 struct RpcImpl {
@@ -289,6 +296,40 @@ impl JamRpcServer for RpcImpl {
             "beefy_root": beefy_root,
             "code_hash": code_hash,
         }))
+    }
+
+    async fn get_service_account(
+        &self,
+        service_id: u32,
+    ) -> Result<serde_json::Value, ErrorObjectOwned> {
+        let (head_hash, head_slot) = self
+            .state
+            .store
+            .get_head()
+            .map_err(|e| internal_error(e.to_string()))?;
+
+        match self
+            .state
+            .store
+            .get_service_metadata(&head_hash, service_id)
+            .map_err(|e| internal_error(e.to_string()))?
+        {
+            Some(meta) => Ok(serde_json::json!({
+                "service_id": service_id,
+                "code_hash": hex::encode(meta.code_hash.0),
+                "balance": meta.balance,
+                "min_accumulate_gas": meta.min_accumulate_gas,
+                "min_on_transfer_gas": meta.min_on_transfer_gas,
+                "total_footprint": meta.total_footprint,
+                "free_storage_offset": meta.free_storage_offset,
+                "accumulation_counter": meta.accumulation_counter,
+                "last_accumulation": meta.last_accumulation,
+                "last_activity": meta.last_activity,
+                "preimage_count": meta.preimage_count,
+                "slot": head_slot,
+            })),
+            None => Err(not_found(format!("service {} not found", service_id))),
+        }
     }
 }
 
@@ -762,5 +803,56 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(json["status"], "ready");
         assert_eq!(json["head_slot"], 42);
+    }
+
+    #[tokio::test]
+    async fn test_get_service_account() {
+        let (url, _state, _rx, store, _dir) = setup().await;
+        let config = Config::tiny();
+        let (mut genesis_state, _secrets) = grey_consensus::genesis::create_genesis(&config);
+
+        // Insert a service account
+        let svc = grey_types::state::ServiceAccount {
+            code_hash: Hash([0xAA; 32]),
+            balance: 1000,
+            min_accumulate_gas: 500,
+            min_on_transfer_gas: 200,
+            storage: std::collections::BTreeMap::new(),
+            preimage_lookup: std::collections::BTreeMap::new(),
+            preimage_info: std::collections::BTreeMap::new(),
+            free_storage_offset: 0,
+            total_footprint: 0,
+            accumulation_counter: 0,
+            last_accumulation: 0,
+            last_activity: 0,
+            preimage_count: 0,
+        };
+        genesis_state.services.insert(42, svc);
+
+        // Store state and set head
+        let block = test_block(1);
+        let hash = store.put_block(&block).unwrap();
+        store.put_state(&hash, &genesis_state, &config).unwrap();
+        store.set_head(&hash, 1).unwrap();
+
+        let client = HttpClientBuilder::default().build(&url).unwrap();
+
+        // Query existing service
+        let result: serde_json::Value = client
+            .request("jam_getServiceAccount", rpc_params![42u32])
+            .await
+            .unwrap();
+        assert_eq!(result["service_id"], 42);
+        assert_eq!(result["balance"], 1000);
+        assert_eq!(result["min_accumulate_gas"], 500);
+        assert_eq!(result["min_on_transfer_gas"], 200);
+        assert_eq!(result["code_hash"], hex::encode([0xAAu8; 32]));
+        assert_eq!(result["slot"], 1);
+
+        // Query non-existent service — should error
+        let err = client
+            .request::<serde_json::Value, _>("jam_getServiceAccount", rpc_params![9999u32])
+            .await;
+        assert!(err.is_err());
     }
 }

--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -51,6 +51,22 @@ const META_HEAD_SLOT: &str = "head_slot";
 const META_FINALIZED_HASH: &str = "finalized_hash";
 const META_FINALIZED_SLOT: &str = "finalized_slot";
 
+/// Service account metadata (fixed-size header fields from the C(255, service_id) KV).
+/// Does not include storage, preimage_lookup, or preimage_info dictionaries.
+#[derive(Debug, Clone)]
+pub struct ServiceMetadata {
+    pub code_hash: Hash,
+    pub balance: u64,
+    pub min_accumulate_gas: u64,
+    pub min_on_transfer_gas: u64,
+    pub total_footprint: u64,
+    pub free_storage_offset: u64,
+    pub accumulation_counter: u32,
+    pub last_accumulation: u32,
+    pub last_activity: u32,
+    pub preimage_count: u32,
+}
+
 /// Persistent store backed by redb.
 pub struct Store {
     db: Database,
@@ -197,6 +213,72 @@ impl Store {
                     return Ok(Some(Hash(h)));
                 }
                 return Ok(None);
+            }
+        }
+        Ok(None)
+    }
+
+    /// Look up a service account's metadata (all fixed-size header fields).
+    /// The service metadata is at key C(255, service_id).
+    /// Layout: version(1) + code_hash(32) + balance(8) + min_accumulate_gas(8) +
+    ///         min_on_transfer_gas(8) + total_footprint(8) + free_storage_offset(8) +
+    ///         accumulation_counter(4) + last_accumulation(4) + last_activity(4) +
+    ///         preimage_count(4) = 89 bytes minimum.
+    pub fn get_service_metadata(
+        &self,
+        block_hash: &Hash,
+        service_id: u32,
+    ) -> Result<Option<ServiceMetadata>, StoreError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(STATE)?;
+        let val = table.get(&block_hash.0)?.ok_or(StoreError::NotFound)?;
+        let kvs = decode_state_kvs(val.value())
+            .ok_or_else(|| StoreError::Codec("invalid state KVs".into()))?;
+
+        let expected_key = grey_merkle::state_serial::key_for_service_pub(255, service_id);
+        for (key, value) in &kvs {
+            if *key == expected_key {
+                if value.len() < 89 {
+                    return Err(StoreError::Codec(format!(
+                        "service metadata too short: {} bytes (need 89)",
+                        value.len()
+                    )));
+                }
+                let v = value;
+                let mut pos = 1; // skip version byte
+                let mut code_hash = [0u8; 32];
+                code_hash.copy_from_slice(&v[pos..pos + 32]);
+                pos += 32;
+                let balance = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let min_accumulate_gas = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let min_on_transfer_gas = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let total_footprint = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let free_storage_offset = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let accumulation_counter = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+                pos += 4;
+                let last_accumulation = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+                pos += 4;
+                let last_activity = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+                pos += 4;
+                let preimage_count = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+
+                return Ok(Some(ServiceMetadata {
+                    code_hash: Hash(code_hash),
+                    balance,
+                    min_accumulate_gas,
+                    min_on_transfer_gas,
+                    total_footprint,
+                    free_storage_offset,
+                    accumulation_counter,
+                    last_accumulation,
+                    last_activity,
+                    preimage_count,
+                }));
             }
         }
         Ok(None)


### PR DESCRIPTION
## Summary

- Add `jam_getServiceAccount` RPC endpoint returning service metadata: code_hash, balance, min_accumulate_gas, min_on_transfer_gas, total_footprint, free_storage_offset, accumulation_counter, last_accumulation, last_activity, preimage_count
- Add `get_service_metadata()` to `grey-store` that reads and parses the C(255, service_id) state KV header without full state deserialization
- Add `ServiceMetadata` struct to `grey-store` for the parsed metadata fields
- Add test covering both found and not-found cases

Addresses #179.

## Scope

This PR addresses: adding the `jam_getServiceAccount` RPC endpoint (from "Add missing endpoints" sub-task).

Remaining sub-tasks in #179:
- `jam_getValidators` endpoint
- WebSocket subscription support
- Per-IP rate limiting
- Optional API key authentication
- Per-query timeout
- Integration tests, error case tests, concurrent request tests

## Test plan

- `cargo test -p grey-rpc` — 19 tests pass (including new `test_get_service_account`)
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- `cargo fmt --all` — clean