### PR TITLE
refactor(grey): deduplicate compute_state_root across testnet modules

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1485,7 +1485,7 @@ fn insert_bounded(set: &mut std::collections::HashSet<Hash>, item: Hash, cap: us
 }
 
 /// Compute a simplified state root.
-fn compute_state_root(state: &State) -> Hash {
+pub(crate) fn compute_state_root(state: &State) -> Hash {
     let mut data = Vec::new();
     data.extend_from_slice(&state.timeslot.to_le_bytes());
     data.extend_from_slice(&state.entropy[0].0);

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -173,12 +173,7 @@ pub async fn run_seq_testnet(
                 let node = &mut nodes[i];
 
                 // Compute state root
-                let state_root = {
-                    let mut data = Vec::new();
-                    data.extend_from_slice(&node.state.timeslot.to_le_bytes());
-                    data.extend_from_slice(&node.state.entropy[0].0);
-                    grey_crypto::blake2b_256(&data)
-                };
+                let state_root = crate::node::compute_state_root(&node.state);
 
                 // Collect guarantees (from RPC submissions)
                 let mut guarantees = std::mem::take(&mut pending_guarantees);

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -285,12 +285,7 @@ pub fn run_sequential_test(num_blocks: u32) -> Result<SequentialTestResult, Stri
                 Some(&s.bandersnatch),
             ) {
                 // Compute state root
-                let state_root = {
-                    let mut data = Vec::new();
-                    data.extend_from_slice(&state.timeslot.to_le_bytes());
-                    data.extend_from_slice(&state.entropy[0].0);
-                    grey_crypto::blake2b_256(&data)
-                };
+                let state_root = crate::node::compute_state_root(&state);
 
                 // Determine extrinsics based on pipeline state
                 let (guarantees, assurances) = match &wp_phase {


### PR DESCRIPTION
## Summary

- Make `compute_state_root` in `node.rs` `pub(crate)` instead of private
- Replace identical 5-line inline blocks in `testnet.rs` and `seq_testnet.rs` with calls to the shared function

Addresses #186.

## Scope

This PR addresses: deduplicate state root computation across node, testnet, and seq_testnet modules.

Remaining sub-tasks in #186:
- stf_error! macro consolidation (complex due to as_str() compatibility)
- Further structural improvements in large files

## Test plan

- `cargo clippy -p grey -- -D warnings` passes
- `cargo fmt --all` clean
- No behavioral change — pure refactoring