### PR TITLE
fix(grey-state): remove dead TransitionError::AccumulationError variant

### DIFF
--- a/grey/crates/grey-state/src/lib.rs
+++ b/grey/crates/grey-state/src/lib.rs
@@ -132,9 +132,6 @@ pub enum TransitionError {
 
     #[error("invalid extrinsic: {0}")]
     InvalidExtrinsic(String),
-
-    #[error("accumulation error: {0}")]
-    AccumulationError(String),
 }
 
 /// Apply a block to the current state, producing a new state (eq 4.1).


### PR DESCRIPTION
## Summary

- Remove `TransitionError::AccumulationError(String)` — defined but never constructed anywhere in the codebase
- The `grey-services` crate has its own properly-typed `AccumulationError` enum that is used instead

Fixes #668.

## Test plan

- `cargo test -p grey-state` — all 102 tests pass
- `cargo clippy -p grey-state -- -D warnings` — clean
- `grep -r 'TransitionError::AccumulationError' grey/` confirms zero usages