### PR TITLE
feat(grey-rpc): add WebSocket subscription support for blocks and finality

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -48,6 +48,10 @@ pub struct RpcState {
     pub config: Config,
     pub status: RwLock<NodeStatus>,
     pub commands: mpsc::Sender<RpcCommand>,
+    /// Broadcast channel for new block notifications (WebSocket subscriptions).
+    pub block_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
+    /// Broadcast channel for finalization notifications (WebSocket subscriptions).
+    pub finality_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
 }
 
 #[rpc(server)]
@@ -116,6 +120,18 @@ pub trait JamRpc {
         &self,
         set: Option<String>,
     ) -> Result<serde_json::Value, ErrorObjectOwned>;
+}
+
+/// WebSocket subscription API.
+#[rpc(server)]
+pub trait JamSubscriptions {
+    /// Subscribe to new block notifications (WebSocket only).
+    #[subscription(name = "subscribeNewBlocks" => "newBlock", unsubscribe = "unsubscribeNewBlocks", item = serde_json::Value)]
+    async fn subscribe_new_blocks(&self) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Subscribe to finalization notifications (WebSocket only).
+    #[subscription(name = "subscribeFinalized" => "finalized", unsubscribe = "unsubscribeFinalized", item = serde_json::Value)]
+    async fn subscribe_finalized(&self) -> jsonrpsee::core::SubscriptionResult;
 }
 
 struct RpcImpl {
@@ -519,6 +535,45 @@ impl JamRpcServer for RpcImpl {
     }
 }
 
+#[async_trait]
+impl JamSubscriptionsServer for RpcImpl {
+    async fn subscribe_new_blocks(
+        &self,
+        pending: jsonrpsee::PendingSubscriptionSink,
+    ) -> jsonrpsee::core::SubscriptionResult {
+        let sink = pending.accept().await?;
+        let mut rx = self.state.block_notifications.subscribe();
+        tokio::spawn(async move {
+            while let Ok(notification) = rx.recv().await {
+                let msg =
+                    jsonrpsee::SubscriptionMessage::from_json(&notification).expect("valid JSON");
+                if sink.send(msg).await.is_err() {
+                    break; // client disconnected
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn subscribe_finalized(
+        &self,
+        pending: jsonrpsee::PendingSubscriptionSink,
+    ) -> jsonrpsee::core::SubscriptionResult {
+        let sink = pending.accept().await?;
+        let mut rx = self.state.finality_notifications.subscribe();
+        tokio::spawn(async move {
+            while let Ok(notification) = rx.recv().await {
+                let msg =
+                    jsonrpsee::SubscriptionMessage::from_json(&notification).expect("valid JSON");
+                if sink.send(msg).await.is_err() {
+                    break; // client disconnected
+                }
+            }
+        });
+        Ok(())
+    }
+}
+
 // ── Health / readiness HTTP endpoints ─────────────────────────────────
 
 /// Tower layer that intercepts GET `/health` and `/ready` before they
@@ -692,9 +747,18 @@ pub async fn start_rpc_server(
         .await?;
     let bound_addr = server.local_addr()?;
 
-    let rpc_impl = RpcImpl { state };
+    let rpc_impl = RpcImpl {
+        state: state.clone(),
+    };
+    let sub_impl = RpcImpl { state };
 
-    let handle = server.start(rpc_impl.into_rpc());
+    // Merge regular RPC methods and subscription methods into one module
+    let mut module = JamRpcServer::into_rpc(rpc_impl);
+    module
+        .merge(JamSubscriptionsServer::into_rpc(sub_impl))
+        .expect("merge subscription methods");
+
+    let handle = server.start(module);
 
     let join = tokio::spawn(async move {
         handle.stopped().await;
@@ -719,6 +783,9 @@ pub fn create_rpc_channel(
 ) -> (Arc<RpcState>, mpsc::Receiver<RpcCommand>) {
     let (tx, rx) = mpsc::channel(256);
 
+    let (block_tx, _) = tokio::sync::broadcast::channel(64);
+    let (finality_tx, _) = tokio::sync::broadcast::channel(64);
+
     let state = Arc::new(RpcState {
         store,
         config,
@@ -732,6 +799,8 @@ pub fn create_rpc_channel(
             validator_index,
         }),
         commands: tx,
+        block_notifications: block_tx,
+        finality_notifications: finality_tx,
     });
 
     (state, rx)


### PR DESCRIPTION
## Summary

- Add WebSocket subscription API: \`jam_subscribeNewBlocks\` and \`jam_subscribeFinalized\` with their unsubscribe counterparts
- Add broadcast channels to \`RpcState\` for block and finality notifications; the node pushes events via \`state.block_notifications.send()\`
- Merge subscription module into the jsonrpsee server alongside regular RPC methods; clients connect via \`ws://\`

Addresses #228.

## Scope

This PR addresses: WebSocket subscription infrastructure (task 2).

Remaining sub-tasks in #228:
- Wire block/finality notifications from node.rs into the broadcast channels
- Rate limiting for WebSocket connections (task 3)

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: connect via \`wscat -c ws://localhost:9933\` and call \`{"jsonrpc":"2.0","method":"jam_subscribeNewBlocks","id":1}\`