### PR TITLE
feat(harness): add throughput scenario

### DIFF
--- a/grey/harness/src/main.rs
+++ b/grey/harness/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
     #[arg(long, default_value = "http://localhost:9933")]
     rpc: String,
 
-    /// Run only the named scenario (e.g. "serial", "repeat", "liveness").
+    /// Run only the named scenario (e.g. "serial", "repeat", "throughput").
     /// If not specified, all scenarios run in order.
     #[arg(long, value_name = "NAME")]
     scenario: Option<String>,
@@ -115,6 +115,14 @@ async fn main() {
     // Run scenarios sequentially.
     let mut results = Vec::new();
     let consistency_supported = !cli.no_testnet && !cli.seq_testnet;
+    let default_scenarios = [
+        "serial",
+        "repeat",
+        "liveness",
+        "invalid_wp",
+        "recovery",
+        "metrics",
+    ];
     let mut all_scenarios = vec![
         "serial",
         "repeat",
@@ -122,6 +130,7 @@ async fn main() {
         "invalid_wp",
         "recovery",
         "metrics",
+        "throughput",
     ];
     if consistency_supported {
         all_scenarios.push("consistency");
@@ -143,7 +152,9 @@ async fn main() {
         }
         vec![name.as_str()]
     } else {
-        all_scenarios.to_vec()
+        // Keep throughput opt-in for now; it is benchmark-style and substantially
+        // slower than the default correctness scenarios used in CI.
+        default_scenarios.to_vec()
     };
 
     for (i, name) in scenario_list.iter().enumerate() {
@@ -156,12 +167,14 @@ async fn main() {
             "recovery" => scenarios::recovery::run(&client).await,
             "metrics" => scenarios::metrics::run(&client).await,
             "consistency" => scenarios::consistency::run(&client).await,
+            "throughput" => scenarios::throughput::run(&client).await,
             _ => unreachable!(),
         };
         let dur = result.duration.as_secs();
         if result.pass {
             println!("  PASS ({dur}s)");
             result.print_latency_summary();
+            result.print_metric_summary();
             if cli.perf && !result.latencies.is_empty() {
                 println!("  Per-operation timing:");
                 for sample in &result.latencies {
@@ -214,6 +227,20 @@ async fn main() {
                         })
                         .collect();
                     obj["latencies"] = serde_json::Value::Array(latencies);
+                }
+                if !r.metrics.is_empty() {
+                    let metrics: Vec<serde_json::Value> = r
+                        .metrics
+                        .iter()
+                        .map(|m| {
+                            serde_json::json!({
+                                "label": m.label,
+                                "value": m.value,
+                                "unit": m.unit,
+                            })
+                        })
+                        .collect();
+                    obj["metrics"] = serde_json::Value::Array(metrics);
                 }
                 obj
             })

--- a/grey/harness/src/poll.rs
+++ b/grey/harness/src/poll.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use tracing::info;
 
 use crate::pixel;
-use crate::rpc::RpcClient;
+use crate::rpc::{RpcClient, SubmitResult};
 
 #[derive(Debug, thiserror::Error)]
 #[error("timed out waiting for {label} ({timeout:?})")]
@@ -71,6 +71,16 @@ pub async fn wait_for_service(
 }
 
 /// Check if a pixel at (x,y) with color (r,g,b) is written in storage.
+pub fn pixel_matches(value: &str, x: u8, y: u8, r: u8, g: u8, b: u8) -> bool {
+    let offset = (y as usize * 100 + x as usize) * 3 * 2; // hex offset
+    if offset + 6 > value.len() {
+        return false;
+    }
+    let expected = format!("{r:02x}{g:02x}{b:02x}");
+    value[offset..offset + 6] == expected
+}
+
+/// Check if a pixel at (x,y) with color (r,g,b) is written in storage.
 pub async fn check_pixel(
     client: &RpcClient,
     service_id: u32,
@@ -86,17 +96,12 @@ pub async fn check_pixel(
     let Some(value) = &storage.value else {
         return false;
     };
-    let offset = (y as usize * 100 + x as usize) * 3 * 2; // hex offset
-    if offset + 6 > value.len() {
-        return false;
-    }
-    let expected = format!("{r:02x}{g:02x}{b:02x}");
-    value[offset..offset + 6] == expected
+    pixel_matches(value, x, y, r, g, b)
 }
 
-/// Submit a pixel work package and wait for it to appear in storage.
+/// Submit a pixel work package but do not wait for confirmation.
 #[allow(clippy::too_many_arguments)]
-pub async fn submit_and_verify_pixel(
+pub async fn submit_pixel_work_package(
     client: &RpcClient,
     service_id: u32,
     x: u8,
@@ -104,8 +109,7 @@ pub async fn submit_and_verify_pixel(
     r: u8,
     g: u8,
     b: u8,
-    timeout: Duration,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<SubmitResult, Box<dyn std::error::Error>> {
     let ctx = client.get_context(service_id).await?;
     assert!(
         ctx.code_hash.is_some(),
@@ -120,16 +124,48 @@ pub async fn submit_and_verify_pixel(
         "submitted ({x},{y}) {color_hex} hash={}...",
         &result.hash[..16.min(result.hash.len())]
     );
+    Ok(result)
+}
 
+/// Wait for a previously-submitted pixel to appear in storage.
+#[allow(clippy::too_many_arguments)]
+pub async fn wait_for_pixel(
+    client: &RpcClient,
+    service_id: u32,
+    x: u8,
+    y: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+    timeout: Duration,
+) -> Result<(), TimeoutError> {
+    let color_hex = format!("#{r:02x}{g:02x}{b:02x}");
     wait_until(
         || async { check_pixel(client, service_id, x, y, r, g, b).await },
         Duration::from_secs(2),
         timeout,
         &format!("pixel ({x},{y}) {color_hex}"),
     )
-    .await?;
+    .await
+}
+
+/// Submit a pixel work package and wait for it to appear in storage.
+#[allow(clippy::too_many_arguments)]
+pub async fn submit_and_verify_pixel(
+    client: &RpcClient,
+    service_id: u32,
+    x: u8,
+    y: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+    timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    submit_pixel_work_package(client, service_id, x, y, r, g, b).await?;
+    wait_for_pixel(client, service_id, x, y, r, g, b, timeout).await?;
 
     let storage = client.read_storage(service_id, "00").await?;
+    let color_hex = format!("#{r:02x}{g:02x}{b:02x}");
     info!("({x},{y}) {color_hex} ok (slot {})", storage.slot);
     Ok(())
 }

--- a/grey/harness/src/scenarios/consistency.rs
+++ b/grey/harness/src/scenarios/consistency.rs
@@ -51,6 +51,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: None,
             latencies,
+            metrics: Vec::new(),
         },
         Err(e) => ScenarioResult {
             name: "consistency",
@@ -58,6 +59,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: Some(e),
             latencies,
+            metrics: Vec::new(),
         },
     }
 }

--- a/grey/harness/src/scenarios/invalid_wp.rs
+++ b/grey/harness/src/scenarios/invalid_wp.rs
@@ -21,6 +21,7 @@ async fn assert_rejected(
             duration: start.elapsed(),
             error: Some(format!("{} should have been rejected", description)),
             latencies: vec![],
+            metrics: vec![],
         });
     }
     None
@@ -59,6 +60,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: Some(format!("node unhealthy after invalid submissions: {}", e)),
             latencies: vec![],
+            metrics: vec![],
         };
     }
 
