### PR TITLE
test(crypto): add known-answer tests for blake2b-256 and keccak-256

### DIFF
--- a/grey/crates/grey-crypto/src/blake2b.rs
+++ b/grey/crates/grey-crypto/src/blake2b.rs
@@ -40,4 +40,24 @@ mod tests {
         let hash2 = blake2b_256(b"world");
         assert_ne!(hash1, hash2);
     }
+
+    /// Known-answer test: blake2b-256("") — RFC 7693 test vector.
+    #[test]
+    fn test_blake2b_256_kat_empty() {
+        let hash = blake2b_256(b"");
+        assert_eq!(
+            hex::encode(hash.0),
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+        );
+    }
+
+    /// Known-answer test: blake2b-256("abc") — RFC 7693 test vector.
+    #[test]
+    fn test_blake2b_256_kat_abc() {
+        let hash = blake2b_256(b"abc");
+        assert_eq!(
+            hex::encode(hash.0),
+            "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"
+        );
+    }
 }

--- a/grey/crates/grey-crypto/src/keccak.rs
+++ b/grey/crates/grey-crypto/src/keccak.rs
@@ -33,4 +33,19 @@ mod tests {
         let hash2 = keccak_256(b"jam");
         assert_eq!(hash1, hash2);
     }
+
+    /// Known-answer test: keccak-256("abc") from NIST test vectors.
+    #[test]
+    fn test_keccak_256_kat_abc() {
+        let hash = keccak_256(b"abc");
+        let expected = "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45";
+        assert_eq!(hex::encode(hash.0), expected);
+    }
+
+    #[test]
+    fn test_keccak_256_different_inputs() {
+        let hash1 = keccak_256(b"hello");
+        let hash2 = keccak_256(b"world");
+        assert_ne!(hash1, hash2);
+    }
 }


### PR DESCRIPTION
## Summary

- Add KAT (known-answer test) for blake2b-256: empty input and "abc" against RFC 7693 reference values
- Add KAT for keccak-256: "abc" against NIST test vector, plus different-inputs test

Addresses #229.

## Test plan

- `cargo test -p grey-crypto -- blake2b keccak` — all 9 tests pass (5 existing + 4 new)
- `cargo clippy -p grey-crypto -- -D warnings` clean