### PR TITLE
feat(grey-rpc): add --metrics-port for standalone Prometheus metrics server

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -722,91 +722,7 @@ where
         } else if is_get && path == "/metrics" {
             let state = self.state.clone();
             Box::pin(async move {
-                let status = state.status.read().await;
-                let head_slot = status.head_slot;
-                let finalized_slot = status.finalized_slot;
-                let blocks_authored = status.blocks_authored;
-                let blocks_imported = status.blocks_imported;
-                let validator_index = status.validator_index;
-                let grandpa_round = status.grandpa_round;
-                let peer_count = state.peer_count.load(std::sync::atomic::Ordering::Relaxed);
-                let queue_events = state
-                    .queue_depth_events
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                let queue_commands = state
-                    .queue_depth_commands
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                let queue_rpc = state
-                    .queue_depth_rpc
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                let pending_blocks = state
-                    .pending_blocks_depth
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                let finality_lag = head_slot.saturating_sub(finalized_slot);
-                let wp_submitted = state
-                    .work_packages_submitted
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                drop(status);
-
-                let stored_blocks = state.store.block_count().unwrap_or(0);
-                let stored_states = state.store.state_count().unwrap_or(0);
-                let stored_chunks = state.store.chunk_count().unwrap_or(0);
-                let stored_votes = state.store.vote_count().unwrap_or(0);
-
-                let body = format!(
-                    "# HELP grey_block_height Current head slot.\n\
-                     # TYPE grey_block_height gauge\n\
-                     grey_block_height {head_slot}\n\
-                     # HELP grey_finalized_height Last finalized slot.\n\
-                     # TYPE grey_finalized_height gauge\n\
-                     grey_finalized_height {finalized_slot}\n\
-                     # HELP grey_blocks_produced_total Blocks authored by this node.\n\
-                     # TYPE grey_blocks_produced_total counter\n\
-                     grey_blocks_produced_total {blocks_authored}\n\
-                     # HELP grey_blocks_imported_total Blocks received and imported.\n\
-                     # TYPE grey_blocks_imported_total counter\n\
-                     grey_blocks_imported_total {blocks_imported}\n\
-                     # HELP grey_stored_blocks Number of blocks in the database.\n\
-                     # TYPE grey_stored_blocks gauge\n\
-                     grey_stored_blocks {stored_blocks}\n\
-                     # HELP grey_stored_states Number of state entries in the database.\n\
-                     # TYPE grey_stored_states gauge\n\
-                     grey_stored_states {stored_states}\n\
-                     # HELP grey_stored_chunks Number of DA chunks in the database.\n\
-                     # TYPE grey_stored_chunks gauge\n\
-                     grey_stored_chunks {stored_chunks}\n\
-                     # HELP grey_stored_votes Number of GRANDPA votes in the database.\n\
-                     # TYPE grey_stored_votes gauge\n\
-                     grey_stored_votes {stored_votes}\n\
-                     # HELP grey_validator_index Validator index of this node.\n\
-                     # TYPE grey_validator_index gauge\n\
-                     grey_validator_index {validator_index}\n\
-                     # HELP grey_grandpa_round Current GRANDPA finality round.\n\
-                     # TYPE grey_grandpa_round gauge\n\
-                     grey_grandpa_round {grandpa_round}\n\
-                     # HELP grey_peer_count Number of connected peers.\n\
-                     # TYPE grey_peer_count gauge\n\
-                     grey_peer_count {peer_count}\n\
-                     # HELP grey_queue_depth_events Network event queue depth.\n\
-                     # TYPE grey_queue_depth_events gauge\n\
-                     grey_queue_depth_events {queue_events}\n\
-                     # HELP grey_queue_depth_commands Network command queue depth.\n\
-                     # TYPE grey_queue_depth_commands gauge\n\
-                     grey_queue_depth_commands {queue_commands}\n\
-                     # HELP grey_queue_depth_rpc RPC command queue depth.\n\
-                     # TYPE grey_queue_depth_rpc gauge\n\
-                     grey_queue_depth_rpc {queue_rpc}\n\
-                     # HELP grey_pending_blocks Pending blocks buffer depth.\n\
-                     # TYPE grey_pending_blocks gauge\n\
-                     grey_pending_blocks {pending_blocks}\n\
-                     # HELP grey_finality_lag Slots between head and last finalized block.\n\
-                     # TYPE grey_finality_lag gauge\n\
-                     grey_finality_lag {finality_lag}\n\
-                     # HELP grey_work_packages_submitted_total Work packages submitted via RPC.\n\
-                     # TYPE grey_work_packages_submitted_total counter\n\
-                     grey_work_packages_submitted_total {wp_submitted}\n"
-                );
-
+                let body = format_metrics(&state).await;
                 Ok(http::Response::builder()
                     .status(200)
                     .header("content-type", "text/plain; version=0.0.4; charset=utf-8")
@@ -940,6 +856,140 @@ where
         let fut = self.inner.call(req);
         Box::pin(fut)
     }
+}
+
+/// Format Prometheus text exposition metrics from the current RPC state.
+pub async fn format_metrics(state: &RpcState) -> String {
+    let status = state.status.read().await;
+    let head_slot = status.head_slot;
+    let finalized_slot = status.finalized_slot;
+    let blocks_authored = status.blocks_authored;
+    let blocks_imported = status.blocks_imported;
+    let validator_index = status.validator_index;
+    let grandpa_round = status.grandpa_round;
+    let peer_count = state.peer_count.load(std::sync::atomic::Ordering::Relaxed);
+    let queue_events = state
+        .queue_depth_events
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let queue_commands = state
+        .queue_depth_commands
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let queue_rpc = state
+        .queue_depth_rpc
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let pending_blocks = state
+        .pending_blocks_depth
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let finality_lag = head_slot.saturating_sub(finalized_slot);
+    let wp_submitted = state
+        .work_packages_submitted
+        .load(std::sync::atomic::Ordering::Relaxed);
+    drop(status);
+
+    let stored_blocks = state.store.block_count().unwrap_or(0);
+    let stored_states = state.store.state_count().unwrap_or(0);
+    let stored_chunks = state.store.chunk_count().unwrap_or(0);
+    let stored_votes = state.store.vote_count().unwrap_or(0);
+
+    format!(
+        "# HELP grey_block_height Current head slot.\n\
+         # TYPE grey_block_height gauge\n\
+         grey_block_height {head_slot}\n\
+         # HELP grey_finalized_height Last finalized slot.\n\
+         # TYPE grey_finalized_height gauge\n\
+         grey_finalized_height {finalized_slot}\n\
+         # HELP grey_blocks_produced_total Blocks authored by this node.\n\
+         # TYPE grey_blocks_produced_total counter\n\
+         grey_blocks_produced_total {blocks_authored}\n\
+         # HELP grey_blocks_imported_total Blocks received and imported.\n\
+         # TYPE grey_blocks_imported_total counter\n\
+         grey_blocks_imported_total {blocks_imported}\n\
+         # HELP grey_stored_blocks Number of blocks in the database.\n\
+         # TYPE grey_stored_blocks gauge\n\
+         grey_stored_blocks {stored_blocks}\n\
+         # HELP grey_stored_states Number of state entries in the database.\n\
+         # TYPE grey_stored_states gauge\n\
+         grey_stored_states {stored_states}\n\
+         # HELP grey_stored_chunks Number of DA chunks in the database.\n\
+         # TYPE grey_stored_chunks gauge\n\
+         grey_stored_chunks {stored_chunks}\n\
+         # HELP grey_stored_votes Number of GRANDPA votes in the database.\n\
+         # TYPE grey_stored_votes gauge\n\
+         grey_stored_votes {stored_votes}\n\
+         # HELP grey_validator_index Validator index of this node.\n\
+         # TYPE grey_validator_index gauge\n\
+         grey_validator_index {validator_index}\n\
+         # HELP grey_grandpa_round Current GRANDPA finality round.\n\
+         # TYPE grey_grandpa_round gauge\n\
+         grey_grandpa_round {grandpa_round}\n\
+         # HELP grey_peer_count Number of connected peers.\n\
+         # TYPE grey_peer_count gauge\n\
+         grey_peer_count {peer_count}\n\
+         # HELP grey_queue_depth_events Network event queue depth.\n\
+         # TYPE grey_queue_depth_events gauge\n\
+         grey_queue_depth_events {queue_events}\n\
+         # HELP grey_queue_depth_commands Network command queue depth.\n\
+         # TYPE grey_queue_depth_commands gauge\n\
+         grey_queue_depth_commands {queue_commands}\n\
+         # HELP grey_queue_depth_rpc RPC command queue depth.\n\
+         # TYPE grey_queue_depth_rpc gauge\n\
+         grey_queue_depth_rpc {queue_rpc}\n\
+         # HELP grey_pending_blocks Pending blocks buffer depth.\n\
+         # TYPE grey_pending_blocks gauge\n\
+         grey_pending_blocks {pending_blocks}\n\
+         # HELP grey_finality_lag Slots between head and last finalized block.\n\
+         # TYPE grey_finality_lag gauge\n\
+         grey_finality_lag {finality_lag}\n\
+         # HELP grey_work_packages_submitted_total Work packages submitted via RPC.\n\
+         # TYPE grey_work_packages_submitted_total counter\n\
+         grey_work_packages_submitted_total {wp_submitted}\n"
+    )
+}
+
+/// Start a standalone metrics HTTP server on the given port.
+/// Serves `/metrics` in Prometheus text exposition format.
+pub async fn start_metrics_server(
+    host: &str,
+    port: u16,
+    state: Arc<RpcState>,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
+    let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let bound_addr = listener.local_addr()?;
+
+    let join = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    tracing::warn!("Metrics server accept error: {e}");
+                    continue;
+                }
+            };
+            let state = state.clone();
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = [0u8; 4096];
+                // Read the HTTP request (we only need to know it arrived)
+                let _ = stream.read(&mut buf).await;
+                let body = format_metrics(&state).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n\
+                     Content-Length: {}\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    tracing::info!("Metrics server listening on {}", bound_addr);
+    Ok((bound_addr, join))
 }
 
 /// Start the JSON-RPC server. Returns the command receiver for the node event loop.
