### PR TITLE
fix: use incremental stepState in ranking CLI

### DIFF
--- a/spec/Genesis/Cli/Ranking.lean
+++ b/spec/Genesis/Cli/Ranking.lean
@@ -33,12 +33,12 @@ def rankingMainWith (forceVariant : Option String := none) : IO UInt32 := runJso
   let forcedV := forceVariant.bind resolveVariantName
   -- Build per-commit contexts (variant + weight function)
   let (contexts, _) := signedCommits.zip indices |>.foldl
-    (fun (ctxs, pastIndices) (commit, idx) =>
-      let state := reconstructState pastIndices
+    (fun (ctxs, state) (commit, idx) =>
       let v := forcedV.getD (activeVariant commit.prCreatedAt)
       let ctx : RankingCommitCtx := { variant := v, getWeight := state.reviewerWeight }
-      (ctxs ++ [ctx], pastIndices ++ [idx])
-    ) (([] : List RankingCommitCtx), ([] : List CommitIndex))
+      let nextState := @stepState (activeVariant idx.epoch) state idx
+      (ctxs ++ [ctx], nextState)
+    ) (([] : List RankingCommitCtx), initEvalState)
   -- Check if BT is active (v3+) — if so, output scores with μ and σ²
   let useBT := contexts.getLast?.map (·.variant.useBradleyTerry) |>.getD false
   if useBT then


### PR DESCRIPTION
## Summary

- Replace `reconstructState pastIndices` (O(n) per iteration) with incremental `stepState` fold (O(1) per iteration) in the ranking CLI's context-building loop
- Reduces per-call complexity from O(n²) to O(n), total replay from O(n³) to O(n²)
- Replay time drops from ~10min to ~4min at current scale (~550 commits)

## Details

`rankingMainWith` in `Ranking.lean` was calling `reconstructState pastIndices` on every iteration of its fold. Since `reconstructState` replays the full index history each time (it's defined as `foldl stepState initEvalState`), this made each ranking invocation O(n²). With N ranking calls during replay, total was O(n³).

The fix carries `EvalState` forward through the fold, applying `stepState` once per iteration — algebraically identical to calling `reconstructState` but O(1) per step instead of O(n).

v3-safe: `btProcessCommit` receives its variant from `ctx.variant`, which is constructed identically. The `getWeight` field comes from the same `EvalState`. Downstream `computeRankingBTWithState` and `computeRankingNetWins` are unchanged.

## Test plan

- [x] `lake build genesis` — builds successfully
- [x] `cargo run -p jar-genesis -- replay --mode verify` — 550/550 indices match
- [x] `cargo run -p jar-genesis -- replay --mode verify-cache` — 551 indices match cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)