### PR TITLE
feat(grey-rpc): add 30-second per-query timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4850,6 +4850,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/grey/crates/grey-rpc/Cargo.toml
+++ b/grey/crates/grey-rpc/Cargo.toml
@@ -12,7 +12,7 @@ grey-crypto = { workspace = true }
 grey-store = { workspace = true }
 jsonrpsee = { version = "0.24", features = ["server", "macros"] }
 tower-http = { version = "0.5", features = ["cors"] }
-tower = "0.4"
+tower = { version = "0.4", features = ["timeout"] }
 http = "1"
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -15,8 +15,13 @@ use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
+
+/// Maximum time an individual RPC request can take before being cancelled.
+/// Prevents slow or hanging queries from blocking the server indefinitely.
+const RPC_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Commands sent from RPC to the node event loop.
 #[derive(Debug)]
@@ -549,6 +554,7 @@ pub async fn start_rpc_server(
     };
     let middleware = tower::ServiceBuilder::new()
         .layer(cors_layer)
+        .layer(tower::timeout::TimeoutLayer::new(RPC_QUERY_TIMEOUT))
         .layer(health_layer);
     // Work packages can be up to ~14MB (MAX_WORK_PACKAGE_BLOB_SIZE), and hex
     // encoding doubles the size. Allow 30MB to accommodate the largest valid


### PR DESCRIPTION
## Summary

- Add `tower::timeout::TimeoutLayer` with a 30-second timeout to the RPC server middleware stack
- Any individual RPC request exceeding 30 seconds is automatically cancelled, preventing slow or hanging queries from blocking the server
- Enable the `timeout` feature on the `tower` dependency

Addresses #179.

## Scope

This PR addresses: per-query timeout (from "Security" sub-tasks).

Remaining sub-tasks in #179:
- Per-IP rate limiting
- Optional API key authentication
- Integration tests, error case tests, concurrent request tests

## Test plan

- All 21 existing RPC tests pass (none exceed the 30s timeout)
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: submit a slow query, verify it's cancelled after 30s