### PR TITLE
feat: v3 Rust tooling — scores.json, defensive snapshots, variances

### DIFF
--- a/tools/jar-genesis/src/lib.rs
+++ b/tools/jar-genesis/src/lib.rs
@@ -6,5 +6,6 @@ pub mod lean;
 pub mod queue;
 pub mod replay;
 pub mod review;
+pub mod snapshot;
 pub mod types;
 pub mod workflow;

--- a/tools/jar-genesis/src/replay.rs
+++ b/tools/jar-genesis/src/replay.rs
@@ -109,16 +109,21 @@ fn get_ranking_snapshot(
     rankings.get(commit_hash).cloned()
 }
 
+/// Result of incremental replay.
+struct ReplayResult {
+    indices: Vec<serde_json::Value>,
+    rankings: HashMap<String, serde_json::Value>,
+    scores: HashMap<String, serde_json::Value>,
+}
+
 /// Core incremental replay loop. Evaluates each signed commit incrementally.
-/// Returns (rebuilt_indices, ranking_snapshots).
-#[allow(clippy::type_complexity)]
 fn replay_incremental(
     spec_dir: &Path,
     signed_commits: &[serde_json::Value],
-) -> Result<(Vec<serde_json::Value>, HashMap<String, serde_json::Value>), Box<dyn std::error::Error>>
-{
+) -> Result<ReplayResult, Box<dyn std::error::Error>> {
     let mut indices: Vec<serde_json::Value> = Vec::new();
     let mut rankings: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut scores: HashMap<String, serde_json::Value> = HashMap::new();
     let mut commits: Vec<serde_json::Value> = Vec::new();
 
     for commit in signed_commits {
@@ -163,10 +168,19 @@ fn replay_incremental(
         let snapshot = ranking_output["ranking"].clone();
 
         let commit_hash = index["commitHash"].as_str().unwrap_or("").to_string();
-        rankings.insert(commit_hash, snapshot);
+        rankings.insert(commit_hash.clone(), snapshot);
+
+        // Capture scores (v3 BT output) if present
+        if let Some(scores_val) = ranking_output.get("scores") {
+            scores.insert(commit_hash, scores_val.clone());
+        }
     }
 
-    Ok((indices, rankings))
+    Ok(ReplayResult {
+        indices,
+        rankings,
+        scores,
+    })
 }
 
 fn spec_dir() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
@@ -201,13 +215,14 @@ pub fn verify() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Build ranking map incrementally
-    let (_, rankings) = replay_incremental(&spec, &signed_commits)?;
+    let result = replay_incremental(&spec, &signed_commits)?;
 
     // Validate using genesis_validate
     let input = serde_json::json!({
         "indices": stored_indices,
         "signedCommits": signed_commits.iter().filter(|c| !c.is_null()).collect::<Vec<_>>(),
-        "rankings": rankings,
+        "rankings": result.rankings,
+        "scores": result.scores,
     });
 
     let result: serde_json::Value = lean::invoke("genesis_validate", &input, &spec)?;
@@ -252,17 +267,17 @@ pub fn verify_cache() -> Result<(), Box<dyn std::error::Error>> {
     let _replayable: Vec<&serde_json::Value> =
         signed_commits.iter().filter(|c| !c.is_null()).collect();
 
-    let (rebuilt_indices, rebuilt_rankings) = replay_incremental(&spec, &signed_commits)?;
+    let result = replay_incremental(&spec, &signed_commits)?;
 
     // Fetch cache
     git::fetch("origin", "genesis-state")?;
     let cache_json = git::show_file("origin/genesis-state:genesis.json")?;
     let cache: Vec<serde_json::Value> = serde_json::from_str(&cache_json)?;
 
-    if rebuilt_indices.len() != cache.len() {
+    if result.indices.len() != cache.len() {
         eprintln!(
             "MISMATCH: rebuilt {} indices but cache has {}.",
-            rebuilt_indices.len(),
+            result.indices.len(),
             cache.len()
         );
         std::process::exit(1);
@@ -271,13 +286,11 @@ pub fn verify_cache() -> Result<(), Box<dyn std::error::Error>> {
     let mut errors = 0;
 
     // Compare indices
-    for i in 0..rebuilt_indices.len() {
-        let r = serde_json::to_string(&rebuilt_indices[i])?;
-        let c = serde_json::to_string(&cache[i])?;
+    for (i, (rebuilt, cached)) in result.indices.iter().zip(cache.iter()).enumerate() {
+        let r = serde_json::to_string(rebuilt)?;
+        let c = serde_json::to_string(cached)?;
         if r != c {
-            let hash = rebuilt_indices[i]["commitHash"]
-                .as_str()
-                .unwrap_or("unknown");
+            let hash = rebuilt["commitHash"].as_str().unwrap_or("unknown");
             eprintln!("MISMATCH at index {i} (commit {hash}):");
             eprintln!("  rebuilt: {r}");
             eprintln!("  cache:   {c}");
@@ -292,15 +305,15 @@ pub fn verify_cache() -> Result<(), Box<dyn std::error::Error>> {
         serde_json::from_str(&cached_ranking_json)?;
 
     if !cached_ranking.is_empty() {
-        if rebuilt_rankings.len() != cached_ranking.len() {
+        if result.rankings.len() != cached_ranking.len() {
             eprintln!(
                 "RANKING MISMATCH: rebuilt {} entries but cache has {}.",
-                rebuilt_rankings.len(),
+                result.rankings.len(),
                 cached_ranking.len()
             );
             errors += 1;
         } else {
-            for (key, rebuilt_val) in &rebuilt_rankings {
+            for (key, rebuilt_val) in &result.rankings {
                 if let Some(cached_val) = cached_ranking.get(key) {
                     let r = serde_json::to_string(rebuilt_val)?;
                     let c = serde_json::to_string(cached_val)?;
@@ -323,10 +336,37 @@ pub fn verify_cache() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("ranking.json not found or empty — skipping ranking verification.");
     }
 
+    // Compare scores (if scores.json exists in cache)
+    let cached_scores_json =
+        git::show_file("origin/genesis-state:scores.json").unwrap_or_else(|_| "{}".to_string());
+    let cached_scores: HashMap<String, serde_json::Value> =
+        serde_json::from_str(&cached_scores_json)?;
+
+    if !cached_scores.is_empty() {
+        for (key, cached_val) in &cached_scores {
+            if let Some(rebuilt_val) = result.scores.get(key) {
+                let r = serde_json::to_string(rebuilt_val)?;
+                let c = serde_json::to_string(cached_val)?;
+                if r != c {
+                    eprintln!("SCORES MISMATCH for commit {}:", &key[..8.min(key.len())]);
+                    eprintln!("  rebuilt: {r}");
+                    eprintln!("  cache:   {c}");
+                    errors += 1;
+                }
+            } else {
+                eprintln!(
+                    "SCORES MISMATCH: key {} not in rebuilt scores.",
+                    &key[..8.min(key.len())]
+                );
+                errors += 1;
+            }
+        }
+    }
+
     if errors == 0 {
         eprintln!(
             "Cache verified: {} indices match rebuilt state.",
-            rebuilt_indices.len()
+            result.indices.len()
         );
         Ok(())
     } else {
@@ -352,18 +392,25 @@ pub fn rebuild() -> Result<(), Box<dyn std::error::Error>> {
     let signed_commits: Vec<serde_json::Value> =
         entries.iter().map(|e| e.signed_commit.clone()).collect();
 
-    let (rebuilt_indices, rebuilt_rankings) = replay_incremental(&spec, &signed_commits)?;
+    let result = replay_incremental(&spec, &signed_commits)?;
 
     eprintln!("=== genesis.json ===");
-    println!("{}", serde_json::to_string_pretty(&rebuilt_indices)?);
+    println!("{}", serde_json::to_string_pretty(&result.indices)?);
     eprintln!("=== ranking.json ===");
     println!(
         "{}",
-        serde_json::to_string_pretty(&serde_json::json!(rebuilt_rankings))?
+        serde_json::to_string_pretty(&serde_json::json!(result.rankings))?
     );
+    if !result.scores.is_empty() {
+        eprintln!("=== scores.json ===");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!(result.scores))?
+        );
+    }
     eprintln!(
         "Rebuilt {} of {} indices.",
-        rebuilt_indices.len(),
+        result.indices.len(),
         entries.len()
     );
 

--- a/tools/jar-genesis/src/snapshot.rs
+++ b/tools/jar-genesis/src/snapshot.rs
@@ -1,0 +1,173 @@
+//! Snapshot lookup: find ranking/variances for a given epoch from the cache.
+//!
+//! Scores (v3 BT output) are the single source of truth for v3. From scores
+//! we derive both the ranking (sorted by mu descending) and variances
+//! (commitId × sigma2 pairs). For v2, we fall back to ranking.json.
+
+/// A snapshot contains the ranking and optionally variances (for v3).
+#[derive(Debug)]
+pub struct Snapshot {
+    pub ranking: serde_json::Value,
+    pub variances: Option<serde_json::Value>,
+}
+
+/// Find the last index with epoch < target_epoch and return its commit hash.
+fn find_prior_commit_hash(indices: &[serde_json::Value], epoch: u64) -> Option<String> {
+    let last = indices
+        .iter()
+        .rfind(|idx| idx["epoch"].as_u64().map(|e| e < epoch).unwrap_or(false))?;
+    last["commitHash"].as_str().map(|s| s.to_string())
+}
+
+/// Derive ranking and variances from a scores array (v3 BT output).
+/// Scores format: [{"commit": "hash", "mu": N, "sigma2": N}, ...]
+/// Returns (ranking sorted by mu desc, variances as [["hash", sigma2], ...]).
+fn derive_from_scores(scores: &serde_json::Value) -> Option<Snapshot> {
+    let arr = scores.as_array()?;
+    // Sort by mu descending to derive ranking
+    let mut entries: Vec<(&serde_json::Value, i64)> = arr
+        .iter()
+        .filter_map(|s| {
+            let mu = s["mu"].as_i64()?;
+            Some((s, mu))
+        })
+        .collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let ranking: Vec<serde_json::Value> = entries
+        .iter()
+        .filter_map(|(s, _)| s.get("commit").cloned())
+        .collect();
+
+    // Extract variances as [["hash", sigma2], ...]
+    let variances: Vec<serde_json::Value> = arr
+        .iter()
+        .filter_map(|s| {
+            let commit = s.get("commit")?;
+            let sigma2 = s.get("sigma2")?;
+            Some(serde_json::json!([commit, sigma2]))
+        })
+        .collect();
+
+    Some(Snapshot {
+        ranking: serde_json::json!(ranking),
+        variances: Some(serde_json::json!(variances)),
+    })
+}
+
+/// Find the snapshot for a given epoch, checking scores.json first (v3),
+/// then falling back to ranking.json (v2).
+///
+/// Returns:
+/// - `Ok(None)` if no prior index exists (first commit, no ranking needed)
+/// - `Ok(Some(snapshot))` if found in either source
+/// - `Err(...)` if a prior index exists but its commit hash is missing from
+///   both sources (stale cache)
+pub fn find(
+    indices: &[serde_json::Value],
+    ranking_map: &serde_json::Value,
+    scores_map: &serde_json::Value,
+    epoch: u64,
+) -> Result<Option<Snapshot>, Box<dyn std::error::Error>> {
+    let commit_hash = match find_prior_commit_hash(indices, epoch) {
+        Some(h) => h,
+        None => return Ok(None),
+    };
+
+    // Try scores.json first (v3)
+    if let Some(scores) = scores_map.get(&commit_hash)
+        && let Some(snapshot) = derive_from_scores(scores)
+    {
+        return Ok(Some(snapshot));
+    }
+
+    // Fall back to ranking.json (v2)
+    if let Some(ranking) = ranking_map.get(&commit_hash) {
+        return Ok(Some(Snapshot {
+            ranking: ranking.clone(),
+            variances: None,
+        }));
+    }
+
+    Err(format!(
+        "cache stale: commit {} not found in ranking.json or scores.json",
+        &commit_hash[..8.min(commit_hash.len())]
+    )
+    .into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_no_prior_index() {
+        let indices: Vec<serde_json::Value> = vec![];
+        let ranking = serde_json::json!({});
+        let scores = serde_json::json!({});
+        assert!(find(&indices, &ranking, &scores, 1000).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_all_future() {
+        let indices = vec![serde_json::json!({"commitHash": "abc", "epoch": 2000})];
+        let ranking = serde_json::json!({"abc": ["abc"]});
+        let scores = serde_json::json!({});
+        assert!(find(&indices, &ranking, &scores, 1000).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_find_ranking_fallback() {
+        let indices = vec![
+            serde_json::json!({"commitHash": "aaa", "epoch": 100}),
+            serde_json::json!({"commitHash": "bbb", "epoch": 200}),
+        ];
+        let ranking = serde_json::json!({
+            "aaa": ["aaa"],
+            "bbb": ["bbb", "aaa"],
+        });
+        let scores = serde_json::json!({});
+        let snap = find(&indices, &ranking, &scores, 250).unwrap().unwrap();
+        assert_eq!(snap.ranking, serde_json::json!(["bbb", "aaa"]));
+        assert!(snap.variances.is_none());
+    }
+
+    #[test]
+    fn test_find_scores_preferred() {
+        let indices = vec![serde_json::json!({"commitHash": "aaa", "epoch": 100})];
+        let ranking = serde_json::json!({"aaa": ["aaa"]});
+        let scores = serde_json::json!({
+            "aaa": [
+                {"commit": "aaa", "mu": 500, "sigma2": 23000000}
+            ]
+        });
+        let snap = find(&indices, &ranking, &scores, 200).unwrap().unwrap();
+        assert_eq!(snap.ranking, serde_json::json!(["aaa"]));
+        assert!(snap.variances.is_some());
+    }
+
+    #[test]
+    fn test_find_scores_sorted_by_mu() {
+        let indices = vec![serde_json::json!({"commitHash": "aaa", "epoch": 100})];
+        let ranking = serde_json::json!({});
+        let scores = serde_json::json!({
+            "aaa": [
+                {"commit": "bbb", "mu": -100, "sigma2": 20000000},
+                {"commit": "aaa", "mu": 500, "sigma2": 23000000}
+            ]
+        });
+        let snap = find(&indices, &ranking, &scores, 200).unwrap().unwrap();
+        // aaa has higher mu, should come first
+        assert_eq!(snap.ranking, serde_json::json!(["aaa", "bbb"]));
+    }
+
+    #[test]
+    fn test_find_stale_cache_errors() {
+        let indices = vec![serde_json::json!({"commitHash": "abc12345", "epoch": 100})];
+        let ranking = serde_json::json!({});
+        let scores = serde_json::json!({});
+        let err = find(&indices, &ranking, &scores, 200).unwrap_err();
+        assert!(err.to_string().contains("cache stale"));
+        assert!(err.to_string().contains("abc12345"));
+    }
+}

--- a/tools/jar-genesis/src/workflow/merge.rs
+++ b/tools/jar-genesis/src/workflow/merge.rs
@@ -6,6 +6,7 @@ use crate::github;
 use crate::lean;
 use crate::replay;
 use crate::review;
+use crate::snapshot;
 use crate::types::{MergeReadiness, SelectTargetsOutput};
 
 /// Run the merge workflow for a PR.
@@ -53,16 +54,23 @@ pub fn run(pr: u64, founder_override: bool) -> Result<(), Box<dyn std::error::Er
     // --- Step 3: Compute comparison targets ---
     let ranking_json =
         git::show_file("origin/genesis-state:ranking.json").unwrap_or_else(|_| "{}".to_string());
-    let ranking: serde_json::Value = serde_json::from_str(&ranking_json)?;
-    let ranking_snapshot = find_ranking_snapshot(&cache_indices, &ranking, pr_created_epoch);
+    let ranking_map: serde_json::Value = serde_json::from_str(&ranking_json)?;
+    let scores_json =
+        git::show_file("origin/genesis-state:scores.json").unwrap_or_else(|_| "{}".to_string());
+    let scores_map: serde_json::Value = serde_json::from_str(&scores_json)?;
+
+    let snap = snapshot::find(&cache_indices, &ranking_map, &scores_map, pr_created_epoch)?;
 
     let mut targets_input = serde_json::json!({
         "prId": pr,
         "prCreatedAt": pr_created_epoch,
         "indices": cache_indices,
     });
-    if let Some(snapshot) = &ranking_snapshot {
-        targets_input["ranking"] = snapshot.clone();
+    if let Some(s) = &snap {
+        targets_input["ranking"] = s.ranking.clone();
+        if let Some(v) = &s.variances {
+            targets_input["variances"] = v.clone();
+        }
     }
 
     let targets_output: SelectTargetsOutput =
@@ -122,8 +130,11 @@ pub fn run(pr: u64, founder_override: bool) -> Result<(), Box<dyn std::error::Er
         "commit": commit_json,
         "pastIndices": cache_indices,
     });
-    if let Some(snapshot) = &ranking_snapshot {
-        eval_input["ranking"] = snapshot.clone();
+    if let Some(s) = &snap {
+        eval_input["ranking"] = s.ranking.clone();
+        if let Some(v) = &s.variances {
+            eval_input["variances"] = v.clone();
+        }
     }
 
     let index: serde_json::Value = lean::invoke("genesis_evaluate", &eval_input, &spec_dir)?;
@@ -266,6 +277,15 @@ fn update_cache(
         serde_json::from_str(&existing_ranking_json)?;
     existing_ranking.insert(new_commit_hash.to_string(), new_ranking.clone());
 
+    // Update scores.json (v3 BT output, if present)
+    let existing_scores_json =
+        git::show_file("origin/genesis-state:scores.json").unwrap_or_else(|_| "{}".to_string());
+    let mut existing_scores: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(&existing_scores_json)?;
+    if let Some(scores) = ranking_output.get("scores") {
+        existing_scores.insert(new_commit_hash.to_string(), scores.clone());
+    }
+
     // Write to genesis-state branch via worktree
     git::fetch("origin", "genesis-state")?;
     git::git_cmd(&[
@@ -287,6 +307,10 @@ fn update_cache(
         "/tmp/genesis-state/ranking.json",
         serde_json::to_string_pretty(&serde_json::Value::Object(existing_ranking))?,
     )?;
+    std::fs::write(
+        "/tmp/genesis-state/scores.json",
+        serde_json::to_string_pretty(&serde_json::Value::Object(existing_scores))?,
+    )?;
 
     git::git_cmd_in("/tmp/genesis-state", &["config", "user.name", "JAR Bot"])?;
     git::git_cmd_in(
@@ -295,7 +319,7 @@ fn update_cache(
     )?;
     git::git_cmd_in(
         "/tmp/genesis-state",
-        &["add", "genesis.json", "ranking.json"],
+        &["add", "genesis.json", "ranking.json", "scores.json"],
     )?;
     git::git_cmd_in(
         "/tmp/genesis-state",
@@ -388,18 +412,6 @@ fn parse_epoch(iso: &str) -> Result<u64, Box<dyn std::error::Error>> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().parse()?)
 }
 
-fn find_ranking_snapshot(
-    indices: &[serde_json::Value],
-    ranking: &serde_json::Value,
-    epoch: u64,
-) -> Option<serde_json::Value> {
-    let last = indices
-        .iter()
-        .rfind(|idx| idx["epoch"].as_u64().map(|e| e < epoch).unwrap_or(false))?;
-    let commit_hash = last["commitHash"].as_str()?;
-    ranking.get(commit_hash).cloned()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,45 +444,6 @@ mod tests {
     fn test_parse_flag_after_blank_line_ignored() {
         let body = "\nSet-Genesis-Author: @alice";
         assert_eq!(parse_flag(body, "Set-Genesis-Author"), None);
-    }
-
-    #[test]
-    fn test_find_ranking_snapshot_empty() {
-        let indices: Vec<serde_json::Value> = vec![];
-        let ranking = serde_json::json!({});
-        assert!(find_ranking_snapshot(&indices, &ranking, 1000).is_none());
-    }
-
-    #[test]
-    fn test_find_ranking_snapshot_all_future() {
-        let indices = vec![serde_json::json!({"commitHash": "abc", "epoch": 2000})];
-        let ranking = serde_json::json!({"abc": ["abc"]});
-        // epoch 1000 < 2000, so nothing is before it
-        assert!(find_ranking_snapshot(&indices, &ranking, 1000).is_none());
-    }
-
-    #[test]
-    fn test_find_ranking_snapshot_picks_last_before_epoch() {
-        let indices = vec![
-            serde_json::json!({"commitHash": "aaa", "epoch": 100}),
-            serde_json::json!({"commitHash": "bbb", "epoch": 200}),
-            serde_json::json!({"commitHash": "ccc", "epoch": 300}),
-        ];
-        let ranking = serde_json::json!({
-            "aaa": ["aaa"],
-            "bbb": ["bbb", "aaa"],
-            "ccc": ["ccc", "bbb", "aaa"],
-        });
-        // epoch 250: last before it is bbb (epoch 200)
-        let snapshot = find_ranking_snapshot(&indices, &ranking, 250).unwrap();
-        assert_eq!(snapshot, serde_json::json!(["bbb", "aaa"]));
-    }
-
-    #[test]
-    fn test_find_ranking_snapshot_missing_key() {
-        let indices = vec![serde_json::json!({"commitHash": "abc", "epoch": 100})];
-        let ranking = serde_json::json!({}); // key not present
-        assert!(find_ranking_snapshot(&indices, &ranking, 200).is_none());
     }
 
     #[test]

--- a/tools/jar-genesis/src/workflow/pr_opened.rs
+++ b/tools/jar-genesis/src/workflow/pr_opened.rs
@@ -4,6 +4,7 @@ use crate::cache;
 use crate::git;
 use crate::github;
 use crate::lean;
+use crate::snapshot;
 use crate::types::SelectTargetsOutput;
 
 /// Run the PR-opened workflow: compute and post comparison targets.
@@ -30,13 +31,15 @@ pub fn run(pr: u64, created_at: &str) -> Result<(), Box<dyn std::error::Error>> 
     // Parse PR created_at to epoch
     let pr_created_epoch = parse_iso8601_to_epoch(created_at)?;
 
-    // Get ranking snapshot
+    // Get ranking + variances snapshot
     let ranking_json =
         git::show_file("origin/genesis-state:ranking.json").unwrap_or_else(|_| "{}".to_string());
-    let ranking: serde_json::Value = serde_json::from_str(&ranking_json)?;
+    let ranking_map: serde_json::Value = serde_json::from_str(&ranking_json)?;
+    let scores_json =
+        git::show_file("origin/genesis-state:scores.json").unwrap_or_else(|_| "{}".to_string());
+    let scores_map: serde_json::Value = serde_json::from_str(&scores_json)?;
 
-    // Find ranking snapshot for this PR's created_at
-    let ranking_snapshot = find_ranking_snapshot(&cache_indices, &ranking, pr_created_epoch);
+    let snap = snapshot::find(&cache_indices, &ranking_map, &scores_map, pr_created_epoch)?;
 
     // Build input for genesis_select_targets
     let mut input = serde_json::json!({
@@ -44,8 +47,11 @@ pub fn run(pr: u64, created_at: &str) -> Result<(), Box<dyn std::error::Error>> 
         "prCreatedAt": pr_created_epoch,
         "indices": cache_indices,
     });
-    if let Some(snapshot) = &ranking_snapshot {
-        input["ranking"] = snapshot.clone();
+    if let Some(s) = &snap {
+        input["ranking"] = s.ranking.clone();
+        if let Some(v) = &s.variances {
+            input["variances"] = v.clone();
+        }
     }
 
     let output: SelectTargetsOutput = lean::invoke("genesis_select_targets", &input, &spec_dir)?;
@@ -83,16 +89,4 @@ fn parse_iso8601_to_epoch(s: &str) -> Result<u64, Box<dyn std::error::Error>> {
     }
     let epoch: u64 = String::from_utf8_lossy(&output.stdout).trim().parse()?;
     Ok(epoch)
-}
-
-fn find_ranking_snapshot(
-    indices: &[serde_json::Value],
-    ranking: &serde_json::Value,
-    epoch: u64,
-) -> Option<serde_json::Value> {
-    let last = indices
-        .iter()
-        .rfind(|idx| idx["epoch"].as_u64().map(|e| e < epoch).unwrap_or(false))?;
-    let commit_hash = last["commitHash"].as_str()?;
-    ranking.get(commit_hash).cloned()
 }


### PR DESCRIPTION
## Summary

- New `snapshot` module with defensive cache lookup — errors early if commit hash missing from both `ranking.json` and `scores.json` (stale cache), replacing silently omitted data that caused cryptic downstream Lean errors
- `scores.json` capture: replay captures BT scores from `genesis ranking` output; merge workflow writes `scores.json` to `genesis-state` branch; `verify-cache` and `rebuild` handle scores
- Variances plumbing: both workflows (PR-opened, merge) read `scores.json`, derive ranking + variances from it (v3 path), and pass to `select-targets` and `evaluate`. Falls back to `ranking.json` for v2 snapshots

`scores.json` is the single v3 source of truth — ranking derived by sorting by mu, variances by extracting sigma2. After v2→v3 transition, `ranking.json` becomes unused.

## Test plan

- [x] `cargo clippy -p jar-genesis -- -D warnings` — clean
- [x] `cargo test -p jar-genesis` — 52 tests pass (including 6 new snapshot tests)
- [x] `cargo run -p jar-genesis -- replay --mode verify` — 564/564 indices match
- [x] `cargo run -p jar-genesis -- replay --mode verify-cache` — 564 indices match cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)