### PR TITLE
fix(genesis): increase queue timeout to 1 hour

### DIFF
--- a/tools/jar-genesis/src/queue.rs
+++ b/tools/jar-genesis/src/queue.rs
@@ -7,7 +7,7 @@
 use crate::github;
 
 const POLL_INTERVAL_SECS: u64 = 10;
-const TIMEOUT_SECS: u64 = 600; // 10 minutes
+const TIMEOUT_SECS: u64 = 3600; // 1 hour
 const GENESIS_WORKFLOW_PREFIX: &str = ".github/workflows/genesis-";
 
 /// Resolve workflow IDs for all genesis workflows by path prefix.


### PR DESCRIPTION
## Summary

- Increase genesis workflow queue timeout from 10 minutes to 1 hour
- Each merge takes ~2-3 minutes; with multiple PRs queued (common after rebases), 10 minutes is insufficient

One-line change: `TIMEOUT_SECS: 600 → 3600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)