### PR TITLE
refactor(grey-state): reuse precomputed hashes in preimages apply loop

### DIFF
--- a/grey/crates/grey-state/src/preimages.rs
+++ b/grey/crates/grey-state/src/preimages.rs
@@ -68,17 +68,14 @@ pub fn process_preimages(
     // eq 12.38: Apply changes — store blobs, update request timeslots, track stats.
     let mut stats: BTreeMap<ServiceId, PreimageServiceRecord> = BTreeMap::new();
 
-    for (sid, blob) in preimages {
-        let hash = grey_crypto::blake2b_256(blob);
-        let length = blob.len() as u32;
-
+    for ((sid, hash, length), (_, blob)) in hashed.iter().zip(preimages.iter()) {
         let account = accounts.get_mut(sid).unwrap();
 
         // Store blob
-        account.blobs.insert(hash, blob.clone());
+        account.blobs.insert(*hash, blob.clone());
 
         // Update request: record the timeslot when preimage was provided
-        if let Some(timeslots) = account.requests.get_mut(&(hash, length)) {
+        if let Some(timeslots) = account.requests.get_mut(&(*hash, *length)) {
             *timeslots = vec![current_timeslot];
         }
 


### PR DESCRIPTION
## Summary

- Eliminate redundant `blake2b_256` recomputation in the preimages apply loop by zipping with the already-computed `hashed` vector from the validation phase
- Removes 3 lines of duplicate computation (hash + length recalculation) per preimage processed

Addresses #186.

## Scope

This PR addresses: eliminate redundant blake2b_256 recomputation in preimages.rs apply loop

Remaining sub-tasks in #186:
- Inline epoch/slot computations in safrole.rs and authoring.rs could use extracted helpers
- disputes.rs super_majority formula could use Config::super_majority_of
- refine.rs has near-identical PVM kernel event loops

## Test plan

- All 7 existing preimages unit tests pass (`cargo test -p grey-state --lib preimages`)
- No behavior change — same hashes are used, just computed once instead of twice