### PR TITLE
fix(grey-bench): increase gas budget for mem benchmarks

### DIFF
--- a/grey/crates/grey-bench/benches/mem_bench.rs
+++ b/grey/crates/grey-bench/benches/mem_bench.rs
@@ -11,10 +11,18 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use grey_bench::mem::*;
 
 /// Compute gas limit proportional to working set size.
+///
+/// Each loop iteration has multiple instructions (load/store + add + add +
+/// branch), and there is both an init loop (n_elems stores) and sweep loops
+/// (n_elems * SWEEPS loads). Budget generously to avoid OutOfGas on large
+/// working sets.
 fn gas_for_size(size_bytes: u64) -> u64 {
     let n_elems = size_bytes / 4;
-    let loads = n_elems * 15; // SWEEPS
-    loads * 100 + 10_000_000
+    let sweeps = 15u64;
+    // ~4 instructions per iteration, ~100 gas each, plus 2x headroom
+    let init_cost = n_elems * 800;
+    let sweep_cost = n_elems * sweeps * 800;
+    init_cost + sweep_cost + 10_000_000
 }
 
 const SIZES: &[(&str, u64)] = &[


### PR DESCRIPTION
## Summary

- Fixes OutOfGas panic in `mem_seq/128M` and `mem_rand/128M` benchmarks
- The gas formula now accounts for both the init loop and sweep loops, with ~4 instructions per iteration and 2x headroom
- All smaller sizes (4K–32M) continue to work with the updated budget

Fixes #681.

## Test plan

- `cargo check -p grey-bench` compiles cleanly
- `cargo clippy -p grey-bench -- -D warnings` passes
- Verify fix: `POLKAVM_ALLOW_EXPERIMENTAL=1 cargo bench -p grey-bench -- mem_seq/128M` should complete without panic