### PR TITLE
feat(harness): add --scenario flag to run individual test scenarios

### DIFF
--- a/grey/harness/src/main.rs
+++ b/grey/harness/src/main.rs
@@ -32,6 +32,11 @@ struct Cli {
     /// RPC endpoint URL.
     #[arg(long, default_value = "http://localhost:9933")]
     rpc: String,
+
+    /// Run only the named scenario (e.g. "serial", "repeat", "liveness").
+    /// If not specified, all scenarios run in order.
+    #[arg(long, value_name = "NAME")]
+    scenario: Option<String>,
 }
 
 #[tokio::main]
@@ -101,7 +106,23 @@ async fn main() {
 
     // Run scenarios sequentially.
     let mut results = Vec::new();
-    let scenario_list = ["serial", "repeat", "liveness"];
+    let all_scenarios = ["serial", "repeat", "liveness"];
+
+    // Filter to a single scenario if --scenario is specified.
+    let scenario_list: Vec<&str> = if let Some(ref name) = cli.scenario {
+        if !all_scenarios.contains(&name.as_str()) {
+            error!(
+                "unknown scenario: {:?} (available: {})",
+                name,
+                all_scenarios.join(", ")
+            );
+            std::process::exit(1);
+        }
+        vec![name.as_str()]
+    } else {
+        all_scenarios.to_vec()
+    };
+
     for (i, name) in scenario_list.iter().enumerate() {
         println!("[{}/{}] {name}", i + 1, scenario_list.len());
         let result = match *name {


### PR DESCRIPTION
## Summary

- Add `--scenario <name>` CLI flag to the integration test harness
- When specified, only the named scenario runs (e.g., `--scenario serial`)
- Without the flag, all scenarios run in order as before
- Validates the name and exits with a clear error listing available scenarios

Addresses #225.

## Scope

This PR addresses: `--scenario <name>` flag for running individual scenarios (task 4).

Remaining sub-tasks in #225:
- Invalid work package scenarios (task 1)
- More RPC error handling tests (concurrent requests, missing params)
- State consistency after errors (task 3)
- Per-RPC-call timeout/retry, log capture (task 4, remaining items)

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: `cargo run -p harness -- --scenario serial --seq-testnet`