@@ -68,5 +70,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         duration: start.elapsed(),
         error: None,
         latencies: vec![],
+        metrics: vec![],
     }
 }

--- a/grey/harness/src/scenarios/liveness.rs
+++ b/grey/harness/src/scenarios/liveness.rs
@@ -38,6 +38,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: None,
             latencies: vec![],
+            metrics: vec![],
         },
         Err(e) => ScenarioResult {
             name: "liveness",
@@ -45,6 +46,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: Some(e),
             latencies: vec![],
+            metrics: vec![],
         },
     }
 }

--- a/grey/harness/src/scenarios/metrics.rs
+++ b/grey/harness/src/scenarios/metrics.rs
@@ -32,6 +32,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: None,
             latencies: vec![],
+            metrics: vec![],
         },
         Err(e) => ScenarioResult {
             name: "metrics",
@@ -39,6 +40,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: Some(e),
             latencies: vec![],
+            metrics: vec![],
         },
     }
 }

--- a/grey/harness/src/scenarios/mod.rs
+++ b/grey/harness/src/scenarios/mod.rs
@@ -7,6 +7,7 @@ pub mod metrics;
 pub mod recovery;
 pub mod repeat;
 pub mod serial;
+pub mod throughput;
 
 use std::time::Duration;
 
@@ -19,6 +20,8 @@ pub struct ScenarioResult {
     pub error: Option<String>,
     /// Per-operation latency samples (e.g., submit-to-confirm times).
     pub latencies: Vec<LatencySample>,
+    /// Scenario-specific numeric metrics (e.g., throughput or queue depth).
+    pub metrics: Vec<ScenarioMetric>,
 }
 
 /// A single latency measurement.
