### PR TITLE
feat(grey-rpc): configurable --rpc-rate-limit flag

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -23,8 +23,8 @@ use tokio::sync::mpsc;
 /// Prevents slow or hanging queries from blocking the server indefinitely.
 const RPC_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum RPC requests per IP per window. Returns HTTP 429 when exceeded.
-const RATE_LIMIT_MAX_REQUESTS: u64 = 1000;
+/// Default maximum RPC requests per IP per window. Returns HTTP 429 when exceeded.
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS: u64 = 1000;
 /// Rate limit window duration.
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 
@@ -795,12 +795,14 @@ struct RateLimitLayer {
     state: Arc<
         std::sync::Mutex<std::collections::HashMap<std::net::IpAddr, (u64, std::time::Instant)>>,
     >,
+    max_requests: u64,
 }
 
 impl RateLimitLayer {
-    fn new() -> Self {
+    fn new(max_requests: u64) -> Self {
         Self {
             state: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            max_requests,
         }
     }
 }
@@ -811,6 +813,7 @@ impl<S> tower::Layer<S> for RateLimitLayer {
         RateLimitService {
             inner,
             state: self.state.clone(),
+            max_requests: self.max_requests,
         }
     }
 }
@@ -821,6 +824,7 @@ struct RateLimitService<S> {
     state: Arc<
         std::sync::Mutex<std::collections::HashMap<std::net::IpAddr, (u64, std::time::Instant)>>,
     >,
+    max_requests: u64,
 }
 
 impl<S, ReqBody> tower::Service<http::Request<ReqBody>> for RateLimitService<S>
@@ -867,7 +871,7 @@ where
             }
 
             entry.0 += 1;
-            if entry.0 > RATE_LIMIT_MAX_REQUESTS {
+            if entry.0 > self.max_requests {
                 tracing::warn!("Rate limit exceeded for IP {}: {}/min", ip, entry.0);
                 let body = serde_json::json!({
                     "error": "rate limit exceeded",
@@ -895,6 +899,7 @@ pub async fn start_rpc_server(
     port: u16,
     state: Arc<RpcState>,
     cors: bool,
+    rate_limit: u64,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
     let addr = format!("0.0.0.0:{}", port);
     let cors_layer = if cors {
@@ -906,7 +911,12 @@ pub async fn start_rpc_server(
     let health_layer = HealthLayer {
         state: state.clone(),
     };
-    let rate_limiter = RateLimitLayer::new();
+    let max_requests = if rate_limit == 0 {
+        u64::MAX
+    } else {
+        rate_limit
+    };
+    let rate_limiter = RateLimitLayer::new(max_requests);
     let middleware = tower::ServiceBuilder::new()
         .layer(cors_layer)
         .layer(rate_limiter)
@@ -949,7 +959,7 @@ pub async fn start_rpc_server(
 pub async fn start_rpc_server_ephemeral(
     state: Arc<RpcState>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
-    start_rpc_server(0, state, false).await
+    start_rpc_server(0, state, false, DEFAULT_RATE_LIMIT_MAX_REQUESTS).await
 }
 
 /// Create RPC state and command channel.

--- a/grey/crates/grey/src/config.rs
+++ b/grey/crates/grey/src/config.rs
@@ -40,6 +40,7 @@ pub struct RpcConfig {
     pub port: Option<u16>,
     pub host: Option<String>,
     pub cors: Option<bool>,
+    pub rate_limit: Option<u64>,
 }
 
 /// Network configuration section.

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -139,6 +139,10 @@ struct Cli {
     #[arg(long, default_value_t = 9933)]
     rpc_port: u16,
 
+    /// Maximum RPC requests per IP per minute (0 to disable rate limiting).
+    #[arg(long, default_value_t = 1000)]
+    rpc_rate_limit: u64,
+
     /// Enable permissive CORS on the RPC server
     #[arg(long)]
     rpc_cors: bool,
@@ -199,6 +203,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             && !cli.rpc_cors
         {
             cli.rpc_cors = v;
+        }
+        if let Some(v) = cfg.rpc.rate_limit
+            && cli.rpc_rate_limit == 1000
+        {
+            cli.rpc_rate_limit = v;
         }
         if let Some(ref peers) = cfg.network.boot_peers
             && cli.peers.is_empty()
@@ -399,6 +408,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         db_path: cli.db_path,
         rpc_port: cli.rpc_port,
         rpc_cors: cli.rpc_cors,
+        rpc_rate_limit: cli.rpc_rate_limit,
         genesis_state: None,
         pruning_depth: cli.pruning_depth,
         keystore_path: cli.keystore_path,

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -59,6 +59,8 @@ pub struct NodeConfig {
     pub rpc_port: u16,
     /// Enable CORS on the RPC server.
     pub rpc_cors: bool,
+    /// Maximum RPC requests per IP per minute (0 = unlimited).
+    pub rpc_rate_limit: u64,
     /// Optional pre-configured genesis state (with services installed, etc.).
     /// If None, the default genesis from create_genesis is used.
     pub genesis_state: Option<State>,
@@ -155,8 +157,13 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
             config.validator_index,
         );
         rpc_state = Some(state_arc.clone());
-        let (_addr, _handle) =
-            grey_rpc::start_rpc_server(config.rpc_port, state_arc, config.rpc_cors).await?;
+        let (_addr, _handle) = grey_rpc::start_rpc_server(
+            config.rpc_port,
+            state_arc,
+            config.rpc_cors,
+            config.rpc_rate_limit,
+        )
+        .await?;
         rpc_rx = Some(rx);
     } else {
         rpc_state = None;

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -72,7 +72,7 @@ pub async fn run_seq_testnet(
 
     if rpc_port > 0 {
         let (addr, _handle) =
-            grey_rpc::start_rpc_server(rpc_port, rpc_state.clone(), rpc_cors).await?;
+            grey_rpc::start_rpc_server(rpc_port, rpc_state.clone(), rpc_cors, 0).await?;
         tracing::info!("Sequential testnet RPC on {addr}");
     }
 

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -171,6 +171,7 @@ pub async fn run_testnet(
                 db_path: format!("/tmp/grey-testnet-{}", genesis_time),
                 rpc_port: 9933 + i,
                 rpc_cors,
+                rpc_rate_limit: 0, // No rate limiting in testnet
                 genesis_state: Some(genesis_clone),
                 pruning_depth: 0, // No pruning in testnet
                 keystore_path: None,


### PR DESCRIPTION
## Summary

- Add `--rpc-rate-limit <N>` CLI flag to configure the maximum RPC requests per IP per minute (default: 1000, 0 to disable rate limiting)
- Thread the rate limit value through `NodeConfig` → `start_rpc_server` → `RateLimitLayer` → `RateLimitService` instead of using a hardcoded constant
- Support `rate_limit` in the `[rpc]` section of the TOML config file

Addresses #228.

## Scope

This PR addresses: configurable `--rpc-rate-limit` CLI flag (task 3 from the issue checklist).

Remaining sub-tasks in #228:
- RPC listen address flag (`--rpc-host`) — already implemented
- Other RPC configuration improvements

## Test plan

- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Verify `--rpc-rate-limit 0` disables rate limiting (sets max to u64::MAX)
- Verify `--rpc-rate-limit 500` reduces the per-IP limit
- Verify TOML config `[rpc] rate_limit = 500` works as fallback