### PR TITLE
feat(grey): enable RPC on all validators in testnet

### DIFF
--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -169,8 +169,8 @@ pub async fn run_testnet(
                 protocol_config: config_clone,
                 genesis_time,
                 db_path: format!("/tmp/grey-testnet-{}", genesis_time),
-                rpc_port: if i == 0 { 9933 } else { 0 },
-                rpc_cors: if i == 0 { rpc_cors } else { false },
+                rpc_port: 9933 + i,
+                rpc_cors,
                 genesis_state: Some(genesis_clone),
                 pruning_depth: 0, // No pruning in testnet
                 keystore_path: None,


### PR DESCRIPTION
## Summary

- Enable RPC on all 6 validators in testnet mode (ports 9933-9938) instead of only validator 0
- Enable CORS on all validators (was only validator 0)
- Foundation for cross-validator state consistency verification

Addresses #232.

## Scope

This PR addresses: multi-RPC testnet (task 1, first bullet).

Remaining sub-tasks in #232:
- Extend harness testnet.rs to spawn with per-validator RPC ports
- Update RpcClient to support multiple endpoints
- Cross-validator state comparison scenarios (task 2)

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: run testnet, verify \`curl localhost:9934/health\` returns OK (validator 1)