### PR TITLE
feat(grey-state): implement invoke(9) — sub-VM execution in refine

### DIFF
--- a/grey/crates/grey-state/src/refine.rs
+++ b/grey/crates/grey-state/src/refine.rs
@@ -793,13 +793,12 @@ fn refine_invoke(pvm: &mut PvmInstance, ctx: &mut RefineHostContext<'_>, depth: 
 
             // Write output to caller's memory (truncated to max_len)
             let write_len = output.len().min(output_max_len as usize);
-            if write_len > 0 {
-                if pvm
+            if write_len > 0
+                && pvm
                     .try_write_bytes(output_ptr, &output[..write_len])
                     .is_none()
-                {
-                    return false; // page fault in caller
-                }
+            {
+                return false; // page fault in caller
             }
             pvm.set_reg(7, output.len() as u64);
             true


### PR DESCRIPTION
## Summary

Implement the `invoke(9)` refine host call, enabling PVM programs to call into other programs by code hash during work item refinement.

- **Separate memory**: invoked program runs in its own PVM instance
- **Gas sub-accounting**: caller provides a gas budget; unused gas is refunded
- **Recursive**: invoke can call invoke, depth-limited to 8
- **Capability attenuation**: invoked programs get a restricted host call set (gas, grow_heap, machine, pages, invoke) — NO export, peek, poke, fetch, or historical_lookup
- **Code lookup**: resolved via `RefineContext::get_code` (blake2b hash)

Register convention:
```
φ[7]=code_hash_ptr  φ[8]=input_ptr  φ[9]=input_len
φ[10]=gas_limit     φ[11]=output_ptr  φ[12]=output_max_len
Returns: φ[7] = output_len, or NONE/OOB/LOW/WHAT sentinel
```

Addresses #340.

## Test plan

- [x] `cargo test -p grey-state --lib` — all 21 tests pass (2 new invoke tests)
- [x] Test: invoke with unknown code hash → returns NONE
- [x] Test: end-to-end invoke — caller writes sub-program hash to memory, invokes echo service, verifies output returned
- [x] `cargo fmt` — formatted