### PR TITLE
test(grey-codec): fuzz decode for Block, Extrinsic, and config-dependent types

### DIFF
--- a/grey/crates/grey-codec/tests/fuzz_decode.rs
+++ b/grey/crates/grey-codec/tests/fuzz_decode.rs
@@ -176,4 +176,34 @@ proptest! {
         let config = Config::full();
         let _ = grey_types::header::Header::decode_with_config(&data, &config);
     }
+
+    #[test]
+    fn fuzz_decode_block_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::Block::decode_with_config(&data, &config);
+    }
+
+    #[test]
+    fn fuzz_decode_extrinsic_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::Extrinsic::decode_with_config(&data, &config);
+    }
+
+    #[test]
+    fn fuzz_decode_assurance_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::Assurance::decode_with_config(&data, &config);
+    }
+
+    #[test]
+    fn fuzz_decode_disputes_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::DisputesExtrinsic::decode_with_config(&data, &config);
+    }
+
+    #[test]
+    fn fuzz_decode_verdict_tiny(data in arb_bytes()) {
+        let config = Config::tiny();
+        let _ = grey_types::header::Verdict::decode_with_config(&data, &config);
+    }
 }


### PR DESCRIPTION
## Summary

- Add 5 fuzz-style proptest cases for `DecodeWithConfig` types that were missing: `Block`, `Extrinsic`, `Assurance`, `DisputesExtrinsic`, `Verdict`
- All use tiny config and verify no panics on random byte input (0-1024 bytes)
- Brings total fuzz decode tests to 34

Addresses #229.

## Scope

This PR addresses: "fuzz_block_decode: random bytes → block decode doesn't panic" from the fuzz targets section.

## Test plan

- `cargo test -p grey-codec --test fuzz_decode` — all 34 tests pass (5 new)
- `cargo clippy --workspace --all-targets -- -D warnings` clean