### PR TITLE
feat(harness): add per-operation latency metrics to scenario results

### DIFF
--- a/grey/harness/src/main.rs
+++ b/grey/harness/src/main.rs
@@ -134,7 +134,9 @@ async fn main() {
         };
         let dur = result.duration.as_secs();
         if result.pass {
-            println!("  PASS ({dur}s)\n");
+            println!("  PASS ({dur}s)");
+            result.print_latency_summary();
+            println!();
         } else {
             println!(
                 "  FAIL: {} ({dur}s)\n",

--- a/grey/harness/src/scenarios/invalid_wp.rs
+++ b/grey/harness/src/scenarios/invalid_wp.rs
@@ -20,6 +20,7 @@ async fn assert_rejected(
             pass: false,
             duration: start.elapsed(),
             error: Some(format!("{} should have been rejected", description)),
+            latencies: vec![],
         });
     }
     None
@@ -57,6 +58,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             pass: false,
             duration: start.elapsed(),
             error: Some(format!("node unhealthy after invalid submissions: {}", e)),
+            latencies: vec![],
         };
     }
 
@@ -65,5 +67,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         pass: true,
         duration: start.elapsed(),
         error: None,
+        latencies: vec![],
     }
 }

--- a/grey/harness/src/scenarios/liveness.rs
+++ b/grey/harness/src/scenarios/liveness.rs
@@ -37,12 +37,14 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             pass: true,
             duration: start.elapsed(),
             error: None,
+            latencies: vec![],
         },
         Err(e) => ScenarioResult {
             name: "liveness",
             pass: false,
             duration: start.elapsed(),
             error: Some(e),
+            latencies: vec![],
         },
     }
 }

--- a/grey/harness/src/scenarios/mod.rs
+++ b/grey/harness/src/scenarios/mod.rs
@@ -14,4 +14,34 @@ pub struct ScenarioResult {
     pub pass: bool,
     pub duration: Duration,
     pub error: Option<String>,
+    /// Per-operation latency samples (e.g., submit-to-confirm times).
+    pub latencies: Vec<LatencySample>,
+}
+
+/// A single latency measurement.
+#[allow(dead_code)]
+pub struct LatencySample {
+    pub label: String,
+    pub duration: Duration,
+}
+
+impl ScenarioResult {
+    /// Print latency summary if samples are present.
+    pub fn print_latency_summary(&self) {
+        if self.latencies.is_empty() {
+            return;
+        }
+        let total: Duration = self.latencies.iter().map(|s| s.duration).sum();
+        let count = self.latencies.len();
+        let avg = total / count as u32;
+        let min = self.latencies.iter().map(|s| s.duration).min().unwrap();
+        let max = self.latencies.iter().map(|s| s.duration).max().unwrap();
+        println!(
+            "  Latency: {} samples, avg={:.1}s, min={:.1}s, max={:.1}s",
+            count,
+            avg.as_secs_f64(),
+            min.as_secs_f64(),
+            max.as_secs_f64()
+        );
+    }
 }

--- a/grey/harness/src/scenarios/repeat.rs
+++ b/grey/harness/src/scenarios/repeat.rs
@@ -26,6 +26,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
                 pass: false,
                 duration: start.elapsed(),
                 error: Some(e.to_string()),
+                latencies: vec![],
             };
         }
     }
@@ -34,5 +35,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         pass: true,
         duration: start.elapsed(),
         error: None,
+        latencies: vec![],
     }
 }

--- a/grey/harness/src/scenarios/serial.rs
+++ b/grey/harness/src/scenarios/serial.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use crate::poll::submit_and_verify_pixel;
 use crate::rpc::RpcClient;
-use crate::scenarios::ScenarioResult;
+use crate::scenarios::{LatencySample, ScenarioResult};
 
 const SERVICE_ID: u32 = 2000;
 const TIMEOUT: Duration = Duration::from_secs(120);
@@ -19,20 +19,29 @@ const PIXELS: [(u8, u8, u8, u8, u8); 5] = [
 
 pub async fn run(client: &RpcClient) -> ScenarioResult {
     let start = Instant::now();
+    let mut latencies = Vec::new();
+
     for (x, y, r, g, b) in PIXELS {
+        let op_start = Instant::now();
         if let Err(e) = submit_and_verify_pixel(client, SERVICE_ID, x, y, r, g, b, TIMEOUT).await {
             return ScenarioResult {
                 name: "serial",
                 pass: false,
                 duration: start.elapsed(),
                 error: Some(e.to_string()),
+                latencies,
             };
         }
+        latencies.push(LatencySample {
+            label: format!("pixel({x},{y})"),
+            duration: op_start.elapsed(),
+        });
     }
     ScenarioResult {
         name: "serial",
         pass: true,
         duration: start.elapsed(),
         error: None,
+        latencies,
     }
 }


### PR DESCRIPTION
## Summary

- Add \`LatencySample\` type and \`latencies\` field to \`ScenarioResult\`
- Serial scenario records submit-to-verify latency for each pixel operation
- Print min/avg/max latency summary after each passed scenario
- Foundation for performance baseline tracking and regression detection

Addresses #227.

## Scope

This PR addresses: per-scenario latency measurement (task 1, first bullet).

Remaining sub-tasks in #227:
- Block production and state transition latency tracking
- Throughput testing (max work packages per epoch)
- CI-integrated benchmark regression detection (task 2)

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: run harness, observe latency summary after serial scenario