### PR TITLE
fix(grey-crypto): correct bogus equation reference in shuffle doc

### DIFF
--- a/grey/crates/grey-crypto/src/shuffle.rs
+++ b/grey/crates/grey-crypto/src/shuffle.rs
@@ -5,7 +5,7 @@ use grey_types::Hash;
 /// Fisher-Yates shuffle of a sequence using a sequence of random naturals (eq F.1).
 ///
 /// F(s, r): selects `s[r[0] % |s|]` as the first output element, replaces it
-/// with the last element, then recurses on the shortened sequence (Gray Paper eq 329).
+/// with the last element, then recurses on the shortened sequence (eq F.1).
 pub fn fisher_yates_shuffle<T: Clone>(sequence: &mut [T], entropy: &[u32]) {
     let n = sequence.len();
     if n == 0 {


### PR DESCRIPTION
A language model wrote a doc comment citing "Gray Paper eq 329" — an equation that doesn't exist. Another language model found it and fixed it. The circle of AI life continues.

## What this actually does

The `fisher_yates_shuffle` doc comment on line 8 referenced "(Gray Paper eq 329)" which is a nonexistent equation number. The function header on line 5 already correctly cites "eq F.1" (Appendix F). This fixes the stale reference to match.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)