### PR TITLE
test(fuzz): add erasure coding recover() fuzz target

### DIFF
--- a/grey/fuzz/Cargo.toml
+++ b/grey/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 grey-codec = { path = "../crates/grey-codec" }
 grey-types = { path = "../crates/grey-types" }
+grey-erasure = { path = "../crates/grey-erasure" }
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -29,4 +30,9 @@ doc = false
 [[bin]]
 name = "fuzz_work_package_decode"
 path = "fuzz_targets/fuzz_work_package_decode.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_erasure_recover"
+path = "fuzz_targets/fuzz_erasure_recover.rs"
 doc = false

--- a/grey/fuzz/fuzz_targets/fuzz_erasure_recover.rs
+++ b/grey/fuzz/fuzz_targets/fuzz_erasure_recover.rs
@@ -1,0 +1,56 @@
+//! Fuzz target: random bytes into erasure coding recover().
+//!
+//! Feeds arbitrary chunk data and indices into the Reed-Solomon recovery
+//! function. Verifies that no input causes a panic — only Ok or Err.
+
+#![no_main]
+
+use grey_erasure::{ErasureParams, recover};
+use libfuzzer_sys::fuzz_target;
+
+const TINY: ErasureParams = ErasureParams::TINY; // 2 data, 6 total
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 3 {
+        return;
+    }
+
+    // Use first byte as original data length (1-255)
+    let orig_len = data[0] as usize;
+    if orig_len == 0 {
+        return;
+    }
+
+    // Use second byte to select which 2 shard indices to provide
+    let combo = data[1] as usize;
+    let n = TINY.total_shards;
+    let k = TINY.data_shards;
+
+    // Pick 2 distinct indices from 0..n using combo byte
+    let i = combo % n;
+    let j = (combo / n + 1) % n;
+    let (i, j) = if i == j { (i, (i + 1) % n) } else { (i, j) };
+
+    // Split remaining data into k chunks
+    let chunk_data = &data[2..];
+    let chunk_len = if chunk_data.is_empty() {
+        1
+    } else {
+        (chunk_data.len() / k).max(1)
+    };
+
+    let mut indexed = Vec::with_capacity(k);
+    for (idx, shard_idx) in [i, j].iter().enumerate() {
+        let start = idx * chunk_len;
+        let end = (start + chunk_len).min(chunk_data.len());
+        let chunk = if start < chunk_data.len() {
+            chunk_data[start..end].to_vec()
+        } else {
+            vec![0; chunk_len]
+        };
+        indexed.push((chunk, *shard_idx));
+    }
+
+    // This should never panic — only Ok or Err
+    let _ = recover(&TINY, &indexed, orig_len);
+});


### PR DESCRIPTION
## Summary

- Add `fuzz_erasure_recover` fuzz target that feeds arbitrary bytes into the Reed-Solomon recovery function
- Tests that `recover()` never panics on malformed input — only returns Ok or Err
- Uses TINY config (k=2, n=6) with fuzzer-controlled chunk content, shard indices, and original data length

Addresses #229.

## Scope

This PR addresses: fuzz target for erasure coding (PVM program fuzzing mentioned in issue, but erasure coding is a simpler start).

Remaining sub-tasks in #229:
- Fuzz PVM programs through recompiler
- Proptest for protocol types (Header, Block)
- State transition invariant properties

## Test plan

- Fuzz target follows the same pattern as existing `fuzz_codec_decode` and `fuzz_block_decode`
- Run with: `cd grey/fuzz && cargo +nightly fuzz run fuzz_erasure_recover`