### PR TITLE
feat(harness): add invalid_wp scenario for negative testing

### DIFF
--- a/grey/harness/src/main.rs
+++ b/grey/harness/src/main.rs
@@ -106,7 +106,7 @@ async fn main() {
 
     // Run scenarios sequentially.
     let mut results = Vec::new();
-    let all_scenarios = ["serial", "repeat", "liveness"];
+    let all_scenarios = ["serial", "repeat", "liveness", "invalid_wp"];
 
     // Filter to a single scenario if --scenario is specified.
     let scenario_list: Vec<&str> = if let Some(ref name) = cli.scenario {
@@ -129,6 +129,7 @@ async fn main() {
             "serial" => scenarios::serial::run(&client).await,
             "repeat" => scenarios::repeat::run(&client).await,
             "liveness" => scenarios::liveness::run(&client).await,
+            "invalid_wp" => scenarios::invalid_wp::run(&client).await,
             _ => unreachable!(),
         };
         let dur = result.duration.as_secs();

--- a/grey/harness/src/scenarios/invalid_wp.rs
+++ b/grey/harness/src/scenarios/invalid_wp.rs
@@ -1,0 +1,69 @@
+//! Scenario: submit various invalid work packages and verify error responses.
+//!
+//! Tests that the node correctly rejects malformed inputs without crashing.
+
+use std::time::Instant;
+
+use crate::rpc::RpcClient;
+use crate::scenarios::ScenarioResult;
+
+/// Submit a work package and assert it is rejected.
+async fn assert_rejected(
+    client: &RpcClient,
+    data: &str,
+    description: &str,
+    start: &Instant,
+) -> Option<ScenarioResult> {
+    if client.submit_work_package(data).await.is_ok() {
+        return Some(ScenarioResult {
+            name: "invalid_wp",
+            pass: false,
+            duration: start.elapsed(),
+            error: Some(format!("{} should have been rejected", description)),
+        });
+    }
+    None
+}
+
+pub async fn run(client: &RpcClient) -> ScenarioResult {
+    let start = Instant::now();
+
+    // Test 1: Random bytes (invalid JAM codec)
+    let random_hex = hex::encode([0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04]);
+    if let Some(r) = assert_rejected(client, &random_hex, "random bytes", &start).await {
+        return r;
+    }
+
+    // Test 2: Empty work package
+    if let Some(r) = assert_rejected(client, "", "empty work package", &start).await {
+        return r;
+    }
+
+    // Test 3: Invalid hex
+    if let Some(r) = assert_rejected(client, "not-hex-data", "invalid hex", &start).await {
+        return r;
+    }
+
+    // Test 4: Oversized payload (15MB > MAX_WORK_PACKAGE_BLOB_SIZE)
+    let oversized = hex::encode(vec![0u8; 15_000_000]);
+    if let Some(r) = assert_rejected(client, &oversized, "oversized work package", &start).await {
+        return r;
+    }
+
+    // Test 5: Verify node is still healthy after all invalid submissions
+    if let Err(e) = client.get_status().await {
+        return ScenarioResult {
+            name: "invalid_wp",
+            pass: false,
+            duration: start.elapsed(),
+            error: Some(format!("node unhealthy after invalid submissions: {}", e)),
+        };
+    }
+
+    ScenarioResult {
+        name: "invalid_wp",
+        pass: true,
+        duration: start.elapsed(),
+        error: None,
+    }
+}

--- a/grey/harness/src/scenarios/mod.rs
+++ b/grey/harness/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 //! Integration test scenarios.
 
+pub mod invalid_wp;
 pub mod liveness;
 pub mod repeat;
 pub mod serial;


### PR DESCRIPTION
## Summary

- Add \`invalid_wp\` harness scenario that submits 4 types of invalid work packages (random bytes, empty, invalid hex, oversized) and verifies each is rejected
- Verifies node remains healthy after all invalid submissions
- Runnable individually via \`--scenario invalid_wp\`

Addresses #225.

## Scope

This PR addresses: invalid work package scenarios (task 1, bullets 1-2 + oversized + health check).

Remaining sub-tasks in #225:
- Wrong service ID, wrong code hash, wrong context scenarios
- State consistency after errors (task 3)
- Log capture, structured error reporting (task 4)

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`cargo run -p harness -- --scenario invalid_wp --seq-testnet\`