### PR TITLE
feat: v3 readiness — global ranking variant + variances plumbing

### DIFF
--- a/spec/Genesis/Cli/Evaluate.lean
+++ b/spec/Genesis/Cli/Evaluate.lean
@@ -1,11 +1,14 @@
 /-
   genesis_evaluate CLI
 
-  Input:  {"commit": {...}, "pastIndices": [...], "ranking": [...] (required for v2)}
+  Input:  {"commit": {...}, "pastIndices": [...],
+           "ranking": [...] (required for v2+),
+           "variances": [...] (required for v3)}
   Output: CommitIndex JSON
 
   For v2 (useRankedTargets), the "ranking" field is REQUIRED.
-  Missing ranking for a v2 commit is a fatal error.
+  For v3 (useBradleyTerry), the "variances" field is also REQUIRED.
+  Missing fields for the active variant are fatal errors.
 -/
 
 import Genesis.Cli.Common
@@ -23,7 +26,13 @@ def evaluateMain : IO UInt32 := runJsonPipe fun j => do
     |>.map some
   else
     pure none
-  let (idx, warnings) := evaluateWithWarnings pastIndices commit ranking
+  let variances ← if v.useBradleyTerry then
+    IO.ofExcept (j.getObjValAs? (List (CommitId × Nat)) "variances"
+      |>.mapError (s!"v3 variant active (useBradleyTerry=true) but variances field missing: " ++ ·))
+    |>.map some
+  else
+    pure none
+  let (idx, warnings) := evaluateWithWarnings pastIndices commit ranking variances
   let baseJson := toJson idx
   match baseJson with
   | .obj kvs => return .obj (kvs.insert "warnings" (toJson warnings))

--- a/spec/Genesis/Cli/Ranking.lean
+++ b/spec/Genesis/Cli/Ranking.lean
@@ -31,11 +31,15 @@ def rankingMainWith (forceVariant : Option String := none) : IO UInt32 := runJso
   let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
   -- Resolve forced variant (if any)
   let forcedV := forceVariant.bind resolveVariantName
-  -- Build per-commit contexts (variant + weight function)
+  -- Use a single global variant for ranking (ranking is a property of the
+  -- state, not per-commit). When v3 activates, all commits are reranked
+  -- under v3 rules — there are no "v2 commits" in v3's eyes.
+  let globalV := forcedV.getD
+    (activeVariant (indices.getLast?.map (·.epoch) |>.getD 0))
+  -- Build per-commit contexts (global variant + per-commit weight function)
   let (contexts, _) := signedCommits.zip indices |>.foldl
