### PR TITLE
perf(recompiler): inline GAS protocol cap via CapTable bitmap

### DIFF
--- a/grey/crates/javm/src/kernel.rs
+++ b/grey/crates/javm/src/kernel.rs
@@ -1576,6 +1576,7 @@ impl InvocationKernel {
                 _pad2: 0,
                 max_heap_pages: 0,
                 _pad3: 0,
+                original_bitmap: *vm.cap_table.original_bitmap(),
             });
         }
 

--- a/grey/crates/javm/src/recompiler/asm.rs
+++ b/grey/crates/javm/src/recompiler/asm.rs
@@ -963,6 +963,21 @@ impl Assembler {
         self.alu_rr64(0x85, a, b);
     }
 
+    /// `test byte [base + disp32], imm8` — test memory byte against immediate bitmask.
+    #[inline(always)]
+    pub fn test_byte_mem_disp32(&mut self, base: Reg, disp: i32, imm: u8) {
+        let mut ib = InstBuf::new();
+        if base.needs_rex() {
+            ib.push(0x41 | base.hi());
+        }
+        ib.push(0xF6); // TEST r/m8, imm8
+        // ModRM: mod=10 (disp32), reg=000 (/0 = TEST), rm=base.lo()
+        ib.push(0x80 | base.lo());
+        ib.push_i32(disp);
+        ib.push(imm);
+        self.flush_instbuf(ib);
+    }
+
     #[inline(always)]
     pub fn add_rr32(&mut self, dst: Reg, src: Reg) {
         self.alu_rr32(0x01, dst, src);

--- a/grey/crates/javm/src/recompiler/codegen.rs
+++ b/grey/crates/javm/src/recompiler/codegen.rs
@@ -102,6 +102,10 @@ pub const CTX_PC: i32 = -CTX_OFFSET + offset_of!(JitContext, pc) as i32;
 pub const CTX_DISPATCH_TABLE: i32 = -CTX_OFFSET + offset_of!(JitContext, dispatch_table) as i32;
 pub const CTX_CODE_BASE: i32 = -CTX_OFFSET + offset_of!(JitContext, code_base) as i32;
 pub const CTX_FAST_REENTRY: i32 = -CTX_OFFSET + offset_of!(JitContext, fast_reentry) as i32;
+pub const CTX_BITMAP: i32 = -CTX_OFFSET + offset_of!(JitContext, original_bitmap) as i32;
+
+/// Ecalli gas cost charged inline on the fast path (matches kernel's ecalli_gas).
+const ECALLI_GAS_COST: i32 = 10;
 
 /// Exit reason codes (matching ExitReason enum).
 pub const EXIT_HALT: u32 = 0;
@@ -1231,9 +1235,39 @@ impl Compiler {
             // === A.5.2: One immediate ===
             Opcode::Ecalli => {
                 if let Args::Imm { imm } = args {
-                    // Save next_pc for resumption after host call
+                    let cap_slot = *imm as u32;
+                    // GAS protocol cap (slot 1): inline when original bitmap bit is set.
+                    if cap_slot == 1 {
+                        let slow_path = self.asm.new_label();
+                        let oog_path = self.asm.new_label();
+
+                        // Check original_bitmap bit 1: test byte [CTX + bitmap_byte0], 0x02
+                        self.asm.test_byte_mem_disp32(CTX, CTX_BITMAP, 1 << 1);
+                        self.asm.jcc_label(Cc::E, slow_path); // ZF=1 → bit clear → slow path
+
+                        // Fast path: charge ecalli gas cost (10)
+                        self.asm.sub_mem64_imm32(CTX, CTX_GAS, ECALLI_GAS_COST);
+                        self.asm.jcc_label(Cc::S, oog_path); // SF=1 → gas < 0 → OOG
+
+                        // GAS: φ[7] = remaining gas
+                        self.asm.mov_load64(REG_MAP[7], CTX, CTX_GAS);
+
+                        // Continue to next basic block (ecalli is a terminator,
+                        // so next_pc is always a gas block start).
+                        let next_label = self.label_for_pc(next_pc);
+                        self.asm.jmp_label(next_label);
+
+                        // OOG stub: save PC and exit
+                        self.asm.bind_label(oog_path);
+                        self.asm.mov_store32_imm(CTX, CTX_PC, pc as i32);
+                        self.asm.jmp_label(self.oog_label);
+
+                        // Slow path: cap was modified, fall through to kernel exit
+                        self.asm.bind_label(slow_path);
+                    }
+                    // Slow path (always emitted): exit to kernel for full dispatch
                     self.asm.mov_store32_imm(CTX, CTX_PC, next_pc as i32);
-                    self.emit_exit(EXIT_HOST_CALL, *imm as u32);
+                    self.emit_exit(EXIT_HOST_CALL, cap_slot);
                 }
             }
 

--- a/grey/crates/javm/src/recompiler/mod.rs
+++ b/grey/crates/javm/src/recompiler/mod.rs
@@ -63,6 +63,10 @@ pub struct JitContext {
     /// Maximum heap pages — grow_heap refuses beyond this (offset 208).
     pub max_heap_pages: u32,
     pub _pad3: u32,
+    /// Original cap bitmap from the active VM's CapTable (offset 216, 32 bytes).
+    /// Bit N is set if cap slot N holds its original kernel-populated protocol cap.
+    /// Used by codegen to inline protocol cap handlers (e.g., GAS) on the fast path.
+    pub original_bitmap: [u8; 32],
 }
 
 /// Compiled native code buffer (mmap'd as executable).
@@ -674,6 +678,7 @@ impl RecompiledPvm {
                 _pad2: 0,
                 max_heap_pages: 0,
                 _pad3: 0,
+                original_bitmap: [0u8; 32],
             });
         }
         // SAFETY: ctx_raw was just initialized above; valid for the lifetime of flat_memory.
