### PR TITLE
refactor: extract build_ticket_vrf_input() to deduplicate VRF input construction

### DIFF
--- a/grey/crates/grey-consensus/src/authoring.rs
+++ b/grey/crates/grey-consensus/src/authoring.rs
@@ -76,10 +76,7 @@ pub fn is_slot_author_with_keypair(
 
             // For each attempt (0..N), compute VRF output and check against ticket ID
             for attempt in 0..config.tickets_per_validator as u8 {
-                let mut vrf_input = Vec::with_capacity(48);
-                vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-                vrf_input.extend_from_slice(&eta2.0);
-                vrf_input.push(attempt);
+                let vrf_input = grey_crypto::bandersnatch::build_ticket_vrf_input(&eta2.0, attempt);
 
                 if let Some(ticket_id) = kp.vrf_output_for_input(&vrf_input)
                     && ticket_id == ticket.id.0
@@ -333,10 +330,7 @@ mod tests {
 
         for (vi, s) in secrets.iter().enumerate() {
             for attempt in 0..config.tickets_per_validator as u8 {
-                let mut vrf_input = Vec::with_capacity(48);
-                vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-                vrf_input.extend_from_slice(&eta2.0);
-                vrf_input.push(attempt);
+                let vrf_input = grey_crypto::bandersnatch::build_ticket_vrf_input(&eta2.0, attempt);
 
                 if let Some(ticket_id) = s.bandersnatch.vrf_output_for_input(&vrf_input) {
                     all_tickets.push((

--- a/grey/crates/grey-crypto/src/bandersnatch.rs
+++ b/grey/crates/grey-crypto/src/bandersnatch.rs
@@ -283,6 +283,15 @@ pub fn vrf_output_hash(signature: &[u8]) -> Option<[u8; 32]> {
 
 use grey_types::signing_contexts;
 
+/// Build the VRF input for ticket operations: X_T ⌢ η₂ ⌢ E₁(attempt) (eq 6.29).
+pub fn build_ticket_vrf_input(eta2: &[u8; 32], attempt: u8) -> Vec<u8> {
+    let mut input = Vec::with_capacity(48);
+    input.extend_from_slice(signing_contexts::TICKET_SEAL);
+    input.extend_from_slice(eta2);
+    input.push(attempt);
+    input
+}
+
 /// Verify a ticket Ring VRF proof and return the ticket ID.
 ///
 /// Constructs the VRF input as: X_T ⌢ η₂ ⌢ E₁(attempt) (eq 6.29).
@@ -293,10 +302,7 @@ pub fn verify_ticket(
     attempt: u8,
     proof: &[u8],
 ) -> Option<[u8; 32]> {
-    let mut vrf_input = Vec::with_capacity(48);
-    vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-    vrf_input.extend_from_slice(eta2);
-    vrf_input.push(attempt);
+    let vrf_input = build_ticket_vrf_input(eta2, attempt);
     ring_vrf_verify(ring_size, ring_commitment, &vrf_input, &[], proof)
 }
 
@@ -395,10 +401,7 @@ mod tests {
         let eta2 = [0u8; 32];
         let attempt = 0u8;
 
-        let mut vrf_input = Vec::new();
-        vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-        vrf_input.extend_from_slice(&eta2);
-        vrf_input.push(attempt);
+        let vrf_input = build_ticket_vrf_input(&eta2, attempt);
 
         let proof = keypairs[prover_idx]
             .ring_vrf_sign(&ring_keys, prover_idx, &vrf_input, &[])
@@ -431,10 +434,7 @@ mod tests {
         let eta2 = [7u8; 32];
 
         // Compute ticket IDs for validator 3, attempt 0
-        let mut vrf_input = Vec::new();
-        vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-        vrf_input.extend_from_slice(&eta2);
-        vrf_input.push(0);
+        let vrf_input = build_ticket_vrf_input(&eta2, 0);
 
         let ticket_id = keypairs[3].vrf_output_for_input(&vrf_input).unwrap();
 

--- a/grey/crates/grey/src/tickets.rs
+++ b/grey/crates/grey/src/tickets.rs
@@ -11,7 +11,7 @@ use grey_consensus::genesis::ValidatorSecrets;
 use grey_types::config::Config;
 use grey_types::header::TicketProof;
 use grey_types::state::State;
-use grey_types::{Hash, Timeslot, signing_contexts};
+use grey_types::{Hash, Timeslot};
 use std::collections::BTreeSet;
 
 /// Maximum ticket attempts per validator per epoch (N=2 in tiny, N=2 in full).
@@ -143,10 +143,7 @@ fn generate_ticket_proof(
     ring_keys: &[[u8; 32]],
     key_index: usize,
 ) -> Option<TicketProof> {
-    let mut vrf_input = Vec::with_capacity(15 + 32 + 1);
-    vrf_input.extend_from_slice(signing_contexts::TICKET_SEAL);
-    vrf_input.extend_from_slice(&eta2.0);
-    vrf_input.push(attempt);
+    let vrf_input = grey_crypto::bandersnatch::build_ticket_vrf_input(&eta2.0, attempt);
 
     // Generate Ring VRF proof (784 bytes: 32-byte output + 752-byte ring proof)
     let proof = secrets


### PR DESCRIPTION
## Summary

- Extract `build_ticket_vrf_input(eta2, attempt)` helper in `grey_crypto::bandersnatch` to deduplicate the identical 4-line VRF input construction pattern (TICKET_SEAL ⌢ η₂ ⌢ attempt)
- Replace 6 duplicate instances across grey-crypto (verify_ticket + 2 tests), grey-consensus (authoring + test), and grey node (tickets)
- Net reduction: -9 lines

Addresses #186.

## Scope

This PR addresses: ticket VRF input construction duplication across 3 crates.

Remaining sub-tasks in #186:
- Guarantee signature message construction dedup (3 locations)
- Test vector JSON parsing helper consolidation

## Test plan

- `cargo test -p grey-crypto -p grey-consensus` — all tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean