### PR TITLE
fix(grey-transpiler): resolve service entry points before branch target pass

### DIFF
--- a/grey/crates/grey-transpiler/src/linker.rs
+++ b/grey/crates/grey-transpiler/src/linker.rs
@@ -179,14 +179,9 @@ pub fn link_elf_service(elf_data: &[u8]) -> Result<Vec<u8>, TranspileError> {
     let mut rw_data = elf.rw_data.clone();
     rewrite_data_code_ptrs(&elf, &mut ctx, &mut ro_data, &mut rw_data);
 
-    crate::peephole_fuse_load_imm_alu(&mut ctx.code, &mut ctx.bitmask, &ctx.jump_table);
-    crate::ensure_branch_targets_are_block_starts(
-        &mut ctx.code,
-        &mut ctx.bitmask,
-        &mut ctx.jump_table,
-    );
-
-    // Resolve entry points to PVM offsets
+    // Resolve entry points to PVM offsets BEFORE peephole/branch passes,
+    // since ensure_branch_targets_are_block_starts inserts bytes and shifts
+    // all offsets (invalidating address_map entries).
     let refine_pvm = ctx.address_map.get(&refine_addr).copied().ok_or_else(|| {
         TranspileError::InvalidSection(format!(
             "refine symbol at {:#x} not in translated code",
@@ -205,7 +200,9 @@ pub fn link_elf_service(elf_data: &[u8]) -> Result<Vec<u8>, TranspileError> {
             ))
         })?;
 
-    // Patch dispatch header: jump to refine at byte 0, jump to accumulate at byte 5
+    // Patch dispatch header BEFORE the passes so the jumps are treated as
+    // normal branch instructions and their offsets get adjusted automatically
+    // by ensure_branch_targets_are_block_starts.
     ctx.code[0] = 40; // jump opcode
     let refine_rel = refine_pvm as i32;
     ctx.code[1..5].copy_from_slice(&refine_rel.to_le_bytes());
@@ -213,6 +210,21 @@ pub fn link_elf_service(elf_data: &[u8]) -> Result<Vec<u8>, TranspileError> {
     ctx.code[5] = 40; // jump opcode
     let acc_rel = (accumulate_pvm as i32) - 5;
     ctx.code[6..10].copy_from_slice(&acc_rel.to_le_bytes());
+
+    // Mark dispatch targets as instruction starts so the passes see them.
+    if (refine_pvm as usize) < ctx.bitmask.len() {
+        ctx.bitmask[refine_pvm as usize] = 1;
+    }
+    if (accumulate_pvm as usize) < ctx.bitmask.len() {
+        ctx.bitmask[accumulate_pvm as usize] = 1;
+    }
+
+    crate::peephole_fuse_load_imm_alu(&mut ctx.code, &mut ctx.bitmask, &ctx.jump_table);
+    crate::ensure_branch_targets_are_block_starts(
+        &mut ctx.code,
+        &mut ctx.bitmask,
+        &mut ctx.jump_table,
+    );
 
     Ok(emitter::build_standard_program(
         &ro_data,

--- a/grey/crates/javm/src/program.rs
+++ b/grey/crates/javm/src/program.rs
@@ -211,6 +211,24 @@ pub fn initialize_program(program_blob: &[u8], arguments: &[u8], gas: Gas) -> Op
     Some(pvm)
 }
 
+/// Initialize a program with a specific entry point (PC offset).
+///
+/// Service blobs have dual entry points:
+/// - PC=0: refine (stateless computation)
+/// - PC=5: accumulate (stateful effects)
+///
+/// This is identical to `initialize_program` but sets the initial PC.
+pub fn initialize_program_at(
+    program_blob: &[u8],
+    arguments: &[u8],
+    gas: Gas,
+    entry_pc: u32,
+) -> Option<Pvm> {
+    let mut pvm = initialize_program(program_blob, arguments, gas)?;
+    pvm.set_pc(entry_pc);
+    Some(pvm)
+}
+
 /// Memory layout offsets for direct flat-buffer writes.
 pub struct DataLayout {
     pub mem_size: u32,

--- a/grey/crates/javm/src/vm.rs
+++ b/grey/crates/javm/src/vm.rs
@@ -134,6 +134,12 @@ impl Pvm {
         }
     }
 
+    /// Set the program counter to a specific offset.
+    /// Used by service blobs to select refine (PC=0) or accumulate (PC=5) entry points.
+    pub fn set_pc(&mut self, pc: u32) {
+        self.pc = pc;
+    }
+
     /// Create a simple PVM for testing (code only, trivial bitmask).
     pub fn new_simple(
         code: Vec<u8>,


### PR DESCRIPTION
## Summary

- Fix `link_elf_service`: resolve refine/accumulate entry point addresses from `address_map` BEFORE running `ensure_branch_targets_are_block_starts`, which inserts fallthrough bytes and shifts all code offsets (invalidating the address_map)
- Patch the dispatch header jumps (PC=0→refine, PC=5→accumulate) before the pass so they get adjusted automatically like all other branch targets
- Mark dispatch targets as instruction starts in the bitmask so the pass handles them correctly
- Add `initialize_program_at(blob, args, gas, entry_pc)` to javm for service blob dual-entry support
- Add `Pvm::set_pc()` for selecting refine (PC=0) or accumulate (PC=5) entry points

## Test plan

- [x] `cargo build --workspace` — clean build
- [x] `cargo test -p javm` + `cargo test -p grey-transpiler` — all pass
- [x] `GREY_PVM=recompiler cargo test -p grey-bench --lib` — all 11 tests pass
- [x] `cargo fmt --check` + `cargo clippy --workspace` — clean