### PR TITLE
refactor: macro-ify codec impls and extract hash collection helpers

### DIFF
--- a/grey/crates/grey-codec/src/decode.rs
+++ b/grey/crates/grey-codec/src/decode.rs
@@ -137,68 +137,32 @@ impl Decode for bool {
 
 // --- Fixed-size cryptographic type decoders ---
 
-impl Decode for grey_types::Hash {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 32)?;
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&data[..32]);
-        Ok((grey_types::Hash(bytes), 32))
-    }
+/// Implement Decode for a newtype wrapper around a fixed-size byte array.
+/// All these types are `Type([u8; N])` and decode by reading exactly N bytes.
+macro_rules! impl_decode_fixed_bytes {
+    ($($type:ty => $size:expr),+ $(,)?) => {
+        $(
+            impl Decode for $type {
+                fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
+                    ensure_bytes(data, $size)?;
+                    let mut bytes = [0u8; $size];
+                    bytes.copy_from_slice(&data[..$size]);
+                    Ok((Self(bytes), $size))
+                }
+            }
+        )+
+    };
 }
 
-impl Decode for grey_types::Ed25519PublicKey {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 32)?;
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&data[..32]);
-        Ok((grey_types::Ed25519PublicKey(bytes), 32))
-    }
-}
-
-impl Decode for grey_types::BandersnatchPublicKey {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 32)?;
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&data[..32]);
-        Ok((grey_types::BandersnatchPublicKey(bytes), 32))
-    }
-}
-
-impl Decode for grey_types::BandersnatchSignature {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 96)?;
-        let mut bytes = [0u8; 96];
-        bytes.copy_from_slice(&data[..96]);
-        Ok((grey_types::BandersnatchSignature(bytes), 96))
-    }
-}
-
-impl Decode for grey_types::Ed25519Signature {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 64)?;
-        let mut bytes = [0u8; 64];
-        bytes.copy_from_slice(&data[..64]);
-        Ok((grey_types::Ed25519Signature(bytes), 64))
-    }
-}
-
-impl Decode for grey_types::BlsPublicKey {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 144)?;
-        let mut bytes = [0u8; 144];
-        bytes.copy_from_slice(&data[..144]);
-        Ok((grey_types::BlsPublicKey(bytes), 144))
-    }
-}
-
-impl Decode for grey_types::BandersnatchRingRoot {
-    fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
-        ensure_bytes(data, 144)?;
-        let mut bytes = [0u8; 144];
-        bytes.copy_from_slice(&data[..144]);
-        Ok((grey_types::BandersnatchRingRoot(bytes), 144))
-    }
-}
+impl_decode_fixed_bytes!(
+    grey_types::Hash => 32,
+    grey_types::Ed25519PublicKey => 32,
+    grey_types::BandersnatchPublicKey => 32,
+    grey_types::Ed25519Signature => 64,
+    grey_types::BandersnatchSignature => 96,
+    grey_types::BlsPublicKey => 144,
+    grey_types::BandersnatchRingRoot => 144,
+);
 
 // --- Generic container decoders ---
 

--- a/grey/crates/grey-codec/src/encode.rs
+++ b/grey/crates/grey-codec/src/encode.rs
@@ -109,35 +109,27 @@ impl Encode for [u8; 96] {
     }
 }
 
-impl Encode for grey_types::Hash {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
+/// Implement Encode for newtype wrappers around byte arrays.
+/// All these types are `Type([u8; N])` and encode by writing all bytes.
+macro_rules! impl_encode_fixed_bytes {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl Encode for $type {
+                fn encode_to(&self, buf: &mut Vec<u8>) {
+                    buf.extend_from_slice(&self.0);
+                }
+            }
+        )+
+    };
 }
 
