### PR TITLE
feat(grey): add --seq-testnet-blocks flag for extended stability testing

### DIFF
--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -115,6 +115,11 @@ struct Cli {
     #[arg(long)]
     seq_testnet: bool,
 
+    /// Number of blocks to produce in sequential testnet mode (default: from config).
+    /// Use with --seq-testnet for extended stability testing.
+    #[arg(long)]
+    seq_testnet_blocks: Option<u32>,
+
     /// Database path for persistent storage
     #[arg(long, default_value = "./grey-db")]
     db_path: String,
@@ -307,7 +312,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Deterministic sequential testnet
     if cli.seq_testnet {
         tracing::info!("Running deterministic sequential testnet");
-        return seq_testnet::run_seq_testnet(cli.rpc_port, cli.rpc_cors).await;
+        return seq_testnet::run_seq_testnet(cli.rpc_port, cli.rpc_cors, cli.seq_testnet_blocks)
+            .await;
     }
 
     // Networked testnet mode

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -51,6 +51,7 @@ impl SeqNode {
 pub async fn run_seq_testnet(
     rpc_port: u16,
     rpc_cors: bool,
+    max_blocks: Option<u32>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = Config::tiny();
     let (mut genesis_state, secrets) = create_genesis(&config);
@@ -105,6 +106,15 @@ pub async fn run_seq_testnet(
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
             tracing::info!("Shutting down sequential testnet");
+            break;
+        }
+        if let Some(max) = max_blocks
+            && blocks_produced >= max
+        {
+            tracing::info!(
+                "Reached {} blocks, stopping sequential testnet",
+                blocks_produced
+            );
             break;
         }
         // Check for RPC commands (non-blocking)


### PR DESCRIPTION
## Summary

- Add \`--seq-testnet-blocks <N>\` CLI flag to stop the sequential testnet after N blocks
- Without the flag, existing behavior preserved (runs until Ctrl+C)
- Enables extended stability testing: \`grey --seq-testnet --seq-testnet-blocks 10000\`

Addresses #230.

## Scope

This PR addresses: extended sequential testnet (task 1, first bullet).

Remaining sub-tasks in #230:
- Memory usage reporting per block
- Storage growth tracking
- Long-running test CI job

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`grey --seq-testnet --seq-testnet-blocks 100\` — stops after 100 blocks