### PR TITLE
refactor: merge duplicate report iteration loops in update_statistics

### DIFF
--- a/grey/crates/grey-state/src/accumulate.rs
+++ b/grey/crates/grey-state/src/accumulate.rs
@@ -1395,16 +1395,8 @@ fn update_statistics(
             entry.extrinsic_count += digest.extrinsics_count as u32;
             entry.extrinsic_size += digest.extrinsics_size as u64;
             entry.exports += digest.exports_count as u32;
-        }
-    }
-
-    // N(s) = count of work-item digests for service s in accumulated reports
-    for report in reports {
-        for digest in &report.results {
-            stat_map
-                .entry(digest.service_id)
-                .or_default()
-                .accumulate_count += 1;
+            // N(s) = count of work-item digests for service s
+            entry.accumulate_count += 1;
         }
     }
 


### PR DESCRIPTION
## Summary

- Merge two separate loops over `reports/digests` in `update_statistics` into one: the first updated refinement stats, the second only incremented `accumulate_count` — both iterate the same data
- Net: -8 lines, one fewer iteration over all report digests

Addresses #186.

## Test plan

- `cargo test -p grey-state` — all 29 tests pass
- `cargo clippy -p grey-state -- -D warnings` clean