### PR TITLE
fix(genesis): use origin/master in count_genesis_trailers

### DIFF
--- a/tools/jar-genesis/src/git.rs
+++ b/tools/jar-genesis/src/git.rs
@@ -100,7 +100,10 @@ pub fn parse_trailer(message: &str, key: &str) -> Option<String> {
 
 /// Count the number of Genesis-Index trailers in the merge history.
 pub fn count_genesis_trailers(genesis_commit: &str) -> Result<usize, GitError> {
-    let range = format!("{genesis_commit}..HEAD");
+    // Use origin/master to see all trailers even if HEAD is behind
+    // (e.g. during review workflow where checkout is stale).
+    let _ = git(&["fetch", "origin", "master"]);
+    let range = format!("{genesis_commit}..origin/master");
     let output = git(&["log", "--merges", "--format=%B", &range])?;
     let count = output
         .lines()


### PR DESCRIPTION
## Summary

- Fix `count_genesis_trailers` to use `origin/master` instead of `HEAD`
- Same class of bug as the merge workflow fix in PR #205: the review workflow's checkout can be behind `origin/master` when a concurrent merge happens, causing `"N entries cached, N-1 in git history"` errors

## Test plan

- [x] `cargo check -p jar-genesis` passes
- [ ] Review workflow no longer fails with stale trailer count when concurrent merges happen

🤖 Generated with [Claude Code](https://claude.com/claude-code)