### PR TITLE
fix(grey-store): prune_states removes orphaned checksum entries

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -815,9 +815,11 @@ impl Store {
         let txn = self.db.begin_write()?;
         let count = to_delete.len() as u32;
         {
-            let mut table = txn.open_table(STATE)?;
+            let mut state_table = txn.open_table(STATE)?;
+            let mut checksum_table = txn.open_table(STATE_CHECKSUMS)?;
             for hash in &to_delete {
-                table.remove(hash)?;
+                state_table.remove(hash)?;
+                checksum_table.remove(hash)?;
             }
         }
         txn.commit()?;


### PR DESCRIPTION
## Summary

- Fix `prune_states` to also remove `STATE_CHECKSUMS` entries alongside `STATE` entries
- Same class of bug as PR #331 (delete_state) — checksum entries were leaked during pruning
- Both tables are now cleaned in a single write transaction

Addresses #222.

## Test plan

- `cargo test -p grey-store` — all 20 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean