### PR TITLE
refactor: extract sign_guarantee() to deduplicate guarantee signing

### DIFF
--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -20,6 +20,16 @@ use grey_types::{Ed25519Signature, Hash, signing_contexts};
 use scale::Encode;
 use std::collections::{BTreeMap, HashSet};
 
+/// Sign a guarantee message: X_G ⌢ report_hash.
+///
+/// Constructs the signing payload per GP Section 11 and signs with Ed25519.
+pub fn sign_guarantee(report_hash: &Hash, secrets: &ValidatorSecrets) -> Ed25519Signature {
+    let mut message = Vec::with_capacity(13 + 32);
+    message.extend_from_slice(signing_contexts::GUARANTEE);
+    message.extend_from_slice(&report_hash.0);
+    secrets.ed25519.sign(&message)
+}
+
 /// Tracks pending guarantees and chunks for availability.
 #[derive(Default)]
 pub struct GuarantorState {
@@ -173,10 +183,7 @@ pub fn process_work_package(
     );
 
     // 5. Sign the guarantee
-    let mut message = Vec::with_capacity(13 + 32);
-    message.extend_from_slice(signing_contexts::GUARANTEE);
-    message.extend_from_slice(&report_hash.0);
-    let signature = secrets.ed25519.sign(&message);
+    let signature = sign_guarantee(&report_hash, secrets);
 
     let guarantee = Guarantee {
         report,

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -22,7 +22,7 @@ use grey_store::Store;
 use grey_types::config::Config;
 use grey_types::header::{Assurance, Block};
 use grey_types::state::State;
-use grey_types::{BandersnatchPublicKey, Hash, Timeslot, signing_contexts};
+use grey_types::{BandersnatchPublicKey, Hash, Timeslot};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of out-of-order blocks to buffer. Prevents memory
@@ -473,10 +473,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     // Add a second guarantor co-signature (minimum 2 required)
                                     let co_signer_idx = if config.validator_index == 0 { 1u16 } else { 0 };
                                     let co_secrets = &all_secrets[co_signer_idx as usize];
-                                    let mut msg = Vec::with_capacity(13 + 32);
-                                    msg.extend_from_slice(signing_contexts::GUARANTEE);
-                                    msg.extend_from_slice(&report_hash.0);
-                                    let co_sig = co_secrets.ed25519.sign(&msg);
+                                    let co_sig = crate::guarantor::sign_guarantee(&report_hash, co_secrets);
                                     // Only co-sign the newly created guarantee (the last one),
                                     // not all pending guarantees — they have different report hashes.
                                     if let Some(g) = guarantor_state.pending_guarantees.last_mut() {
@@ -1313,10 +1310,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                             // Co-sign with a second validator (testnet only)
                                             let co_idx = if config.validator_index == 0 { 1u16 } else { 0 };
                                             let co_secrets = &all_secrets[co_idx as usize];
-                                            let mut msg = Vec::with_capacity(13 + 32);
-                                            msg.extend_from_slice(signing_contexts::GUARANTEE);
-                                            msg.extend_from_slice(&report_hash.0);
-                                            let co_sig = co_secrets.ed25519.sign(&msg);
+                                            let co_sig = crate::guarantor::sign_guarantee(&report_hash, co_secrets);
                                             // Only co-sign the newly created guarantee (the last one),
                                             // not all pending guarantees — they have different report hashes.
                                             if let Some(g) = guarantor_state.pending_guarantees.last_mut() {


### PR DESCRIPTION
## Summary

- Extract `sign_guarantee(report_hash, secrets)` helper in `guarantor.rs` to build the guarantee signing message (GUARANTEE context ⌢ report_hash) and sign with Ed25519
- Replace 3 identical 4-line blocks across `guarantor.rs` and `node.rs` (2 co-signing locations)
- Remove unused `signing_contexts` import from `node.rs`

Addresses #186.

## Scope

This PR addresses: guarantee signature message construction duplication.

Remaining sub-tasks in #186:
- Test vector JSON parsing helper consolidation across stf_*.rs files

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean
- No behavioral change — pure refactoring