### PR TITLE
refactor(grey-types): extract signing_message() for equivocation evidence

### DIFF
--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -303,6 +303,18 @@ impl EquivocationEvidence {
         bytes
     }
 
+    /// Build the full signing message: `EQUIVOCATION_EVIDENCE` context ⌢ `sign_bytes()`.
+    ///
+    /// Ready for ed25519 sign or verify — no need to manually prepend the context.
+    pub fn signing_message(&self) -> Vec<u8> {
+        let ctx = signing_contexts::EQUIVOCATION_EVIDENCE;
+        let payload = self.sign_bytes();
+        let mut msg = Vec::with_capacity(ctx.len() + payload.len());
+        msg.extend_from_slice(ctx);
+        msg.extend_from_slice(&payload);
+        msg
+    }
+
     /// Create evidence, normalising so block_a < block_b.
     pub fn new(slot: Timeslot, h1: Hash, h2: Hash) -> Self {
         let (block_a, block_b) = if h1 < h2 { (h1, h2) } else { (h2, h1) };

--- a/grey/crates/grey/src/finality.rs
+++ b/grey/crates/grey/src/finality.rs
@@ -623,13 +623,8 @@ impl GrandpaState {
         // Validate validator index
         let key = validator_keys.get(usize::from(countersig.validator_index))?;
 
-        // Build signed message: context ⌢ sign_bytes (matching how sign_vote works)
-        let ctx = signing_contexts::EQUIVOCATION_EVIDENCE;
-        let payload = countersig.evidence.sign_bytes();
-        let mut msg = Vec::with_capacity(ctx.len() + payload.len());
-        msg.extend_from_slice(ctx);
-        msg.extend_from_slice(&payload);
-
+        // Verify signature over context-prefixed signing message
+        let msg = countersig.evidence.signing_message();
         if !grey_crypto::ed25519_verify(key, &msg, &countersig.signature) {
             tracing::warn!(
                 validator_index = countersig.validator_index,

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1447,12 +1447,7 @@ fn broadcast_equivocation(
         data: evidence.encode(),
     });
     // Sign and broadcast our own countersig
-    let ctx = grey_types::signing_contexts::EQUIVOCATION_EVIDENCE;
-    let payload = evidence.sign_bytes();
-    let mut msg = Vec::with_capacity(ctx.len() + payload.len());
-    msg.extend_from_slice(ctx);
-    msg.extend_from_slice(&payload);
-    let sig = secrets.ed25519.sign(&msg);
+    let sig = secrets.ed25519.sign(&evidence.signing_message());
     let countersig = grey_types::EquivocationCountersig {
         evidence,
         validator_index,


### PR DESCRIPTION
## Summary

- Add `EquivocationEvidence::signing_message()` that returns the full context-prefixed signing message (context ⌢ sign_bytes)
- Replace 5-line manual message construction in both `node.rs` (signing path) and `finality.rs` (verification path)

Addresses #186.

## Scope

This PR addresses: deduplicate equivocation evidence signing message construction across node.rs and finality.rs.

Remaining sub-tasks in #186: further dedup opportunities across grey crates.

## Test plan

- `cargo check --workspace` — compiles clean
- `cargo test -p grey-types --lib` — 77 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- `cargo fmt --all` — formatted