### PR TITLE
feat(grey): add --export-chain-spec flag to save chain spec to file

### DIFF
--- a/grey/crates/grey/src/chainspec.rs
+++ b/grey/crates/grey/src/chainspec.rs
@@ -35,7 +35,6 @@ pub struct ChainSpecConfig {
 
 impl ChainSpec {
     /// Create a chain spec from a Config and genesis state.
-    #[allow(dead_code)] // Used by tests; will be used by --export-chain-spec
     pub fn from_genesis(config: &Config, _genesis_state: &State) -> Self {
         // Compute genesis hash from the config blob
         let config_blob = config.encode_config_blob();
@@ -59,7 +58,6 @@ impl ChainSpec {
     }
 
     /// Save chain spec to a JSON file.
-    #[allow(dead_code)] // Used by tests; will be used by --export-chain-spec
     pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let json = serde_json::to_string_pretty(self)?;
         std::fs::write(path, json)?;

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -77,6 +77,10 @@ struct Cli {
     #[arg(long)]
     info: bool,
 
+    /// Export the chain spec to a JSON file and exit.
+    #[arg(long, value_name = "PATH")]
+    export_chain_spec: Option<String>,
+
     /// Verify integrity of all stored state data and exit.
     /// Checks blake2b checksums for every stored state entry.
     #[arg(long)]
@@ -307,6 +311,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     if cli.info {
         chainspec::print_genesis_info(&config);
+        return Ok(());
+    }
+
+    if let Some(ref path) = cli.export_chain_spec {
+        let (genesis_state, _) = grey_consensus::genesis::create_genesis(&config);
+        let spec = chainspec::ChainSpec::from_genesis(&config, &genesis_state);
+        spec.save(std::path::Path::new(path))
+            .map_err(|e| format!("failed to export chain spec: {e}"))?;
+        println!("Chain spec exported to {}", path);
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Add \`--export-chain-spec <path>\` CLI flag that generates and saves the chain spec JSON, then exits
- Activates \`ChainSpec::from_genesis\` and \`save\` methods (removes dead_code annotations)
- Usage: \`grey --export-chain-spec chain-spec.json --tiny\`

Addresses #224.

## Test plan

- \`cargo test --workspace\` — all tests pass (including chainspec roundtrip tests)
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`grey --export-chain-spec /tmp/spec.json --tiny && cat /tmp/spec.json\`