### PR TITLE
refactor: extract Config::one_third_of to deduplicate threshold calculation

### DIFF
--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -59,9 +59,8 @@ pub fn process_disputes(
     current_validators: &[ValidatorKey],
     previous_validators: &[ValidatorKey],
 ) -> Result<DisputeOutput, DisputeError> {
-    let val_count = current_validators.len() as u16;
     let super_majority = Config::super_majority_of(current_validators.len()) as u16;
-    let one_third = val_count / 3;
+    let one_third = Config::one_third_of(current_validators.len()) as u16;
     let current_epoch = current_timeslot / config.epoch_length;
 
     // eq 10.10: Judgments within each verdict must be sorted by validator index, no duplicates

--- a/grey/crates/grey-state/src/transition.rs
+++ b/grey/crates/grey-state/src/transition.rs
@@ -168,7 +168,7 @@ fn apply_judgments(
 ) {
     let val_count = state.current_validators.len();
     let supermajority = Config::super_majority_of(val_count);
-    let one_third = val_count / 3;
+    let one_third = Config::one_third_of(val_count);
 
     // Process verdicts (eq 10.12-10.19)
     for verdict in &disputes.verdicts {

--- a/grey/crates/grey-types/src/config.rs
+++ b/grey/crates/grey-types/src/config.rs
@@ -92,6 +92,11 @@ impl Config {
         (count * 2 / 3) + 1
     }
 
+    /// One-third threshold for a given validator count. GP#514.
+    pub fn one_third_of(count: usize) -> usize {
+        count / 3
+    }
+
     /// Valid validator count: multiples of 3 in [6, 3*(C+1)]. GP#514.
     pub fn is_valid_val_count(&self, z: u16) -> bool {
         z >= 6 && z <= 3 * (self.core_count + 1) && z.is_multiple_of(3)


### PR DESCRIPTION
## Summary

- Add `Config::one_third_of(count)` alongside the existing `super_majority_of(count)`
- Replace inline `val_count / 3` in disputes.rs and transition.rs with the new helper
- Also removes the now-unused `val_count` binding in disputes.rs

Addresses #186.

## Scope

This PR addresses: deduplicate one-third threshold calculation across disputes.rs and transition.rs

Remaining sub-tasks in #186:
- Near-identical PVM kernel event loops in refine.rs
- Epoch/slot computations inlined in safrole.rs and authoring.rs

## Test plan

- `cargo test -p grey-state` — all 102 tests pass
- `cargo clippy -p grey-state -p grey-types -- -D warnings` — clean