### PR TITLE
feat(grey): add SIGUSR1 debug state dump

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -157,6 +157,10 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     let shutdown = tokio::signal::ctrl_c();
     tokio::pin!(shutdown);
 
+    // SIGUSR1: dump debug state to log
+    let mut sigusr1 = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+        .expect("failed to register SIGUSR1 handler");
+
     // Main loop: check timeslots every 500ms
     let mut interval = tokio::time::interval(Duration::from_millis(500));
     let mut last_authored_slot: Timeslot = 0;
@@ -186,6 +190,39 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                     grandpa.finalized_slot
                 );
                 break;
+            }
+            // SIGUSR1: dump debug state snapshot to log
+            _ = sigusr1.recv() => {
+                let head_hash = state
+                    .recent_blocks
+                    .headers
+                    .last()
+                    .map(|h| hex::encode(&h.header_hash.0[..8]))
+                    .unwrap_or_else(|| "none".into());
+                tracing::info!(
+                    "=== SIGUSR1 debug dump (validator {}) ===\n\
+                     State: slot={}, head=0x{}, services={}\n\
+                     Finality: round={}, finalized_slot={}, prevotes={}, precommits={}\n\
+                     Guarantor: pending_guarantees={}, available_cores={}, received_chunks={}\n\
+                     Assurances: collected={}\n\
+                     Pending blocks: {}\n\
+                     Counters: authored={}, imported={}",
+                    config.validator_index,
+                    state.timeslot,
+                    head_hash,
+                    state.services.len(),
+                    grandpa.round,
+                    grandpa.finalized_slot,
+                    grandpa.prevotes.len(),
+                    grandpa.precommits.len(),
+                    guarantor_state.pending_guarantees.len(),
+                    guarantor_state.available_cores.len(),
+                    guarantor_state.received_chunks.len(),
+                    collected_assurances.len(),
+                    pending_blocks.len(),
+                    blocks_authored,
+                    blocks_imported,
+                );
             }
             _ = interval.tick() => {
                 let now = SystemTime::now()


### PR DESCRIPTION
## Summary

- Register a SIGUSR1 handler in the node's main event loop
- On signal, log a snapshot of: current timeslot, head hash, service count, GRANDPA round/finalized slot/vote counts, pending guarantees, available cores, collected assurances, pending blocks, and authored/imported counters
- Useful for runtime debugging without restarting the node (`kill -USR1 <pid>`)

Addresses #224.

## Scope

This PR addresses: SIGUSR1 debug state dump (task 3, bullet 3).

Remaining sub-tasks in #224:
- Config file support (task 1)
- Chain spec loading (task 2)
- SIGHUP config reload (task 3, bullet 2 — depends on task 1)

## Test plan

- `cargo test --workspace` — all existing tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: run a node, send `kill -USR1 <pid>`, verify state dump appears in log output