### PR TITLE
refactor(grey): deduplicate filter_offenders across crates

### DIFF
--- a/grey/crates/grey-consensus/src/safrole.rs
+++ b/grey/crates/grey-consensus/src/safrole.rs
@@ -53,15 +53,8 @@ pub fn fallback_key_sequence(
 ///
 /// Replaces any validator whose Ed25519 key is in the offenders set with the null key.
 pub fn filter_offenders(keys: &[ValidatorKey], offenders: &Judgments) -> Vec<ValidatorKey> {
-    keys.iter()
-        .map(|k| {
-            if offenders.offenders.contains(&k.ed25519) {
-                ValidatorKey::null()
-            } else {
-                k.clone()
-            }
-        })
-        .collect()
+    let offender_slice: Vec<_> = offenders.offenders.iter().cloned().collect();
+    grey_state::safrole::filter_offenders(keys, &offender_slice)
 }
 
 /// Accumulate entropy (eq 6.22).

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -261,7 +261,7 @@ pub(crate) fn accumulate_entropy(eta0: &Hash, entropy: &Hash) -> Hash {
 }
 
 /// Filter offenders from a validator key set (eq 6.14: Φ).
-fn filter_offenders(keys: &[ValidatorKey], offenders: &[Ed25519PublicKey]) -> Vec<ValidatorKey> {
+pub fn filter_offenders(keys: &[ValidatorKey], offenders: &[Ed25519PublicKey]) -> Vec<ValidatorKey> {
     let offender_set: BTreeSet<_> = offenders.iter().collect();
     keys.iter()
         .map(|k| {

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -261,7 +261,10 @@ pub(crate) fn accumulate_entropy(eta0: &Hash, entropy: &Hash) -> Hash {
 }
 
 /// Filter offenders from a validator key set (eq 6.14: Φ).
-pub fn filter_offenders(keys: &[ValidatorKey], offenders: &[Ed25519PublicKey]) -> Vec<ValidatorKey> {
+pub fn filter_offenders(
+    keys: &[ValidatorKey],
+    offenders: &[Ed25519PublicKey],
+) -> Vec<ValidatorKey> {
     let offender_set: BTreeSet<_> = offenders.iter().collect();
     keys.iter()
         .map(|k| {


### PR DESCRIPTION
## Summary

- Makes `filter_offenders` in `grey-state::safrole` public
- Changes `grey-consensus::safrole::filter_offenders` to delegate to the grey-state implementation instead of reimplementing the same validator-nulling logic

Addresses #186.

## Scope

This PR addresses: duplicated `filter_offenders` function across grey-state and grey-consensus.

Remaining sub-tasks in #186:
- Near-identical PVM kernel event loops in refine.rs
- Epoch/slot computations inlined in safrole.rs and authoring.rs

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test -p grey-consensus` passes (filter_offenders tests exercise the delegated path)
- No behavioral change — both implementations had identical logic