### PR TITLE
feat(grey-codec): add proptest property-based codec tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1558,7 @@ dependencies = [
  "grey-crypto",
  "grey-types",
  "hex",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3707,6 +3723,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,6 +3903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4231,6 +4281,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -5078,6 +5140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +5277,15 @@ dependencies = [
  "ark-transcript",
  "w3f-pcs",
  "w3f-plonk-common",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ reed-solomon-simd = "3.1"
 redb = "3.1"
 tracing = "0.1"
 tracing-test = "0.2"
+proptest = "1"
 tokio = { version = "1", features = ["full"] }
 libp2p = { version = "0.54", features = ["gossipsub", "noise", "tcp", "yamux", "tokio", "macros", "identify", "request-response"] }
 clap = { version = "4", features = ["derive"] }

--- a/grey/crates/grey-codec/Cargo.toml
+++ b/grey/crates/grey-codec/Cargo.toml
@@ -14,3 +14,4 @@ thiserror = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+proptest = { workspace = true }

--- a/grey/crates/grey-codec/tests/proptest_codec.rs
+++ b/grey/crates/grey-codec/tests/proptest_codec.rs
@@ -1,0 +1,80 @@
+//! Property-based tests for the JAM codec using proptest.
+//!
+//! Tests that encode → decode roundtrips produce the original value
+//! for all inputs, not just hand-picked examples.
+
+use grey_codec::decode::decode_compact;
+use grey_codec::encode::encode_compact;
+use grey_codec::{Decode, Encode};
+use proptest::prelude::*;
+
+// ── Compact integer roundtrip ───────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn compact_u64_roundtrip(value in any::<u64>()) {
+        let mut buf = Vec::new();
+        encode_compact(value, &mut buf);
+
+        let (decoded, bytes_consumed) = decode_compact(&buf)
+            .expect("decode_compact should succeed for any encoded value");
+
+        prop_assert_eq!(decoded, value, "roundtrip mismatch for {}", value);
+        prop_assert_eq!(bytes_consumed, buf.len(), "should consume entire buffer");
+    }
+
+    #[test]
+    fn compact_small_values_roundtrip(value in 0u64..256) {
+        let mut buf = Vec::new();
+        encode_compact(value, &mut buf);
+
+        let (decoded, _) = decode_compact(&buf).unwrap();
+        prop_assert_eq!(decoded, value);
+
+        // Small values should encode compactly (1-2 bytes)
+        prop_assert!(buf.len() <= 2, "small value {} encoded to {} bytes", value, buf.len());
+    }
+
+    #[test]
+    fn compact_encoding_is_prefix_free(a in any::<u64>(), b in any::<u64>()) {
+        // Two different values should never produce the same encoding
+        if a != b {
+            let mut buf_a = Vec::new();
+            let mut buf_b = Vec::new();
+            encode_compact(a, &mut buf_a);
+            encode_compact(b, &mut buf_b);
+            prop_assert_ne!(buf_a, buf_b, "different values {} and {} should have different encodings", a, b);
+        }
+    }
+}
+
+// ── Fixed-width integer roundtrip ───────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn u32_roundtrip(value in any::<u32>()) {
+        let encoded = value.encode();
+        let (decoded, len) = u32::decode(&encoded).expect("u32 decode should succeed");
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(len, 4);
+        prop_assert_eq!(encoded.len(), 4);
+    }
+
+    #[test]
+    fn u64_roundtrip(value in any::<u64>()) {
+        let encoded = value.encode();
+        let (decoded, len) = u64::decode(&encoded).expect("u64 decode should succeed");
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(len, 8);
+        prop_assert_eq!(encoded.len(), 8);
+    }
+
+    #[test]
+    fn u16_roundtrip(value in any::<u16>()) {
+        let encoded = value.encode();
+        let (decoded, len) = u16::decode(&encoded).expect("u16 decode should succeed");
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(len, 2);
+        prop_assert_eq!(encoded.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `proptest` workspace dependency and 6 property-based tests for the JAM codec
- Tests: compact u64 roundtrip, small value compactness, prefix-free encoding, u16/u32/u64 fixed-width roundtrips
- Exercises codec with random inputs to catch edge cases hand-written tests miss

Addresses #229.

## Scope

This PR addresses: codec roundtrip property tests (task 1, first bullet).

Remaining sub-tasks in #229:
- Header codec roundtrip property tests
- PVM instruction encoding roundtrip
- Merkle trie insertion/lookup properties
- Fuzzing targets (task 2)

## Test plan

- `cargo test -p grey-codec --test proptest_codec` — 6 property tests pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean