### PR TITLE
feat(grey): detect state transition time degradation in seq_testnet

### DIFF
--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -282,6 +282,32 @@ pub async fn run_seq_testnet(
                                  avg={avg}µs, min={min}µs, max={max}µs, p50={p50}µs, p99={p99}µs \
                                  ({count} samples)"
                             );
+
+                            // Degradation detection: compare recent 100 blocks to first 100
+                            if count >= 200 {
+                                let early_avg: u64 =
+                                    transition_times[..100].iter().sum::<u64>() / 100;
+                                let recent_start = count.saturating_sub(100);
+                                let recent_avg: u64 =
+                                    transition_times[recent_start..].iter().sum::<u64>() / 100;
+                                let ratio = if early_avg > 0 {
+                                    recent_avg as f64 / early_avg as f64
+                                } else {
+                                    1.0
+                                };
+                                if ratio > 2.0 {
+                                    tracing::warn!(
+                                        "DEGRADATION DETECTED @ block #{blocks_produced}: \
+                                         recent avg={recent_avg}µs is {ratio:.1}x slower than \
+                                         early avg={early_avg}µs (threshold: 2.0x)"
+                                    );
+                                } else if ratio > 1.5 {
+                                    tracing::info!(
+                                        "Transition slowdown @ block #{blocks_produced}: \
+                                         recent avg={recent_avg}µs is {ratio:.1}x of early avg={early_avg}µs"
+                                    );
+                                }
+                            }
                         }
 
                         // Storage growth report every 100 blocks


### PR DESCRIPTION
## Summary

- Compare average transition time of last 100 blocks vs first 100 blocks
- Warn at >2x slowdown ("DEGRADATION DETECTED"), info at >1.5x
- Runs every 100 blocks alongside existing timing report (from PR #362)

Addresses #230.

## Scope

This PR addresses: Detect degradation: if block N+10000 takes >2x block N, flag regression

Remaining sub-tasks in #230:
- Memory profiling with valgrind/DHAT
- Verify RSS growth is bounded
- Archive vs pruned mode storage growth comparison

## Test plan

- `cargo build -p grey` — compiles cleanly
- `cargo clippy -p grey -- -D warnings` — no warnings
- Manual: `grey --seq-testnet --seq-testnet-blocks 500` shows degradation check at block 200+