### PR TITLE
feat(grey): load persisted GRANDPA votes on node startup

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -858,6 +858,26 @@ impl Store {
         Ok(votes)
     }
 
+    /// Get the highest round number from persisted GRANDPA votes.
+    /// Returns 0 if no votes are stored.
+    pub fn get_latest_grandpa_round(&self) -> Result<u64, StoreError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(GRANDPA_VOTES)?;
+        // Keys are sorted by (round LE, vote_type, validator_index).
+        // The last entry has the highest round.
+        match table.last()? {
+            Some(entry) => {
+                let key = entry.0.value();
+                if key.len() >= 8 {
+                    Ok(u64::from_le_bytes(key[0..8].try_into().unwrap()))
+                } else {
+                    Ok(0)
+                }
+            }
+            None => Ok(0),
+        }
+    }
+
     /// Remove all GRANDPA votes for rounds ≤ `up_to_round`.
     pub fn prune_grandpa_votes(&self, up_to_round: u64) -> Result<u32, StoreError> {
         let txn = self.db.begin_read()?;
@@ -1409,6 +1429,31 @@ mod tests {
         // Round 2 should still have its vote
         let votes = store.get_grandpa_votes_for_round(2).unwrap();
         assert_eq!(votes.len(), 1);
+    }
+
+    #[test]
+    fn test_get_latest_grandpa_round() {
+        let (store, _dir) = temp_store();
+        let block_hash = Hash([42u8; 32]);
+        let sig = [7u8; 64];
+
+        // No votes yet
+        assert_eq!(store.get_latest_grandpa_round().unwrap(), 0);
+
+        // Store votes for rounds 1 and 3
+        store
+            .put_grandpa_vote(1, 0x01, 0, &block_hash, 10, &sig)
+            .unwrap();
+        store
+            .put_grandpa_vote(3, 0x01, 1, &block_hash, 12, &sig)
+            .unwrap();
+
+        assert_eq!(store.get_latest_grandpa_round().unwrap(), 3);
+
+        // Prune round 3 — should fall back to round 1
+        store.prune_grandpa_votes(3).unwrap();
+        // After pruning all rounds ≤ 3, no votes remain
+        assert_eq!(store.get_latest_grandpa_round().unwrap(), 0);
     }
 
     #[test]

--- a/grey/crates/grey/src/finality.rs
+++ b/grey/crates/grey/src/finality.rs
@@ -101,6 +101,52 @@ impl GrandpaState {
         }
     }
 
+    /// Load persisted votes from a previous session into the current round.
+    ///
+    /// `persisted_votes` is a list of `(vote_type, validator_index, block_hash, block_slot, signature)`.
+    /// Vote type: 0 = prevote, 1 = precommit.
+    /// Only votes matching the current round are loaded; others are ignored.
+    /// Returns the number of votes loaded.
+    pub fn load_persisted_votes(
+        &mut self,
+        round: u64,
+        persisted_votes: &[(u8, u16, Hash, u32, [u8; 64])],
+    ) -> usize {
+        self.round = round;
+        let mut loaded = 0;
+        for &(vote_type, validator_index, block_hash, block_slot, signature) in persisted_votes {
+            let vote = Vote {
+                block_hash,
+                block_slot,
+                round,
+                validator_index,
+                signature: Ed25519Signature(signature),
+            };
+            match vote_type {
+                0 => {
+                    // Prevote
+                    self.prevotes.entry(validator_index).or_insert_with(|| {
+                        loaded += 1;
+                        self.prevote_archive
+                            .insert((round, validator_index), block_hash);
+                        vote.clone()
+                    });
+                }
+                1 => {
+                    // Precommit
+                    self.precommits.entry(validator_index).or_insert_with(|| {
+                        loaded += 1;
+                        self.precommit_archive
+                            .insert((round, validator_index), block_hash);
+                        vote.clone()
+                    });
+                }
+                _ => {} // Unknown vote type, skip
+            }
+        }
+        loaded
+    }
+
     /// Byzantine fault tolerance threshold: 2f+1 where f = (n-1)/3.
     /// Equivalent to ceil(2n/3) for supermajority.
     fn threshold(&self) -> usize {
@@ -819,5 +865,57 @@ mod tests {
                 prop_assert!(decode_vote_message(&data).is_none());
             }
         }
