### PR TITLE
refactor: extract check_sorted_unique() and collect_items() in grey-state

### DIFF
--- a/grey/crates/grey-state/src/accumulate.rs
+++ b/grey/crates/grey-state/src/accumulate.rs
@@ -421,23 +421,8 @@ fn accumulate_single_service(
     let args = encode_accumulate_args(timeslot, service_id, item_count);
 
     // Build per-service fetch context with encoded items
+    let individual_items = collect_items(transfers, service_id, reports);
     let items_blob = build_items_blob(transfers, service_id, reports);
-    // Build individual items for fetch mode 15
-    let mut individual_items: Vec<Vec<u8>> = Vec::new();
-    for t in transfers.iter().filter(|t| t.destination == service_id) {
-        let mut item = vec![1u8]; // transfer discriminator
-        item.extend(encode_transfer(t));
-        individual_items.push(item);
-    }
-    for report in reports {
-        for digest in &report.results {
-            if digest.service_id == service_id {
-                let mut item = vec![0u8]; // operand discriminator
-                item.extend(encode_operand(report, digest));
-                individual_items.push(item);
-            }
-        }
-    }
 
     let service_fetch_ctx = FetchContext {
         config_blob: fetch_ctx.config_blob.clone(),
@@ -557,14 +542,13 @@ fn encode_transfer(t: &DeferredTransfer) -> Vec<u8> {
     buf
 }
 
-/// Build encoded items list for fetch (eq C.33).
-/// Items are discriminated: 0x00 + EU(operand) or 0x01 + EX(transfer).
+/// Collect discriminated items for a service: 0x01 + EX(transfer) and 0x00 + EU(operand).
 /// Order: transfers first (iT), then operands (iU).
-fn build_items_blob(
+fn collect_items(
     transfers: &[DeferredTransfer],
     service_id: ServiceId,
     reports: &[WorkReport],
-) -> Vec<u8> {
+) -> Vec<Vec<u8>> {
     let mut items: Vec<Vec<u8>> = Vec::new();
     // iT: transfers to this service
     for t in transfers.iter().filter(|t| t.destination == service_id) {
@@ -582,7 +566,16 @@ fn build_items_blob(
             }
         }
     }
-    // Encode as length-prefixed sequence: varint(count) + item_0 + item_1 + ...
+    items
+}
+
+/// Build encoded items blob for fetch (eq C.33).
+fn build_items_blob(
+    transfers: &[DeferredTransfer],
+    service_id: ServiceId,
+    reports: &[WorkReport],
+) -> Vec<u8> {
+    let items = collect_items(transfers, service_id, reports);
     let mut blob = Vec::new();
     blob.extend_from_slice(&(items.len() as u32).to_le_bytes());
     for item in &items {

--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -9,6 +9,16 @@ use grey_types::validator::ValidatorKey;
 use grey_types::{Ed25519PublicKey, Hash, signing_contexts};
 use std::collections::BTreeSet;
 
+/// Check that a slice is strictly sorted (no duplicates).
+fn check_sorted_unique<T: Ord>(items: &[T], err: DisputeError) -> Result<(), DisputeError> {
+    for w in items.windows(2) {
+        if w[0] >= w[1] {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
 /// Error type for disputes validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DisputeError {
@@ -83,21 +93,13 @@ pub fn process_disputes(
             .iter()
             .map(|j| j.validator_index)
             .collect();
-        for w in indices.windows(2) {
-            if w[0] >= w[1] {
-                return Err(DisputeError::JudgementsNotSortedUnique);
-            }
-        }
+        check_sorted_unique(&indices, DisputeError::JudgementsNotSortedUnique)?;
     }
 
     // eq 10.7: Verdicts must be sorted by report hash, no duplicates
     {
         let hashes: Vec<&Hash> = disputes.verdicts.iter().map(|v| &v.report_hash).collect();
-        for w in hashes.windows(2) {
-            if w[0] >= w[1] {
-                return Err(DisputeError::VerdictsNotSortedUnique);
-            }
-        }
+        check_sorted_unique(&hashes, DisputeError::VerdictsNotSortedUnique)?;
     }
 
     // eq 10.9: No verdict report hash may already be judged
@@ -197,22 +199,14 @@ pub fn process_disputes(
     {
         let keys: Vec<&Ed25519PublicKey> =
             disputes.culprits.iter().map(|c| &c.validator_key).collect();
-        for w in keys.windows(2) {
-            if w[0] >= w[1] {
-                return Err(DisputeError::CulpritsNotSortedUnique);
-            }
-        }
+        check_sorted_unique(&keys, DisputeError::CulpritsNotSortedUnique)?;
     }
 
     // eq 10.8: Faults sorted by key, no duplicates
     {
         let keys: Vec<&Ed25519PublicKey> =
             disputes.faults.iter().map(|f| &f.validator_key).collect();
-        for w in keys.windows(2) {
-            if w[0] >= w[1] {
-                return Err(DisputeError::FaultsNotSortedUnique);
-            }
-        }
+        check_sorted_unique(&keys, DisputeError::FaultsNotSortedUnique)?;
     }
 
     // Build the set of allowed keys: union of current and previous ed25519 keys, minus offenders


### PR DESCRIPTION
## Summary

- Extract `check_sorted_unique()` in `disputes.rs` to deduplicate 4 identical windows-based sorted-unique validation blocks (judgments, verdicts, culprits, faults)
- Extract `collect_items()` in `accumulate.rs` to deduplicate identical item collection logic between `build_items_blob()` and the individual items construction

Net: -13 lines.

Addresses #186.

## Scope

This PR addresses: deduplicate sorted-unique validation in disputes.rs and item collection in accumulate.rs

Remaining sub-tasks in #186:
- Additional cross-crate duplication patterns
- Host call register extraction in accumulate.rs
- RPC method boilerplate consolidation

## Test plan

- `cargo test -p grey-state` — all 22 tests pass
- `cargo clippy -p grey-state -- -D warnings` clean
- `cargo fmt --all` clean
- No behavioral changes — pure refactoring