### PR TITLE
feat: activate v3 Bradley-Terry ranking at 2026-04-10 14:00 UTC

### DIFF
--- a/spec/Genesis/State.lean
+++ b/spec/Genesis/State.lean
@@ -49,7 +49,7 @@ def founderWeight : Nat := 1
 def genesisSchedule : List (Epoch × GenesisVariant) :=
   [ (0, GenesisVariant.v1)
   , (1774188000, GenesisVariant.v2)  -- 2026-03-22 14:00 UTC: rank-based target selection
-  , (4102444800, GenesisVariant.v3)  -- 2100-01-01 00:00 UTC: Bradley-Terry ranking (inactive placeholder)
+  , (1775829600, GenesisVariant.v3)  -- 2026-04-10 14:00 UTC: Bradley-Terry ranking
   ]
 
 /-- Resolve the active variant for a given epoch. -/


### PR DESCRIPTION
## Summary

- Set v3 activation epoch to `1775829600` (2026-04-10 14:00 UTC)
- PRs created after this time will use Bradley-Terry ranking with variance-weighted target selection

All v3 infrastructure is already live:
- #656: Lean spec — global ranking variant + variances plumbing
- #659: Rust tooling — scores.json, defensive snapshots, variances

## Test plan

- [x] `lake build genesis` — builds
- [x] `make test` — 26/26 genesis tests pass
- [x] `replay --mode verify` — 587/587 indices match (activation epoch is in the future, no behavioral change for existing commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)