### PR TITLE
refactor(grey-state): use Config::super_majority_of in disputes.rs

### DIFF
--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -60,7 +60,7 @@ pub fn process_disputes(
     previous_validators: &[ValidatorKey],
 ) -> Result<DisputeOutput, DisputeError> {
     let val_count = current_validators.len() as u16;
-    let super_majority = (val_count * 2 / 3) + 1;
+    let super_majority = Config::super_majority_of(current_validators.len()) as u16;
     let one_third = val_count / 3;
     let current_epoch = current_timeslot / config.epoch_length;
 


### PR DESCRIPTION
## Summary

- Replace inline `(val_count * 2 / 3) + 1` super-majority formula in disputes.rs with the existing `Config::super_majority_of()` helper
- Aligns with how assurances.rs and transition.rs already compute the threshold

Addresses #186.

## Scope

This PR addresses: replace inline super-majority formula in disputes.rs with Config::super_majority_of

Remaining sub-tasks in #186:
- Epoch/slot computations inlined in safrole.rs and authoring.rs could use extracted helpers
- refine.rs has near-identical PVM kernel event loops
- preimages.rs double hashing (PR #663)

## Test plan

- All 11 disputes unit tests pass (`cargo test -p grey-state --lib disputes`)
- Formula is numerically identical: `(count * 2 / 3) + 1`