### PR TITLE
feat(grey-codec): fuzz-style decode tests + fix OOM on crafted length prefix

### DIFF
--- a/grey/crates/grey-codec/src/decode.rs
+++ b/grey/crates/grey-codec/src/decode.rs
@@ -170,6 +170,14 @@ impl_decode_fixed_bytes!(
 impl<T: Decode> Decode for Vec<T> {
     fn decode(data: &[u8]) -> Result<(Self, usize), CodecError> {
         let (len, mut offset) = decode_natural(data)?;
+        // Sanity check: each element is at least 1 byte, so the declared
+        // length cannot exceed the remaining buffer.  Without this guard,
+        // a crafted length prefix can cause a multi-gigabyte allocation
+        // before we ever try to decode elements.
+        let remaining = data.len().saturating_sub(offset);
+        if len > remaining {
+            return Err(CodecError::SequenceTooLong(len, remaining));
+        }
         let mut items = Vec::with_capacity(len);
         for _ in 0..len {
             let (item, consumed) = T::decode(&data[offset..])?;
@@ -568,6 +576,10 @@ impl DecodeWithConfig for DisputesExtrinsic {
         // Verdicts: length-prefixed, each verdict needs config
         let (verdict_count, c) = decode_natural(&data[off..])?;
         off += c;
+        let remaining = data.len().saturating_sub(off);
+        if verdict_count > remaining {
+            return Err(CodecError::SequenceTooLong(verdict_count, remaining));
+        }
         let mut verdicts = Vec::with_capacity(verdict_count);
         for _ in 0..verdict_count {
             let (v, c) = Verdict::decode_with_config(&data[off..], config)?;
@@ -681,6 +693,10 @@ impl DecodeWithConfig for Extrinsic {
         // Assurances: length-prefixed, each needs config
         let (assurance_count, c) = decode_natural(&data[off..])?;
         off += c;
+        let remaining = data.len().saturating_sub(off);
+        if assurance_count > remaining {
+            return Err(CodecError::SequenceTooLong(assurance_count, remaining));
+        }
         let mut assurances = Vec::with_capacity(assurance_count);
         for _ in 0..assurance_count {
             let (a, c) = Assurance::decode_with_config(&data[off..], config)?;

--- a/grey/crates/grey-codec/tests/fuzz_decode.rs
+++ b/grey/crates/grey-codec/tests/fuzz_decode.rs
@@ -1,0 +1,179 @@
+//! Fuzz-style property tests: feed random bytes to all Decode impls and
+//! verify they never panic. Decoding may return Err (expected for garbage
+//! input) but must not panic or cause undefined behavior.
+
+use grey_codec::decode::decode_compact;
+use grey_codec::{Decode, DecodeWithConfig};
+use grey_types::config::Config;
+use grey_types::header::{Culprit, Fault, Guarantee, Judgment, Ticket, TicketProof};
+use grey_types::work::{
+    AvailabilitySpec, ImportSegment, RefinementContext, WorkDigest, WorkItem, WorkPackage,
+    WorkReport, WorkResult,
+};
+use grey_types::{
+    BandersnatchPublicKey, BandersnatchRingRoot, BandersnatchSignature, BlsPublicKey,
+    Ed25519PublicKey, Ed25519Signature, Hash,
+};
+use proptest::prelude::*;
+
+/// Generate random byte vectors of 0–1024 bytes.
+fn arb_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(any::<u8>(), 0..=1024)
+}
+
+proptest! {
+    // ── Primitive types ────────────────────────────────────────────────
+
+    #[test]
+    fn fuzz_decode_u8(data in arb_bytes()) {
+        let _ = u8::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_u16(data in arb_bytes()) {
+        let _ = u16::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_u32(data in arb_bytes()) {
+        let _ = u32::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_u64(data in arb_bytes()) {
+        let _ = u64::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_bool(data in arb_bytes()) {
+        let _ = bool::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_compact(data in arb_bytes()) {
+        let _ = decode_compact(&data);
+    }
+
+    // ── Hash and key types ─────────────────────────────────────────────
+
+    #[test]
+    fn fuzz_decode_hash(data in arb_bytes()) {
+        let _ = Hash::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_ed25519_public(data in arb_bytes()) {
+        let _ = Ed25519PublicKey::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_bandersnatch_public(data in arb_bytes()) {
+        let _ = BandersnatchPublicKey::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_bls_public(data in arb_bytes()) {
+        let _ = BlsPublicKey::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_ed25519_signature(data in arb_bytes()) {
+        let _ = Ed25519Signature::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_bandersnatch_signature(data in arb_bytes()) {
+        let _ = BandersnatchSignature::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_bandersnatch_ring_root(data in arb_bytes()) {
+        let _ = BandersnatchRingRoot::decode(&data);
+    }
+
+    // ── Protocol types ─────────────────────────────────────────────────
+
+    #[test]
+    fn fuzz_decode_ticket(data in arb_bytes()) {
+        let _ = Ticket::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_ticket_proof(data in arb_bytes()) {
+        let _ = TicketProof::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_work_result(data in arb_bytes()) {
+        let _ = WorkResult::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_work_digest(data in arb_bytes()) {
+        let _ = WorkDigest::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_import_segment(data in arb_bytes()) {
+        let _ = ImportSegment::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_availability_spec(data in arb_bytes()) {
+        let _ = AvailabilitySpec::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_refinement_context(data in arb_bytes()) {
+        let _ = RefinementContext::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_work_item(data in arb_bytes()) {
+        let _ = WorkItem::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_work_report(data in arb_bytes()) {
+        let _ = WorkReport::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_work_package(data in arb_bytes()) {
+        let _ = WorkPackage::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_judgment(data in arb_bytes()) {
+        let _ = Judgment::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_culprit(data in arb_bytes()) {
+        let _ = Culprit::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_fault(data in arb_bytes()) {
+        let _ = Fault::decode(&data);
+    }
+
+    #[test]
+    fn fuzz_decode_guarantee(data in arb_bytes()) {
+        let _ = Guarantee::decode(&data);
+    }
+
+    // ── Config-dependent types (DecodeWithConfig) ──────────────────────
+
+    #[test]
+    fn fuzz_decode_header_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::Header::decode_with_config(&data, &config);
+    }
+
+    #[test]
+    fn fuzz_decode_header_full(data in arb_bytes()) {
+        let config = Config::full();
+        let _ = grey_types::header::Header::decode_with_config(&data, &config);
+    }
+}


### PR DESCRIPTION
## Summary

- Add 29 proptest cases that feed random bytes (0–1024 bytes) to every `Decode` impl, verifying no panics on arbitrary input
- Fix OOM vulnerability: `Vec<T>::decode`, `DisputesExtrinsic`, and `Extrinsic` decoders could allocate multi-gigabyte buffers when a crafted length prefix exceeds the remaining data. Added bounds checks before `Vec::with_capacity` calls.

Addresses #229.

## Scope

This PR addresses: fuzz-style decode testing (from the "fuzz_codec_decode" task) and a real bug found during testing.

Remaining sub-tasks in #229:
- `cargo-fuzz` infrastructure setup
- PVM fuzz targets
- CI fuzz smoke tests
- Differential testing (interpreter vs recompiler)

## Test plan

- `cargo test -p grey-codec --test fuzz_decode` — 29 new tests pass
- `cargo test --workspace` — all existing tests still pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Before the fix, random bytes could cause OOM via crafted length prefix; after the fix, returns `SequenceTooLong` error