### PR TITLE
refactor(javm): migrate KernelError and VmStateError to thiserror

### DIFF
--- a/grey/crates/javm/src/kernel.rs
+++ b/grey/crates/javm/src/kernel.rs
@@ -2510,29 +2510,22 @@ pub enum FaultType {
 }
 
 /// Kernel errors.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum KernelError {
+    #[error("invalid JAR blob")]
     InvalidBlob,
+    #[error("memory allocation failed")]
     MemoryError,
+    #[error("insufficient gas for initialization")]
     OutOfGas,
+    #[error("untyped pool exhausted")]
     OutOfMemory,
+    #[error("exceeded max CODE caps ({MAX_CODE_CAPS})")]
     TooManyCodeCaps,
+    #[error("cap table full")]
     CapTableFull,
+    #[error("JIT compilation failed")]
     CompileError,
-}
-
-impl core::fmt::Display for KernelError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::InvalidBlob => write!(f, "invalid JAR blob"),
-            Self::MemoryError => write!(f, "memory allocation failed"),
-            Self::OutOfGas => write!(f, "insufficient gas for initialization"),
-            Self::OutOfMemory => write!(f, "untyped pool exhausted"),
-            Self::TooManyCodeCaps => write!(f, "exceeded max CODE caps ({MAX_CODE_CAPS})"),
-            Self::CapTableFull => write!(f, "cap table full"),
-            Self::CompileError => write!(f, "JIT compilation failed"),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/grey/crates/javm/src/vm_pool.rs
+++ b/grey/crates/javm/src/vm_pool.rs
@@ -156,20 +156,11 @@ pub struct CallFrame {
 }
 
 /// Errors from VM state transitions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("invalid VM state transition: {from:?} -> {to:?}")]
 pub struct VmStateError {
     pub from: VmState,
     pub to: VmState,
-}
-
-impl core::fmt::Display for VmStateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "invalid VM state transition: {:?} -> {:?}",
-            self.from, self.to
-        )
-    }
 }
 
 /// Maximum number of CODE caps per invocation.


### PR DESCRIPTION
## Summary

- Replaces hand-rolled `Display` impl on `KernelError` with `#[derive(thiserror::Error)]`
- Replaces hand-rolled `Display` impl on `VmStateError` with `#[derive(thiserror::Error)]`
- Both types now also implement `std::error::Error` (previously missing)

Addresses #186.

## Scope

This PR addresses: hand-rolled error types in javm (kernel.rs and vm_pool.rs).

## Test plan

- `cargo test -p javm` passes (140 tests)
- `cargo clippy -p javm -- -D warnings` clean
- No behavioral change — identical Display output