### PR TITLE
feat(harness): add recovery scenario for state consistency after errors

### DIFF
--- a/grey/harness/src/main.rs
+++ b/grey/harness/src/main.rs
@@ -106,7 +106,7 @@ async fn main() {
 
     // Run scenarios sequentially.
     let mut results = Vec::new();
-    let all_scenarios = ["serial", "repeat", "liveness", "invalid_wp"];
+    let all_scenarios = ["serial", "repeat", "liveness", "invalid_wp", "recovery"];
 
     // Filter to a single scenario if --scenario is specified.
     let scenario_list: Vec<&str> = if let Some(ref name) = cli.scenario {
@@ -130,6 +130,7 @@ async fn main() {
             "repeat" => scenarios::repeat::run(&client).await,
             "liveness" => scenarios::liveness::run(&client).await,
             "invalid_wp" => scenarios::invalid_wp::run(&client).await,
+            "recovery" => scenarios::recovery::run(&client).await,
             _ => unreachable!(),
         };
         let dur = result.duration.as_secs();

--- a/grey/harness/src/scenarios/mod.rs
+++ b/grey/harness/src/scenarios/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod invalid_wp;
 pub mod liveness;
+pub mod recovery;
 pub mod repeat;
 pub mod serial;
 

--- a/grey/harness/src/scenarios/recovery.rs
+++ b/grey/harness/src/scenarios/recovery.rs
@@ -1,0 +1,68 @@
+//! Scenario: verify node recovers after processing invalid inputs.
+//!
+//! Submits several invalid work packages, then submits a valid pixel
+//! and verifies it is correctly stored. Confirms that error handling
+//! does not corrupt the pipeline.
+
+use std::time::{Duration, Instant};
+
+use crate::poll::submit_and_verify_pixel;
+use crate::rpc::RpcClient;
+use crate::scenarios::{LatencySample, ScenarioResult};
+
+const SERVICE_ID: u32 = 2000;
+const TIMEOUT: Duration = Duration::from_secs(120);
+
+pub async fn run(client: &RpcClient) -> ScenarioResult {
+    let start = Instant::now();
+
+    // Phase 1: Submit several invalid work packages (should all be rejected)
+    let invalid_payloads = [
+        hex::encode([0xDE, 0xAD, 0xBE, 0xEF]),
+        String::new(),               // empty
+        hex::encode(vec![0u8; 100]), // random bytes
+    ];
+    for payload in &invalid_payloads {
+        // Ignore errors — we expect rejections
+        let _ = client.submit_work_package(payload).await;
+    }
+
+    // Phase 2: Submit a valid pixel and verify it is stored correctly
+    let op_start = Instant::now();
+    if let Err(e) = submit_and_verify_pixel(client, SERVICE_ID, 99, 99, 128, 64, 32, TIMEOUT).await
+    {
+        return ScenarioResult {
+            name: "recovery",
+            pass: false,
+            duration: start.elapsed(),
+            error: Some(format!(
+                "valid pixel failed after invalid submissions: {}",
+                e
+            )),
+            latencies: vec![],
+        };
+    }
+    let latency = LatencySample {
+        label: "pixel(99,99) after errors".into(),
+        duration: op_start.elapsed(),
+    };
+
+    // Phase 3: Verify node status is healthy
+    if let Err(e) = client.get_status().await {
+        return ScenarioResult {
+            name: "recovery",
+            pass: false,
+            duration: start.elapsed(),
+            error: Some(format!("node unhealthy after recovery: {}", e)),
+            latencies: vec![latency],
+        };
+    }
+
+    ScenarioResult {
+        name: "recovery",
+        pass: true,
+        duration: start.elapsed(),
+        error: None,
+        latencies: vec![latency],
+    }
+}


### PR DESCRIPTION
## Summary

- Add \`recovery\` harness scenario: submits invalid work packages, then verifies a valid pixel submission succeeds
- Confirms error handling doesn't corrupt the processing pipeline
- Includes latency measurement for the valid submission after errors

Addresses #225.

## Scope

This PR addresses: state consistency after errors (task 3).

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: \`cargo run -p harness -- --scenario recovery --seq-testnet\`