-impl Encode for grey_types::Ed25519PublicKey {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
-}
-
-impl Encode for grey_types::BandersnatchPublicKey {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
-}
-
-impl Encode for grey_types::BandersnatchSignature {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
-}
-
-impl Encode for grey_types::Ed25519Signature {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
-}
+impl_encode_fixed_bytes!(
+    grey_types::Hash,
+    grey_types::Ed25519PublicKey,
+    grey_types::BandersnatchPublicKey,
+    grey_types::BandersnatchSignature,
+    grey_types::Ed25519Signature,
+);
 
 /// Encode a variable-length sequence with length prefix.
 impl<T: Encode> Encode for Vec<T> {

--- a/grey/crates/grey-merkle/src/state_serial.rs
+++ b/grey/crates/grey-merkle/src/state_serial.rs
@@ -422,31 +422,14 @@ fn serialize_safrole(safrole: &SafroleState, config: &Config) -> Vec<u8> {
 /// C(5): ψ judgments — 4 sorted sets.
 fn serialize_judgments(judgments: &Judgments) -> Vec<u8> {
     let mut buf = Vec::new();
-
-    // ↕ψG
-    encode_compact(judgments.good.len() as u64, &mut buf);
-    for hash in &judgments.good {
-        buf.extend_from_slice(&hash.0);
-    }
-
-    // ↕ψB
-    encode_compact(judgments.bad.len() as u64, &mut buf);
-    for hash in &judgments.bad {
-        buf.extend_from_slice(&hash.0);
-    }
-
-    // ↕ψW
-    encode_compact(judgments.wonky.len() as u64, &mut buf);
-    for hash in &judgments.wonky {
-        buf.extend_from_slice(&hash.0);
-    }
-
-    // ↕ψO
+    encode_hash_set(&judgments.good, &mut buf);
+    encode_hash_set(&judgments.bad, &mut buf);
+    encode_hash_set(&judgments.wonky, &mut buf);
+    // ↕ψO — offenders are Ed25519PublicKey (also 32 bytes)
     encode_compact(judgments.offenders.len() as u64, &mut buf);
     for key in &judgments.offenders {
         buf.extend_from_slice(&key.0);
     }
-
     buf
 }
 
@@ -854,6 +837,27 @@ fn read_hash(data: &[u8], pos: &mut usize) -> Result<Hash, String> {
     Ok(Hash(h))
 }
 
+/// Encode a compact-length-prefixed collection of 32-byte hashes.
+fn encode_hash_set(hashes: &std::collections::BTreeSet<Hash>, buf: &mut Vec<u8>) {
+    encode_compact(hashes.len() as u64, buf);
+    for hash in hashes {
+        buf.extend_from_slice(&hash.0);
+    }
+}
+
+/// Decode a compact-length-prefixed collection of 32-byte hashes into a BTreeSet.
+fn decode_hash_set(
+    data: &[u8],
+    pos: &mut usize,
+) -> Result<std::collections::BTreeSet<Hash>, String> {
+    let count = decode_compact(data, pos)? as usize;
+    let mut set = std::collections::BTreeSet::new();
+    for _ in 0..count {
+        set.insert(read_hash(data, pos)?);
+    }
+    Ok(set)
+}
+
 fn read_u32(data: &[u8], pos: &mut usize) -> Result<u32, String> {
     if *pos + 4 > data.len() {
         return Err("unexpected end reading u32".into());
@@ -1054,37 +1058,30 @@ fn deserialize_safrole(data: &[u8], config: &Config) -> Result<SafroleState, Str
 
 fn deserialize_judgments(data: &[u8]) -> Result<Judgments, String> {
     let mut pos = 0;
-    let mut judgments = Judgments::default();
 
-    let good_count = decode_compact(data, &mut pos)? as usize;
-    for _ in 0..good_count {
-        judgments.good.insert(read_hash(data, &mut pos)?);
-    }
+    let good = decode_hash_set(data, &mut pos)?;
+    let bad = decode_hash_set(data, &mut pos)?;
+    let wonky = decode_hash_set(data, &mut pos)?;
 
-    let bad_count = decode_compact(data, &mut pos)? as usize;
-    for _ in 0..bad_count {
-        judgments.bad.insert(read_hash(data, &mut pos)?);
-    }
-
-    let wonky_count = decode_compact(data, &mut pos)? as usize;
-    for _ in 0..wonky_count {
-        judgments.wonky.insert(read_hash(data, &mut pos)?);
-    }
-
+    // Offenders are Ed25519PublicKey (also 32 bytes, but different type)
     let offender_count = decode_compact(data, &mut pos)? as usize;
+    let mut offenders = std::collections::BTreeSet::new();
     for _ in 0..offender_count {
         if pos + 32 > data.len() {
             return Err("unexpected end reading offender key".into());
         }
         let mut key = [0u8; 32];
         key.copy_from_slice(&data[pos..pos + 32]);
-        judgments
-            .offenders
-            .insert(grey_types::Ed25519PublicKey(key));
+        offenders.insert(grey_types::Ed25519PublicKey(key));
         pos += 32;
     }
 
-    Ok(judgments)
+    Ok(Judgments {
+        good,
+        bad,
+        wonky,
+        offenders,
+    })
 }
 
 fn deserialize_entropy(data: &[u8]) -> Result<[Hash; 4], String> {


### PR DESCRIPTION
## Summary

Three deduplication improvements across 2 crates:

1. **grey-codec/decode.rs**: Replace 7 identical `Decode` impls for fixed-size crypto types (Hash, Ed25519PublicKey, BandersnatchPublicKey, Ed25519Signature, BandersnatchSignature, BlsPublicKey, BandersnatchRingRoot) with a single `impl_decode_fixed_bytes!` macro
2. **grey-codec/encode.rs**: Replace 5 identical `Encode` impls with `impl_encode_fixed_bytes!` macro  
3. **grey-merkle/state_serial.rs**: Extract `encode_hash_set`/`decode_hash_set` helpers, simplifying `serialize_judgments` (24→6 lines) and `deserialize_judgments` (20→6 lines for the hash portions)

**Net: -47 lines** (80 added, 127 removed). All conformance tests pass.

Addresses #186.

## Test plan

- `cargo test --workspace` — all 142+ tests pass including conformance vectors
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- No behavioral changes — pure refactoring with macro expansion producing identical code