### PR TITLE
feat(grey-rpc): add protocol_version and genesis_hash to jam_getChainSpec

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -436,7 +436,11 @@ impl JamRpcServer for RpcImpl {
     async fn get_chain_spec(&self) -> Result<serde_json::Value, ErrorObjectOwned> {
         self.track_request("jam_getChainSpec");
         let c = &self.state.config;
+        let config_blob = c.encode_config_blob();
+        let genesis_hash = grey_crypto::blake2b_256(&config_blob);
         Ok(serde_json::json!({
+            "protocol_version": "0.7.2",
+            "genesis_hash": hex::encode(genesis_hash.0),
             "validators_count": c.validators_count,
             "core_count": c.core_count,
             "epoch_length": c.epoch_length,
@@ -1533,6 +1537,12 @@ mod tests {
         assert_eq!(result["epoch_length"], 12);
         assert_eq!(result["slot_period"], 6);
         assert!(result["gas_total_accumulation"].as_u64().unwrap() > 0);
+        // New fields: protocol_version and genesis_hash
+        assert_eq!(result["protocol_version"], "0.7.2");
+        assert!(
+            result["genesis_hash"].as_str().unwrap().len() == 64,
+            "genesis_hash should be 32-byte hex"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `protocol_version` field ("0.7.2") to chain spec response
- Add `genesis_hash` field (blake2b-256 of the config blob, hex-encoded)
- Updated test to verify new fields are present and correctly formatted

Addresses #228.

## Scope

This PR addresses: chain spec includes protocol version and genesis hash

Remaining sub-tasks in #228:
- Validator endpoint: each validator includes keys, activity stats
- Service account endpoint: returns code hash, balance, storage counts

## Test plan

- `cargo test -p grey-rpc` — all 42 tests pass
- `test_get_chain_spec` verifies protocol_version is "0.7.2" and genesis_hash is 64-char hex