### PR TITLE
refactor(grey): add Config::epoch_of and slot_in_epoch helpers

### DIFF
--- a/grey/crates/grey-consensus/src/authoring.rs
+++ b/grey/crates/grey-consensus/src/authoring.rs
@@ -57,7 +57,7 @@ pub fn is_slot_author_with_keypair(
     bandersnatch_pubkey: &BandersnatchPublicKey,
     keypair: Option<&grey_crypto::BandersnatchKeypair>,
 ) -> Option<u16> {
-    let slot_in_epoch = timeslot % config.epoch_length;
+    let slot_in_epoch = config.slot_in_epoch(timeslot);
 
     match &state.safrole.seal_key_series {
         SealKeySeries::Fallback(keys) => {
@@ -152,8 +152,8 @@ pub fn author_block_with_extrinsics(
     let vrf_signature = BandersnatchSignature(vrf_sig_bytes);
 
     // Build epoch marker if crossing epoch boundary
-    let old_epoch = state.timeslot / config.epoch_length;
-    let new_epoch = timeslot / config.epoch_length;
+    let old_epoch = config.epoch_of(state.timeslot);
+    let new_epoch = config.epoch_of(timeslot);
     let epoch_marker = if new_epoch > old_epoch {
         Some(EpochMarker {
             entropy: state.entropy[0],
@@ -170,8 +170,8 @@ pub fn author_block_with_extrinsics(
     };
 
     // Build winning tickets marker if crossing Y boundary
-    let old_slot = state.timeslot % config.epoch_length;
-    let new_slot = timeslot % config.epoch_length;
+    let old_slot = config.slot_in_epoch(state.timeslot);
+    let new_slot = config.slot_in_epoch(timeslot);
     let y = config.ticket_submission_end();
     let tickets_marker = if new_epoch == old_epoch
         && old_slot < y

--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -61,7 +61,7 @@ pub fn process_disputes(
 ) -> Result<DisputeOutput, DisputeError> {
     let super_majority = Config::super_majority_of(current_validators.len()) as u16;
     let one_third = Config::one_third_of(current_validators.len()) as u16;
-    let current_epoch = current_timeslot / config.epoch_length;
+    let current_epoch = config.epoch_of(current_timeslot);
 
     // eq 10.10: Judgments within each verdict must be sorted by validator index, no duplicates
     for verdict in &disputes.verdicts {

--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -171,7 +171,6 @@ pub fn process_reports(
     let num_cores = config.core_count as usize;
     let num_validators = state.curr_validators.len();
     let rotation_period = config.rotation_period();
-    let epoch_length = config.epoch_length;
 
     // eq 11.24: Guarantees must be sorted by core_index
     if !crate::is_strictly_sorted_by_key(guarantees, |g| g.report.core_index) {
@@ -188,7 +187,7 @@ pub fn process_reports(
     let assignment_m =
         compute_core_assignments(config, &state.entropy[2], current_slot, num_validators);
     let prev_timeslot = current_slot.saturating_sub(rotation_period);
-    let prev_same_epoch = prev_timeslot / epoch_length == current_slot / epoch_length;
+    let prev_same_epoch = config.epoch_of(prev_timeslot) == config.epoch_of(current_slot);
     let prev_entropy = if prev_same_epoch {
         &state.entropy[2]
     } else {

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -102,10 +102,10 @@ pub fn process_safrole(
     }
 
     // eq 6.2: Compute epoch indices
-    let old_epoch = pre.tau / e;
-    let new_epoch = input.slot / e;
-    let old_slot_in_epoch = pre.tau % e;
-    let new_slot_in_epoch = input.slot % e;
+    let old_epoch = config.epoch_of(pre.tau);
+    let new_epoch = config.epoch_of(input.slot);
+    let old_slot_in_epoch = config.slot_in_epoch(pre.tau);
+    let new_slot_in_epoch = config.slot_in_epoch(input.slot);
     let is_epoch_change = new_epoch > old_epoch;
 
     // Validate ticket extrinsic (eq 6.30)

--- a/grey/crates/grey-state/src/statistics.rs
+++ b/grey/crates/grey-state/src/statistics.rs
@@ -29,8 +29,8 @@ pub fn update_statistics(
     available_reports: &[WorkReport],
     accumulation_stats: &std::collections::BTreeMap<grey_types::ServiceId, (javm::Gas, u32)>,
 ) {
-    let old_epoch = prior_timeslot / config.epoch_length;
-    let new_epoch = new_timeslot / config.epoch_length;
+    let old_epoch = config.epoch_of(prior_timeslot);
+    let new_epoch = config.epoch_of(new_timeslot);
 
     let num_validators = stats.current.len();
 

--- a/grey/crates/grey-types/src/config.rs
+++ b/grey/crates/grey-types/src/config.rs
@@ -97,6 +97,16 @@ impl Config {
         count / 3
     }
 
+    /// Epoch index for a given timeslot: floor(τ / E).
+    pub fn epoch_of(&self, timeslot: u32) -> u32 {
+        timeslot / self.epoch_length
+    }
+
+    /// Slot position within an epoch: τ mod E.
+    pub fn slot_in_epoch(&self, timeslot: u32) -> u32 {
+        timeslot % self.epoch_length
+    }
+
     /// Valid validator count: multiples of 3 in [6, 3*(C+1)]. GP#514.
     pub fn is_valid_val_count(&self, z: u16) -> bool {
         z >= 6 && z <= 3 * (self.core_count + 1) && z.is_multiple_of(3)
@@ -248,6 +258,29 @@ mod tests {
         assert_eq!(c.rotations_per_epoch(), 3);
         let c = Config::full(); // E=600, R=10
         assert_eq!(c.rotations_per_epoch(), 60);
+    }
+
+    #[test]
+    fn test_epoch_of() {
+        let c = Config::tiny(); // E=12
+        assert_eq!(c.epoch_of(0), 0);
+        assert_eq!(c.epoch_of(11), 0);
+        assert_eq!(c.epoch_of(12), 1);
+        assert_eq!(c.epoch_of(25), 2);
+        let c = Config::full(); // E=600
+        assert_eq!(c.epoch_of(599), 0);
+        assert_eq!(c.epoch_of(600), 1);
+    }
+
+    #[test]
+    fn test_slot_in_epoch() {
+        let c = Config::tiny(); // E=12
+        assert_eq!(c.slot_in_epoch(0), 0);
+        assert_eq!(c.slot_in_epoch(5), 5);
+        assert_eq!(c.slot_in_epoch(12), 0);
+        assert_eq!(c.slot_in_epoch(15), 3);
+        let c = Config::full(); // E=600
+        assert_eq!(c.slot_in_epoch(601), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `Config::epoch_of(timeslot)` and `Config::slot_in_epoch(timeslot)` helper methods
- Replaces inline `timeslot / config.epoch_length` and `timeslot % config.epoch_length` at 8 call sites across disputes.rs, statistics.rs, safrole.rs, reports.rs, and authoring.rs
- Removes a now-unused local `epoch_length` binding in reports.rs

Addresses #186.

## Scope

This PR addresses: inlined epoch/slot computations across grey-state and grey-consensus.

Remaining sub-tasks in #186:
- Near-identical PVM kernel event loops in refine.rs

## Test plan

- New unit tests for `epoch_of` and `slot_in_epoch` with both tiny and full configs
- `cargo test -p grey-types -- config` passes (13 tests)
- `cargo test -p grey-state` passes
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- No behavioral change — pure extraction of inline arithmetic into named helpers