### PR TITLE
test(grey-erasure): proptest recovery from any k-of-n shard combination

### DIFF
--- a/grey/crates/grey-erasure/tests/proptest_erasure.rs
+++ b/grey/crates/grey-erasure/tests/proptest_erasure.rs
@@ -62,3 +62,44 @@ proptest! {
         }
     }
 }
+
+// Recovery from any k-of-n shards is expensive (15 pairs per iteration),
+// so use fewer proptest cases.
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(8))]
+
+    /// Recovery succeeds using any combination of data_shards out of total_shards.
+    /// For TINY (2 data, 6 total), tests all C(6,2)=15 pairs per input.
+    #[test]
+    fn recover_from_any_k_shards(data in arb_data()) {
+        let chunks = encode(&TINY, &data).expect("encode should succeed");
+        let k = TINY.data_shards; // 2
+        let n = TINY.total_shards; // 6
+
+        // Try every combination of k shards from n
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let indexed: Vec<(Vec<u8>, usize)> = vec![
+                    (chunks[i].clone(), i),
+                    (chunks[j].clone(), j),
+                ];
+                let recovered = recover(&TINY, &indexed, data.len())
+                    .unwrap_or_else(|e| panic!(
+                        "recover failed with shards ({}, {}): {:?}", i, j, e
+                    ));
+                prop_assert_eq!(
+                    &recovered, &data,
+                    "recovery mismatch with shards ({}, {})", i, j
+                );
+            }
+        }
+
+        // Also verify that k-1 shards (just 1) is not enough
+        let single: Vec<(Vec<u8>, usize)> = vec![(chunks[0].clone(), 0)];
+        let result = recover(&TINY, &single, data.len());
+        prop_assert!(
+            result.is_err(),
+            "recovery with fewer than k={} shards should fail", k
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `recover_from_any_k_shards` proptest that verifies erasure recovery works with every possible pair of 2 shards from 6 (all 15 combinations of C(6,2))
- Also verifies that recovery with fewer than k shards fails (negative case)
- Uses 8 proptest cases to keep CI runtime reasonable (~50s in debug mode)

Addresses #229.

## Scope

This PR addresses: "Corrupting any chunk still allows recovery from remaining k chunks" from the erasure coding properties checklist.

Remaining sub-tasks in #229:
- `cargo-fuzz` infrastructure setup
- PVM fuzz targets
- State transition property tests
- Differential testing

## Test plan

- `cargo test -p grey-erasure --test proptest_erasure` — all 5 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean