### PR TITLE
refactor: consolidate signing context constants into grey-types

### DIFF
--- a/grey/crates/grey-consensus/src/authoring.rs
+++ b/grey/crates/grey-consensus/src/authoring.rs
@@ -16,15 +16,7 @@ fn encode_header_unsigned(header: &Header) -> Vec<u8> {
     header.data.encode()
 }
 
-/// Entropy VRF context string (Appendix I.4.5: X_E = $jam_entropy).
-const ENTROPY_CONTEXT: &[u8] = b"jam_entropy";
-
-/// Fallback seal context string (Appendix I.4.5: X_F = $jam_fallback_seal).
-const FALLBACK_SEAL_CONTEXT: &[u8] = b"jam_fallback_seal";
-
-/// Ticket seal context string (Appendix I.4.5: X_T = $jam_ticket_seal).
-/// Used for both ticket generation (Ring VRF) and ticket-mode block sealing.
-const TICKET_SEAL_CONTEXT: &[u8] = b"jam_ticket_seal";
+use grey_types::signing_contexts;
 
 /// Check if a validator is the block author for a given timeslot.
 ///
@@ -85,7 +77,7 @@ pub fn is_slot_author_with_keypair(
             // For each attempt (0..N), compute VRF output and check against ticket ID
             for attempt in 0..config.tickets_per_validator as u8 {
                 let mut vrf_input = Vec::with_capacity(48);
-                vrf_input.extend_from_slice(TICKET_SEAL_CONTEXT);
+                vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
                 vrf_input.extend_from_slice(&eta2.0);
                 vrf_input.push(attempt);
 
@@ -157,7 +149,7 @@ pub fn author_block_with_extrinsics(
         .unwrap_or(Hash::ZERO);
 
     // VRF signature for entropy (HV)
-    let vrf_input = build_vrf_input(ENTROPY_CONTEXT, timeslot, &[]);
+    let vrf_input = build_vrf_input(signing_contexts::ENTROPY, timeslot, &[]);
     let vrf_sig_bytes = secrets.bandersnatch.vrf_sign(&vrf_input, b"");
     let vrf_signature = BandersnatchSignature(vrf_sig_bytes);
 
@@ -226,9 +218,9 @@ pub fn author_block_with_extrinsics(
     let unsigned_hash = compute_unsigned_header_hash_bytes(&header);
     let is_ticket_mode = matches!(&state.safrole.seal_key_series, SealKeySeries::Tickets(_));
     let seal_context = if is_ticket_mode {
-        TICKET_SEAL_CONTEXT
+        signing_contexts::TICKET_SEAL
     } else {
-        FALLBACK_SEAL_CONTEXT
+        signing_contexts::FALLBACK_SEAL
     };
     let seal_input = build_vrf_input(seal_context, timeslot, &unsigned_hash);
     let seal_bytes = secrets.bandersnatch.seal_sign(&seal_input, b"");
@@ -342,7 +334,7 @@ mod tests {
         for (vi, s) in secrets.iter().enumerate() {
             for attempt in 0..config.tickets_per_validator as u8 {
                 let mut vrf_input = Vec::with_capacity(48);
-                vrf_input.extend_from_slice(TICKET_SEAL_CONTEXT);
+                vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
                 vrf_input.extend_from_slice(&eta2.0);
                 vrf_input.push(attempt);
 

--- a/grey/crates/grey-crypto/src/bandersnatch.rs
+++ b/grey/crates/grey-crypto/src/bandersnatch.rs
@@ -281,8 +281,7 @@ pub fn vrf_output_hash(signature: &[u8]) -> Option<[u8; 32]> {
     Some(result)
 }
 
-/// Ticket VRF context string (Appendix I.4.5: X_T = $jam_ticket_seal).
-pub const TICKET_SEAL_CONTEXT: &[u8] = b"jam_ticket_seal";
+use grey_types::signing_contexts;
 
 /// Verify a ticket Ring VRF proof and return the ticket ID.
 ///
@@ -295,7 +294,7 @@ pub fn verify_ticket(
     proof: &[u8],
 ) -> Option<[u8; 32]> {
     let mut vrf_input = Vec::with_capacity(48);
-    vrf_input.extend_from_slice(TICKET_SEAL_CONTEXT);
+    vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
     vrf_input.extend_from_slice(eta2);
     vrf_input.push(attempt);
     ring_vrf_verify(ring_size, ring_commitment, &vrf_input, &[], proof)
@@ -397,7 +396,7 @@ mod tests {
         let attempt = 0u8;
 
         let mut vrf_input = Vec::new();
-        vrf_input.extend_from_slice(TICKET_SEAL_CONTEXT);
+        vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
         vrf_input.extend_from_slice(&eta2);
         vrf_input.push(attempt);
 
@@ -433,7 +432,7 @@ mod tests {
 
         // Compute ticket IDs for validator 3, attempt 0
         let mut vrf_input = Vec::new();
-        vrf_input.extend_from_slice(TICKET_SEAL_CONTEXT);
+        vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
         vrf_input.extend_from_slice(&eta2);
         vrf_input.push(0);
 

--- a/grey/crates/grey-network/src/lib.rs
+++ b/grey/crates/grey-network/src/lib.rs
@@ -7,35 +7,5 @@
 
 pub mod service;
 
-/// Signing context strings used in the JAM protocol (Appendix I.4.5).
-pub mod signing_contexts {
-    /// XA: Ed25519 availability assurances.
-    pub const AVAILABLE: &[u8] = b"jam_available";
-
-    /// XB: BLS accumulate-result-root-MMR commitment.
-    pub const BEEFY: &[u8] = b"jam_beefy";
-
-    /// XE: On-chain entropy generation.
-    pub const ENTROPY: &[u8] = b"jam_entropy";
-
-    /// XF: Bandersnatch fallback block seal.
-    pub const FALLBACK_SEAL: &[u8] = b"jam_fallback_seal";
-
-    /// XG: Ed25519 guarantee statements.
-    pub const GUARANTEE: &[u8] = b"jam_guarantee";
-
-    /// XI: Ed25519 audit announcement statements.
-    pub const ANNOUNCE: &[u8] = b"jam_announce";
-
-    /// XT: Bandersnatch RingVRF ticket generation and regular block seal.
-    pub const TICKET_SEAL: &[u8] = b"jam_ticket_seal";
-
-    /// XU: Bandersnatch audit selection entropy.
-    pub const AUDIT: &[u8] = b"jam_audit";
-
-    /// X⊺: Ed25519 judgments for valid work-reports.
-    pub const VALID: &[u8] = b"jam_valid";
-
-    /// X⊥: Ed25519 judgments for invalid work-reports.
-    pub const INVALID: &[u8] = b"jam_invalid";
-}
+/// Re-export signing contexts from grey-types (single source of truth).
+pub use grey_types::signing_contexts;

--- a/grey/crates/grey-state/src/assurances.rs
+++ b/grey/crates/grey-state/src/assurances.rs
@@ -3,12 +3,12 @@
 //! Processes availability assurances to determine which pending work reports
 //! have become available.
 
-use grey_types::Hash;
 use grey_types::config::Config;
 use grey_types::header::Assurance;
 use grey_types::state::PendingReport;
 use grey_types::validator::ValidatorKey;
 use grey_types::work::WorkReport;
+use grey_types::{Hash, signing_contexts};
 
 /// Error type for assurances validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,7 +87,7 @@ pub fn process_assurances(
         let payload_hash = grey_crypto::blake2b_256(&payload);
 
         let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(b"jam_available");
+        message.extend_from_slice(signing_contexts::AVAILABLE);
         message.extend_from_slice(&payload_hash.0);
 
         if !grey_crypto::ed25519_verify(ed25519_key, &message, &a.signature) {

--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -6,7 +6,7 @@ use grey_types::config::Config;
 use grey_types::header::DisputesExtrinsic;
 use grey_types::state::{Judgments, PendingReport};
 use grey_types::validator::ValidatorKey;
-use grey_types::{Ed25519PublicKey, Hash};
+use grey_types::{Ed25519PublicKey, Hash, signing_contexts};
 use std::collections::BTreeSet;
 
 /// Error type for disputes validation.
@@ -134,9 +134,9 @@ pub fn process_disputes(
 
             let ed25519_key = &validators[idx].ed25519;
             let domain: &[u8] = if judgment.is_valid {
-                b"jam_valid"
+                signing_contexts::VALID
             } else {
-                b"jam_invalid"
+                signing_contexts::INVALID
             };
 
             let mut message = Vec::with_capacity(domain.len() + 32);
@@ -248,7 +248,7 @@ pub fn process_disputes(
 
         // Verify guarantee signature: X_G = "jam_guarantee"
         let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(b"jam_guarantee");
+        message.extend_from_slice(signing_contexts::GUARANTEE);
         message.extend_from_slice(&culprit.report_hash.0);
 
         if !grey_crypto::ed25519_verify(&culprit.validator_key, &message, &culprit.signature) {
@@ -285,10 +285,10 @@ pub fn process_disputes(
         }
 
         // Verify judgment signature
-        let domain = if fault.is_valid {
-            b"jam_valid".as_slice()
+        let domain: &[u8] = if fault.is_valid {
+            signing_contexts::VALID
         } else {
-            b"jam_invalid".as_slice()
+            signing_contexts::INVALID
         };
         let mut message = Vec::with_capacity(domain.len() + 32);
         message.extend_from_slice(domain);

--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -5,7 +5,7 @@
 use grey_types::config::Config;
 use grey_types::validator::ValidatorKey;
 use grey_types::work::{WorkReport, WorkResult};
-use grey_types::{Ed25519PublicKey, Ed25519Signature, Hash, ServiceId, Timeslot};
+use grey_types::{Ed25519PublicKey, Ed25519Signature, Hash, ServiceId, Timeslot, signing_contexts};
 use javm::Gas;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -321,7 +321,7 @@ pub fn process_reports(
         let encoded_report = scale::Encode::encode(report);
         let report_hash = grey_crypto::blake2b_256(&encoded_report);
         let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(b"jam_guarantee");
+        message.extend_from_slice(signing_contexts::GUARANTEE);
         message.extend_from_slice(&report_hash.0);
 
         for (idx, sig) in &guarantee.signatures {

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -11,6 +11,49 @@ pub mod state;
 pub mod validator;
 pub mod work;
 
+/// Signing context strings used in the JAM protocol (Appendix I.4.5).
+///
+/// Each context is a unique byte prefix mixed into signatures to prevent
+/// cross-protocol replay attacks. Centralised here as the single source
+/// of truth — all crates import from this module.
+pub mod signing_contexts {
+    /// XA: Ed25519 availability assurances.
+    pub const AVAILABLE: &[u8] = b"jam_available";
+
+    /// XB: BLS accumulate-result-root-MMR commitment.
+    pub const BEEFY: &[u8] = b"jam_beefy";
+
+    /// XE: On-chain entropy generation.
+    pub const ENTROPY: &[u8] = b"jam_entropy";
+
+    /// XF: Bandersnatch fallback block seal.
+    pub const FALLBACK_SEAL: &[u8] = b"jam_fallback_seal";
+
+    /// XG: Ed25519 guarantee statements.
+    pub const GUARANTEE: &[u8] = b"jam_guarantee";
+
+    /// XI: Ed25519 audit announcement statements.
+    pub const ANNOUNCE: &[u8] = b"jam_announce";
+
+    /// XT: Bandersnatch RingVRF ticket generation and regular block seal.
+    pub const TICKET_SEAL: &[u8] = b"jam_ticket_seal";
+
+    /// XU: Bandersnatch audit selection entropy.
+    pub const AUDIT: &[u8] = b"jam_audit";
+
+    /// X⊺: Ed25519 judgments for valid work-reports.
+    pub const VALID: &[u8] = b"jam_valid";
+
+    /// X⊥: Ed25519 judgments for invalid work-reports.
+    pub const INVALID: &[u8] = b"jam_invalid";
+
+    /// GRANDPA prevote context.
+    pub const PREVOTE: &[u8] = b"jam_prevote";
+
+    /// GRANDPA precommit context.
+    pub const PRECOMMIT: &[u8] = b"jam_precommit";
+}
+
 use std::fmt;
 
 /// Decode a 0x-prefixed hex string to bytes.

--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -11,7 +11,7 @@ use grey_state::refine::RefineContext;
 use grey_types::config::Config;
 use grey_types::state::State;
 use grey_types::work::{WorkReport, WorkResult};
-use grey_types::{Ed25519Signature, Hash, Timeslot, ValidatorIndex};
+use grey_types::{Ed25519Signature, Hash, Timeslot, ValidatorIndex, signing_contexts};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Tranche timing: 8 seconds per tranche (T_A).
@@ -170,7 +170,7 @@ pub fn compute_audit_tranche(
     max_tranches: u32,
 ) -> u32 {
     let mut input = Vec::with_capacity(8 + 32 + 32 + 2);
-    input.extend_from_slice(b"jam_audit");
+    input.extend_from_slice(signing_contexts::AUDIT);
     input.extend_from_slice(&entropy.0);
     input.extend_from_slice(&report_hash.0);
     input.extend_from_slice(&validator_index.to_le_bytes());
@@ -253,9 +253,9 @@ pub fn create_announcement(
 ) -> AuditAnnouncement {
     // Sign: X_⊺ or X_⊥ ++ report_hash
     let context = if is_valid {
-        b"jam_valid" as &[u8]
+        signing_contexts::VALID
     } else {
-        b"jam_invalid" as &[u8]
+        signing_contexts::INVALID
     };
     let mut message = Vec::with_capacity(context.len() + 32);
     message.extend_from_slice(context);
@@ -310,9 +310,9 @@ pub fn verify_announcement(announcement: &AuditAnnouncement, state: &State) -> b
     let ed25519_key = &state.current_validators[idx].ed25519;
 
     let context = if announcement.is_valid {
-        b"jam_valid" as &[u8]
+        signing_contexts::VALID
     } else {
-        b"jam_invalid" as &[u8]
+        signing_contexts::INVALID
     };
     let mut message = Vec::with_capacity(context.len() + 32);
     message.extend_from_slice(context);

--- a/grey/crates/grey/src/finality.rs
+++ b/grey/crates/grey/src/finality.rs
@@ -14,10 +14,7 @@ use grey_types::config::Config;
 use grey_types::{Ed25519Signature, Hash, Timeslot, ValidatorIndex};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-/// Signing context for GRANDPA prevotes.
-const PREVOTE_CONTEXT: &[u8] = b"jam_prevote";
-/// Signing context for GRANDPA precommits.
-const PRECOMMIT_CONTEXT: &[u8] = b"jam_precommit";
+use grey_types::signing_contexts;
 
 /// A GRANDPA vote (prevote or precommit).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -594,8 +591,8 @@ fn sign_vote(
     vote_type: VoteType,
 ) -> Vote {
     let context = match vote_type {
-        VoteType::Prevote => PREVOTE_CONTEXT,
-        VoteType::Precommit => PRECOMMIT_CONTEXT,
+        VoteType::Prevote => signing_contexts::PREVOTE,
+        VoteType::Precommit => signing_contexts::PRECOMMIT,
     };
 
     let mut message = Vec::with_capacity(context.len() + 32 + 4 + 8);
@@ -624,8 +621,8 @@ pub fn verify_vote(vote: &Vote, vote_type: VoteType, state: &grey_types::state::
     let ed25519_key = &state.current_validators[idx].ed25519;
 
     let context = match vote_type {
-        VoteType::Prevote => PREVOTE_CONTEXT,
-        VoteType::Precommit => PRECOMMIT_CONTEXT,
+        VoteType::Prevote => signing_contexts::PREVOTE,
+        VoteType::Precommit => signing_contexts::PRECOMMIT,
     };
 
     let mut message = Vec::with_capacity(context.len() + 32 + 4 + 8);

--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -16,7 +16,7 @@ use grey_types::config::Config;
 use grey_types::header::{Assurance, Guarantee};
 use grey_types::state::State;
 use grey_types::work::{WorkPackage, WorkReport};
-use grey_types::{Ed25519Signature, Hash};
+use grey_types::{Ed25519Signature, Hash, signing_contexts};
 use scale::Encode;
 use std::collections::{BTreeMap, HashSet};
 
@@ -93,7 +93,7 @@ impl GuarantorState {
         let payload_hash = grey_crypto::blake2b_256(&payload);
 
         let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(b"jam_available");
+        message.extend_from_slice(signing_contexts::AVAILABLE);
         message.extend_from_slice(&payload_hash.0);
 
         let signature = secrets.ed25519.sign(&message);
@@ -174,7 +174,7 @@ pub fn process_work_package(
 
     // 5. Sign the guarantee
     let mut message = Vec::with_capacity(13 + 32);
-    message.extend_from_slice(b"jam_guarantee");
+    message.extend_from_slice(signing_contexts::GUARANTEE);
     message.extend_from_slice(&report_hash.0);
     let signature = secrets.ed25519.sign(&message);
 

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -22,7 +22,7 @@ use grey_store::Store;
 use grey_types::config::Config;
 use grey_types::header::{Assurance, Block};
 use grey_types::state::State;
-use grey_types::{BandersnatchPublicKey, Hash, Timeslot};
+use grey_types::{BandersnatchPublicKey, Hash, Timeslot, signing_contexts};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of out-of-order blocks to buffer. Prevents memory
@@ -474,7 +474,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     let co_signer_idx = if config.validator_index == 0 { 1u16 } else { 0 };
                                     let co_secrets = &all_secrets[co_signer_idx as usize];
                                     let mut msg = Vec::with_capacity(13 + 32);
-                                    msg.extend_from_slice(b"jam_guarantee");
+                                    msg.extend_from_slice(signing_contexts::GUARANTEE);
                                     msg.extend_from_slice(&report_hash.0);
                                     let co_sig = co_secrets.ed25519.sign(&msg);
                                     // Only co-sign the newly created guarantee (the last one),
@@ -1314,7 +1314,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                             let co_idx = if config.validator_index == 0 { 1u16 } else { 0 };
                                             let co_secrets = &all_secrets[co_idx as usize];
                                             let mut msg = Vec::with_capacity(13 + 32);
-                                            msg.extend_from_slice(b"jam_guarantee");
+                                            msg.extend_from_slice(signing_contexts::GUARANTEE);
                                             msg.extend_from_slice(&report_hash.0);
                                             let co_sig = co_secrets.ed25519.sign(&msg);
                                             // Only co-sign the newly created guarantee (the last one),

--- a/grey/crates/grey/src/tickets.rs
+++ b/grey/crates/grey/src/tickets.rs
@@ -11,7 +11,7 @@ use grey_consensus::genesis::ValidatorSecrets;
 use grey_types::config::Config;
 use grey_types::header::TicketProof;
 use grey_types::state::State;
-use grey_types::{Hash, Timeslot};
+use grey_types::{Hash, Timeslot, signing_contexts};
 use std::collections::BTreeSet;
 
 /// Maximum ticket attempts per validator per epoch (N=2 in tiny, N=2 in full).
@@ -144,7 +144,7 @@ fn generate_ticket_proof(
     key_index: usize,
 ) -> Option<TicketProof> {
     let mut vrf_input = Vec::with_capacity(15 + 32 + 1);
-    vrf_input.extend_from_slice(grey_crypto::bandersnatch::TICKET_SEAL_CONTEXT);
+    vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
     vrf_input.extend_from_slice(&eta2.0);
     vrf_input.push(attempt);
 


### PR DESCRIPTION
## Summary

- Move `signing_contexts` module from grey-network to grey-types as the single source of truth for all JAM protocol signing context strings (Appendix I.4.5)
- Replace 20+ hardcoded `b"jam_*"` string literals and duplicate `const` definitions across 7 crates with imports from `grey_types::signing_contexts`
- Add `PREVOTE` and `PRECOMMIT` contexts to the central module (previously defined only in grey/src/finality.rs)
- grey-network re-exports `grey_types::signing_contexts` for backwards compatibility

Addresses #186.

## Scope

This PR addresses: signing context constant duplication across grey-types, grey-network, grey-consensus, grey-crypto, grey-state, and grey (node binary).

Remaining sub-tasks in #186:
- Test vector JSON parsing helper consolidation in grey-state tests
- Test file discovery pattern dedup in stf_blocks.rs

## Test plan

- `cargo test -p grey-state -p grey-consensus -p grey-crypto -p grey-network` — all tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean