### PR TITLE
feat(grey-rpc): add jam_getBlockRange endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -126,6 +126,15 @@ pub trait JamRpc {
         &self,
         set: Option<String>,
     ) -> Result<serde_json::Value, ErrorObjectOwned>;
+
+    /// Get block hashes for a range of slots. Returns an array of {slot, hash} objects.
+    /// Useful for block explorers and monitoring.
+    #[method(name = "jam_getBlockRange")]
+    async fn get_block_range(
+        &self,
+        from_slot: u32,
+        to_slot: u32,
+    ) -> Result<serde_json::Value, ErrorObjectOwned>;
 }
 
 /// WebSocket subscription API.
@@ -537,6 +546,38 @@ impl JamRpcServer for RpcImpl {
             "count": count,
             "validators": entries,
             "slot": head_slot,
+        }))
+    }
+
+    async fn get_block_range(
+        &self,
+        from_slot: u32,
+        to_slot: u32,
+    ) -> Result<serde_json::Value, ErrorObjectOwned> {
+        if to_slot < from_slot {
+            return Err(internal_error("to_slot must be >= from_slot"));
+        }
+        // Limit range to prevent DoS (max 1000 slots per request)
+        let range_size = to_slot.saturating_sub(from_slot);
+        if range_size > 1000 {
+            return Err(internal_error("range too large (max 1000 slots)"));
+        }
+
+        let mut blocks = Vec::new();
+        for slot in from_slot..=to_slot {
+            if let Ok(hash) = self.state.store.get_block_hash_by_slot(slot) {
+                blocks.push(serde_json::json!({
+                    "slot": slot,
+                    "hash": hex::encode(hash.0),
+                }));
+            }
+        }
+
+        Ok(serde_json::json!({
+            "from_slot": from_slot,
+            "to_slot": to_slot,
+            "blocks": blocks,
+            "count": blocks.len(),
         }))
     }
 }


### PR DESCRIPTION
## Summary

- Add \`jam_getBlockRange(from_slot, to_slot)\` RPC endpoint returning block hashes for a slot range
- Limits range to 1000 slots per request to prevent DoS
- Returns \`{from_slot, to_slot, blocks: [{slot, hash}...], count}\`

Addresses #228.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`curl -X POST -d '{"jsonrpc":"2.0","method":"jam_getBlockRange","params":[0,10],"id":1}' localhost:9933\`