### PR TITLE
refactor: extract build_guarantee_message() to deduplicate guarantee message construction

### DIFF
--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -239,10 +239,7 @@ pub fn process_disputes(
         }
 
         // Verify guarantee signature: X_G = "jam_guarantee"
-        let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(signing_contexts::GUARANTEE);
-        message.extend_from_slice(&culprit.report_hash.0);
-
+        let message = signing_contexts::build_guarantee_message(&culprit.report_hash.0);
         if !grey_crypto::ed25519_verify(&culprit.validator_key, &message, &culprit.signature) {
             return Err(DisputeError::BadSignature);
         }

--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -320,9 +320,7 @@ pub fn process_reports(
         // Verify Ed25519 signatures
         let encoded_report = scale::Encode::encode(report);
         let report_hash = grey_crypto::blake2b_256(&encoded_report);
-        let mut message = Vec::with_capacity(13 + 32);
-        message.extend_from_slice(signing_contexts::GUARANTEE);
-        message.extend_from_slice(&report_hash.0);
+        let message = signing_contexts::build_guarantee_message(&report_hash.0);
 
         for (idx, sig) in &guarantee.signatures {
             let ed25519_key = &validators[*idx as usize].ed25519;

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -63,6 +63,16 @@ pub mod signing_contexts {
         message.extend_from_slice(report_hash);
         message
     }
+
+    /// Build a guarantee signing message: X_G ⌢ report_hash.
+    ///
+    /// Used for signing and verifying work-report guarantees (Section 11).
+    pub fn build_guarantee_message(report_hash: &[u8; 32]) -> Vec<u8> {
+        let mut message = Vec::with_capacity(GUARANTEE.len() + 32);
+        message.extend_from_slice(GUARANTEE);
+        message.extend_from_slice(report_hash);
+        message
+    }
 }
 
 use std::fmt;

--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -24,9 +24,7 @@ use std::collections::{BTreeMap, HashSet};
 ///
 /// Constructs the signing payload per GP Section 11 and signs with Ed25519.
 pub fn sign_guarantee(report_hash: &Hash, secrets: &ValidatorSecrets) -> Ed25519Signature {
-    let mut message = Vec::with_capacity(13 + 32);
-    message.extend_from_slice(signing_contexts::GUARANTEE);
-    message.extend_from_slice(&report_hash.0);
+    let message = signing_contexts::build_guarantee_message(&report_hash.0);
     secrets.ed25519.sign(&message)
 }
 


### PR DESCRIPTION
## Summary

- Add `build_guarantee_message(report_hash)` to `grey_types::signing_contexts` to construct the guarantee signing payload (GUARANTEE ⌢ report_hash)
- Replace 3 identical message construction blocks across `guarantor.rs`, `reports.rs`, and `disputes.rs`

Addresses #186.

## Test plan

- `cargo test -p grey-state` — all tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean