### PR TITLE
feat: add cargo-deny configuration for license compliance

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,62 @@
+# cargo-deny configuration for the JAR workspace.
+# Run: cargo deny check
+# See: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Exclude internal service/benchmark crates that don't have license fields
+# (they're internal-only RISC-V guest programs, not published)
+exclude = [
+    "bench-blake2b",
+    "bench-ecrecover",
+    "bench-ed25519",
+    "bench-keccak",
+    "bench-prime-sieve",
+    "counter-service",
+    "sample-service",
+    "pixels-service",
+    "pixels-authorizer",
+    "javm-guest-tests",
+]
+
+[licenses]
+# Project license
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "BlueOak-1.0.0",
+    "CC0-1.0",
+    "MPL-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "CDLA-Permissive-2.0",
+    # ring uses a custom ISC-style license
+    "OpenSSL",
+]
+# Confidence threshold for license detection
+confidence-threshold = 0.8
+
+# Some crates have non-standard license expressions
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+# Warn on multiple versions of the same crate (don't fail)
+multiple-versions = "warn"
+# Deny wildcard dependencies
+wildcards = "deny"
+
+[advisories]
+# Use the RustSec advisory database
+ignore = []
+
+[sources]
+# Only allow crates from crates.io and git
+unknown-registry = "deny"
+unknown-git = "warn"


### PR DESCRIPTION
## Summary

- Add `deny.toml` with license allowlist covering all current dependencies (Apache-2.0, MIT, BSD, ISC, MPL-2.0, CDLA-Permissive-2.0, etc.)
- Exclude internal service/benchmark crates (RISC-V guest programs without license fields)
- Configure duplicate crate warning, wildcard dependency ban, and advisory database checks
- `cargo deny check` passes with zero errors

Addresses #180.

## Scope

This PR addresses: `cargo deny` for license compliance and duplicate detection.

Remaining sub-tasks in #180:
- Add `cargo deny check` to CI workflow
- SBOM generation (optional)
- Benchmark regression detection
- Code coverage

## Test plan

- `cargo deny check licenses` — passes (all licenses explicitly allowed)
- `cargo deny check` — zero errors
- `cargo test --workspace` — all tests pass (deny.toml is config-only, no code changes)