### PR TITLE
fix(grey-rpc): wire --rpc-host flag through to RPC server

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -928,12 +928,13 @@ where
 
 /// Start the JSON-RPC server. Returns the command receiver for the node event loop.
 pub async fn start_rpc_server(
+    host: &str,
     port: u16,
     state: Arc<RpcState>,
     cors: bool,
     rate_limit: u64,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
-    let addr = format!("0.0.0.0:{}", port);
+    let addr = format!("{}:{}", host, port);
     let cors_layer = if cors {
         tracing::info!("RPC CORS enabled (permissive)");
         tower_http::cors::CorsLayer::permissive()
@@ -991,7 +992,14 @@ pub async fn start_rpc_server(
 pub async fn start_rpc_server_ephemeral(
     state: Arc<RpcState>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
-    start_rpc_server(0, state, false, DEFAULT_RATE_LIMIT_MAX_REQUESTS).await
+    start_rpc_server(
+        "127.0.0.1",
+        0,
+        state,
+        false,
+        DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+    )
+    .await
 }
 
 /// Create RPC state and command channel.

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -204,6 +204,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         {
             cli.rpc_cors = v;
         }
+        if let Some(ref v) = cfg.rpc.host
+            && cli.rpc_host == "127.0.0.1"
+        {
+            cli.rpc_host = v.clone();
+        }
         if let Some(v) = cfg.rpc.rate_limit
             && cli.rpc_rate_limit == 1000
         {
@@ -419,6 +424,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         db_path: cli.db_path,
         rpc_port: cli.rpc_port,
         rpc_cors: cli.rpc_cors,
+        rpc_host: cli.rpc_host,
         rpc_rate_limit: cli.rpc_rate_limit,
         genesis_state: None,
         pruning_depth: cli.pruning_depth,

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -59,6 +59,8 @@ pub struct NodeConfig {
     pub rpc_port: u16,
     /// Enable CORS on the RPC server.
     pub rpc_cors: bool,
+    /// RPC listen address (e.g. "127.0.0.1" or "0.0.0.0").
+    pub rpc_host: String,
     /// Maximum RPC requests per IP per minute (0 = unlimited).
     pub rpc_rate_limit: u64,
     /// Optional pre-configured genesis state (with services installed, etc.).
@@ -158,6 +160,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
         );
         rpc_state = Some(state_arc.clone());
         let (_addr, _handle) = grey_rpc::start_rpc_server(
+            &config.rpc_host,
             config.rpc_port,
             state_arc,
             config.rpc_cors,

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -72,7 +72,7 @@ pub async fn run_seq_testnet(
 
     if rpc_port > 0 {
         let (addr, _handle) =
-            grey_rpc::start_rpc_server(rpc_port, rpc_state.clone(), rpc_cors, 0).await?;
+            grey_rpc::start_rpc_server("0.0.0.0", rpc_port, rpc_state.clone(), rpc_cors, 0).await?;
         tracing::info!("Sequential testnet RPC on {addr}");
     }
 

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -171,6 +171,7 @@ pub async fn run_testnet(
                 db_path: format!("/tmp/grey-testnet-{}", genesis_time),
                 rpc_port: 9933 + i,
                 rpc_cors,
+                rpc_host: "127.0.0.1".to_string(),
                 rpc_rate_limit: 0, // No rate limiting in testnet
                 genesis_state: Some(genesis_clone),
                 pruning_depth: 0, // No pruning in testnet


### PR DESCRIPTION
## Summary

- Wire the `--rpc-host` CLI flag through `NodeConfig` → `start_rpc_server` so operators can control the RPC listen address (was hardcoded to `0.0.0.0`)
- Add `host` parameter to `start_rpc_server` function signature
- Add config file fallback for `[rpc] host`
- Testnet uses `127.0.0.1`, sequential testnet uses `0.0.0.0`

Addresses #228.

## Scope

This PR addresses: wiring the `--rpc-host` flag that was already defined but unused.

## Test plan

- `cargo test -p grey-rpc` — all 30 tests pass (ephemeral server uses `127.0.0.1`)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `--rpc-host 0.0.0.0` binds all interfaces; `--rpc-host 127.0.0.1` restricts to localhost