### PR TITLE
refactor(grey): add Config::rotation_of and rotation_in_epoch helpers

### DIFF
--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -250,16 +250,8 @@ pub fn process_reports(
         }
 
         // Determine which rotation this guarantee belongs to
-        let current_rot = if rotation_period > 0 {
-            current_slot / rotation_period
-        } else {
-            0
-        };
-        let guarantee_rot = if rotation_period > 0 {
-            guarantee.slot / rotation_period
-        } else {
-            0
-        };
+        let current_rot = config.rotation_of(current_slot);
+        let guarantee_rot = config.rotation_of(guarantee.slot);
 
         // Report slot must not be in the future
         if guarantee.slot > current_slot {
@@ -470,8 +462,6 @@ fn compute_core_assignments(
 ) -> Vec<usize> {
     let v = validator_count;
     let c = config.core_count as usize;
-    let r = config.rotation_period();
-    let e = config.epoch_length;
 
     // Step 1: initial assignment [floor(C*i/V) | i < V]
     let mut cores: Vec<usize> = (0..v).map(|i| c * i / v).collect();
@@ -480,11 +470,7 @@ fn compute_core_assignments(
     grey_crypto::shuffle::shuffle_with_hash(&mut cores, entropy);
 
     // Step 3: Apply rotation R(c, n) = [(x + n) mod C | x <- c]
-    let rot_offset = if r > 0 {
-        ((timeslot % e) / r) as usize
-    } else {
-        0
-    };
+    let rot_offset = config.rotation_in_epoch(timeslot) as usize;
     for core in &mut cores {
         *core = (*core + rot_offset) % c;
     }

--- a/grey/crates/grey-types/src/config.rs
+++ b/grey/crates/grey-types/src/config.rs
@@ -122,6 +122,22 @@ impl Config {
         self.rotation_period_val
     }
 
+    /// Rotation index for a given timeslot: floor(τ / R).
+    pub fn rotation_of(&self, timeslot: u32) -> u32 {
+        let r = self.rotation_period();
+        if r > 0 { timeslot / r } else { 0 }
+    }
+
+    /// Rotation offset within an epoch: floor((τ mod E) / R).
+    pub fn rotation_in_epoch(&self, timeslot: u32) -> u32 {
+        let r = self.rotation_period();
+        if r > 0 {
+            self.slot_in_epoch(timeslot) / r
+        } else {
+            0
+        }
+    }
+
     /// G: Number of guarantors per core = floor(V / C).
     pub fn guarantors_per_core(&self) -> u16 {
         self.validators_count / self.core_count
@@ -281,6 +297,43 @@ mod tests {
         assert_eq!(c.slot_in_epoch(15), 3);
         let c = Config::full(); // E=600
         assert_eq!(c.slot_in_epoch(601), 1);
+    }
+
+    #[test]
+    fn test_rotation_of() {
+        let c = Config::tiny(); // R=4
+        assert_eq!(c.rotation_of(0), 0);
+        assert_eq!(c.rotation_of(3), 0);
+        assert_eq!(c.rotation_of(4), 1);
+        assert_eq!(c.rotation_of(9), 2);
+        let c = Config::full(); // R=10
+        assert_eq!(c.rotation_of(0), 0);
+        assert_eq!(c.rotation_of(9), 0);
+        assert_eq!(c.rotation_of(10), 1);
+        assert_eq!(c.rotation_of(25), 2);
+    }
+
+    #[test]
+    fn test_rotation_in_epoch() {
+        let c = Config::tiny(); // E=12, R=4
+        assert_eq!(c.rotation_in_epoch(0), 0); // slot_in_epoch=0, 0/4=0
+        assert_eq!(c.rotation_in_epoch(4), 1); // slot_in_epoch=4, 4/4=1
+        assert_eq!(c.rotation_in_epoch(8), 2); // slot_in_epoch=8, 8/4=2
+        assert_eq!(c.rotation_in_epoch(12), 0); // slot_in_epoch=0 (new epoch), 0/4=0
+        assert_eq!(c.rotation_in_epoch(16), 1); // slot_in_epoch=4, 4/4=1
+        let c = Config::full(); // E=600, R=10
+        assert_eq!(c.rotation_in_epoch(0), 0);
+        assert_eq!(c.rotation_in_epoch(10), 1);
+        assert_eq!(c.rotation_in_epoch(599), 59); // slot 599 / 10 = 59
+        assert_eq!(c.rotation_in_epoch(600), 0); // new epoch
+    }
+
+    #[test]
+    fn test_rotation_of_zero_period() {
+        let mut c = Config::tiny();
+        c.rotation_period_val = 0;
+        assert_eq!(c.rotation_of(100), 0);
+        assert_eq!(c.rotation_in_epoch(100), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `Config::rotation_of(timeslot)` and `Config::rotation_in_epoch(timeslot)` helpers with div-by-zero protection
- Replace inline rotation arithmetic in `reports.rs` with the new helpers
- Follow the established pattern from `epoch_of()`/`slot_in_epoch()` (PR #677)

Addresses #186.

## Scope

This PR addresses: extract rotation index computation into Config domain helpers.

Remaining sub-tasks in #186:
- stf_error! macro migration to thiserror (complex due to as_str() compatibility)
- Further structural improvements in large files

## Test plan

- All 43 STF reports test vectors pass
- New unit tests for `rotation_of`, `rotation_in_epoch`, and zero-period edge case
- `cargo clippy` and `cargo fmt` clean