### PR TITLE
fix(grey): add --rpc-host to docker-compose for container accessibility

### DIFF
--- a/grey/docker-compose.yml
+++ b/grey/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "--tiny"
       - "--db-path=/data"
       - "--rpc-port=9933"
+      - "--rpc-host=0.0.0.0"
       - "--rpc-cors"
     ports:
       - "9000:9000"   # P2P


### PR DESCRIPTION
## Summary

- Add `--rpc-host=0.0.0.0` to validator-0's command in `docker-compose.yml`
- Without this, the RPC server binds to `127.0.0.1` inside the container, making port 9933 inaccessible from the host despite the port mapping

Addresses #231.

## Test plan

- `docker compose -f grey/docker-compose.yml up --build` starts the testnet
- `curl http://localhost:9933/health` returns `{"status":"ok"}` from the host