### PR TITLE
feat(grey): SIGHUP handler for config file reload

### DIFF
--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -461,6 +461,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         pruning_depth: cli.pruning_depth,
         keystore_path: cli.keystore_path,
         metrics_port: cli.metrics_port,
+        config_path: cli.config.clone(),
     })
     .await
 }

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -72,6 +72,8 @@ pub struct NodeConfig {
     pub keystore_path: Option<String>,
     /// Expose Prometheus metrics on a separate port (0 = disabled).
     pub metrics_port: u16,
+    /// Path to the TOML config file (for SIGHUP reload). None if no config file.
+    pub config_path: Option<String>,
 }
 
 // FinalityTracker replaced by GrandpaState (see finality.rs)
@@ -258,6 +260,11 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     let mut sigusr1 = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
         .expect("failed to register SIGUSR1 handler");
 
+    // SIGHUP: reload config file
+    let mut sighup = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+        .expect("failed to register SIGHUP handler");
+    let config_path = config.config_path.clone();
+
     // Main loop: check timeslots every 500ms
     let mut interval = tokio::time::interval(Duration::from_millis(500));
     let mut last_authored_slot: Timeslot = 0;
@@ -321,6 +328,30 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                     blocks_authored,
                     blocks_imported,
                 );
+            }
+            _ = sighup.recv() => {
+                if let Some(ref path) = config_path {
+                    tracing::info!("SIGHUP received — reloading config from {}", path);
+                    match crate::config::ConfigFile::load(std::path::Path::new(path)) {
+                        Ok(new_cfg) => {
+                            if let Some(ref level) = new_cfg.logging.level {
+                                tracing::info!("Config reload: log level = {:?}", level);
+                            }
+                            if let Some(ref peers) = new_cfg.network.boot_peers {
+                                tracing::info!("Config reload: boot_peers = {:?} ({} entries)", peers, peers.len());
+                            }
+                            if let Some(ref format) = new_cfg.logging.format {
+                                tracing::info!("Config reload: log format = {:?}", format);
+                            }
+                            tracing::info!("Config reload complete (note: only logging changes are informational; runtime values are not yet hot-swapped)");
+                        }
+                        Err(e) => {
+                            tracing::warn!("SIGHUP config reload failed: {}", e);
+                        }
+                    }
+                } else {
+                    tracing::info!("SIGHUP received but no config file was specified (--config)");
+                }
             }
             _ = interval.tick() => {
                 let now = SystemTime::now()

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -177,6 +177,7 @@ pub async fn run_testnet(
                 pruning_depth: 0, // No pruning in testnet
                 keystore_path: None,
                 metrics_port: 0,
+                config_path: None,
             };
             if let Err(e) = crate::node::run_node(node_config).await {
                 tracing::error!("Validator {} exited with error: {}", i, e);


### PR DESCRIPTION
## Summary

- Register SIGHUP signal handler in the node event loop
- On SIGHUP, re-read the TOML config file and log detected changes (log level, boot peers, log format)
- Graceful fallback: logs message if no --config file was specified
- Currently informational — actual hot-swapping requires tracing reload handle (follow-up)

Addresses #224.

## Scope

This PR addresses: SIGHUP — reload config file

Remaining sub-tasks in #224:
- Define config schema covering all current CLI flags
- Test: load config from file, verify all values applied
- Built-in specs: --chain mainnet

## Test plan

- `cargo test -p grey` — all 57 tests pass
- `cargo clippy -p grey -- -D warnings` — clean
- Manual: `kill -HUP <pid>` logs "SIGHUP received — reloading config from <path>"