### PR TITLE
feat(grey): add --verify-state CLI flag for integrity scan

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -276,6 +276,45 @@ impl Store {
         Ok(true)
     }
 
+    /// Verify integrity of all stored state entries.
+    ///
+    /// Returns `(verified, skipped, failed)` counts:
+    /// - verified: checksum matched
+    /// - skipped: no checksum stored (legacy data)
+    /// - failed: checksum mismatch (corruption detected)
+    ///
+    /// Logs each failure but does not stop on first error.
+    pub fn verify_all_states(&self) -> Result<(u32, u32, u32), StoreError> {
+        let txn = self.db.begin_read()?;
+        let state_table = txn.open_table(STATE)?;
+
+        let mut block_hashes: Vec<[u8; 32]> = Vec::new();
+        for entry in state_table.iter()? {
+            let entry = entry?;
+            block_hashes.push(*entry.0.value());
+        }
+        drop(state_table);
+        drop(txn);
+
+        let mut verified = 0u32;
+        let mut skipped = 0u32;
+        let mut failed = 0u32;
+
+        for hash in &block_hashes {
+            match self.verify_state_integrity(&Hash(*hash)) {
+                Ok(true) => verified += 1,
+                Ok(false) => skipped += 1,
+                Err(StoreError::IntegrityError { .. }) => {
+                    failed += 1;
+                    // Error already logged by verify_state_integrity or caller
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok((verified, skipped, failed))
+    }
+
     /// Load and decode state KV pairs for a block hash.
     fn load_state_kvs(&self, block_hash: &Hash) -> Result<StateKvs, StoreError> {
         let txn = self.db.begin_read()?;

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -75,6 +75,11 @@ struct Cli {
     #[arg(long)]
     info: bool,
 
+    /// Verify integrity of all stored state data and exit.
+    /// Checks blake2b checksums for every stored state entry.
+    #[arg(long)]
+    verify_state: bool,
+
     /// Run a sequential block production test (no networking)
     #[arg(long)]
     test: bool,
@@ -291,6 +296,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     if cli.info {
         chainspec::print_genesis_info(&config);
+        return Ok(());
+    }
+
+    if cli.verify_state {
+        let db_path = format!("{}/node-{}.redb", cli.db_path, cli.validator_index);
+        println!("Verifying state integrity in {}...", db_path);
+        let store = grey_store::Store::open(&db_path)?;
+        let (verified, skipped, failed) = store.verify_all_states()?;
+        println!(
+            "State integrity check complete: {} verified, {} skipped (no checksum), {} FAILED",
+            verified, skipped, failed
+        );
+        if failed > 0 {
+            std::process::exit(1);
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Add `--verify-state` CLI flag that scans all stored state entries and verifies blake2b checksums on startup
- Reports verified/skipped/failed counts and exits with code 1 if any corruption is found
- Add `verify_all_states()` to grey-store that iterates all state entries and returns counts

Addresses #222.

## Scope

This PR addresses: `--verify-state` CLI flag for full integrity scan (task 4, part 3).

Remaining sub-tasks in #222:
- Wiring pruning/expiration into the node's finalization flow
- Compression (task 5, optional)

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: run `grey --verify-state --db-path <path>` against a node database, verify output shows verification results