+    }
+
+    #[test]
+    fn test_load_persisted_votes() {
+        let mut grandpa = GrandpaState::new(6);
+        let hash_a = Hash([1u8; 32]);
+        let hash_b = Hash([2u8; 32]);
+
+        let votes = vec![
+            (0u8, 0u16, hash_a, 10u32, [0xAA; 64]), // prevote from v0
+            (0u8, 1u16, hash_a, 10u32, [0xBB; 64]), // prevote from v1
+            (1u8, 0u16, hash_a, 10u32, [0xCC; 64]), // precommit from v0
+            (1u8, 2u16, hash_b, 11u32, [0xDD; 64]), // precommit from v2
+            (2u8, 3u16, hash_a, 10u32, [0xEE; 64]), // unknown type, should be skipped
+        ];
+
+        let loaded = grandpa.load_persisted_votes(5, &votes);
+        assert_eq!(loaded, 4, "should load 4 valid votes (skip unknown type)");
+        assert_eq!(grandpa.round, 5);
+        assert_eq!(grandpa.prevotes.len(), 2);
+        assert_eq!(grandpa.precommits.len(), 2);
+
+        // Verify vote contents
+        assert_eq!(grandpa.prevotes[&0].block_hash, hash_a);
+        assert_eq!(grandpa.prevotes[&1].block_hash, hash_a);
+        assert_eq!(grandpa.precommits[&0].block_hash, hash_a);
+        assert_eq!(grandpa.precommits[&2].block_hash, hash_b);
+
+        // Archives should be populated
+        assert_eq!(grandpa.prevote_archive.len(), 2);
+        assert_eq!(grandpa.precommit_archive.len(), 2);
+    }
+
+    #[test]
+    fn test_load_persisted_votes_no_duplicates() {
+        let mut grandpa = GrandpaState::new(6);
+        let hash_a = Hash([1u8; 32]);
+        let hash_b = Hash([2u8; 32]);
+
+        // Load first batch
+        let votes1 = vec![(0u8, 0u16, hash_a, 10u32, [0xAA; 64])];
+        grandpa.load_persisted_votes(5, &votes1);
+        assert_eq!(grandpa.prevotes.len(), 1);
+
+        // Load second batch with duplicate — should not overwrite
+        let votes2 = vec![(0u8, 0u16, hash_b, 11u32, [0xBB; 64])];
+        let loaded = grandpa.load_persisted_votes(5, &votes2);
+        assert_eq!(loaded, 0, "duplicate should not be loaded");
+        assert_eq!(
+            grandpa.prevotes[&0].block_hash, hash_a,
+            "original vote preserved"
+        );
     }
 }

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -172,6 +172,25 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     // Initialize state
     let mut state = genesis_state;
     let mut grandpa = GrandpaState::new(protocol.validators_count);
+
+    // Load persisted GRANDPA votes from previous session (if any).
+    match store.get_latest_grandpa_round() {
+        Ok(round) if round > 0 => match store.get_grandpa_votes_for_round(round) {
+            Ok(votes) if !votes.is_empty() => {
+                let loaded = grandpa.load_persisted_votes(round, &votes);
+                tracing::info!(
+                    "Loaded {} persisted GRANDPA votes for round {}",
+                    loaded,
+                    round
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Failed to load GRANDPA votes: {}", e),
+        },
+        Ok(_) => {} // No persisted votes
+        Err(e) => tracing::warn!("Failed to read GRANDPA round: {}", e),
+    }
+
     let mut blocks_authored = 0u64;
     let mut blocks_imported = 0u64;
     let genesis_time = config.genesis_time;


### PR DESCRIPTION
## Summary

- Add `get_latest_grandpa_round()` to grey-store — reads the highest round from persisted GRANDPA votes
- Add `load_persisted_votes()` to `GrandpaState` — replays persisted votes into prevotes/precommits maps and equivocation archives
- Wire vote loading into `run_node()` startup — on restart, the node resumes with its previous round's votes instead of starting from scratch
- Add 3 tests: vote loading, duplicate prevention, latest round query

Addresses #221.

## Scope

This PR addresses: "Load unfinalized votes on node startup" from the issue checklist.

Remaining sub-tasks in #221:
- Test: restart node mid-round, verify it continues finalizing
- GRANDPA catchup request/response messages
- Report equivocators to dispute system
- Track all votes in unfinalized range (not just current round)

## Test plan

- `cargo test -p grey -- test_load_persisted` — 2 new tests pass
- `cargo test -p grey-store -- test_get_latest_grandpa` — 1 new test passes
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- On restart, node logs "Loaded N persisted GRANDPA votes for round R"