### PR TITLE
fix(javm): make recompiler compile on non-Linux/x86-64 platforms

### DIFF
--- a/grey/crates/grey-state/src/pvm_backend.rs
+++ b/grey/crates/grey-state/src/pvm_backend.rs
@@ -20,11 +20,11 @@ fn pvm_mode() -> &'static str {
 
 /// Backend-agnostic PVM instance.
 enum Backend {
-    Interpreter(javm::vm::Pvm),
-    Recompiler(javm::RecompiledPvm),
+    Interpreter(Box<javm::vm::Pvm>),
+    Recompiler(Box<javm::RecompiledPvm>),
     Compare {
-        interp: javm::vm::Pvm,
-        recomp: javm::RecompiledPvm,
+        interp: Box<javm::vm::Pvm>,
+        recomp: Box<javm::RecompiledPvm>,
         step: u32,
     },
 }
@@ -40,21 +40,21 @@ impl PvmInstance {
         match pvm_mode() {
             "recompiler" => javm::recompiler::initialize_program_recompiled(code_blob, args, gas)
                 .map(|pvm| PvmInstance {
-                    inner: Backend::Recompiler(pvm),
+                    inner: Backend::Recompiler(Box::new(pvm)),
                 }),
             "compare" => {
                 let interp = javm::program::initialize_program(code_blob, args, gas)?;
                 let recomp = javm::recompiler::initialize_program_recompiled(code_blob, args, gas)?;
                 Some(PvmInstance {
                     inner: Backend::Compare {
-                        interp,
-                        recomp,
+                        interp: Box::new(interp),
+                        recomp: Box::new(recomp),
                         step: 0,
                     },
                 })
             }
             _ => javm::program::initialize_program(code_blob, args, gas).map(|pvm| PvmInstance {
-                inner: Backend::Interpreter(pvm),
+                inner: Backend::Interpreter(Box::new(pvm)),
             }),
         }
     }

--- a/grey/crates/javm/src/lib.rs
+++ b/grey/crates/javm/src/lib.rs
@@ -14,7 +14,11 @@ pub mod gas_cost;
 pub mod gas_sim;
 pub mod instruction;
 pub mod program;
-#[cfg(feature = "std")]
+// Real JIT recompiler on Linux x86-64; interpreter-backed shim everywhere else.
+#[cfg(all(feature = "std", target_os = "linux", target_arch = "x86_64"))]
+pub mod recompiler;
+#[cfg(all(feature = "std", not(all(target_os = "linux", target_arch = "x86_64"))))]
+#[path = "recompiler_shim.rs"]
 pub mod recompiler;
 pub mod vm;
 

--- a/grey/crates/javm/src/recompiler_shim.rs
+++ b/grey/crates/javm/src/recompiler_shim.rs
@@ -1,0 +1,100 @@
+//! Stub recompiler for non-Linux/x86-64 platforms.
+//!
+//! Exposes the same public API as `recompiler/mod.rs` but backs execution
+//! with the interpreter, so all callers compile and run on any platform.
+//! On supported platforms (Linux x86-64) the real JIT recompiler is used instead.
+
+pub use crate::ExitReason;
+use crate::vm::Pvm;
+use crate::{Gas, PVM_REGISTER_COUNT, program};
+
+// Make predecode available at the same path callers expect
+// (crate::recompiler::predecode). The file has no platform-specific code.
+#[path = "recompiler/predecode.rs"]
+pub mod predecode;
+
+/// Interpreter-backed stub that mirrors the `RecompiledPvm` API.
+pub struct RecompiledPvm(Pvm);
+
+/// Initialize from a standard program blob (same signature as the real recompiler).
+pub fn initialize_program_recompiled(
+    code_blob: &[u8],
+    args: &[u8],
+    gas: Gas,
+) -> Option<RecompiledPvm> {
+    program::initialize_program(code_blob, args, gas).map(RecompiledPvm)
+}
+
+impl RecompiledPvm {
+    /// Run until the next exit point (halt, panic, OOG, host call, page fault).
+    pub fn run(&mut self) -> ExitReason {
+        self.0.run().0
+    }
+
+    pub fn registers(&self) -> &[u64; PVM_REGISTER_COUNT] {
+        &self.0.registers
+    }
+
+    pub fn registers_mut(&mut self) -> &mut [u64; PVM_REGISTER_COUNT] {
+        &mut self.0.registers
+    }
+
+    pub fn gas(&self) -> Gas {
+        self.0.gas
+    }
+
+    pub fn set_gas(&mut self, gas: Gas) {
+        self.0.gas = gas;
+    }
+
+    pub fn pc(&self) -> u32 {
+        self.0.pc
+    }
+
+    pub fn set_pc(&mut self, pc: u32) {
+        self.0.pc = pc;
+    }
+
+    pub fn set_register(&mut self, idx: usize, val: u64) {
+        self.0.registers[idx] = val;
+    }
+
+    pub fn heap_top(&self) -> u32 {
+        self.0.heap_top
+    }
+
+    pub fn set_heap_top(&mut self, top: u32) {
+        self.0.heap_top = top;
+    }
+
+    pub fn read_byte(&self, addr: u32) -> Option<u8> {
+        self.0.read_u8(addr)
+    }
+
+    /// Returns `true` on success, `false` on page fault (matches real recompiler).
+    pub fn write_byte(&mut self, addr: u32, value: u8) -> bool {
+        self.0.write_u8(addr, value)
+    }
+
+    /// Returns `None` on page fault (matches real recompiler).
+    pub fn read_bytes(&self, addr: u32, len: u32) -> Option<Vec<u8>> {
+        let a = addr as usize;
+        let end = a + len as usize;
+        self.0.flat_mem.get(a..end).map(|s| s.to_vec())
+    }
+
+    /// No native code on this platform — returns an empty slice.
+    pub fn native_code_bytes(&self) -> &[u8] {
+        &[]
+    }
+
+    /// Returns `true` on success, `false` on page fault (matches real recompiler).
+    pub fn write_bytes(&mut self, addr: u32, data: &[u8]) -> bool {
+        for (i, &byte) in data.iter().enumerate() {
+            if !self.0.write_u8(addr.wrapping_add(i as u32), byte) {
+                return false;
+            }
+        }
+        true
+    }
+}


### PR DESCRIPTION
## Summary

- The JIT recompiler uses `libc::mremap`/`MREMAP_MAYMOVE` (Linux-only syscall) and `extern "sysv64"` ABI (x86-64 only) — the workspace failed to build on macOS aarch64 with 12 compiler errors
- Add `recompiler_shim.rs`: exposes the same public API as the real recompiler (`RecompiledPvm`, `initialize_program_recompiled`, `predecode`) but backed by the interpreter
- `lib.rs` swaps real JIT ↔ shim via a single `#[cfg]` — all callers unchanged, zero platform guards scattered through the codebase
- Box `Backend` enum variants in `pvm_backend.rs` to fix `clippy::large_enum_variant` (Compare held 692 bytes on stack)

## Test plan

- [x] `cargo build --workspace` passes on macOS aarch64
- [x] `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings` passes
- [x] `cargo test --workspace` passes (interpreter path, same as before on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)