### PR TITLE
feat(spec): prove encodeTransferAmount size invariants

### DIFF
--- a/spec/Jar/Proofs/BalanceEcon.lean
+++ b/spec/Jar/Proofs/BalanceEcon.lean
@@ -42,6 +42,12 @@ theorem balanceEcon_serializeEcon_size [JamConfig] (e : BalanceEcon) :
         ++ Codec.encodeFixedNat 8 e.gratis.toNat).size = 16
   rw [byteArray_append_size, encodeFixedNat_size, encodeFixedNat_size]
 
+/-- encodeTransferAmount always produces exactly 8 bytes for the transfer amount. -/
+theorem balanceEcon_encodeTransferAmount_size [JamConfig] (t : BalanceTransfer) :
+    (@EconModel.encodeTransferAmount BalanceEcon BalanceTransfer _ t).size = 8 := by
+  show (Codec.encodeFixedNat 8 t.amount.toNat).size = 8
+  rw [encodeFixedNat_size]
+
 /-- encodeInfo produces exactly 24 bytes (8 balance + 8 threshold + 8 gratis). -/
 theorem balanceEcon_encodeInfo_size [JamConfig] (e : BalanceEcon)
     (items bytes bI bL bS : Nat) :

--- a/spec/Jar/Proofs/QuotaEcon.lean
+++ b/spec/Jar/Proofs/QuotaEcon.lean
@@ -60,6 +60,12 @@ theorem quotaEcon_serializeEcon_size [JamConfig] (e : QuotaEcon) :
         ++ Codec.encodeFixedNat 8 e.quotaBytes.toNat).size = 16
   rw [byteArray_append_size, encodeFixedNat_size, encodeFixedNat_size]
 
+/-- encodeTransferAmount always produces exactly 8 bytes, even in coinless mode. -/
+theorem quotaEcon_encodeTransferAmount_size [JamConfig] (t : QuotaTransfer) :
+    (@EconModel.encodeTransferAmount QuotaEcon QuotaTransfer _ t).size = 8 := by
+  show (Codec.encodeFixedNat 8 0).size = 8
+  rw [encodeFixedNat_size]
+
 /-- encodeInfo produces exactly 24 bytes (8 + 8 + 8 padding). -/
 theorem quotaEcon_encodeInfo_size [JamConfig] (e : QuotaEcon)
     (items bytes bI bL bS : Nat) :


### PR DESCRIPTION
## Summary

- prove that `BalanceEcon.encodeTransferAmount` always produces exactly 8 bytes
- prove that `QuotaEcon.encodeTransferAmount` always produces exactly 8 bytes, including coinless mode
- keep the change scoped to the `#374` proof chunk without pulling in other pending proof work

## Scope

This PR addresses: proving `encodeTransferAmount` always produces 8 bytes for both `BalanceEcon` and `QuotaEcon`.

Remaining sub-tasks in #374:
- prove `QuotaEcon.canAffordStorage` monotonicity
- prove `deserializeEcon ∘ serializeEcon` roundtrips, likely with supporting codec lemmas

Addresses #374.

## Test plan

- `cd spec && lake build`
- `cd spec && make test`
- `cd grey && cargo fmt --all`
- `cd grey && cargo clippy --workspace --all-targets --features javm/signals -- -D warnings`