### PR TITLE
feat(grey): apply config file log_level to tracing setup

### DIFF
--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -175,6 +175,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         {
             cli.peers = peers.clone();
         }
+        // Apply log level from config file if CLI flag not set
+        if cli.log_level.is_none() {
+            cli.log_level = cfg.logging.level;
+        }
     }
 
     // Build EnvFilter: CLI arg > config file > RUST_LOG env var > "info"


### PR DESCRIPTION
## Summary

- Wire the `logging.level` field from the TOML config file into the tracing EnvFilter chain
- Priority: `--log-level` CLI flag > config file `logging.level` > `RUST_LOG` env > `"info"`
- Previously the config file's log level was parsed but not applied

Addresses #224.

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: create config.toml with `[logging] level = "debug"`, run without `--log-level`, verify debug output