### PR TITLE
feat(grey): add peer count to /metrics endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -58,6 +58,8 @@ pub struct RpcState {
     pub block_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
     /// Broadcast channel for finalization notifications (WebSocket subscriptions).
     pub finality_notifications: tokio::sync::broadcast::Sender<serde_json::Value>,
+    /// Connected peer count (updated by the node on PeerIdentified events).
+    pub peer_count: std::sync::atomic::AtomicU32,
 }
 
 #[rpc(server)]
@@ -699,6 +701,7 @@ where
                 let blocks_imported = status.blocks_imported;
                 let validator_index = status.validator_index;
                 let grandpa_round = status.grandpa_round;
+                let peer_count = state.peer_count.load(std::sync::atomic::Ordering::Relaxed);
                 drop(status);
 
                 let stored_blocks = state.store.block_count().unwrap_or(0);
@@ -736,7 +739,10 @@ where
                      grey_validator_index {validator_index}\n\
                      # HELP grey_grandpa_round Current GRANDPA finality round.\n\
                      # TYPE grey_grandpa_round gauge\n\
-                     grey_grandpa_round {grandpa_round}\n"
+                     grey_grandpa_round {grandpa_round}\n\
+                     # HELP grey_peer_count Number of connected peers.\n\
+                     # TYPE grey_peer_count gauge\n\
+                     grey_peer_count {peer_count}\n"
                 );
 
                 Ok(http::Response::builder()
@@ -958,6 +964,7 @@ pub fn create_rpc_channel(
         commands: tx,
         block_notifications: block_tx,
         finality_notifications: finality_tx,
+        peer_count: std::sync::atomic::AtomicU32::new(0),
     });
 
     (state, rx)

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1111,6 +1111,10 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                             peer_id,
                             vi
                         );
+                        // Increment peer count for metrics
+                        if let Some(ref rpc_st) = rpc_state {
+                            rpc_st.peer_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add \`peer_count\` AtomicU32 to RpcState, incremented on PeerIdentified events
- Expose as \`grey_peer_count\` gauge in the \`/metrics\` Prometheus endpoint
- Enables monitoring network connectivity and peer discovery health

Addresses #223.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: run testnet, \`curl localhost:9933/metrics | grep peer_count\`