### PR TITLE
feat(grey): add stored state count to /metrics endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -599,6 +599,7 @@ where
                 drop(status);
 
                 let stored_blocks = state.store.block_count().unwrap_or(0);
+                let stored_states = state.store.state_count().unwrap_or(0);
 
                 let body = format!(
                     "# HELP grey_block_height Current head slot.\n\
@@ -616,6 +617,9 @@ where
                      # HELP grey_stored_blocks Number of blocks in the database.\n\
                      # TYPE grey_stored_blocks gauge\n\
                      grey_stored_blocks {stored_blocks}\n\
+                     # HELP grey_stored_states Number of state entries in the database.\n\
+                     # TYPE grey_stored_states gauge\n\
+                     grey_stored_states {stored_states}\n\
                      # HELP grey_validator_index Validator index of this node.\n\
                      # TYPE grey_validator_index gauge\n\
                      grey_validator_index {validator_index}\n"
@@ -1298,6 +1302,7 @@ mod tests {
         assert!(body.contains("grey_blocks_produced_total 10"));
         assert!(body.contains("grey_blocks_imported_total 40"));
         assert!(body.contains("grey_stored_blocks 1"));
+        assert!(body.contains("grey_stored_states 0"));
         assert!(body.contains("# TYPE grey_block_height gauge"));
         assert!(body.contains("# TYPE grey_blocks_produced_total counter"));
     }

--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -215,6 +215,13 @@ impl Store {
         Ok(table.len()?)
     }
 
+    /// Count the number of stored state entries.
+    pub fn state_count(&self) -> Result<u64, StoreError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(STATE)?;
+        Ok(table.len()?)
+    }
+
     // ── State ───────────────────────────────────────────────────────────
 
     /// Store chain state for a given block hash.


### PR DESCRIPTION
## Summary

- Add `state_count()` method to grey-store for counting stored state entries
- Expose as `grey_stored_states` gauge in the `/metrics` endpoint
- Helps operators track storage growth alongside `grey_stored_blocks`

Addresses #223.

## Test plan

- `test_metrics_endpoint` — verifies `grey_stored_states 0` appears in output
- `cargo test -p grey-rpc` — 30 tests pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean