### PR TITLE
feat(grey): add RSS memory reporting to sequential testnet

### DIFF
--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -255,8 +255,9 @@ pub async fn run_seq_testnet(
                         blocks_produced += 1;
 
                         if blocks_produced.is_multiple_of(10) || blocks_produced <= 5 {
+                            let rss_mb = get_rss_mb();
                             tracing::info!(
-                                "Slot {slot}: block #{blocks_produced} by v{author_idx}, hash=0x{}",
+                                "Slot {slot}: block #{blocks_produced} by v{author_idx}, hash=0x{}, rss={rss_mb:.1}MB",
                                 hex::encode(&header_hash.0[..8])
                             );
                         }
@@ -337,5 +338,25 @@ fn install_services(state: &mut State, config: &Config) {
         if state.auth_pool[core].is_empty() {
             state.auth_pool[core].push(Hash::ZERO);
         }
+    }
+}
+
+/// Get the current process RSS (Resident Set Size) in megabytes.
+/// Reads from /proc/self/statm on Linux; returns 0 on other platforms.
+fn get_rss_mb() -> f64 {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(statm) = std::fs::read_to_string("/proc/self/statm")
+            && let Some(rss_pages) = statm.split_whitespace().nth(1)
+            && let Ok(pages) = rss_pages.parse::<u64>()
+        {
+            let page_size = 4096u64; // standard page size
+            return (pages * page_size) as f64 / (1024.0 * 1024.0);
+        }
+        0.0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0.0
     }
 }


### PR DESCRIPTION
## Summary

- Log RSS (Resident Set Size) in MB at each block milestone in sequential testnet
- Reads from \`/proc/self/statm\` on Linux; returns 0 on other platforms
- Enables detecting memory leaks during extended stability tests (\`--seq-testnet-blocks 10000\`)

Addresses #230.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`grey --seq-testnet --seq-testnet-blocks 100\` — observe rss=X.XMB in log output