### PR TITLE
feat(grey): add docker-compose template for 6-validator testnet

### DIFF
--- a/grey/docker-compose.yml
+++ b/grey/docker-compose.yml
@@ -1,0 +1,134 @@
+# Grey — 6-validator local testnet via Docker Compose.
+#
+# Start:  docker compose -f grey/docker-compose.yml up --build
+# Stop:   docker compose -f grey/docker-compose.yml down -v
+# Logs:   docker compose -f grey/docker-compose.yml logs -f validator-0
+# RPC:    curl http://localhost:9933/health
+#
+# Validator 0 exposes RPC on port 9933. All validators use --tiny config
+# and auto-discover peers via boot peer addresses.
+
+x-grey-common: &grey-common
+  build:
+    context: ..
+    dockerfile: grey/Dockerfile
+  restart: unless-stopped
+  networks:
+    - testnet
+
+services:
+  validator-0:
+    <<: *grey-common
+    container_name: grey-v0
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=0"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=9933"
+      - "--rpc-cors"
+    ports:
+      - "9000:9000"   # P2P
+      - "9933:9933"   # RPC
+    volumes:
+      - v0-data:/data
+    networks:
+      testnet:
+        ipv4_address: 172.28.0.10
+
+  validator-1:
+    <<: *grey-common
+    container_name: grey-v1
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=1"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=0"
+      - "-b=/ip4/172.28.0.10/tcp/9000"
+    depends_on:
+      - validator-0
+    volumes:
+      - v1-data:/data
+
+  validator-2:
+    <<: *grey-common
+    container_name: grey-v2
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=2"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=0"
+      - "-b=/ip4/172.28.0.10/tcp/9000"
+    depends_on:
+      - validator-0
+    volumes:
+      - v2-data:/data
+
+  validator-3:
+    <<: *grey-common
+    container_name: grey-v3
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=3"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=0"
+      - "-b=/ip4/172.28.0.10/tcp/9000"
+    depends_on:
+      - validator-0
+    volumes:
+      - v3-data:/data
+
+  validator-4:
+    <<: *grey-common
+    container_name: grey-v4
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=4"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=0"
+      - "-b=/ip4/172.28.0.10/tcp/9000"
+    depends_on:
+      - validator-0
+    volumes:
+      - v4-data:/data
+
+  validator-5:
+    <<: *grey-common
+    container_name: grey-v5
+    command:
+      - "--listen-addr=0.0.0.0"
+      - "--port=9000"
+      - "-i=5"
+      - "--tiny"
+      - "--db-path=/data"
+      - "--rpc-port=0"
+      - "-b=/ip4/172.28.0.10/tcp/9000"
+    depends_on:
+      - validator-0
+    volumes:
+      - v5-data:/data
+
+volumes:
+  v0-data:
+  v1-data:
+  v2-data:
+  v3-data:
+  v4-data:
+  v5-data:
+
+networks:
+  testnet:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+          gateway: 172.28.0.1
+    driver: bridge


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` for a 6-validator tiny testnet with Docker Compose
- Validator 0 serves as boot node with static IP (172.28.0.10) and exposed RPC on port 9933
- Validators 1-5 connect to validator 0 via boot peer address
- Separate persistent volumes per validator, custom bridge network

Addresses #231.

## Scope

This PR addresses: docker-compose testnet template (task 2).

Remaining sub-tasks in #231:
- Deployment scripts and monitoring (task 3)

## Test plan

- `docker compose -f grey/docker-compose.yml up --build` — verify all 6 validators start
- `curl http://localhost:9933/health` — verify RPC accessible
- `docker compose -f grey/docker-compose.yml down -v` — clean shutdown
- `cargo test --workspace` — all tests pass (config-only, no code changes)