### PR TITLE
feat(grey): add --chain-spec and --chain CLI flags for chain spec loading

### DIFF
--- a/grey/crates/grey/src/chainspec.rs
+++ b/grey/crates/grey/src/chainspec.rs
@@ -35,6 +35,7 @@ pub struct ChainSpecConfig {
 
 impl ChainSpec {
     /// Create a chain spec from a Config and genesis state.
+    #[allow(dead_code)] // Used by tests; will be used by --export-chain-spec
     pub fn from_genesis(config: &Config, _genesis_state: &State) -> Self {
         // Compute genesis hash from the config blob
         let config_blob = config.encode_config_blob();
@@ -58,6 +59,7 @@ impl ChainSpec {
     }
 
     /// Save chain spec to a JSON file.
+    #[allow(dead_code)] // Used by tests; will be used by --export-chain-spec
     pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let json = serde_json::to_string_pretty(self)?;
         std::fs::write(path, json)?;

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -5,7 +5,6 @@
 
 #[allow(dead_code)]
 mod audit;
-#[allow(dead_code)]
 mod chainspec;
 #[allow(dead_code)]
 mod finality;
@@ -54,6 +53,14 @@ struct Cli {
     /// Use tiny test config (V=6, C=2, E=12)
     #[arg(long, default_value_t = true)]
     tiny: bool,
+
+    /// Built-in chain preset: "tiny" (V=6, C=2) or "full" (V=1023, C=341)
+    #[arg(long, value_name = "PRESET")]
+    chain: Option<String>,
+
+    /// Path to a JSON chain spec file (overrides --tiny and --chain)
+    #[arg(long, value_name = "PATH")]
+    chain_spec: Option<String>,
 
     /// Genesis time override (Unix timestamp, 0 = use current time)
     #[arg(long, default_value_t = 0)]
@@ -139,7 +146,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     };
 
-    let config = if cli.tiny {
+    // Resolve protocol config: --chain-spec > --chain > --tiny
+    let config = if let Some(ref path) = cli.chain_spec {
+        let spec = chainspec::ChainSpec::load(std::path::Path::new(path))
+            .map_err(|e| format!("failed to load chain spec from {}: {}", path, e))?;
+        tracing::info!(
+            "Loaded chain spec '{}' from {} (V={}, C={}, E={})",
+            spec.name,
+            path,
+            spec.config.validators_count,
+            spec.config.core_count,
+            spec.config.epoch_length,
+        );
+        spec.to_config()
+    } else if let Some(ref preset) = cli.chain {
+        match preset.as_str() {
+            "tiny" => Config::tiny(),
+            "full" => Config::full(),
+            other => {
+                return Err(format!(
+                    "unknown chain preset: {:?} (expected \"tiny\" or \"full\")",
+                    other
+                )
+                .into());
+            }
+        }
+    } else if cli.tiny {
         Config::tiny()
     } else {
         Config::full()
@@ -208,19 +240,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     if cli.info {
-        println!("Grey — JAM Blockchain Node");
-        println!("Protocol: JAM (Join-Accumulate Machine)");
-        println!("Specification: Gray Paper v0.7.2");
-        println!();
-        println!("Configuration:");
-        println!("  Validators: {}", config.validators_count);
-        println!("  Cores: {}", config.core_count);
-        println!("  Epoch length: {} slots", config.epoch_length);
-        println!("  Slot period: 6s");
-        println!();
-
-        let genesis_hash = grey_crypto::blake2b_256(b"jam");
-        println!("Genesis seed hash: {genesis_hash}");
+        chainspec::print_genesis_info(&config);
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Add `--chain-spec <path>` CLI flag to load a JSON chain spec file
- Add `--chain <preset>` CLI flag for built-in presets ("tiny" or "full")
- Priority: `--chain-spec` > `--chain` > `--tiny` flag
- Activate the previously unused `chainspec` module (remove `#[allow(dead_code)]`)
- Replace inline `--info` output with `chainspec::print_genesis_info`

Addresses #224.

## Scope

This PR addresses: chain spec loading (task 2).

Remaining sub-tasks in #224:
- Config file support with TOML (task 1)
- SIGHUP config reload (task 3, depends on task 1)

## Test plan

- Existing chainspec tests (`test_chain_spec_roundtrip`, `test_chain_spec_to_config`, `test_chain_spec_save_load`) pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: `grey --chain tiny`, `grey --chain-spec path/to/spec.json`, `grey --chain invalid` → clear error