### PR TITLE
refactor(javm): extract extract_reg() for register nibble extraction

### DIFF
--- a/grey/crates/javm/src/gas_cost.rs
+++ b/grey/crates/javm/src/gas_cost.rs
@@ -192,29 +192,29 @@ fn branch_cost(code: &[u8], bitmask: &[u8], target: usize) -> u32 {
     }
 }
 
-/// Extract register A (first register in instruction encoding).
-fn reg_a(code: &[u8], pc: usize) -> u8 {
-    if pc + 1 < code.len() {
-        code[pc + 1] & 0x0F
+/// Extract a 4-bit register nibble from an instruction encoding.
+///
+/// Reads the byte at `pc + byte_offset`, shifts right by `shift`, and masks to 4 bits.
+/// Returns 0 if the byte is out of bounds.
+fn extract_reg(code: &[u8], pc: usize, byte_offset: usize, shift: u8) -> u8 {
+    if pc + byte_offset < code.len() {
+        (code[pc + byte_offset] >> shift) & 0x0F
     } else {
         0
     }
+}
+
+/// Extract register A (first register, lower nibble of byte after opcode).
+fn reg_a(code: &[u8], pc: usize) -> u8 {
+    extract_reg(code, pc, 1, 0)
 }
 /// Extract register B (second register, upper nibble of byte after opcode).
 fn reg_b(code: &[u8], pc: usize) -> u8 {
-    if pc + 1 < code.len() {
-        (code[pc + 1] >> 4) & 0x0F
-    } else {
-        0
-    }
+    extract_reg(code, pc, 1, 4)
 }
-/// Extract register D (third register encoding for 3-reg instructions).
+/// Extract register D (third register, lower nibble of second byte after opcode).
 fn reg_d(code: &[u8], pc: usize) -> u8 {
-    if pc + 2 < code.len() {
-        code[pc + 2] & 0x0F
-    } else {
-        0
-    }
+    extract_reg(code, pc, 2, 0)
 }
 
 /// Compute skip distance (bytes to next instruction start).


### PR DESCRIPTION
## Summary

- Extract common `extract_reg(code, pc, byte_offset, shift)` function to deduplicate the 3 register extraction functions (`reg_a`, `reg_b`, `reg_d`) in gas_cost.rs
- All three performed the same bounds-checked byte read + shift + mask with different parameters

Addresses #186.

## Scope

This PR addresses: duplicated register nibble extraction logic in javm/gas_cost.rs

Remaining sub-tasks in #186:
- Many other duplication patterns remain (see issue comments)

## Test plan

- All 135 javm tests pass
- `cargo clippy -p javm -- -D warnings` — clean
- `cargo fmt --all` — formatted