### PR TITLE
refactor: extract build_judgment_message() to deduplicate judgment signing

### DIFF
--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -133,16 +133,8 @@ pub fn process_disputes(
             }
 
             let ed25519_key = &validators[idx].ed25519;
-            let domain: &[u8] = if judgment.is_valid {
-                signing_contexts::VALID
-            } else {
-                signing_contexts::INVALID
-            };
-
-            let mut message = Vec::with_capacity(domain.len() + 32);
-            message.extend_from_slice(domain);
-            message.extend_from_slice(&verdict.report_hash.0);
-
+            let message =
+                signing_contexts::build_judgment_message(judgment.is_valid, &verdict.report_hash.0);
             if !grey_crypto::ed25519_verify(ed25519_key, &message, &judgment.signature) {
                 return Err(DisputeError::BadSignature);
             }
@@ -285,15 +277,8 @@ pub fn process_disputes(
         }
 
         // Verify judgment signature
-        let domain: &[u8] = if fault.is_valid {
-            signing_contexts::VALID
-        } else {
-            signing_contexts::INVALID
-        };
-        let mut message = Vec::with_capacity(domain.len() + 32);
-        message.extend_from_slice(domain);
-        message.extend_from_slice(&fault.report_hash.0);
-
+        let message =
+            signing_contexts::build_judgment_message(fault.is_valid, &fault.report_hash.0);
         if !grey_crypto::ed25519_verify(&fault.validator_key, &message, &fault.signature) {
             return Err(DisputeError::BadSignature);
         }

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -52,6 +52,17 @@ pub mod signing_contexts {
 
     /// GRANDPA precommit context.
     pub const PRECOMMIT: &[u8] = b"jam_precommit";
+
+    /// Build a judgment signing message: (X_⊺ or X_⊥) ⌢ report_hash.
+    ///
+    /// Used for both signing and verifying valid/invalid work-report judgments.
+    pub fn build_judgment_message(is_valid: bool, report_hash: &[u8; 32]) -> Vec<u8> {
+        let context: &[u8] = if is_valid { VALID } else { INVALID };
+        let mut message = Vec::with_capacity(context.len() + 32);
+        message.extend_from_slice(context);
+        message.extend_from_slice(report_hash);
+        message
+    }
 }
 
 use std::fmt;

--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -252,15 +252,7 @@ pub fn create_announcement(
     secrets: &ValidatorSecrets,
 ) -> AuditAnnouncement {
     // Sign: X_⊺ or X_⊥ ++ report_hash
-    let context = if is_valid {
-        signing_contexts::VALID
-    } else {
-        signing_contexts::INVALID
-    };
-    let mut message = Vec::with_capacity(context.len() + 32);
-    message.extend_from_slice(context);
-    message.extend_from_slice(&report_hash.0);
-
+    let message = signing_contexts::build_judgment_message(is_valid, &report_hash.0);
     let signature = secrets.ed25519.sign(&message);
 
     AuditAnnouncement {
@@ -309,15 +301,10 @@ pub fn verify_announcement(announcement: &AuditAnnouncement, state: &State) -> b
     }
     let ed25519_key = &state.current_validators[idx].ed25519;
 
-    let context = if announcement.is_valid {
-        signing_contexts::VALID
-    } else {
-        signing_contexts::INVALID
-    };
-    let mut message = Vec::with_capacity(context.len() + 32);
-    message.extend_from_slice(context);
-    message.extend_from_slice(&announcement.report_hash.0);
-
+    let message = signing_contexts::build_judgment_message(
+        announcement.is_valid,
+        &announcement.report_hash.0,
+    );
     grey_crypto::ed25519_verify(ed25519_key, &message, &announcement.signature)
 }
 


### PR DESCRIPTION
## Summary

- Add `build_judgment_message(is_valid, report_hash)` to `grey_types::signing_contexts` that constructs the judgment signing payload (VALID/INVALID context + report hash)
- Replace 4 identical 5-line blocks across `audit.rs` (sign + verify) and `disputes.rs` (verdict + fault verification)
- Net reduction: -17 lines

Addresses #186.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean
- No behavioral change — pure refactoring