### PR TITLE
feat(grey): apply config file log_format to tracing setup

### DIFF
--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -209,6 +209,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if cli.log_level.is_none() {
             cli.log_level = cfg.logging.level;
         }
+        // Apply log format from config file if CLI uses default (Plain)
+        if matches!(cli.log_format, LogFormat::Plain)
+            && let Some(ref fmt) = cfg.logging.format
+        {
+            match fmt.as_str() {
+                "json" => cli.log_format = LogFormat::Json,
+                "pretty" => cli.log_format = LogFormat::Pretty,
+                "plain" => {}
+                other => eprintln!("warning: unknown log format in config: {:?}", other),
+            }
+        }
     }
 
     // Build EnvFilter: CLI arg > config file > RUST_LOG env var > "info"


### PR DESCRIPTION
## Summary

- Wire \`logging.format\` from the TOML config file into the tracing format selection
- Supports "json", "pretty", "plain" values; warns on unknown formats
- CLI \`--log-format\` flag takes precedence when explicitly set

Addresses #224.

## Test plan

- \`cargo test --workspace\` — all tests pass
- \`cargo clippy --workspace --all-targets --features javm/signals -- -D warnings\` — clean
- Manual: config.toml with \`[logging] format = "json"\`, verify JSON log output