### PR TITLE
fix(grey-codec): add bounds check in EpochMarker decode to prevent OOM

### DIFF
--- a/grey/crates/grey-codec/src/decode.rs
+++ b/grey/crates/grey-codec/src/decode.rs
@@ -663,6 +663,10 @@ impl DecodeWithConfig for EpochMarker {
         // GP#514: variable-length validator count prefix
         let (count, c) = decode_natural(&data[off..])?;
         off += c;
+        let remaining = data.len().saturating_sub(off);
+        if count > remaining {
+            return Err(CodecError::SequenceTooLong(count, remaining));
+        }
         let mut validators = Vec::with_capacity(count);
         for _ in 0..count {
             let (bk, c) = grey_types::BandersnatchPublicKey::decode(&data[off..])?;


### PR DESCRIPTION
## Summary

- `EpochMarker::decode_with_config` reads a variable-length validator count from the wire (GP#514) but was missing the guard present in every other sequence decoder in the file
- A crafted 9-byte length prefix (`0xFF` + large u64) caused `Vec::with_capacity` to attempt a ~1.4 TB allocation, crashing the process with SIGABRT
- Fix mirrors the existing pattern used in `Vec<T>`, `DisputesExtrinsic`, and `Extrinsic` decoders

## Origin

The vulnerability was introduced in dccd654 (`feat(grey): add erasure_shards to AvailabilitySpec, variable-length epoch marker (GP#514)`), which switched `EpochMarker` from a fixed-size config-driven count (`config.validators_count`) to reading the count from the wire.

Commit 3bc51a2 (`feat(grey-codec): add fuzz-style decode tests and fix OOM on crafted input`) added the fuzz tests and the `Vec<T>` bounds guard in the same area but missed the `EpochMarker` case that had just been introduced.

## Test Plan

- [x] `cargo test -p grey-codec --test fuzz_decode` — all 34 tests pass
- [x] `GREY_PVM=recompiler cargo test -p grey-codec --test fuzz_decode` — reproduces the fix for the CI failure seen in PR #370