@@ -1825,5 +1875,35 @@ mod tests {
         let result: Result<serde_json::Value, _> =
             client.request("jam_getContext", rpc_params![2000u32]).await;
         assert!(result.is_err(), "getContext with no head should error");
+    }
+
+    #[tokio::test]
+    async fn test_standalone_metrics_server() {
+        let (_url, state, _rx, _store, _dir) = setup().await;
+
+        // Start metrics server on ephemeral port
+        let (addr, _handle) = start_metrics_server("127.0.0.1", 0, state).await.unwrap();
+        let metrics_url = format!("http://{}/metrics", addr);
+
+        let (status, body) = http_get(&metrics_url).await;
+        assert_eq!(status, 200);
+        assert!(
+            body.contains("grey_block_height"),
+            "metrics should contain grey_block_height"
+        );
+        assert!(
+            body.contains("grey_peer_count"),
+            "metrics should contain grey_peer_count"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_format_metrics_output() {
+        let (_url, state, _rx, _store, _dir) = setup().await;
+        let body = format_metrics(&state).await;
+        assert!(body.contains("# HELP grey_block_height"));
+        assert!(body.contains("# TYPE grey_block_height gauge"));
+        assert!(body.contains("grey_finalized_height"));
+        assert!(body.contains("grey_work_packages_submitted_total"));
     }
 }

--- a/grey/crates/grey/src/config.rs
+++ b/grey/crates/grey/src/config.rs
@@ -43,6 +43,7 @@ pub struct RpcConfig {
     pub host: Option<String>,
     pub cors: Option<bool>,
     pub rate_limit: Option<u64>,
+    pub metrics_port: Option<u16>,
 }
 
 /// Network configuration section.

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -151,6 +151,10 @@ struct Cli {
     #[arg(long, default_value = "127.0.0.1")]
     rpc_host: String,
 
+    /// Expose Prometheus metrics on a separate port (0 to disable).
+    #[arg(long, default_value_t = 0)]
+    metrics_port: u16,
+
     /// Log output format.
     #[arg(long, value_enum, default_value_t = LogFormat::Plain)]
     log_format: LogFormat,
@@ -224,6 +228,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             && cli.rpc_rate_limit == 1000
         {
             cli.rpc_rate_limit = v;
+        }
+        if let Some(v) = cfg.rpc.metrics_port
+            && cli.metrics_port == 0
+        {
+            cli.metrics_port = v;
         }
         if let Some(ref peers) = cfg.network.boot_peers
             && cli.peers.is_empty()
@@ -440,6 +449,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         genesis_state: None,
         pruning_depth: cli.pruning_depth,
         keystore_path: cli.keystore_path,
+        metrics_port: cli.metrics_port,
     })
     .await
 }

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -70,6 +70,8 @@ pub struct NodeConfig {
     pub pruning_depth: u32,
     /// Optional keystore path for persistent validator keys.
     pub keystore_path: Option<String>,
+    /// Expose Prometheus metrics on a separate port (0 = disabled).
+    pub metrics_port: u16,
 }
 
 // FinalityTracker replaced by GrandpaState (see finality.rs)
