### PR TITLE
perf(transpiler): extend peephole fusion to shifts and comparisons

### DIFF
--- a/grey/crates/grey-transpiler/src/lib.rs
+++ b/grey/crates/grey-transpiler/src/lib.rs
@@ -126,10 +126,15 @@ pub fn peephole_fuse_load_imm_alu(
     let imm_opcode = |three_reg_op: u8| -> Option<u8> {
         match three_reg_op {
             200 => Some(149), // add_64 → add_imm_64
+            202 => Some(150), // mul_64 → mul_imm_64
+            207 => Some(151), // shl_64 → shl_imm_64
+            208 => Some(152), // shr_64 → shr_imm_64
+            209 => Some(153), // sar_64 → sar_imm_64
             210 => Some(132), // and → and_imm
             211 => Some(133), // xor → xor_imm
             212 => Some(134), // or → or_imm
-            202 => Some(150), // mul_64 → mul_imm_64
+            216 => Some(136), // set_lt_u → set_lt_u_imm
+            217 => Some(137), // set_lt_s → set_lt_s_imm
             _ => None,
         }
     };


### PR DESCRIPTION
## Summary

- Extend the `load_imm + ThreeReg ALU` fusion to cover 5 additional opcode pairs: shl_64, shr_64, sar_64, set_lt_u, set_lt_s
- These patterns occur when RISC-V shift/compare instructions use a register loaded with a constant — the fusion eliminates the load_imm and produces a shorter TwoRegOneImm instruction
- Total fusable operations: 10 (was 5)

Addresses #399.

## Scope

This PR addresses: extending peephole load_imm+ALU fusion coverage.

Remaining optimization areas in #399:
- Inter-block liveness analysis
- Superblock formation / trace-based optimization
- Stack frame optimization
- Target JSON / RISC-V codegen tuning

## Test plan

- `cargo test -p grey-transpiler` — all tests pass
- `cargo test -p grey-bench` — all 19 correctness tests pass (interpreter and recompiler results match)
- `cargo fmt --all` — clean