### PR TITLE
refactor(grey-codec): macro-ify byte array Encode impls

### DIFF
--- a/grey/crates/grey-codec/src/encode.rs
+++ b/grey/crates/grey-codec/src/encode.rs
@@ -91,23 +91,20 @@ impl Encode for bool {
     }
 }
 
-impl Encode for [u8; 32] {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(self);
-    }
+/// Implement Encode for fixed-size byte arrays by extending with all bytes.
+macro_rules! impl_encode_byte_array {
+    ($($size:expr),+ $(,)?) => {
+        $(
+            impl Encode for [u8; $size] {
+                fn encode_to(&self, buf: &mut Vec<u8>) {
+                    buf.extend_from_slice(self);
+                }
+            }
+        )+
+    };
 }
 
-impl Encode for [u8; 64] {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(self);
-    }
-}
-
-impl Encode for [u8; 96] {
-    fn encode_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(self);
-    }
-}
+impl_encode_byte_array!(32, 64, 96);
 
 /// Implement Encode for newtype wrappers around byte arrays.
 /// All these types are `Type([u8; N])` and encode by writing all bytes.

--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -893,11 +893,8 @@ pub fn create_rpc_channel(
     validator_index: u16,
 ) -> (Arc<RpcState>, mpsc::Receiver<RpcCommand>) {
     let (tx, rx) = mpsc::channel(256);
-    let (block_tx, _) = tokio::sync::broadcast::channel(64);
-    let (finality_tx, _) = tokio::sync::broadcast::channel(64);
-
-    let (block_tx, _) = tokio::sync::broadcast::channel(64);
-    let (finality_tx, _) = tokio::sync::broadcast::channel(64);
+    let (block_tx, _) = tokio::sync::broadcast::channel::<serde_json::Value>(64);
+    let (finality_tx, _) = tokio::sync::broadcast::channel::<serde_json::Value>(64);
 
     let state = Arc::new(RpcState {
         store,


### PR DESCRIPTION
## Summary

- Replace 3 identical `Encode` impls for `[u8; 32]`, `[u8; 64]`, `[u8; 96]` with `impl_encode_byte_array!` macro
- Fix duplicate broadcast channel creation in `create_rpc_channel` (merge artifact)

Addresses #186.

## Test plan

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` — clean