@@ -26,6 +29,14 @@ pub struct ScenarioResult {
 pub struct LatencySample {
     pub label: String,
     pub duration: Duration,
+}
+
+/// A numeric metric emitted by a scenario.
+#[allow(dead_code)]
+pub struct ScenarioMetric {
+    pub label: String,
+    pub value: f64,
+    pub unit: &'static str,
 }
 
 impl ScenarioResult {
@@ -46,5 +57,22 @@ impl ScenarioResult {
             min.as_secs_f64(),
             max.as_secs_f64()
         );
+    }
+
+    /// Print numeric metrics if present.
+    pub fn print_metric_summary(&self) {
+        if self.metrics.is_empty() {
+            return;
+        }
+
+        println!("  Metrics:");
+        for metric in &self.metrics {
+            let value = if metric.value.fract().abs() < f64::EPSILON {
+                format!("{:.0}", metric.value)
+            } else {
+                format!("{:.2}", metric.value)
+            };
+            println!("    {:30} {:>10} {}", metric.label, value, metric.unit);
+        }
     }
 }

--- a/grey/harness/src/scenarios/recovery.rs
+++ b/grey/harness/src/scenarios/recovery.rs
@@ -40,6 +40,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
                 e
             )),
             latencies: vec![],
+            metrics: vec![],
         };
     }
     let latency = LatencySample {
@@ -55,6 +56,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
             duration: start.elapsed(),
             error: Some(format!("node unhealthy after recovery: {}", e)),
             latencies: vec![latency],
+            metrics: vec![],
         };
     }
 
@@ -64,5 +66,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         duration: start.elapsed(),
         error: None,
         latencies: vec![latency],
+        metrics: vec![],
     }
 }

--- a/grey/harness/src/scenarios/repeat.rs
+++ b/grey/harness/src/scenarios/repeat.rs
@@ -27,6 +27,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
                 duration: start.elapsed(),
                 error: Some(e.to_string()),
                 latencies: vec![],
+                metrics: vec![],
             };
         }
     }
@@ -36,5 +37,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         duration: start.elapsed(),
         error: None,
         latencies: vec![],
+        metrics: vec![],
     }
 }

--- a/grey/harness/src/scenarios/serial.rs
+++ b/grey/harness/src/scenarios/serial.rs
@@ -30,6 +30,7 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
                 duration: start.elapsed(),
                 error: Some(e.to_string()),
                 latencies,