@@ -159,6 +161,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
             config.validator_index,
         );
         rpc_state = Some(state_arc.clone());
+        let metrics_state = state_arc.clone();
         let (_addr, _handle) = grey_rpc::start_rpc_server(
             &config.rpc_host,
             config.rpc_port,
@@ -168,6 +171,16 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
         )
         .await?;
         rpc_rx = Some(rx);
+
+        // Start separate metrics server if configured
+        if config.metrics_port > 0 {
+            let (_metrics_addr, _metrics_handle) = grey_rpc::start_metrics_server(
+                &config.rpc_host,
+                config.metrics_port,
+                metrics_state,
+            )
+            .await?;
+        }
     } else {
         rpc_state = None;
     }

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -176,6 +176,7 @@ pub async fn run_testnet(
                 genesis_state: Some(genesis_clone),
                 pruning_depth: 0, // No pruning in testnet
                 keystore_path: None,
+                metrics_port: 0,
             };
             if let Err(e) = crate::node::run_node(node_config).await {
                 tracing::error!("Validator {} exited with error: {}", i, e);


### PR DESCRIPTION
## Summary

- Extract `format_metrics()` public function from RPC middleware to eliminate metrics body duplication
- Add `start_metrics_server()` for serving `/metrics` on a separate configurable port
- Add `--metrics-port` CLI flag (default 0 = disabled) and `[rpc] metrics_port` config file support
- Tests for both the standalone metrics server and the format_metrics function

Addresses #223.

## Scope

This PR addresses: Expose /metrics on configurable port (--metrics-port, default: 9615)

Remaining sub-tasks in #223:
- Implement remaining core metrics from the metrics table
- Add tracing-opentelemetry integration
- Optional OTLP exporter (--otlp-endpoint)
- Harness scenario that checks /metrics endpoint

## Test plan

- `cargo test -p grey-rpc -- test_standalone_metrics_server` verifies the standalone server responds with Prometheus text format
- `cargo test -p grey-rpc -- test_format_metrics_output` verifies the extracted format function produces correct HELP/TYPE annotations
- Existing `test_metrics_endpoint` still passes (RPC-embedded metrics path unchanged)