### PR TITLE
refactor: extract add_digest to deduplicate statistics accumulation

### DIFF
--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -4,7 +4,7 @@
 
 use grey_types::config::Config;
 use grey_types::validator::ValidatorKey;
-use grey_types::work::{WorkReport, WorkResult};
+use grey_types::work::{WorkDigest, WorkReport, WorkResult};
 use grey_types::{Ed25519PublicKey, Ed25519Signature, Hash, ServiceId, Timeslot, signing_contexts};
 use javm::Gas;
 use std::collections::{BTreeMap, BTreeSet};
@@ -94,6 +94,17 @@ pub struct CoreStats {
     pub gas_used: u64,
 }
 
+impl CoreStats {
+    /// Accumulate refine-load fields from a work digest.
+    fn add_digest(&mut self, digest: &WorkDigest) {
+        self.imports += digest.imports_count as u64;
+        self.extrinsic_count += digest.extrinsics_count as u64;
+        self.extrinsic_size += digest.extrinsics_size as u64;
+        self.exports += digest.exports_count as u64;
+        self.gas_used += digest.gas_used;
+    }
+}
+
 /// Per-service statistics output from reports processing.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ServiceStats {
@@ -107,6 +118,18 @@ pub struct ServiceStats {
     pub exports: u64,
     pub accumulate_count: u32,
     pub accumulate_gas_used: u64,
+}
+
+impl ServiceStats {
+    /// Accumulate refinement fields from a work digest.
+    fn add_digest(&mut self, digest: &WorkDigest) {
+        self.refinement_count += 1;
+        self.refinement_gas_used += digest.gas_used;
+        self.imports += digest.imports_count as u64;
+        self.extrinsic_count += digest.extrinsics_count as u64;
+        self.extrinsic_size += digest.extrinsics_size as u64;
+        self.exports += digest.exports_count as u64;
+    }
 }
 
 /// Reported package output.
@@ -413,23 +436,13 @@ pub fn process_reports(
         }
         for digest in &guarantee.report.results {
             if has_core {
-                let cs = &mut state.cores_statistics[core];
-                cs.gas_used += digest.gas_used;
-                cs.imports += digest.imports_count as u64;
-                cs.extrinsic_count += digest.extrinsics_count as u64;
-                cs.extrinsic_size += digest.extrinsics_size as u64;
-                cs.exports += digest.exports_count as u64;
+                state.cores_statistics[core].add_digest(digest);
             }
-            let ss = state
+            state
                 .services_statistics
                 .entry(digest.service_id)
-                .or_default();
-            ss.refinement_count += 1;
-            ss.refinement_gas_used += digest.gas_used;
-            ss.imports += digest.imports_count as u64;
-            ss.extrinsic_count += digest.extrinsics_count as u64;
-            ss.extrinsic_size += digest.extrinsics_size as u64;
-            ss.exports += digest.exports_count as u64;
+                .or_default()
+                .add_digest(digest);
         }
     }
 

--- a/grey/crates/grey-state/src/statistics.rs
+++ b/grey/crates/grey-state/src/statistics.rs
@@ -123,11 +123,7 @@ fn compute_core_statistics(
             continue;
         }
         for digest in &report.results {
-            core_stats[c].imports += digest.imports_count as u64;
-            core_stats[c].extrinsic_count += digest.extrinsics_count as u64;
-            core_stats[c].extrinsic_size += digest.extrinsics_size as u64;
-            core_stats[c].exports += digest.exports_count as u64;
-            core_stats[c].gas_used += digest.gas_used;
+            core_stats[c].add_digest(digest);
         }
         // L(c): bundle size from incoming reports
         core_stats[c].bundle_size += report.package_spec.bundle_length as u64;
@@ -173,12 +169,7 @@ fn compute_service_statistics(
     for report in incoming_reports {
         for digest in &report.results {
             let entry = svc_stats.entry(digest.service_id).or_default();
-            entry.refinement_count += 1;
-            entry.refinement_gas_used += digest.gas_used;
-            entry.imports += digest.imports_count as u64;
-            entry.extrinsic_count += digest.extrinsics_count as u64;
-            entry.extrinsic_size += digest.extrinsics_size as u64;
-            entry.exports += digest.exports_count as u64;
+            entry.add_digest(digest);
         }
     }
 

--- a/grey/crates/grey-types/src/state.rs
+++ b/grey/crates/grey-types/src/state.rs
@@ -4,7 +4,7 @@
 
 use crate::header::Ticket;
 use crate::validator::ValidatorKey;
-use crate::work::WorkReport;
+use crate::work::{WorkDigest, WorkReport};
 use crate::{
     BandersnatchPublicKey, BandersnatchRingRoot, Ed25519PublicKey, Gas, Hash, ServiceId, Timeslot,
 };
@@ -251,6 +251,17 @@ pub struct CoreStatistics {
     pub gas_used: Gas,
 }
 
+impl CoreStatistics {
+    /// Accumulate refine-load fields from a work digest.
+    pub fn add_digest(&mut self, digest: &WorkDigest) {
+        self.imports += digest.imports_count as u64;
+        self.extrinsic_count += digest.extrinsics_count as u64;
+        self.extrinsic_size += digest.extrinsics_size as u64;
+        self.exports += digest.exports_count as u64;
+        self.gas_used += digest.gas_used;
+    }
+}
+
 /// Per-service statistics for a single block (GP π_S, eq 13.1).
 /// Fields ordered per GP type definition: p, r, i, x, z, e, a.
 #[derive(Clone, Debug, Default, scale::Encode, scale::Decode)]
@@ -275,6 +286,18 @@ pub struct ServiceStatistics {
     pub accumulate_count: u64,
     /// a.1: Items accumulated — gas used.
     pub accumulate_gas_used: Gas,
+}
+
+impl ServiceStatistics {
+    /// Accumulate refinement fields from a work digest.
+    pub fn add_digest(&mut self, digest: &WorkDigest) {
+        self.refinement_count += 1;
+        self.refinement_gas_used += digest.gas_used;
+        self.imports += digest.imports_count as u64;
+        self.extrinsic_count += digest.extrinsics_count as u64;
+        self.extrinsic_size += digest.extrinsics_size as u64;
+        self.exports += digest.exports_count as u64;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add `CoreStatistics::add_digest()` and `ServiceStatistics::add_digest()` methods in grey-types to encapsulate the 5-6 line digest field accumulation pattern
- Add matching `CoreStats::add_digest()` and `ServiceStats::add_digest()` methods in reports.rs (which has its own local stats types)
- Replace 4 inline accumulation loops (2 in statistics.rs, 2 in reports.rs) with single method calls

Addresses #186.

## Scope

This PR addresses: deduplicate digest field accumulation across statistics.rs and reports.rs

Remaining sub-tasks in #186:
- Epoch/slot computations inlined in safrole.rs and authoring.rs
- Near-identical PVM kernel event loops in refine.rs

## Test plan

- `cargo test -p grey-state` — all 102 tests pass including STF statistics vectors
- `cargo clippy -p grey-state -p grey-types -- -D warnings` — clean