### PR TITLE
feat(grey-rpc): add /metrics endpoint with Prometheus-format metrics

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -558,6 +558,14 @@ fn json_response(status: u16, body: String) -> http::Response<HttpBody> {
         .unwrap()
 }
 
+fn text_response(status: u16, content_type: &str, body: String) -> http::Response<HttpBody> {
+    http::Response::builder()
+        .status(status)
+        .header("content-type", content_type)
+        .body(HttpBody::from(body))
+        .unwrap()
+}
+
 impl<S, ReqBody> tower::Service<http::Request<ReqBody>> for HealthService<S>
 where
     S: tower::Service<http::Request<ReqBody>, Response = http::Response<HttpBody>>
@@ -587,6 +595,40 @@ where
         if is_get && path == "/health" {
             let body = serde_json::json!({"status": "ok"}).to_string();
             Box::pin(async move { Ok(json_response(200, body)) })
+        } else if is_get && path == "/metrics" {
+            let state = self.state.clone();
+            Box::pin(async move {
+                let status = state.status.read().await;
+                let finalized_slot = status.finalized_slot;
+                let head_slot = status.head_slot;
+                let blocks_authored = status.blocks_authored;
+                let blocks_imported = status.blocks_imported;
+                let validator_index = status.validator_index;
+                drop(status);
+
+                let body = format!(
+                    "# HELP grey_block_height Current head slot.\n\
+                     # TYPE grey_block_height gauge\n\
+                     grey_block_height {head_slot}\n\
+                     # HELP grey_finalized_height Last finalized slot.\n\
+                     # TYPE grey_finalized_height gauge\n\
+                     grey_finalized_height {finalized_slot}\n\
+                     # HELP grey_blocks_produced_total Blocks authored by this node.\n\
+                     # TYPE grey_blocks_produced_total counter\n\
+                     grey_blocks_produced_total {blocks_authored}\n\
+                     # HELP grey_blocks_imported_total Blocks received and imported.\n\
+                     # TYPE grey_blocks_imported_total counter\n\
+                     grey_blocks_imported_total {blocks_imported}\n\
+                     # HELP grey_validator_index Validator index of this node.\n\
+                     # TYPE grey_validator_index gauge\n\
+                     grey_validator_index {validator_index}\n"
+                );
+                Ok(text_response(
+                    200,
+                    "text/plain; version=0.0.4; charset=utf-8",
+                    body,
+                ))
+            })
         } else if is_get && path == "/ready" {
             let state = self.state.clone();
             Box::pin(async move {
@@ -1197,5 +1239,26 @@ mod tests {
             .request::<serde_json::Value, _>("jam_getBlockBySlot", rpc_params![99999u32])
             .await;
         assert!(err.is_err(), "non-existent slot should return error");
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint() {
+        let (url, state, _rx, _store, _dir) = setup().await;
+        {
+            let mut status = state.status.write().await;
+            status.head_slot = 50;
+            status.finalized_slot = 45;
+            status.blocks_authored = 10;
+            status.blocks_imported = 40;
+        }
+
+        let (status, body) = http_get(&format!("{}/metrics", url)).await;
+        assert_eq!(status, 200);
+        assert!(body.contains("grey_block_height 50"));
+        assert!(body.contains("grey_finalized_height 45"));
+        assert!(body.contains("grey_blocks_produced_total 10"));
+        assert!(body.contains("grey_blocks_imported_total 40"));
+        assert!(body.contains("# TYPE grey_block_height gauge"));
+        assert!(body.contains("# TYPE grey_blocks_produced_total counter"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `GET /metrics` endpoint returning core node metrics in Prometheus text exposition format
- Metrics: `grey_block_height`, `grey_finalized_height`, `grey_blocks_produced_total`, `grey_blocks_imported_total`, `grey_validator_index`
- No new dependencies — uses existing `NodeStatus` data and HTTP middleware alongside `/health` and `/ready`
- Scrape-ready for Prometheus with proper `# HELP`, `# TYPE`, and `text/plain; version=0.0.4` content type

Addresses #223.

## Scope

This PR addresses: Prometheus metrics endpoint (task 1, core metrics).

Remaining sub-tasks in #223:
- Additional metrics (queue depths, peer count, GRANDPA round)
- Configurable `--metrics-port` (separate port from RPC)
- OpenTelemetry tracing spans (task 2)

## Test plan

- `test_metrics_endpoint` — verifies correct metric names, values, and Prometheus format
- `cargo test -p grey-rpc` — 29 tests pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: `curl localhost:9933/metrics` returns scrapeable Prometheus text