### PR TITLE
feat(grey): add --pruning-depth flag and wire pruning into finalization

### DIFF
--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -100,6 +100,11 @@ struct Cli {
     #[arg(long, default_value = "./grey-db")]
     db_path: String,
 
+    /// Number of blocks to retain after finalization (0 = archive mode, no pruning).
+    /// After each finalization, blocks older than finalized_slot - pruning_depth are removed.
+    #[arg(long, default_value_t = 0)]
+    pruning_depth: u32,
+
     /// JSON-RPC server port (0 to disable)
     #[arg(long, default_value_t = 9933)]
     rpc_port: u16,
@@ -351,6 +356,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         rpc_port: cli.rpc_port,
         rpc_cors: cli.rpc_cors,
         genesis_state: None,
+        pruning_depth: cli.pruning_depth,
     })
     .await
 }

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -53,6 +53,8 @@ pub struct NodeConfig {
     /// Optional pre-configured genesis state (with services installed, etc.).
     /// If None, the default genesis from create_genesis is used.
     pub genesis_state: Option<State>,
+    /// Number of blocks to keep after finalization (0 = archive mode, no pruning).
+    pub pruning_depth: u32,
 }
 
 // FinalityTracker replaced by GrandpaState (see finality.rs)
@@ -909,6 +911,19 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                                 hex::encode(&fin_hash.0[..8])
                                             );
                                             let _ = store.set_finalized(&fin_hash, fin_slot);
+
+                                            // Prune old blocks/state if pruning is enabled
+                                            if config.pruning_depth > 0 && fin_slot > config.pruning_depth {
+                                                let keep_after = fin_slot - config.pruning_depth;
+                                                match store.prune_before_slot(keep_after) {
+                                                    Ok(0) => {}
+                                                    Ok(n) => tracing::debug!(
+                                                        "Pruned {} blocks (keeping slots >= {})",
+                                                        n, keep_after
+                                                    ),
+                                                    Err(e) => tracing::warn!("Pruning failed: {}", e),
+                                                }
+                                            }
 
                                             // Advance to next round
                                             if grandpa.should_advance_round() {

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -172,6 +172,7 @@ pub async fn run_testnet(
                 rpc_port: if i == 0 { 9933 } else { 0 },
                 rpc_cors: if i == 0 { rpc_cors } else { false },
                 genesis_state: Some(genesis_clone),
+                pruning_depth: 0, // No pruning in testnet
             };
             if let Err(e) = crate::node::run_node(node_config).await {
                 tracing::error!("Validator {} exited with error: {}", i, e);


### PR DESCRIPTION
## Summary

- Add `--pruning-depth <N>` CLI flag (default 0 = archive mode, no pruning)
- After each GRANDPA finalization, call `store.prune_before_slot(finalized_slot - pruning_depth)` to remove old blocks, state, checksums, and slot index entries
- Add `pruning_depth` field to `NodeConfig`, defaulting to 0 in testnet mode

Addresses #222.

## Scope

This PR addresses: `--pruning-depth` CLI flag and node integration (task 2, wiring).

This completes the core pruning feature: store method (PR #241) + CLI flag + finalization hook (this PR).

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: run `grey --pruning-depth 100`, observe pruning logs after finalization