### PR TITLE
feat(grey): add SIGTERM handler for graceful shutdown

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -226,8 +226,15 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
         genesis_time
     );
 
-    // Graceful shutdown signal
-    let shutdown = tokio::signal::ctrl_c();
+    // Graceful shutdown on SIGINT (Ctrl+C) or SIGTERM (kill)
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .expect("failed to register SIGTERM handler");
+    let shutdown = async {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => "SIGINT",
+            _ = sigterm.recv() => "SIGTERM",
+        }
+    };
     tokio::pin!(shutdown);
 
     // SIGUSR1: dump debug state to log
@@ -242,10 +249,11 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
 
     loop {
         tokio::select! {
-            _ = &mut shutdown => {
+            signal_name = &mut shutdown => {
                 tracing::info!(
-                    "Validator {} received shutdown signal, flushing state...",
-                    config.validator_index
+                    "Validator {} received {}, flushing state...",
+                    config.validator_index,
+                    signal_name
                 );
                 // Persist final head state
                 let head_hash = state


### PR DESCRIPTION
## Summary

- Add SIGTERM handler alongside existing SIGINT (Ctrl+C) for graceful shutdown
- Both signals now handled via a combined async future — no code duplication
- Ensures Docker stop, systemd stop, and `kill <pid>` all trigger proper state flushing

Addresses #224.

## Scope

This PR addresses: "SIGTERM / SIGINT — graceful shutdown" from the signal handling section.

Remaining sub-tasks in #224:
- SIGHUP config reload

## Test plan

- `cargo test -p grey` — all 50 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `kill <pid>` now logs "received SIGTERM, flushing state..." instead of abrupt termination