### PR TITLE
feat(grey): periodic storage growth reporting in seq_testnet

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -13,7 +13,7 @@ use grey_types::config::Config;
 use grey_types::header::Block;
 use grey_types::state::State;
 use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Current schema version. Bump this when table layouts change.
 /// The store refuses to open a database with a different version.
@@ -97,6 +97,8 @@ pub type PersistedVote = (u8, u16, Hash, u32, [u8; 64]);
 /// Persistent store backed by redb.
 pub struct Store {
     db: Database,
+    /// Path to the database file (for metrics/diagnostics).
+    db_path: PathBuf,
 }
 
 /// Run schema migrations from `from_version` to `to_version`.
@@ -184,10 +186,18 @@ impl Store {
         }
         txn.commit()?;
 
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            db_path: path.as_ref().to_path_buf(),
+        })
     }
 
     /// Return the schema version stored in the database.
+    /// Get the database file path.
+    pub fn path(&self) -> &Path {
+        &self.db_path
+    }
+
     pub fn schema_version(&self) -> Result<u32, StoreError> {
         let txn = self.db.begin_read()?;
         let table = txn.open_table(META)?;

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -261,6 +261,22 @@ pub async fn run_seq_testnet(
                                 hex::encode(&header_hash.0[..8])
                             );
                         }
+
+                        // Storage growth report every 100 blocks
+                        if blocks_produced.is_multiple_of(100) {
+                            let blocks = store.block_count().unwrap_or(0);
+                            let states = store.state_count().unwrap_or(0);
+                            let chunks = store.chunk_count().unwrap_or(0);
+                            let votes = store.vote_count().unwrap_or(0);
+                            let db_size_mb = std::fs::metadata(store.path())
+                                .map(|m| m.len() as f64 / (1024.0 * 1024.0))
+                                .unwrap_or(0.0);
+                            tracing::info!(
+                                "Storage report @ block #{blocks_produced}: \
+                                 db={db_size_mb:.1}MB, blocks={blocks}, states={states}, \
+                                 chunks={chunks}, votes={votes}"
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::error!("Slot {slot}: block by v{author_idx} FAILED: {e}");


### PR DESCRIPTION
## Summary

- Log DB file size and table counts (blocks, states, chunks, votes) every 100 blocks during sequential testnet runs
- Add `Store::path()` method and store the DB file path in the `Store` struct
- Helps operators monitor storage growth rates during long-running stability tests

Addresses #230.

## Scope

This PR addresses: "Measure DB size per 1000 blocks" and "Track and report at every 1000 blocks" (reports every 100 for faster feedback).

Remaining sub-tasks in #230:
- Memory leak detection (valgrind/DHAT profiling)
- Bounded growth assertions after pruning
- State transition time degradation detection

## Test plan

- `cargo test -p grey-store` — all 21 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Run `grey --seq-testnet --seq-testnet-blocks 200` to see storage reports at blocks 100, 200