-    (fun (ctxs, state) (commit, idx) =>
-      let v := forcedV.getD (activeVariant commit.prCreatedAt)
-      let ctx : RankingCommitCtx := { variant := v, getWeight := state.reviewerWeight }
+    (fun (ctxs, state) (_, idx) =>
+      let ctx : RankingCommitCtx := { variant := globalV, getWeight := state.reviewerWeight }
       let nextState := @stepState (activeVariant idx.epoch) state idx
       (ctxs ++ [ctx], nextState)
     ) (([] : List RankingCommitCtx), initEvalState)

--- a/spec/Genesis/Cli/Validate.lean
+++ b/spec/Genesis/Cli/Validate.lean
@@ -1,12 +1,15 @@
 /-
   genesis_validate CLI
 
-  Input:  {"indices": [...], "signedCommits": [...], "rankings": {...} (required for v2)}
+  Input:  {"indices": [...], "signedCommits": [...],
+           "rankings": {...} (required for v2+),
+           "scores": {...} (required for v3)}
   Output: {"valid": bool, "errors": [...]}
 
   Re-evaluates each signed commit against prior indices and checks
   that the stored CommitIndex matches. For v2 commits, the rankings
-  map is REQUIRED for target validation.
+  map is REQUIRED for target validation. For v3 commits, the scores
+  map is also REQUIRED (variances are derived from it).
 -/
 
 import Genesis.Cli.Common
@@ -24,10 +27,27 @@ def lookupRanking (pastIndices : List CommitIndex) (rankings : Lean.Json)
   | some lastIdx =>
     (rankings.getObjValAs? (List CommitId) (toString lastIdx.commitHash)).toOption
 
+/-- Look up variances from the scores map: find the latest prior commit,
+    extract (commitId, sigma2) pairs from its scores entry. -/
+def lookupVariances (pastIndices : List CommitIndex) (scoresJson : Lean.Json)
+    (prCreatedAt : Epoch) : Option (List (CommitId × Nat)) :=
+  let prior := pastIndices.filter (fun idx => idx.epoch < prCreatedAt)
+  match prior.getLast? with
+  | none => none
+  | some lastIdx =>
+    match scoresJson.getObjValAs? (List Json) (toString lastIdx.commitHash) with
+    | .ok scores =>
+      some (scores.filterMap fun s =>
+        match s.getObjValAs? CommitId "commit", s.getObjValAs? Nat "sigma2" with
+        | .ok c, .ok v => some (c, v)
+        | _, _ => none)
+    | .error _ => none
+
 def validateMain : IO UInt32 := runJsonPipe fun j => do
   let indices ← IO.ofExcept (j.getObjValAs? (List CommitIndex) "indices")
   let signedCommits ← IO.ofExcept (j.getObjValAs? (List SignedCommit) "signedCommits")
   let rankingsJson := j.getObjVal? "rankings" |>.toOption |>.getD (Lean.Json.mkObj [])
+  let scoresJson := j.getObjVal? "scores" |>.toOption |>.getD (Lean.Json.mkObj [])
   if indices.length != signedCommits.length then
     return Json.mkObj [
       ("valid", toJson false),
@@ -37,14 +57,22 @@ def validateMain : IO UInt32 := runJsonPipe fun j => do
   let mut pastIndices : List CommitIndex := []
   for (idx, commit) in indices.zip signedCommits do
     let v := activeVariant commit.prCreatedAt
-    -- Look up ranking for v2 commits
+    -- Look up ranking for v2+ commits
     let ranking := lookupRanking pastIndices rankingsJson commit.prCreatedAt
-    -- Error if v2 requires ranking but it's missing
+    -- Error if v2+ requires ranking but it's missing
     if v.useRankedTargets && ranking.isNone then
       errors := errors.push (Json.str s!"commit {idx.commitHash}: v2 active but ranking not found in rankings map")
       pastIndices := pastIndices ++ [idx]
       continue
-    let expected := evaluate pastIndices commit ranking
+    -- Look up variances for v3 commits
+    let variances := if v.useBradleyTerry then
+      lookupVariances pastIndices scoresJson commit.prCreatedAt
+    else none
+    if v.useBradleyTerry && variances.isNone then
+      errors := errors.push (Json.str s!"commit {idx.commitHash}: v3 active but variances not found in scores map")
+      pastIndices := pastIndices ++ [idx]
+      continue
+    let expected := evaluate pastIndices commit ranking variances
     -- Compare key fields
     if expected.commitHash != idx.commitHash then
       errors := errors.push (Json.str s!"commit {idx.commitHash}: hash mismatch")

--- a/spec/Genesis/Scoring.lean
+++ b/spec/Genesis/Scoring.lean
@@ -562,13 +562,22 @@ def selectComparisonTargetsRanked
 
 /-- Validate comparison targets in a signed commit.
     For v1 (useRankedTargets=false): validates against time-based selection.
-    For v2 (useRankedTargets=true): validates against rank-based selection. -/
+    For v2 (useRankedTargets=true): validates against rank-based selection.
+    For v3 (useBradleyTerry=true): validates against variance-weighted selection. -/
 def validateComparisonTargets [gv : GenesisVariant]
     (commit : SignedCommit)
     (scoredCommits : List (CommitId × Epoch))
-    (ranking : Option (List CommitId) := none) : Bool :=
+    (ranking : Option (List CommitId) := none)
+    (variances : Option (List (CommitId × Nat)) := none) : Bool :=
   let eligible := scoredCommits.filter (fun (_, epoch) => epoch < commit.prCreatedAt)
   if eligible.isEmpty then commit.comparisonTargets.isEmpty
+  else if gv.useBradleyTerry then
+    match ranking, variances with
+    | some r, some v =>
+      let expected := selectComparisonTargetsVariance r v scoredCommits
+        (min gv.rankingSize eligible.length) commit.prId commit.prCreatedAt
+      commit.comparisonTargets == expected
+    | _, _ => false  -- v3 requires both ranking and variances
   else if gv.useRankedTargets then
     match ranking with
     | some r =>
@@ -582,15 +591,17 @@ def validateComparisonTargets [gv : GenesisVariant]
     commit.comparisonTargets == expected
 
 /-- Compute the score for a single signed commit.
-    For v2, ranking is required for target validation. -/
+    For v2, ranking is required for target validation.
+    For v3, both ranking and variances are required. -/
 def commitScore [gv : GenesisVariant]
     (commit : SignedCommit)
     (scoredCommits : List (CommitId × Epoch))
     (ranking : Option (List CommitId))
     (getWeight : ContributorId → Nat)
+    (variances : Option (List (CommitId × Nat)) := none)
     : CommitScore :=
   let zeroScore : CommitScore := { difficulty := 0, novelty := 0, designQuality := 0 }
-  if !(validateComparisonTargets commit scoredCommits ranking) then
+  if !(validateComparisonTargets commit scoredCommits ranking variances) then
     zeroScore
   else
     let approvedReviews := filterReviews commit.reviews commit.metaReviews getWeight
@@ -636,9 +647,10 @@ def commitScoreWithWarnings [gv : GenesisVariant]
     (scoredCommits : List (CommitId × Epoch))
     (ranking : Option (List CommitId))
     (getWeight : ContributorId → Nat)
+    (variances : Option (List (CommitId × Nat)) := none)
     : CommitScore × List String :=
   let zeroScore : CommitScore := { difficulty := 0, novelty := 0, designQuality := 0 }
-  if !(validateComparisonTargets commit scoredCommits ranking) then
+  if !(validateComparisonTargets commit scoredCommits ranking variances) then
     (zeroScore, ["score is zero: comparison targets validation failed"])
   else
     let reviewWarnings := commit.reviews.foldl (fun acc r =>

--- a/spec/Genesis/State.lean
+++ b/spec/Genesis/State.lean
@@ -144,8 +144,9 @@ def EvalState.reviewerWeight (s : EvalState) (id : ContributorId) : Nat :=
 /-- Evaluate a single signed commit given pre-built state.
     Uses the current [GenesisVariant] for scoring parameters. -/
 def evaluateWithState (state : EvalState) (commit : SignedCommit)
-    (ranking : Option (List CommitId) := none) : CommitIndex :=
-  let score := commitScore commit state.scoredCommits ranking state.reviewerWeight
+    (ranking : Option (List CommitId) := none)
+    (variances : Option (List (CommitId × Nat)) := none) : CommitIndex :=
+  let score := commitScore commit state.scoredCommits ranking state.reviewerWeight variances
   let approved := filterReviews commit.reviews commit.metaReviews (state.reviewerWeight ·)
   let approvedReviewers := approved
     |>.filter (fun (r : EmbeddedReview) => state.reviewerWeight r.reviewer > 0)
@@ -169,8 +170,9 @@ def evaluateWithState (state : EvalState) (commit : SignedCommit)
 
 /-- Like evaluateWithState but also returns validation warnings. -/
 def evaluateWithStateAndWarnings (state : EvalState) (commit : SignedCommit)
-    (ranking : Option (List CommitId) := none) : CommitIndex × List String :=
-  let (score, warnings) := commitScoreWithWarnings commit state.scoredCommits ranking state.reviewerWeight
+    (ranking : Option (List CommitId) := none)
+    (variances : Option (List (CommitId × Nat)) := none) : CommitIndex × List String :=
+  let (score, warnings) := commitScoreWithWarnings commit state.scoredCommits ranking state.reviewerWeight variances
   let approved := filterReviews commit.reviews commit.metaReviews (state.reviewerWeight ·)
   let approvedReviewers := approved
     |>.filter (fun (r : EmbeddedReview) => state.reviewerWeight r.reviewer > 0)
@@ -208,17 +210,19 @@ def reconstructState (pastIndices : List CommitIndex) : EvalState :=
     State reconstruction uses per-index variants.
     Scoring uses the variant active at commit.prCreatedAt. -/
 def evaluate (pastIndices : List CommitIndex) (commit : SignedCommit)
-    (ranking : Option (List CommitId) := none) : CommitIndex :=
+    (ranking : Option (List CommitId) := none)
+    (variances : Option (List (CommitId × Nat)) := none) : CommitIndex :=
   let state := reconstructState pastIndices
   letI := activeVariant commit.prCreatedAt
-  evaluateWithState state commit ranking
+  evaluateWithState state commit ranking variances
 
 /-- Like evaluate but also returns validation warnings. -/
 def evaluateWithWarnings (pastIndices : List CommitIndex) (commit : SignedCommit)
-    (ranking : Option (List CommitId) := none) : CommitIndex × List String :=
+    (ranking : Option (List CommitId) := none)
+    (variances : Option (List (CommitId × Nat)) := none) : CommitIndex × List String :=
   let state := reconstructState pastIndices
   letI := activeVariant commit.prCreatedAt
-  evaluateWithStateAndWarnings state commit ranking
+  evaluateWithStateAndWarnings state commit ranking variances
 
 /-- Evaluate a full sequence of signed commits. -/
 def evaluateAll (signedCommits : List SignedCommit) : List CommitIndex :=


### PR DESCRIPTION
## Summary

- Ranking now uses a single global variant (latest epoch) instead of per-commit dispatch — ranking is a property of the state, not individual commits
- `validateComparisonTargets` supports v3 variance-weighted target selection via optional variances parameter
- Variances plumbed through the full evaluate chain (`commitScore` → `evaluateWithState` → `evaluate`), all defaulting to `none`
- Evaluate CLI requires `variances` when v3 (`useBradleyTerry`) is active
- Validate CLI accepts optional `scores` map, derives variances via `lookupVariances` helper

All changes are backward-compatible — no behavioral change for existing v1/v2 commits. This is preparatory work for v3 activation (activation epoch change is separate).

## Test plan

- [x] `lake build genesis` — builds successfully
- [x] `make test` — 26/26 genesis tests pass
- [x] `cargo run -p jar-genesis -- replay --mode verify` — 562/562 indices match

🤖 Generated with [Claude Code](https://claude.com/claude-code)