### PR TITLE
refactor: extract test file discovery and JSON loading helpers

### DIFF
--- a/grey/crates/grey-state/tests/common/mod.rs
+++ b/grey/crates/grey-state/tests/common/mod.rs
@@ -10,6 +10,37 @@ use grey_types::{
 use std::collections::BTreeMap;
 use std::path::Path;
 
+/// Discover test vector file stems in a directory matching `*.input.jar1.json`.
+///
+/// Returns a sorted list of stems (the filename prefix before `.input.jar1.json`).
+/// Convenience wrapper for `discover_test_stems_variant` with the default "jar1" variant.
+pub fn discover_test_stems(dir: &str) -> Vec<String> {
+    discover_test_stems_variant(dir, "jar1")
+}
+
+/// Discover test vector file stems in a directory matching `*.input.{variant}.json`.
+///
+/// Returns a sorted list of stems (the filename prefix before `.input.{variant}.json`).
+pub fn discover_test_stems_variant(dir: &str, variant: &str) -> Vec<String> {
+    let suffix = format!(".input.{variant}.json");
+    let mut stems: Vec<String> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("failed to read dir {dir}: {e}"))
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name().into_string().ok()?;
+            name.strip_suffix(&suffix).map(String::from)
+        })
+        .collect();
+    stems.sort();
+    stems
+}
+
+/// Load and parse a JSON file, panicking with a descriptive message on failure.
+pub fn load_json(path: &str) -> serde_json::Value {
+    let contents =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    serde_json::from_str(&contents).unwrap_or_else(|e| panic!("failed to parse {path}: {e}"))
+}
+
 /// Decode a 0x-prefixed hex string to bytes. Panics on invalid input.
 pub fn decode_hex(s: &str) -> Vec<u8> {
     hex::decode(s.strip_prefix("0x").unwrap_or(s)).expect("bad hex")
@@ -235,23 +266,6 @@ pub fn load_jar_test(dir: &str, stem: &str) -> serde_json::Value {
     }
 
     input_json
-}
-
-/// Discover all test stems for a given category directory (gp072_tiny variant).
-/// Returns stems sorted alphabetically.
-pub fn discover_test_stems(dir: &str) -> Vec<String> {
-    let variant = "jar1";
-    let suffix = format!(".input.{variant}.json");
-    let mut stems = Vec::new();
-    for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("failed to read dir {dir}: {e}"))
-    {
-        let name = entry.unwrap().file_name().into_string().unwrap();
-        if let Some(stem) = name.strip_suffix(&suffix) {
-            stems.push(stem.to_string());
-        }
-    }
-    stems.sort();
-    stems
 }
 
 /// Parse a ValidatorKey from a JSON value.

--- a/grey/crates/grey-state/tests/stf_blocks.rs
+++ b/grey/crates/grey-state/tests/stf_blocks.rs
@@ -235,19 +235,8 @@ fn parse_keyvals(v: &serde_json::Value) -> Vec<([u8; 31], Vec<u8>)> {
 fn run_independent_trace(trace_name: &str) {
     let dir = format!("{BLOCKS_DIR}/{trace_name}");
     let config = Config::full();
-
-    // Discover block files
     let variant = "jar1";
-    let suffix = format!(".input.{variant}.json");
-    let mut stems: Vec<String> = Vec::new();
-    for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("failed to read dir {dir}: {e}"))
-    {
-        let name = entry.unwrap().file_name().into_string().unwrap();
-        if let Some(stem) = name.strip_suffix(&suffix) {
-            stems.push(stem.to_string());
-        }
-    }
-    stems.sort();
+    let stems = common::discover_test_stems_variant(&dir, variant);
 
     let mut passed = 0;
     let mut failed = 0;
@@ -257,17 +246,8 @@ fn run_independent_trace(trace_name: &str) {
         let input_path = format!("{dir}/{stem}.input.{variant}.json");
         let output_path = format!("{dir}/{stem}.output.{variant}.json");
 
-        let input_json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&input_path)
-                .unwrap_or_else(|e| panic!("failed to read {input_path}: {e}")),
-        )
-        .unwrap_or_else(|e| panic!("failed to parse {input_path}: {e}"));
-
-        let output_json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&output_path)
-                .unwrap_or_else(|e| panic!("failed to read {output_path}: {e}")),
-        )
-        .unwrap_or_else(|e| panic!("failed to parse {output_path}: {e}"));
+        let input_json = common::load_json(&input_path);
+        let output_json = common::load_json(&output_path);
 
         // Check if this is an expected error
         if output_json.get("error").is_some() {
@@ -400,25 +380,10 @@ fn run_sequential_trace(trace_name: &str) {
     let dir = format!("{BLOCKS_DIR}/{trace_name}");
     let config = Config::full();
     let variant = "jar1";
-
-    // Discover block files
-    let suffix = format!(".input.{variant}.json");
-    let mut stems: Vec<String> = Vec::new();
-    for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("failed to read dir {dir}: {e}"))
-    {
-        let name = entry.unwrap().file_name().into_string().unwrap();
-        if let Some(stem) = name.strip_suffix(&suffix) {
-            stems.push(stem.to_string());
-        }
-    }
-    stems.sort();
+    let stems = common::discover_test_stems_variant(&dir, variant);
 
     // Load first block's keyvals
-    let first_input: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(format!("{dir}/{}.input.{variant}.json", stems[0]))
-            .expect("failed to read first block"),
-    )
-    .expect("failed to parse first block");
+    let first_input = common::load_json(&format!("{dir}/{}.input.{variant}.json", stems[0]));
 
     let kvs = parse_keyvals(&first_input["pre_state"]["keyvals"]);
     let (mut state, mut opaque) =
@@ -431,15 +396,8 @@ fn run_sequential_trace(trace_name: &str) {
         let input_path = format!("{dir}/{stem}.input.{variant}.json");
         let output_path = format!("{dir}/{stem}.output.{variant}.json");
 
-        let input_json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&input_path).expect("failed to read block input"),
-        )
-        .expect("failed to parse block input");
-
-        let output_json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(&output_path).expect("failed to read block output"),
-        )
-        .expect("failed to parse block output");
+        let input_json = common::load_json(&input_path);
+        let output_json = common::load_json(&output_path);
 
         let block = parse_block_from_json(&input_json["block"]);
 


### PR DESCRIPTION
## Summary

- Extract `discover_test_stems_variant(dir, variant)` helper to deduplicate identical 10-line block file discovery pattern in `stf_blocks.rs`
- Extract `load_json(path)` helper to replace 4-line read+parse+unwrap pattern (5 call sites)
- Make the existing `discover_test_stems(dir)` delegate to the new parameterized version
- Net reduction: -28 lines

Addresses #186.

## Scope

This PR addresses: test file discovery and JSON loading duplication in grey-state tests.

Remaining sub-tasks in #186:
- Test vector JSON parsing helper consolidation across stf_*.rs files

## Test plan

- `cargo test -p grey-state` — all tests pass
- `cargo fmt --all` — clean