### PR TITLE
feat(grey-rpc): add jam_getPeers endpoint

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -137,6 +137,10 @@ pub trait JamRpc {
         from_slot: u32,
         to_slot: u32,
     ) -> Result<serde_json::Value, ErrorObjectOwned>;
+
+    /// Get peer connectivity information.
+    #[method(name = "jam_getPeers")]
+    async fn get_peers(&self) -> Result<serde_json::Value, ErrorObjectOwned>;
 }
 
 /// WebSocket subscription API.
@@ -580,6 +584,16 @@ impl JamRpcServer for RpcImpl {
             "to_slot": to_slot,
             "blocks": blocks,
             "count": blocks.len(),
+        }))
+    }
+
+    async fn get_peers(&self) -> Result<serde_json::Value, ErrorObjectOwned> {
+        let peer_count = self
+            .state
+            .peer_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        Ok(serde_json::json!({
+            "peer_count": peer_count,
         }))
     }
 }


### PR DESCRIPTION
## Summary

- Add \`jam_getPeers\` RPC endpoint returning peer connectivity information
- Currently returns \`{peer_count}\` from the shared atomic counter
- Foundation for richer peer info (validator mappings, latency) in future PRs

Addresses #228.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean