### PR TITLE
feat(grey): wire chunk expiration into finalization flow

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -925,6 +925,17 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                                 }
                                             }
 
+                                            // Expire old DA chunks (TTL = 2 * epoch_length)
+                                            let chunk_ttl = 2 * protocol.epoch_length;
+                                            match store.prune_expired_chunks(fin_slot, chunk_ttl) {
+                                                Ok(0) => {}
+                                                Ok(n) => tracing::debug!(
+                                                    "Expired chunks for {} reports (TTL={})",
+                                                    n, chunk_ttl
+                                                ),
+                                                Err(e) => tracing::warn!("Chunk expiration failed: {}", e),
+                                            }
+
                                             // Advance to next round
                                             if grandpa.should_advance_round() {
                                                 grandpa.advance_round();


### PR DESCRIPTION
## Summary

- Call `store.prune_expired_chunks(fin_slot, 2 * epoch_length)` after each GRANDPA finalization
- DA chunks older than 2 epochs are automatically removed, bounding storage growth
- Runs alongside existing block pruning and vote cleanup in the finalization handler

Addresses #222.

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: run a testnet with chunk storage, observe chunks being expired after finalization