### PR TITLE
refactor: extract cosign_last_guarantee() to deduplicate co-signing

### DIFF
--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -30,6 +30,25 @@ pub fn sign_guarantee(report_hash: &Hash, secrets: &ValidatorSecrets) -> Ed25519
     secrets.ed25519.sign(&message)
 }
 
+/// Add a co-signature to the most recently created guarantee.
+///
+/// In testnet mode, a second validator co-signs every guarantee to meet
+/// the minimum-2 guarantor requirement. This helper picks the co-signer
+/// (index 1 if we're 0, else 0), signs, and appends the credential.
+pub fn cosign_last_guarantee(
+    guarantor_state: &mut GuarantorState,
+    report_hash: &Hash,
+    validator_index: u16,
+    all_secrets: &[ValidatorSecrets],
+) {
+    let co_idx = if validator_index == 0 { 1u16 } else { 0 };
+    let co_secrets = &all_secrets[co_idx as usize];
+    let co_sig = sign_guarantee(report_hash, co_secrets);
+    if let Some(g) = guarantor_state.pending_guarantees.last_mut() {
+        g.credentials.push((co_idx, co_sig));
+    }
+}
+
 /// Tracks pending guarantees and chunks for availability.
 #[derive(Default)]
 pub struct GuarantorState {

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -471,14 +471,12 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                             ) {
                                 Ok(report_hash) => {
                                     // Add a second guarantor co-signature (minimum 2 required)
-                                    let co_signer_idx = if config.validator_index == 0 { 1u16 } else { 0 };
-                                    let co_secrets = &all_secrets[co_signer_idx as usize];
-                                    let co_sig = crate::guarantor::sign_guarantee(&report_hash, co_secrets);
-                                    // Only co-sign the newly created guarantee (the last one),
-                                    // not all pending guarantees — they have different report hashes.
-                                    if let Some(g) = guarantor_state.pending_guarantees.last_mut() {
-                                        g.credentials.push((co_signer_idx, co_sig));
-                                    }
+                                    crate::guarantor::cosign_last_guarantee(
+                                        &mut guarantor_state,
+                                        &report_hash,
+                                        config.validator_index,
+                                        &all_secrets,
+                                    );
 
                                     tracing::info!(
                                         "Validator {} created WP guarantee (2 signers), report_hash=0x{}",
@@ -1308,14 +1306,12 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     ) {
                                         Ok(report_hash) => {
                                             // Co-sign with a second validator (testnet only)
-                                            let co_idx = if config.validator_index == 0 { 1u16 } else { 0 };
-                                            let co_secrets = &all_secrets[co_idx as usize];
-                                            let co_sig = crate::guarantor::sign_guarantee(&report_hash, co_secrets);
-                                            // Only co-sign the newly created guarantee (the last one),
-                                            // not all pending guarantees — they have different report hashes.
-                                            if let Some(g) = guarantor_state.pending_guarantees.last_mut() {
-                                                g.credentials.push((co_idx, co_sig));
-                                            }
+                                            crate::guarantor::cosign_last_guarantee(
+                                                &mut guarantor_state,
+                                                &report_hash,
+                                                config.validator_index,
+                                                &all_secrets,
+                                            );
                                             // Broadcast only the new guarantee to peers
                                             if let Some(g) = guarantor_state.pending_guarantees.last() {
                                                 let g_data = guarantor::encode_guarantee(g);


### PR DESCRIPTION
## Summary

- Extract `cosign_last_guarantee()` helper in `guarantor.rs` to deduplicate identical 7-line co-signing blocks in two locations in `node.rs`
- Both blocks computed the same co-signer index, signed the guarantee, and appended the credential to the last pending guarantee

Addresses #186.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean
- No behavioral change — pure refactoring