### PR TITLE
refactor(grey-store): deduplicate get_service_code_hash via get_service_metadata

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -432,24 +432,14 @@ impl Store {
     }
 
     /// Look up a service account's code hash directly from state KVs.
-    /// The service metadata is at key C(255, service_id), and code_hash is bytes [1..33].
     pub fn get_service_code_hash(
         &self,
         block_hash: &Hash,
         service_id: u32,
     ) -> Result<Option<Hash>, StoreError> {
-        let kvs = self.load_state_kvs(block_hash)?;
-        let expected_key = grey_merkle::state_key_for_service(255, service_id);
-        Ok(Self::find_in_kvs(&kvs, &expected_key).and_then(|value| {
-            // Service account: version(1) + code_hash(32) + ...
-            if value.len() >= 33 {
-                let mut h = [0u8; 32];
-                h.copy_from_slice(&value[1..33]);
-                Some(Hash(h))
-            } else {
-                None
-            }
-        }))
+        Ok(self
+            .get_service_metadata(block_hash, service_id)?
+            .map(|m| m.code_hash))
     }
 
     /// Look up a service account's metadata (all fixed-size header fields).


### PR DESCRIPTION
## Summary

- Implement `get_service_code_hash` by delegating to `get_service_metadata` instead of duplicating the state KV lookup + manual byte slicing
- Reduces 13 lines to 3 while preserving identical behavior

Addresses #186.

## Scope

This PR addresses: deduplicate service code hash lookup in grey-store.

Remaining sub-tasks in #186:
- stf_error! macro consolidation (complex due to as_str() compatibility)
- Further structural improvements in large files

## Test plan

- `test_get_service_code_hash` passes (existing test, unchanged)
- All 37 grey-store tests pass
- `cargo clippy` and `cargo fmt` clean