### PR TITLE
refactor(grey): extract make_validator_seed to deduplicate seed derivation

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -160,18 +160,9 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
             crate::keystore::Keystore::open(ks_path).map_err(|e| format!("keystore error: {e}"))?;
         if !ks.has_keys(config.validator_index) {
             // Derive seeds for persistence (same deterministic derivation as genesis)
-            let mut ed_seed = [0u8; 32];
-            ed_seed[0] = config.validator_index as u8;
-            ed_seed[1] = (config.validator_index >> 8) as u8;
-            ed_seed[31] = 0xED;
-            let mut band_seed = [0u8; 32];
-            band_seed[0] = config.validator_index as u8;
-            band_seed[1] = (config.validator_index >> 8) as u8;
-            band_seed[31] = 0xBA;
-            let mut bls_seed = [0u8; 32];
-            bls_seed[0] = config.validator_index as u8;
-            bls_seed[1] = (config.validator_index >> 8) as u8;
-            bls_seed[31] = 0xBB;
+            let ed_seed = make_validator_seed(config.validator_index, 0xED);
+            let band_seed = make_validator_seed(config.validator_index, 0xBA);
+            let bls_seed = make_validator_seed(config.validator_index, 0xBB);
             let ed_public = my_secrets.ed25519.public_key().0;
             ks.save_seeds(
                 config.validator_index,
@@ -1425,6 +1416,15 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
 }
 
 /// Insert into a bounded `HashSet`, evicting an arbitrary entry if at capacity.
+/// Build a deterministic 32-byte seed from a validator index and a key-type tag.
+fn make_validator_seed(index: u16, tag: u8) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    seed[0] = index as u8;
+    seed[1] = (index >> 8) as u8;
+    seed[31] = tag;
+    seed
+}
+
 fn insert_bounded(set: &mut std::collections::HashSet<Hash>, item: Hash, cap: usize) {
     if set.len() >= cap
         && let Some(&old) = set.iter().next()


### PR DESCRIPTION
## Summary

- Extract `make_validator_seed(index, tag)` helper to replace 3 identical 4-line seed derivation blocks for ed25519 (0xED), bandersnatch (0xBA), and BLS (0xBB) keys

Addresses #186.

## Scope

This PR addresses: deduplicate triplicated validator seed construction in node.rs

Remaining sub-tasks in #186: further deduplication opportunities across grey crates

## Test plan

- `cargo check -p grey` passes
- `cargo clippy -p grey -- -D warnings` passes
- `cargo fmt --all -- --check` passes
- Same seed bytes produced — identical derivation logic