### PR TITLE
docs: add Open Graph and Twitter Card meta tags

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block extrahead %}
+  {{ super() }}
   <style>
     /* Hide default content elements on home page */
     .md-main__inner { margin: 0; }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ page.title }} - JAR Chain">
+  <meta property="og:description" content="{{ config.site_description }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta property="og:site_name" content="JAR Chain">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page.title }} - JAR Chain">
+  <meta name="twitter:description" content="{{ config.site_description }}">
+{% endblock %}


### PR DESCRIPTION
## Summary

- Add `docs/overrides/main.html` with Open Graph and Twitter Card meta tags for all pages
- Add `{{ super() }}` to `home.html` so the home page inherits the meta tags
- Uses `summary` card type (no image yet — can upgrade to `summary_large_image` when we add an OG image)
- Workaround for Zensical not yet supporting social cards natively

## Test plan

- [ ] Share jarchain.org link on Twitter/X — should show title and description preview
- [ ] Share a subpage (e.g., jarchain.org/genesis/) — should show page-specific title

🤖 Generated with [Claude Code](https://claude.com/claude-code)