### PR TITLE
feat: support mnemonic seed import in keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +515,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -1512,6 +1532,7 @@ dependencies = [
 name = "grey"
 version = "0.1.0"
 dependencies = [
+ "bip39",
  "build-javm",
  "clap",
  "futures",
@@ -1838,6 +1859,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_fmt"
@@ -5179,6 +5209,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ blake2 = "0.10"
 sha3 = "0.10"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.8"
+bip39 = "2.2.2"
 thiserror = "2"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/grey/crates/grey/Cargo.toml
+++ b/grey/crates/grey/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 hex = { workspace = true }
+bip39 = { workspace = true }
 thiserror = { workspace = true }
 libp2p = { workspace = true }
 futures = { workspace = true }

--- a/grey/crates/grey/src/keystore.rs
+++ b/grey/crates/grey/src/keystore.rs
@@ -8,6 +8,11 @@
 
 use std::path::{Path, PathBuf};
 
+use bip39::{Language, Mnemonic};
+
+const ED25519_MNEMONIC_DOMAIN: &[u8] = b"grey-keystore-ed25519-v1";
+const BANDERSNATCH_MNEMONIC_DOMAIN: &[u8] = b"grey-keystore-bandersnatch-v1";
+
 /// A file-based keystore that persists validator key seeds to disk.
 pub struct Keystore {
     /// Directory containing key files.
@@ -27,6 +32,33 @@ struct KeyFile {
     bandersnatch_seed: String,
     /// Ed25519 public key (hex-encoded 32 bytes, for verification).
     ed25519_public: String,
+}
+
+fn derive_domain_separated_seed(
+    master_seed: &[u8; 64],
+    validator_index: u16,
+    domain: &[u8],
+) -> [u8; 32] {
+    let mut input = Vec::with_capacity(domain.len() + std::mem::size_of::<u16>() + 64);
+    input.extend_from_slice(domain);
+    input.extend_from_slice(&validator_index.to_be_bytes());
+    input.extend_from_slice(master_seed);
+    grey_crypto::blake2b_256(&input).0
+}
+
+fn derive_validator_seeds_from_mnemonic(
+    validator_index: u16,
+    mnemonic: &str,
+    passphrase: Option<&str>,
+) -> Result<([u8; 32], [u8; 32]), KeystoreError> {
+    let mnemonic = Mnemonic::parse_in(Language::English, mnemonic.trim())
+        .map_err(|e| KeystoreError::Mnemonic(e.to_string()))?;
+    let master_seed = mnemonic.to_seed(passphrase.unwrap_or(""));
+    let ed25519_seed =
+        derive_domain_separated_seed(&master_seed, validator_index, ED25519_MNEMONIC_DOMAIN);
+    let bandersnatch_seed =
+        derive_domain_separated_seed(&master_seed, validator_index, BANDERSNATCH_MNEMONIC_DOMAIN);
+    Ok((ed25519_seed, bandersnatch_seed))
 }
 
 impl Keystore {
@@ -152,6 +184,27 @@ impl Keystore {
             &ed25519_public,
         )
     }
+
+    /// Import validator keys derived from a BIP-39 mnemonic seed phrase.
+    pub fn import_mnemonic(
+        &self,
+        validator_index: u16,
+        mnemonic: &str,
+        passphrase: Option<&str>,
+    ) -> Result<PathBuf, KeystoreError> {
+        let (ed25519_seed, bandersnatch_seed) =
+            derive_validator_seeds_from_mnemonic(validator_index, mnemonic, passphrase)?;
+
+        let ed25519_keypair = grey_crypto::ed25519::Ed25519Keypair::from_seed(&ed25519_seed);
+        let ed25519_public = ed25519_keypair.public_key().0;
+
+        self.save_seeds(
+            validator_index,
+            &ed25519_seed,
+            &bandersnatch_seed,
+            &ed25519_public,
+        )
+    }
 }
 
 /// Errors from the keystore.
@@ -159,6 +212,8 @@ impl Keystore {
 pub enum KeystoreError {
     #[error("I/O error: {0}")]
     Io(String),
+    #[error("invalid mnemonic: {0}")]
+    Mnemonic(String),
     #[error("key not found for validator {0}")]
     NotFound(u16),
 }
@@ -282,5 +337,63 @@ mod tests {
             ks.import_raw_hex(0, "zz".repeat(32).as_str(), "aa".repeat(32).as_str())
                 .is_err()
         );
+    }
+
+    #[test]
+    fn test_import_mnemonic_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let ks = Keystore::open(dir.path().join("keys")).unwrap();
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+        let path = ks.import_mnemonic(4, mnemonic, None).unwrap();
+        assert!(path.exists());
+
+        let (expected_ed, expected_band) =
+            derive_validator_seeds_from_mnemonic(4, mnemonic, None).unwrap();
+        let (loaded_ed, loaded_band) = ks.load_seeds(4).unwrap();
+        assert_eq!(loaded_ed, expected_ed);
+        assert_eq!(loaded_band, expected_band);
+
+        let json = std::fs::read_to_string(path).unwrap();
+        let key_file: KeyFile = serde_json::from_str(&json).unwrap();
+        let expected_public = grey_crypto::ed25519::Ed25519Keypair::from_seed(&expected_ed)
+            .public_key()
+            .0;
+        assert_eq!(key_file.ed25519_public, hex::encode(expected_public));
+    }
+
+    #[test]
+    fn test_mnemonic_derivation_is_validator_specific() {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+        let validator_0 = derive_validator_seeds_from_mnemonic(0, mnemonic, None).unwrap();
+        let validator_1 = derive_validator_seeds_from_mnemonic(1, mnemonic, None).unwrap();
+
+        assert_ne!(validator_0.0, validator_1.0);
+        assert_ne!(validator_0.1, validator_1.1);
+    }
+
+    #[test]
+    fn test_mnemonic_derivation_honors_passphrase() {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+        let without_passphrase = derive_validator_seeds_from_mnemonic(2, mnemonic, None).unwrap();
+        let with_passphrase =
+            derive_validator_seeds_from_mnemonic(2, mnemonic, Some("validator-passphrase"))
+                .unwrap();
+
+        assert_ne!(without_passphrase.0, with_passphrase.0);
+        assert_ne!(without_passphrase.1, with_passphrase.1);
+    }
+
+    #[test]
+    fn test_import_mnemonic_invalid_phrase() {
+        let dir = tempfile::tempdir().unwrap();
+        let ks = Keystore::open(dir.path().join("keys")).unwrap();
+
+        let err = ks
+            .import_mnemonic(1, "not a valid bip39 phrase", None)
+            .unwrap_err();
+        assert!(matches!(err, KeystoreError::Mnemonic(_)));
     }
 }


### PR DESCRIPTION
## Summary
- add keystore support for importing validator seeds from BIP-39 English mnemonics
- derive validator-specific ed25519 and bandersnatch seeds via explicit domain separation and optional passphrase input
- cover roundtrip, validator isolation, passphrase handling, and invalid mnemonic errors with keystore tests

## Testing
- cargo fmt --all
- cargo test -p grey keystore
- cargo test -p grey
- cargo clippy --workspace --all-targets --features javm/signals -- -D warnings

Part of #177.