### PR TITLE
feat(grey): add proptest for finality vote message encode/decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1529,7 @@ dependencies = [
  "hex",
  "javm",
  "libp2p",
+ "proptest",
  "serde",
  "serde_json",
  "tokio",
@@ -3707,6 +3723,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,6 +3903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4231,6 +4281,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -5078,6 +5140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +5277,15 @@ dependencies = [
  "ark-transcript",
  "w3f-pcs",
  "w3f-plonk-common",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ reed-solomon-simd = "3.1"
 redb = "3.1"
 tracing = "0.1"
 tracing-test = "0.2"
+proptest = "1"
 tokio = { version = "1", features = ["full"] }
 libp2p = { version = "0.54", features = ["gossipsub", "noise", "tcp", "yamux", "tokio", "macros", "identify", "request-response"] }
 clap = { version = "4", features = ["derive"] }

--- a/grey/crates/grey/Cargo.toml
+++ b/grey/crates/grey/Cargo.toml
@@ -33,5 +33,8 @@ hex = { workspace = true }
 libp2p = { workspace = true }
 futures = { workspace = true }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [build-dependencies]
 build-javm = { path = "../build-javm" }

--- a/grey/crates/grey/src/finality.rs
+++ b/grey/crates/grey/src/finality.rs
@@ -749,4 +749,75 @@ mod tests {
         bad_vote.validator_index = 1; // Wrong key
         assert!(!verify_vote(&bad_vote, VoteType::Prevote, &chain_state));
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn arb_vote_type() -> impl Strategy<Value = VoteType> {
+            prop_oneof![Just(VoteType::Prevote), Just(VoteType::Precommit),]
+        }
+
+        proptest! {
+            #[test]
+            fn vote_message_encode_decode_roundtrip(
+                block_hash in prop::array::uniform32(any::<u8>()),
+                block_slot in any::<u32>(),
+                round in any::<u64>(),
+                validator_index in any::<u16>(),
+                signature in prop::array::uniform32(any::<u8>())
+                    .prop_flat_map(|a| prop::array::uniform32(any::<u8>()).prop_map(move |b| {
+                        let mut sig = [0u8; 64];
+                        sig[..32].copy_from_slice(&a);
+                        sig[32..].copy_from_slice(&b);
+                        sig
+                    })),
+                vote_type in arb_vote_type(),
+            ) {
+                let msg = VoteMessage {
+                    vote_type,
+                    vote: Vote {
+                        block_hash: Hash(block_hash),
+                        block_slot,
+                        round,
+                        validator_index,
+                        signature: Ed25519Signature(signature),
+                    },
+                };
+
+                let encoded = encode_vote_message(&msg);
+                prop_assert_eq!(encoded.len(), 111, "encoded vote should be exactly 111 bytes");
+
+                let decoded = decode_vote_message(&encoded);
+                prop_assert!(decoded.is_some(), "decode should succeed for any valid encoding");
+
+                let decoded = decoded.unwrap();
+                prop_assert_eq!(decoded.vote_type, msg.vote_type);
+                prop_assert_eq!(decoded.vote.block_hash, msg.vote.block_hash);
+                prop_assert_eq!(decoded.vote.block_slot, msg.vote.block_slot);
+                prop_assert_eq!(decoded.vote.round, msg.vote.round);
+                prop_assert_eq!(decoded.vote.validator_index, msg.vote.validator_index);
+                prop_assert_eq!(decoded.vote.signature.0, msg.vote.signature.0);
+            }
+
+            #[test]
+            fn decode_rejects_short_messages(data in prop::collection::vec(any::<u8>(), 0..110)) {
+                // Any message shorter than 111 bytes should fail to decode
+                prop_assert!(decode_vote_message(&data).is_none());
+            }
+
+            #[test]
+            fn decode_rejects_invalid_vote_type(
+                rest in prop::collection::vec(any::<u8>(), 110..=110),
+            ) {
+                // Vote type byte must be 0x01 or 0x02; 0x00 and 0x03+ should fail
+                let mut data = vec![0x00];
+                data.extend_from_slice(&rest);
+                prop_assert!(decode_vote_message(&data).is_none());
+
+                data[0] = 0x03;
+                prop_assert!(decode_vote_message(&data).is_none());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add 3 property-based tests for GRANDPA vote message serialization in finality.rs
- Tests: encode/decode roundtrip for all vote fields, short message rejection, invalid vote type rejection
- Add proptest as dev-dependency for the grey binary crate

Addresses #229.

## Scope

This PR addresses: finality vote message property tests (extending task 1).

Remaining sub-tasks in #229:
- Header codec roundtrip property tests
- PVM instruction encoding roundtrip
- Merkle trie properties
- Fuzzing targets (task 2)

## Test plan

- `cargo test -p grey -- finality::tests::proptests` — 3 property tests pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean