### PR TITLE
refactor(grey): extract broadcast_vote helper for finality vote broadcasting

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -29,6 +29,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// exhaustion from peers sending blocks far ahead of our current state.
 const MAX_PENDING_BLOCKS: usize = 100;
 
+/// Encode a finality vote message and broadcast it to the network.
+fn broadcast_vote(
+    net_commands: &tokio::sync::mpsc::Sender<NetworkCommand>,
+    msg: &finality::VoteMessage,
+) {
+    let data = finality::encode_vote_message(msg);
+    let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote { data });
+}
+
 /// Node configuration.
 pub struct NodeConfig {
     /// Validator index in the genesis set.
@@ -656,10 +665,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     config.validator_index,
                                     my_secrets,
                                 ) {
-                                    let vote_data = finality::encode_vote_message(&prevote_msg);
-                                    let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote {
-                                        data: vote_data,
-                                    });
+                                    broadcast_vote(&net_commands, &prevote_msg);
                                 }
 
                                 // Try to precommit if prevote threshold reached
@@ -667,10 +673,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     config.validator_index,
                                     my_secrets,
                                 ) {
-                                    let vote_data = finality::encode_vote_message(&precommit_msg);
-                                    let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote {
-                                        data: vote_data,
-                                    });
+                                    broadcast_vote(&net_commands, &precommit_msg);
                                 }
                             }
                             Err(e) => {
@@ -893,19 +896,13 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                         config.validator_index,
                                         my_secrets,
                                     ) {
-                                        let vote_data = finality::encode_vote_message(&prevote_msg);
-                                        let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote {
-                                            data: vote_data,
-                                        });
+                                        broadcast_vote(&net_commands, &prevote_msg);
                                     }
                                     if let Some(precommit_msg) = grandpa.create_precommit(
                                         config.validator_index,
                                         my_secrets,
                                     ) {
-                                        let vote_data = finality::encode_vote_message(&precommit_msg);
-                                        let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote {
-                                            data: vote_data,
-                                        });
+                                        broadcast_vote(&net_commands, &precommit_msg);
                                     }
                                 }
                                 Err(e) => {
@@ -961,10 +958,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                                 config.validator_index,
                                                 my_secrets,
                                             ) {
-                                                let vote_data = finality::encode_vote_message(&precommit_msg);
-                                                let _ = net_commands.try_send(NetworkCommand::BroadcastFinalityVote {
-                                                    data: vote_data,
-                                                });
+                                                broadcast_vote(&net_commands, &precommit_msg);
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Summary

- Extract \`broadcast_vote()\` helper that encodes a vote message and broadcasts it via \`try_send(BroadcastFinalityVote)\`
- Replace 5 identical encode+broadcast sequences in node.rs with single-line calls
- Net: -6 lines (14 added, 20 removed)

Addresses #186.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean