### PR TITLE
refactor(grey-state): add stf_error! macro to deduplicate error definitions

### DIFF
--- a/grey/crates/grey-state/src/assurances.rs
+++ b/grey/crates/grey-state/src/assurances.rs
@@ -10,25 +10,15 @@ use grey_types::state::PendingReport;
 use grey_types::validator::ValidatorKey;
 use grey_types::work::WorkReport;
 
-/// Error type for assurances validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AssuranceError {
-    NotSortedOrUniqueAssurers,
-    BadSignature,
-    BadValidatorIndex,
-    CoreNotEngaged,
-    BadAttestationParent,
-}
-
-impl AssuranceError {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::NotSortedOrUniqueAssurers => "not_sorted_or_unique_assurers",
-            Self::BadSignature => "bad_signature",
-            Self::BadValidatorIndex => "bad_validator_index",
-            Self::CoreNotEngaged => "core_not_engaged",
-            Self::BadAttestationParent => "bad_attestation_parent",
-        }
+stf_error! {
+    /// Error type for assurances validation.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum AssuranceError {
+        NotSortedOrUniqueAssurers => "not_sorted_or_unique_assurers",
+        BadSignature => "bad_signature",
+        BadValidatorIndex => "bad_validator_index",
+        CoreNotEngaged => "core_not_engaged",
+        BadAttestationParent => "bad_attestation_parent",
     }
 }
 

--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -18,46 +18,25 @@ fn check_sorted_unique<T: Ord + Clone>(items: &[T], err: DisputeError) -> Result
     }
 }
 
-/// Error type for disputes validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DisputeError {
-    JudgementsNotSortedUnique,
-    VerdictsNotSortedUnique,
-    CulpritsNotSortedUnique,
-    FaultsNotSortedUnique,
-    BadSignature,
-    BadVoteSplit,
-    NotEnoughCulprits,
-    NotEnoughFaults,
-    AlreadyJudged,
-    OffenderAlreadyReported,
-    CulpritsVerdictNotBad,
-    FaultVerdictWrong,
-    BadGuarantorKey,
-    BadAuditorKey,
-    BadJudgementAge,
-}
-
-impl DisputeError {
-    /// Convert to the error string used in test vectors.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::JudgementsNotSortedUnique => "judgements_not_sorted_unique",
-            Self::VerdictsNotSortedUnique => "verdicts_not_sorted_unique",
-            Self::CulpritsNotSortedUnique => "culprits_not_sorted_unique",
-            Self::FaultsNotSortedUnique => "faults_not_sorted_unique",
-            Self::BadSignature => "bad_signature",
-            Self::BadVoteSplit => "bad_vote_split",
-            Self::NotEnoughCulprits => "not_enough_culprits",
-            Self::NotEnoughFaults => "not_enough_faults",
-            Self::AlreadyJudged => "already_judged",
-            Self::OffenderAlreadyReported => "offender_already_reported",
-            Self::CulpritsVerdictNotBad => "culprits_verdict_not_bad",
-            Self::FaultVerdictWrong => "fault_verdict_wrong",
-            Self::BadGuarantorKey => "bad_guarantor_key",
-            Self::BadAuditorKey => "bad_auditor_key",
-            Self::BadJudgementAge => "bad_judgement_age",
-        }
+stf_error! {
+    /// Error type for disputes validation.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum DisputeError {
+        JudgementsNotSortedUnique => "judgements_not_sorted_unique",
+        VerdictsNotSortedUnique => "verdicts_not_sorted_unique",
+        CulpritsNotSortedUnique => "culprits_not_sorted_unique",
+        FaultsNotSortedUnique => "faults_not_sorted_unique",
+        BadSignature => "bad_signature",
+        BadVoteSplit => "bad_vote_split",
+        NotEnoughCulprits => "not_enough_culprits",
+        NotEnoughFaults => "not_enough_faults",
+        AlreadyJudged => "already_judged",
+        OffenderAlreadyReported => "offender_already_reported",
+        CulpritsVerdictNotBad => "culprits_verdict_not_bad",
+        FaultVerdictWrong => "fault_verdict_wrong",
+        BadGuarantorKey => "bad_guarantor_key",
+        BadAuditorKey => "bad_auditor_key",
+        BadJudgementAge => "bad_judgement_age",
     }
 }
 

--- a/grey/crates/grey-state/src/lib.rs
+++ b/grey/crates/grey-state/src/lib.rs
@@ -2,6 +2,32 @@
 //!
 //! Implements the state transition function Υ(σ, B) → σ' (eq 4.1).
 
+/// Define an STF error enum with an `as_str()` method for test-vector output.
+///
+/// Each variant maps to a snake_case string. Variants are listed once;
+/// the macro generates both the enum and the `as_str()` match.
+macro_rules! stf_error {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $( $variant:ident => $str:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        $vis enum $name {
+            $( $variant, )+
+        }
+
+        impl $name {
+            pub fn as_str(&self) -> &'static str {
+                match self {
+                    $( Self::$variant => $str, )+
+                }
+            }
+        }
+    };
+}
+
 pub mod accumulate;
 pub mod assurances;
 pub mod authorizations;

--- a/grey/crates/grey-state/src/preimages.rs
+++ b/grey/crates/grey-state/src/preimages.rs
@@ -6,19 +6,12 @@
 use grey_types::{Hash, ServiceId, Timeslot};
 use std::collections::BTreeMap;
 
-/// Error type for preimage validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PreimageError {
-    PreimagesNotSortedUnique,
-    PreimageUnneeded,
-}
-
-impl PreimageError {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::PreimagesNotSortedUnique => "preimages_not_sorted_unique",
-            Self::PreimageUnneeded => "preimage_unneeded",
-        }
+stf_error! {
+    /// Error type for preimage validation.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum PreimageError {
+        PreimagesNotSortedUnique => "preimages_not_sorted_unique",
+        PreimageUnneeded => "preimage_unneeded",
     }
 }
 

--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -18,65 +18,35 @@ const MAX_OUTPUT_PER_ITEM: usize = 18_432;
 /// Maximum segment root lookup entries per work report.
 const MAX_SEGMENT_LOOKUPS: usize = 4;
 
-/// Error type for reports validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReportError {
-    OutOfOrderGuarantee,
-    BadCoreIndex,
-    CoreEngaged,
-    DuplicatePackage,
-    MissingWorkResults,
-    NotSortedOrUniqueGuarantors,
-    BadValidatorIndex,
-    BannedValidator,
-    InsufficientGuarantees,
-    WrongAssignment,
-    BadSignature,
-    AnchorNotRecent,
-    BadStateRoot,
-    BadBeefyMmrRoot,
-    FutureReportSlot,
-    ReportEpochBeforeLast,
-    CoreUnauthorized,
-    BadServiceId,
-    BadCodeHash,
-    ServiceItemGasTooLow,
-    WorkReportGasTooHigh,
-    WorkReportTooBig,
-    TooManyDependencies,
-    DependencyMissing,
-    SegmentRootLookupInvalid,
-}
-
-impl ReportError {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::OutOfOrderGuarantee => "out_of_order_guarantee",
-            Self::BadCoreIndex => "bad_core_index",
-            Self::CoreEngaged => "core_engaged",
-            Self::DuplicatePackage => "duplicate_package",
-            Self::MissingWorkResults => "missing_work_results",
-            Self::NotSortedOrUniqueGuarantors => "not_sorted_or_unique_guarantors",
-            Self::BadValidatorIndex => "bad_validator_index",
-            Self::BannedValidator => "banned_validator",
-            Self::InsufficientGuarantees => "insufficient_guarantees",
-            Self::WrongAssignment => "wrong_assignment",
-            Self::BadSignature => "bad_signature",
-            Self::AnchorNotRecent => "anchor_not_recent",
-            Self::BadStateRoot => "bad_state_root",
-            Self::BadBeefyMmrRoot => "bad_beefy_mmr_root",
-            Self::FutureReportSlot => "future_report_slot",
-            Self::ReportEpochBeforeLast => "report_epoch_before_last",
-            Self::CoreUnauthorized => "core_unauthorized",
-            Self::BadServiceId => "bad_service_id",
-            Self::BadCodeHash => "bad_code_hash",
-            Self::ServiceItemGasTooLow => "service_item_gas_too_low",
-            Self::WorkReportGasTooHigh => "work_report_gas_too_high",
-            Self::WorkReportTooBig => "work_report_too_big",
-            Self::TooManyDependencies => "too_many_dependencies",
-            Self::DependencyMissing => "dependency_missing",
-            Self::SegmentRootLookupInvalid => "segment_root_lookup_invalid",
-        }
+stf_error! {
+    /// Error type for reports validation.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum ReportError {
+        OutOfOrderGuarantee => "out_of_order_guarantee",
+        BadCoreIndex => "bad_core_index",
+        CoreEngaged => "core_engaged",
+        DuplicatePackage => "duplicate_package",
+        MissingWorkResults => "missing_work_results",
+        NotSortedOrUniqueGuarantors => "not_sorted_or_unique_guarantors",
+        BadValidatorIndex => "bad_validator_index",
+        BannedValidator => "banned_validator",
+        InsufficientGuarantees => "insufficient_guarantees",
+        WrongAssignment => "wrong_assignment",
+        BadSignature => "bad_signature",
+        AnchorNotRecent => "anchor_not_recent",
+        BadStateRoot => "bad_state_root",
+        BadBeefyMmrRoot => "bad_beefy_mmr_root",
+        FutureReportSlot => "future_report_slot",
+        ReportEpochBeforeLast => "report_epoch_before_last",
+        CoreUnauthorized => "core_unauthorized",
+        BadServiceId => "bad_service_id",
+        BadCodeHash => "bad_code_hash",
+        ServiceItemGasTooLow => "service_item_gas_too_low",
+        WorkReportGasTooHigh => "work_report_gas_too_high",
+        WorkReportTooBig => "work_report_too_big",
+        TooManyDependencies => "too_many_dependencies",
+        DependencyMissing => "dependency_missing",
+        SegmentRootLookupInvalid => "segment_root_lookup_invalid",
     }
 }
 

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -10,29 +10,17 @@ use grey_types::validator::ValidatorKey;
 use grey_types::{BandersnatchPublicKey, BandersnatchRingRoot, Ed25519PublicKey, Hash};
 use std::collections::BTreeSet;
 
-/// Errors from the Safrole sub-transition.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SafroleError {
-    BadSlot,
-    UnexpectedTicket,
-    BadTicketAttempt,
-    BadTicketOrder,
-    BadTicketProof,
-    DuplicateTicket,
-    TicketNotRetained,
-}
-
-impl SafroleError {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::BadSlot => "bad_slot",
-            Self::UnexpectedTicket => "unexpected_ticket",
-            Self::BadTicketAttempt => "bad_ticket_attempt",
-            Self::BadTicketOrder => "bad_ticket_order",
-            Self::BadTicketProof => "bad_ticket_proof",
-            Self::DuplicateTicket => "duplicate_ticket",
-            Self::TicketNotRetained => "ticket_not_retained",
-        }
+stf_error! {
+    /// Errors from the Safrole sub-transition.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum SafroleError {
+        BadSlot => "bad_slot",
+        UnexpectedTicket => "unexpected_ticket",
+        BadTicketAttempt => "bad_ticket_attempt",
+        BadTicketOrder => "bad_ticket_order",
+        BadTicketProof => "bad_ticket_proof",
+        DuplicateTicket => "duplicate_ticket",
+        TicketNotRetained => "ticket_not_retained",
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `stf_error!` macro that generates both an error enum and its `as_str()` method from a single declaration
- Convert all 5 STF error types to use the macro: `DisputeError`, `SafroleError`, `PreimageError`, `AssuranceError`, `ReportError`
- Net reduction of 54 lines — each error variant is now listed once instead of twice

Addresses #186.

## Scope

This PR addresses: deduplicate the repeated enum + as_str() pattern across 5 STF error types.

Remaining sub-tasks in #186: further dedup opportunities across grey crates.

## Test plan

- `cargo test -p grey-state` — all tests pass
- `cargo clippy -p grey-state --all-targets -- -D warnings` — no warnings
- `cargo fmt --all` — formatted