### PR TITLE
feat(grey): add chunk and vote count to /metrics endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -600,6 +600,8 @@ where
 
                 let stored_blocks = state.store.block_count().unwrap_or(0);
                 let stored_states = state.store.state_count().unwrap_or(0);
+                let stored_chunks = state.store.chunk_count().unwrap_or(0);
+                let stored_votes = state.store.vote_count().unwrap_or(0);
 
                 let body = format!(
                     "# HELP grey_block_height Current head slot.\n\
@@ -620,6 +622,12 @@ where
                      # HELP grey_stored_states Number of state entries in the database.\n\
                      # TYPE grey_stored_states gauge\n\
                      grey_stored_states {stored_states}\n\
+                     # HELP grey_stored_chunks Number of DA chunks in the database.\n\
+                     # TYPE grey_stored_chunks gauge\n\
+                     grey_stored_chunks {stored_chunks}\n\
+                     # HELP grey_stored_votes Number of GRANDPA votes in the database.\n\
+                     # TYPE grey_stored_votes gauge\n\
+                     grey_stored_votes {stored_votes}\n\
                      # HELP grey_validator_index Validator index of this node.\n\
                      # TYPE grey_validator_index gauge\n\
                      grey_validator_index {validator_index}\n"
@@ -1303,6 +1311,8 @@ mod tests {
         assert!(body.contains("grey_blocks_imported_total 40"));
         assert!(body.contains("grey_stored_blocks 1"));
         assert!(body.contains("grey_stored_states 0"));
+        assert!(body.contains("grey_stored_chunks 0"));
+        assert!(body.contains("grey_stored_votes 0"));
         assert!(body.contains("# TYPE grey_block_height gauge"));
         assert!(body.contains("# TYPE grey_blocks_produced_total counter"));
     }

--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -222,6 +222,20 @@ impl Store {
         Ok(table.len()?)
     }
 
+    /// Count the number of stored DA chunks.
+    pub fn chunk_count(&self) -> Result<u64, StoreError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(CHUNKS)?;
+        Ok(table.len()?)
+    }
+
+    /// Count the number of stored GRANDPA votes.
+    pub fn vote_count(&self) -> Result<u64, StoreError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(GRANDPA_VOTES)?;
+        Ok(table.len()?)
+    }
+
     // ── State ───────────────────────────────────────────────────────────
 
     /// Store chain state for a given block hash.


### PR DESCRIPTION
## Summary

- Add `chunk_count()` and `vote_count()` methods to grey-store
- Expose as `grey_stored_chunks` and `grey_stored_votes` gauges in the `/metrics` endpoint
- Complete storage observability: operators can now see all 4 table sizes (blocks, states, chunks, votes)

Addresses #223.

## Test plan

- `test_metrics_endpoint` — verifies new metrics appear with correct values
- `cargo test -p grey-rpc` — 30 tests pass
- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean