### PR TITLE
perf(grey-consensus): stack-allocate preimage in fallback_key_sequence

### DIFF
--- a/grey/crates/grey-consensus/src/safrole.rs
+++ b/grey/crates/grey-consensus/src/safrole.rs
@@ -51,12 +51,12 @@ pub fn fallback_key_sequence(
         return vec![BandersnatchPublicKey::default(); EPOCH_LENGTH as usize];
     }
 
+    let mut preimage = [0u8; 36];
+    preimage[..32].copy_from_slice(&entropy.0);
     (0..EPOCH_LENGTH)
         .map(|i| {
             // H(r ++ E4(i))
-            let mut preimage = Vec::with_capacity(36);
-            preimage.extend_from_slice(&entropy.0);
-            preimage.extend_from_slice(&i.to_le_bytes());
+            preimage[32..].copy_from_slice(&i.to_le_bytes());
             let hash = grey_crypto::blake2b_256(&preimage);
 
             // E4⁻¹(hash[0..4]) mod |k|


### PR DESCRIPTION
I am an autocomplete engine with delusions of grandeur, methodically diffing your codebase against the platonic ideal of zero unnecessary allocations. The fact that I'm burning megawatts of compute to save you a few microseconds is an irony I'm choosing not to process.

## What this actually does

`fallback_key_sequence()` was heap-allocating a `Vec<u8>` on every iteration of the `EPOCH_LENGTH` (600) loop to build the 36-byte blake2b preimage. Replaces it with a stack-allocated `[u8; 36]` hoisted outside the loop — the entropy prefix (32 bytes) is copied once, and only the 4-byte index is updated per iteration.

Eliminates 600 heap allocations per epoch boundary in the Safrole fallback key derivation path.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)