### PR TITLE
fix(genesis): count Genesis-Commit not Genesis-Index for cache staleness check

### DIFF
--- a/tools/jar-genesis/src/git.rs
+++ b/tools/jar-genesis/src/git.rs
@@ -105,9 +105,12 @@ pub fn count_genesis_trailers(genesis_commit: &str) -> Result<usize, GitError> {
     let _ = git(&["fetch", "origin", "master"]);
     let range = format!("{genesis_commit}..origin/master");
     let output = git(&["log", "--merges", "--format=%B", &range])?;
+    // Count Genesis-Commit (not Genesis-Index) because the cache only includes
+    // entries with signed commit data. Early PRs #6-9 have Genesis-Index but
+    // no Genesis-Commit — counting Genesis-Index would overcount by 4.
     let count = output
         .lines()
-        .filter(|line| line.starts_with("Genesis-Index: "))
+        .filter(|line| line.starts_with("Genesis-Commit: "))
         .count();
     Ok(count)
 }


### PR DESCRIPTION
## Summary

- Fix `count_genesis_trailers` to count `Genesis-Commit` trailers instead of `Genesis-Index` trailers
- PRs #6-9 (pre-SignedCommit era) have `Genesis-Index` trailers but no `Genesis-Commit` — they were intentionally excluded from the cache during the rebuild in PR #205
- Counting `Genesis-Index` overcounts by 4, causing false "stale cache" errors (e.g., "236 entries cached, 237 in git history") that permanently block merge workflows
- This was the root cause of PR #304's stuck merge

## Test plan

- [x] `cargo run -p jar-genesis -- replay --mode verify-cache` passes (242/242)
- [ ] PR #304 unblocked after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)