### PR TITLE
feat(grey-state): implement refine host calls (Ψ_R) — GP §14

### DIFF
--- a/grey/crates/grey-state/src/refine.rs
+++ b/grey/crates/grey-state/src/refine.rs
@@ -541,7 +541,10 @@ fn refine_machine(pvm: &mut PvmInstance, ctx: &RefineHostContext<'_>) -> bool {
         1 => {
             // Code hash: write to buffer at φ[8], return 32
             let buf_ptr = pvm.reg(8) as u32;
-            if pvm.try_write_bytes(buf_ptr, &ctx.item.code_hash.0).is_none() {
+            if pvm
+                .try_write_bytes(buf_ptr, &ctx.item.code_hash.0)
+                .is_none()
+            {
                 return false;
             }
             pvm.set_reg(7, 32);


### PR DESCRIPTION
## Summary

- Implement missing refine host calls per Gray Paper §14: `grow_heap(1)`, `fetch(2)`, `machine(5)`
- Add proper host call gas charging (g=10 per call, was missing)
- Restructure dispatch with `RefineHostContext` for clean data passing and proper OOG/page-fault propagation
- Apply same fixes to is-authorized (Ψ_I) host calls

Previously only `gas(0)` and `export(4)` were implemented — all others returned HOST_WHAT. Now programs can access their payload, import segments, and extrinsics via `fetch(2)`, allocate memory via `grow_heap(1)`, and query service info via `machine(5)`.

## Scope

This PR addresses the Grey (Rust) side of #340.

Remaining work in #340:
- Lean spec: add host call dispatch loop to `refine` in `Jar.Services`
- Grey: implement `historical_lookup(3)`, `peek(6)`, `poke(7)`, `pages(8)`, `invoke(9)`, `expunge(10)`
- Verify host call ID numbering against latest GP version

Addresses #340.

## Test plan

- [x] `cargo build --workspace` — clean build, no warnings
- [x] `cargo test --workspace` — all tests pass
- [x] Existing refine tests still pass (process_work_package, encode_work_package, etc.)