### PR TITLE
feat(grey): wire block and finality notifications to WebSocket subscribers

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -53,6 +53,10 @@ pub struct RpcState {
     pub config: Config,
     pub status: RwLock<NodeStatus>,
     pub commands: mpsc::Sender<RpcCommand>,
+    /// Broadcast channel for new block notifications (WebSocket subscriptions).
+    pub block_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
+    /// Broadcast channel for finalization notifications (WebSocket subscriptions).
+    pub finality_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
 }
 
 #[rpc(server)]
@@ -829,6 +833,8 @@ pub fn create_rpc_channel(
     validator_index: u16,
 ) -> (Arc<RpcState>, mpsc::Receiver<RpcCommand>) {
     let (tx, rx) = mpsc::channel(256);
+    let (block_tx, _) = tokio::sync::broadcast::channel(64);
+    let (finality_tx, _) = tokio::sync::broadcast::channel(64);
 
     let state = Arc::new(RpcState {
         store,
@@ -843,6 +849,8 @@ pub fn create_rpc_channel(
             validator_index,
         }),
         commands: tx,
+        block_notifications: block_tx,
+        finality_notifications: finality_tx,
     });
 
     (state, rx)

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -576,6 +576,18 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     hex::encode(&header_hash.0[..8])
                                 );
 
+                                // Push new block notification to WebSocket subscribers
+                                if let Some(ref rpc_st) = rpc_state {
+                                    let _ = rpc_st.block_notifications.send(serde_json::json!({
+                                        "hash": hex::encode(header_hash.0),
+                                        "slot": current_slot,
+                                        "author_index": block.header.author_index,
+                                        "parent_hash": hex::encode(block.header.parent_hash.0),
+                                        "guarantees": block.extrinsic.guarantees.len(),
+                                        "assurances": block.extrinsic.assurances.len(),
+                                    }));
+                                }
+
                                 // Register guarantees from this block for auditing
                                 // and mark cores as available for assurance generation
                                 for guarantee in &block.extrinsic.guarantees {
@@ -777,6 +789,18 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                         tracing::error!("Failed to update head: {}", e);
                                     }
 
+                                    // Push new block notification to WebSocket subscribers
+                                    if let Some(ref rpc_st) = rpc_state {
+                                        let _ = rpc_st.block_notifications.send(serde_json::json!({
+                                            "hash": hex::encode(import_hash.0),
+                                            "slot": slot,
+                                            "author_index": block.header.author_index,
+                                            "parent_hash": hex::encode(block.header.parent_hash.0),
+                                            "guarantees": block.extrinsic.guarantees.len(),
+                                            "assurances": block.extrinsic.assurances.len(),
+                                        }));
+                                    }
+
                                     // Register guarantees from imported block for auditing,
                                     // mark cores as available for assurance generation,
                                     // and remove matching guarantees from our pending list
@@ -925,6 +949,15 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                                 hex::encode(&fin_hash.0[..8])
                                             );
                                             let _ = store.set_finalized(&fin_hash, fin_slot);
+
+                                            // Push finality notification to WebSocket subscribers
+                                            if let Some(ref rpc_st) = rpc_state {
+                                                let _ = rpc_st.finality_notifications.send(serde_json::json!({
+                                                    "hash": hex::encode(fin_hash.0),
+                                                    "slot": fin_slot,
+                                                    "round": grandpa.round,
+                                                }));
+                                            }
 
                                             // Prune finalized GRANDPA votes
                                             if grandpa.round > 1 {


### PR DESCRIPTION
## Summary

- Push new block notifications after block authoring and import: `{hash, slot, author_index, parent_hash, guarantees, assurances}`
- Push finality notifications after GRANDPA finalization: `{hash, slot, round}`
- Add broadcast channels to RpcState (will deduplicate with PR #275 on merge)

Addresses #228.

## Scope

This PR addresses: wiring block/finality events from node.rs to WebSocket broadcast channels (task 2, integration).

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean
- Manual: connect via WebSocket, subscribe, verify notifications arrive on block production