### PR TITLE
feat(grey-network): add priority-based message dropping under backpressure

### DIFF
--- a/grey/crates/grey-network/src/service.rs
+++ b/grey/crates/grey-network/src/service.rs
@@ -436,12 +436,61 @@ async fn run_network_loop(
 ) {
     let mut peers = PeerTracker::new();
 
-    // Helper: try_send an event, warn and drop on full (never block the network loop).
+    // Priority-aware event sending. Under backpressure (>80% full), only
+    // critical and high priority messages are accepted; lower priorities are
+    // dropped to preserve liveness for finality and block propagation.
+    //
+    // Priority levels (from issue #178):
+    //   Critical: finality votes (protocol liveness depends on these)
+    //   High:     blocks, chunk/block requests (chain progress)
+    //   Normal:   assurances, announcements (availability, audit)
+    //   Low:      guarantees, tickets (can be re-requested)
+    const BACKPRESSURE_THRESHOLD: usize = EVENT_CHANNEL_CAPACITY / 5; // 20% remaining
+
     macro_rules! send_event {
-        ($event:expr) => {
+        ($event:expr, critical) => {
+            // Critical: always attempt to send
             if let Err(mpsc::error::TrySendError::Full(_)) = event_tx.try_send($event) {
                 tracing::warn!(
-                    "Validator {} network event channel full, dropping message",
+                    "Validator {} event channel full, dropping CRITICAL message",
+                    validator_index,
+                );
+            }
+        };
+        ($event:expr, high) => {
+            if let Err(mpsc::error::TrySendError::Full(_)) = event_tx.try_send($event) {
+                tracing::warn!(
+                    "Validator {} event channel full, dropping high-priority message",
+                    validator_index,
+                );
+            }
+        };
+        ($event:expr, normal) => {
+            if event_tx.capacity() < BACKPRESSURE_THRESHOLD {
+                tracing::debug!(
+                    "Validator {} event channel congested ({}/{}), dropping normal-priority message",
+                    validator_index,
+                    EVENT_CHANNEL_CAPACITY - event_tx.capacity(),
+                    EVENT_CHANNEL_CAPACITY,
+                );
+            } else if let Err(mpsc::error::TrySendError::Full(_)) = event_tx.try_send($event) {
+                tracing::warn!(
+                    "Validator {} event channel full, dropping normal-priority message",
+                    validator_index,
+                );
+            }
+        };
+        ($event:expr, low) => {
+            if event_tx.capacity() < BACKPRESSURE_THRESHOLD {
+                tracing::debug!(
+                    "Validator {} event channel congested ({}/{}), dropping low-priority message",
+                    validator_index,
+                    EVENT_CHANNEL_CAPACITY - event_tx.capacity(),
+                    EVENT_CHANNEL_CAPACITY,
+                );
+            } else if let Err(mpsc::error::TrySendError::Full(_)) = event_tx.try_send($event) {
+                tracing::warn!(
+                    "Validator {} event channel full, dropping low-priority message",
                     validator_index,
                 );
             }
@@ -469,32 +518,32 @@ async fn run_network_loop(
                             send_event!(NetworkEvent::BlockReceived {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, high);
                         } else if topic == FINALITY_TOPIC {
                             send_event!(NetworkEvent::FinalityVote {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, critical);
                         } else if topic == GUARANTEES_TOPIC {
                             send_event!(NetworkEvent::GuaranteeReceived {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, low);
                         } else if topic == ASSURANCES_TOPIC {
                             send_event!(NetworkEvent::AssuranceReceived {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, normal);
                         } else if topic == ANNOUNCEMENTS_TOPIC {
                             send_event!(NetworkEvent::AnnouncementReceived {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, normal);
                         } else if topic == TICKETS_TOPIC {
                             send_event!(NetworkEvent::TicketReceived {
                                 data: message.data,
                                 source: propagation_source,
-                            });
+                            }, low);
                         }
                     }
                     // Handle request-response events
@@ -517,7 +566,7 @@ async fn run_network_loop(
                                                 report_hash,
                                                 chunk_index,
                                                 response_tx: tx,
-                                            });
+                                            }, high);
                                             // Wait briefly for the node to respond
                                             rx.await.ok().flatten().unwrap_or_default()
                                         }
@@ -530,7 +579,7 @@ async fn run_network_loop(
                                             send_event!(NetworkEvent::BlockRequest {
                                                 block_hash,
                                                 response_tx: tx,
-                                            });
+                                            }, high);
                                             rx.await.ok().flatten().unwrap_or_default()
                                         }
                                         _ => {
@@ -579,7 +628,7 @@ async fn run_network_loop(
                         send_event!(NetworkEvent::PeerIdentified {
                             peer_id,
                             validator_index: vi,
-                        });
+                        }, high);
                         tracing::info!(
                             "Validator {} identified peer {} (validator={:?}), total_peers={}",
                             validator_index,


### PR DESCRIPTION
## Summary

- Replace the single-priority `send_event!` macro with a priority-aware version supporting four levels: critical, high, normal, low
- When the event channel is >80% full, drop normal and low priority messages to preserve capacity for finality votes and blocks
- Priority assignments: finality votes (critical) > blocks/requests (high) > assurances/announcements (normal) > guarantees/tickets (low)

Addresses #178.

## Scope

This PR addresses: graceful degradation with message prioritization under backpressure.

Remaining sub-tasks in #178:
- Queue depth metrics exposure (track as Prometheus-compatible metric)
- Alert on persistent queue saturation

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: under load, observe that low-priority messages are dropped first while finality votes and blocks continue flowing