### PR TITLE
refactor(grey-erasure): migrate ErasureError to thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "reed-solomon-simd",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/grey/crates/grey-erasure/Cargo.toml
+++ b/grey/crates/grey-erasure/Cargo.toml
@@ -8,6 +8,7 @@ description = "Reed-Solomon erasure coding in GF(2^16) for JAM data availability
 [dependencies]
 grey-types = { workspace = true }
 reed-solomon-simd = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/grey/crates/grey-erasure/src/lib.rs
+++ b/grey/crates/grey-erasure/src/lib.rs
@@ -37,35 +37,24 @@ impl ErasureParams {
 }
 
 /// Errors from erasure coding operations.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErasureError {
     /// Not enough chunks to recover (need at least data_shards).
+    #[error("insufficient chunks: have {have}, need {need}")]
     InsufficientChunks { have: usize, need: usize },
     /// Invalid chunk index (>= total_shards).
+    #[error("invalid chunk index: {0}")]
     InvalidIndex(usize),
     /// Chunk size mismatch.
+    #[error("chunk size mismatch")]
     SizeMismatch,
     /// RS encoding failed.
+    #[error("encoding failed: {0}")]
     EncodingFailed(String),
     /// RS recovery failed.
+    #[error("recovery failed: {0}")]
     RecoveryFailed(String),
 }
-
-impl std::fmt::Display for ErasureError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InsufficientChunks { have, need } => {
-                write!(f, "insufficient chunks: have {have}, need {need}")
-            }
-            Self::InvalidIndex(idx) => write!(f, "invalid chunk index: {idx}"),
-            Self::SizeMismatch => write!(f, "chunk size mismatch"),
-            Self::EncodingFailed(e) => write!(f, "encoding failed: {e}"),
-            Self::RecoveryFailed(e) => write!(f, "recovery failed: {e}"),
-        }
-    }
-}
-
-impl std::error::Error for ErasureError {}
 
 /// Encode a data blob into `total_shards` coded chunks (eq H.4).
 ///


### PR DESCRIPTION
## Summary

- Replaces hand-rolled `Display` and `Error` impls on `ErasureError` with `#[derive(thiserror::Error)]`
- Adds `thiserror` as a dependency to `grey-erasure`
- Follows codebase convention: "thiserror for errors" (AGENTS.md)

Addresses #186.

## Scope

This PR addresses: hand-rolled error type in grey-erasure.

Remaining sub-tasks in #186:
- `KernelError` and `VmStateError` in javm still use hand-rolled Display

## Test plan

- `cargo test -p grey-erasure` passes (24 tests)
- `cargo clippy -p grey-erasure -- -D warnings` clean
- No behavioral change — identical Display output