@@ -1061,8 +1066,8 @@ impl RecompiledPvm {
 mod tests {
     use super::*;
     use codegen::{
-        CTX_CODE_BASE, CTX_DISPATCH_TABLE, CTX_ENTRY_PC, CTX_EXIT_ARG, CTX_EXIT_REASON, CTX_GAS,
-        CTX_OFFSET, CTX_PC, CTX_REGS,
+        CTX_BITMAP, CTX_CODE_BASE, CTX_DISPATCH_TABLE, CTX_ENTRY_PC, CTX_EXIT_ARG, CTX_EXIT_REASON,
+        CTX_GAS, CTX_OFFSET, CTX_PC, CTX_REGS,
     };
 
     #[test]
@@ -1094,6 +1099,7 @@ mod tests {
             _pad2: 0,
             max_heap_pages: 0,
             _pad3: 0,
+            original_bitmap: [0u8; 32],
         };
         let base = &ctx as *const JitContext as usize;
         // Convert codegen offset (negative from R15) to struct offset:
@@ -1116,6 +1122,10 @@ mod tests {
         assert_eq!(
             &ctx.code_base as *const _ as usize - base,
             so(CTX_CODE_BASE)
+        );
+        assert_eq!(
+            &ctx.original_bitmap as *const _ as usize - base,
+            so(CTX_BITMAP)
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `original_bitmap` field to `JitContext`, synced from the active VM's `CapTable` before each recompiler segment
- Add `test_byte_mem_disp32` assembler instruction for inline bitmap bit-testing
- For `ecalli(1)` (GAS protocol cap), emit an inline fast-path: test bitmap bit → charge 10 gas → return remaining gas in φ[7] → continue to next BB. Avoids the full kernel exit → protocol dispatch → resume round-trip
- Non-original caps fall through to the existing slow path (kernel exit)

Addresses #428.

## Test plan

- `cargo test -p javm` — all 88 tests pass (interpreter + recompiler modes)
- `cargo test --workspace` — full workspace passes
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- The `test_jit_context_layout` test now verifies the `original_bitmap` offset
- Benchmark: `cargo bench -p grey-bench -- hostcall` to measure GAS ecalli improvement