+                metrics: vec![],
             };
         }
         latencies.push(LatencySample {
@@ -43,5 +44,6 @@ pub async fn run(client: &RpcClient) -> ScenarioResult {
         duration: start.elapsed(),
         error: None,
         latencies,
+        metrics: vec![],
     }
 }

--- a/grey/harness/src/scenarios/throughput.rs
+++ b/grey/harness/src/scenarios/throughput.rs
@@ -1,0 +1,293 @@
+//! Scenario: measure sustained valid work-package throughput.
+//!
+//! The pixels service is stateful, so each work package must be built against
+//! the latest service context. That makes a "fire 12 stale writes at once"
+//! benchmark misleading: later submissions would be measuring stale-context
+//! rejection or queueing artifacts rather than steady-state throughput.
+//!
+//! Instead, this scenario keeps the pipeline saturated with *valid* work:
+//! submit immediately after each prior pixel is confirmed, then report the
+//! sustained confirmed rate over a longer burst.
+//!
+//! This remains intentionally opt-in via `--scenario throughput` so that CI
+//! keeps running the faster correctness-focused scenario set by default.
+
+use std::time::{Duration, Instant};
+
+use tracing::info;
+
+use crate::poll::{pixel_matches, submit_pixel_work_package};
+use crate::rpc::{NodeStatus, RpcClient, StorageResult};
+use crate::scenarios::{LatencySample, ScenarioMetric, ScenarioResult};
+
+const SERVICE_ID: u32 = 2000;
+const BATCH_SIZE: usize = 12;
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+const CONFIRM_TIMEOUT: Duration = Duration::from_secs(180);
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_FINALITY_LAG: u32 = 5;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct PixelSpec {
+    x: u8,
+    y: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+struct ThroughputStats {
+    submitted: usize,
+    total_window: Duration,
+    submit_rpc_avg: Duration,
+    confirm_avg: Duration,
+    confirm_max: Duration,
+    slots_elapsed: u32,
+}
+
+pub async fn run(client: &RpcClient) -> ScenarioResult {
+    let start = Instant::now();
+
+    match run_inner(client).await {
+        Ok((latencies, metrics)) => ScenarioResult {
+            name: "throughput",
+            pass: true,
+            duration: start.elapsed(),
+            error: None,
+            latencies,
+            metrics,
+        },
+        Err(e) => ScenarioResult {
+            name: "throughput",
+            pass: false,
+            duration: start.elapsed(),
+            error: Some(e),
+            latencies: vec![],
+            metrics: vec![],
+        },
+    }
+}
+
+async fn run_inner(
+    client: &RpcClient,
+) -> Result<(Vec<LatencySample>, Vec<ScenarioMetric>), String> {
+    let start_status = wait_for_finality_settle(client).await?;
+    let measurement_start = Instant::now();
+    let pixels = throughput_pixels();
+    let mut latencies = Vec::with_capacity(pixels.len());
+    let mut submit_rpcs = Vec::with_capacity(pixels.len());
+
+    for spec in pixels {
+        let submit_start = Instant::now();
+        submit_pixel_work_package(client, SERVICE_ID, spec.x, spec.y, spec.r, spec.g, spec.b)
+            .await
+            .map_err(|e| format!("submit pixel({},{}): {e}", spec.x, spec.y))?;
+        submit_rpcs.push(submit_start.elapsed());
+        let storage = wait_for_pixel_storage(client, spec).await?;
+        let confirm_latency = submit_start.elapsed();
+        latencies.push(LatencySample {
+            label: format!("pixel({},{})", spec.x, spec.y),
+            duration: confirm_latency,
+        });
+        info!(
+            "confirmed pixel ({},{}) at slot {} in {:.2}s",
+            spec.x,
+            spec.y,
+            storage.slot,
+            confirm_latency.as_secs_f64()
+        );
+    }
+
+    let end_status = client
+        .get_status()
+        .await
+        .map_err(|e| format!("failed to fetch status after throughput scenario: {e}"))?;
+    let confirm_durations: Vec<Duration> = latencies.iter().map(|sample| sample.duration).collect();
+    let stats = ThroughputStats {
+        submitted: latencies.len(),
+        total_window: measurement_start.elapsed(),
+        submit_rpc_avg: average_duration(&submit_rpcs),
+        confirm_avg: average_duration(&confirm_durations),
+        confirm_max: confirm_durations
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(Duration::ZERO),
+        slots_elapsed: end_status.head_slot.saturating_sub(start_status.head_slot),
+    };
+
+    info!(
+        "throughput complete: submitted={} totalWindow={:.2}s slotsElapsed={}",
+        stats.submitted,
+        stats.total_window.as_secs_f64(),
+        stats.slots_elapsed
+    );
+
+    Ok((latencies, build_metrics(&stats)))
+}
+
+async fn wait_for_finality_settle(client: &RpcClient) -> Result<NodeStatus, String> {
+    let settle_deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        let status = client
+            .get_status()
+            .await
+            .map_err(|e| format!("RPC error: {e}"))?;
+        let lag = status.head_slot.saturating_sub(status.finalized_slot);
+        if lag <= MAX_FINALITY_LAG {
+            return Ok(status);
+        }
+        if Instant::now() > settle_deadline {
+            return Err(format!(
+                "finality did not settle within {:?} (head={}, finalized={}, lag={lag})",
+                SETTLE_TIMEOUT, status.head_slot, status.finalized_slot
+            ));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_for_pixel_storage(
+    client: &RpcClient,
+    spec: PixelSpec,
+) -> Result<StorageResult, String> {
+    let deadline = Instant::now() + CONFIRM_TIMEOUT;
+    loop {
+        if Instant::now() > deadline {
+            return Err(format!(
+                "pixel ({},{}) did not appear in storage within {:?}",
+                spec.x, spec.y, CONFIRM_TIMEOUT
+            ));
+        }
+
+        let storage = client
+            .read_storage(SERVICE_ID, "00")
+            .await
+            .map_err(|e| format!("failed to read pixels storage: {e}"))?;
+        if let Some(value) = storage.value.as_deref()
+            && pixel_matches(value, spec.x, spec.y, spec.r, spec.g, spec.b)
+        {
+            return Ok(storage);
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn throughput_pixels() -> Vec<PixelSpec> {
+    (0..BATCH_SIZE)
+        .map(|i| {
+            let i = i as u8;
+            PixelSpec {
+                x: 5 + i,
+                y: 80 + (i / 6),
+                r: 16u8.wrapping_add(i.wrapping_mul(17)),
+                g: 32u8.wrapping_add(i.wrapping_mul(29)),
+                b: 48u8.wrapping_add(i.wrapping_mul(43)),
+            }
+        })
+        .collect()
+}
+
+fn average_duration(samples: &[Duration]) -> Duration {
+    if samples.is_empty() {
+        return Duration::ZERO;
+    }
+    let total: Duration = samples.iter().copied().sum();
+    total / samples.len() as u32
+}
+
+fn build_metrics(stats: &ThroughputStats) -> Vec<ScenarioMetric> {
+    let submitted = stats.submitted as f64;
+    let total_secs = stats.total_window.as_secs_f64().max(f64::EPSILON);
+    let slots = f64::from(stats.slots_elapsed.max(1));
+
+    vec![
+        ScenarioMetric {
+            label: "submitted_wp".into(),
+            value: submitted,
+            unit: "count",
+        },
+        ScenarioMetric {
+            label: "total_window_ms".into(),
+            value: stats.total_window.as_secs_f64() * 1000.0,
+            unit: "ms",
+        },
+        ScenarioMetric {
+            label: "submit_rpc_avg_ms".into(),
+            value: stats.submit_rpc_avg.as_secs_f64() * 1000.0,
+            unit: "ms",
+        },
+        ScenarioMetric {
+            label: "confirm_avg_ms".into(),
+            value: stats.confirm_avg.as_secs_f64() * 1000.0,
+            unit: "ms",
+        },
+        ScenarioMetric {
+            label: "confirm_max_ms".into(),
+            value: stats.confirm_max.as_secs_f64() * 1000.0,
+            unit: "ms",
+        },
+        ScenarioMetric {
+            label: "sustained_confirm_wp_per_sec".into(),
+            value: submitted / total_secs,
+            unit: "wps/s",
+        },
+        ScenarioMetric {
+            label: "sustained_confirm_wp_per_slot".into(),
+            value: submitted / slots,
+            unit: "count",
+        },
+        ScenarioMetric {
+            label: "head_slots_elapsed".into(),
+            value: stats.slots_elapsed as f64,
+            unit: "slots",
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn assert_metric(metrics: &[ScenarioMetric], label: &str, expected: f64) {
+        let actual = metrics
+            .iter()
+            .find(|metric| metric.label == label)
+            .unwrap_or_else(|| panic!("missing metric {label}"))
+            .value;
+        assert!(
+            (actual - expected).abs() < 0.01,
+            "metric {label}: expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn throughput_pixels_are_unique() {
+        let pixels = throughput_pixels();
+        assert_eq!(pixels.len(), BATCH_SIZE);
+
+        let unique_positions: HashSet<(u8, u8)> = pixels.iter().map(|p| (p.x, p.y)).collect();
+        assert_eq!(unique_positions.len(), pixels.len());
+        assert!(pixels.iter().all(|p| (80..=81).contains(&p.y)));
+    }
+
+    #[test]
+    fn build_metrics_reports_expected_rates() {
+        let metrics = build_metrics(&ThroughputStats {
+            submitted: 12,
+            total_window: Duration::from_secs(12),
+            submit_rpc_avg: Duration::from_millis(250),
+            confirm_avg: Duration::from_secs(1),
+            confirm_max: Duration::from_secs(2),
+            slots_elapsed: 4,
+        });
+
+        assert_metric(&metrics, "submitted_wp", 12.0);
+        assert_metric(&metrics, "confirm_avg_ms", 1000.0);
+        assert_metric(&metrics, "confirm_max_ms", 2000.0);
+        assert_metric(&metrics, "sustained_confirm_wp_per_sec", 1.0);
+        assert_metric(&metrics, "sustained_confirm_wp_per_slot", 3.0);
+    }
+}


### PR DESCRIPTION
## Summary

- add an opt-in `throughput` harness scenario that measures sustained valid work-package confirmation throughput over a 12-pixel run
- refactor harness pixel submission helpers so throughput measurements can separate RPC submission timing from end-to-end storage confirmation timing
- extend harness scenario reporting and JSON output with numeric metrics such as sustained rate and confirmation latency

Addresses #227.

## Scope

This PR addresses: the throughput testing scenario and metric reporting chunk for the Grey harness.

Remaining sub-tasks in #227:
- add multi-core saturation and max-block-load scenarios
- store baseline performance data in-repo and compare it in CI
- add longer stress and regression-detection scenarios

## Test plan

- `cargo fmt --all`
- `cargo test -p harness`
- `cargo run -p harness -- --seq-testnet --scenario throughput`
- `cargo clippy --workspace --all-targets --features javm/signals -- -D warnings`
