### PR TITLE
refactor(grey-rpc): extract parse_hash_hex to deduplicate hex→Hash parsing

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -130,6 +130,18 @@ fn not_found(msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(-32001, msg.into(), None::<()>)
 }
 
+/// Parse a hex-encoded 32-byte hash, stripping optional "0x" prefix.
+fn parse_hash_hex(hex_str: &str) -> Result<Hash, ErrorObjectOwned> {
+    let bytes =
+        hex::decode(hex_str.trim_start_matches("0x")).map_err(|e| internal_error(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(internal_error("hash must be 32 bytes"));
+    }
+    let mut h = [0u8; 32];
+    h.copy_from_slice(&bytes);
+    Ok(Hash(h))
+}
+
 #[async_trait]
 impl JamRpcServer for RpcImpl {
     async fn get_status(&self) -> Result<serde_json::Value, ErrorObjectOwned> {
@@ -151,15 +163,9 @@ impl JamRpcServer for RpcImpl {
     }
 
     async fn get_block(&self, hash_hex: String) -> Result<serde_json::Value, ErrorObjectOwned> {
-        let hash_bytes = hex::decode(hash_hex.trim_start_matches("0x"))
-            .map_err(|e| internal_error(e.to_string()))?;
-        if hash_bytes.len() != 32 {
-            return Err(internal_error("hash must be 32 bytes"));
-        }
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&hash_bytes);
+        let hash = parse_hash_hex(&hash_hex)?;
 
-        match self.state.store.get_block(&Hash(hash)) {
+        match self.state.store.get_block(&hash) {
             Ok(block) => Ok(serde_json::json!({
                 "timeslot": block.header.timeslot,
                 "author_index": block.header.author_index,
@@ -383,14 +389,7 @@ impl JamRpcServer for RpcImpl {
     ) -> Result<serde_json::Value, ErrorObjectOwned> {
         // Resolve block hash: use provided hash or default to head
         let (block_hash, slot) = if let Some(hex) = block_hash_hex {
-            let hash_bytes = hex::decode(hex.trim_start_matches("0x"))
-                .map_err(|e| internal_error(e.to_string()))?;
-            if hash_bytes.len() != 32 {
-                return Err(internal_error("hash must be 32 bytes"));
-            }
-            let mut h = [0u8; 32];
-            h.copy_from_slice(&hash_bytes);
-            let hash = Hash(h);
+            let hash = parse_hash_hex(&hex)?;
             // Look up the block to get the slot
             let block = self
                 .state


### PR DESCRIPTION
## Summary

- Extract `parse_hash_hex()` helper that decodes a hex string (with optional `0x` prefix) into a 32-byte `Hash`, with proper error handling
- Replace two identical 6-line hex→Hash parsing blocks in `get_block` and `get_state_summary` with single-line calls
- Net result: -1 line total, eliminates duplicated error handling

Addresses #186.

## Scope

This PR addresses: hex→Hash parsing duplication in grey-rpc.

Additional dedup opportunities identified in #186:
- State KV scanning pattern in grey-store (4 methods with identical boilerplate)
- Vote counting aggregation in finality.rs (3 methods with similar loops)

## Test plan

- All 22 existing RPC tests pass (behavior is identical)
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean