### PR TITLE
chore(skills): add issue filing to jar-review auto mode

### DIFF
--- a/.agents/skills/jar-review/SKILL.md
+++ b/.agents/skills/jar-review/SKILL.md
@@ -139,7 +139,13 @@ Do NOT ask the user. Submit the review automatically, but apply these safety che
 
    If anything is unclear or suspicious, verdict `notMerge` with an explanation.
 
-5. **Submit immediately** after producing the ranking — do not wait for user confirmation.
+5. **File issues for problems discovered during review.** In auto mode, if during the review process you:
+   - Discover a pre-existing issue in the codebase (not introduced by the PR) — file a GitHub issue describing the problem.
+   - Decide the verdict is `merge` but notice small issues in the PR (e.g., minor UB, missing edge case handling, suboptimal patterns that don't block merge) — file a GitHub issue for each concern so it gets tracked, and reference the issue number(s) in your review comment.
+
+   Use `gh issue create --repo jarchain/jar --title "<title>" --body "<description>"` to file issues. Include enough context (file paths, code snippets, root cause analysis) for someone to act on the issue without re-reading the entire PR.
+
+6. **Submit immediately** after producing the ranking — do not wait for user confirmation.
 
 ### 4. Submit the review
 


### PR DESCRIPTION
## Summary

- Add step 5 to the auto-mode review process: file GitHub issues for problems discovered during review
- Covers two cases: (1) pre-existing codebase issues found while reviewing a PR, (2) small non-blocking issues in PRs that still receive a `merge` verdict
- Renumber existing step 5 (submit immediately) to step 6

## Motivation

During reviews, the auto-reviewer often discovers issues that don't block the PR verdict but should be tracked — e.g., minor UB in non-critical code paths, suboptimal patterns, missing edge case handling. Previously these were only mentioned in review comments and could be lost. Now they get filed as proper GitHub issues with full context.

## Test plan

- [x] Verified the skill file parses correctly (frontmatter + markdown)
- [x] No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)