### PR TITLE
refactor(grey-services): eliminate double blake2b_256 in integrate_preimages

### DIFF
--- a/grey/crates/grey-services/src/accumulation.rs
+++ b/grey/crates/grey-services/src/accumulation.rs
@@ -340,12 +340,15 @@ pub fn accumulate_all(
     }
 }
 
+/// Check if a preimage with a pre-computed hash and length is solicited.
+fn is_solicited_by_key(account: &ServiceAccount, hash: &Hash, len: u32) -> bool {
+    account.preimage_info.contains_key(&(*hash, len)) && !account.preimage_lookup.contains_key(hash)
+}
+
 /// Check if a preimage is solicited but not yet provided for a service (eq 12.36: Y).
 pub fn is_preimage_solicited(account: &ServiceAccount, data: &[u8]) -> bool {
     let hash = grey_crypto::blake2b_256(data);
-    let len = data.len() as u32;
-    // Solicited means: entry exists in preimage_info but NOT in preimage_lookup
-    account.preimage_info.contains_key(&(hash, len)) && !account.preimage_lookup.contains_key(&hash)
+    is_solicited_by_key(account, &hash, data.len() as u32)
 }
 
 /// Integrate preimage extrinsics into service state (eq 12.37-12.38).
@@ -360,12 +363,12 @@ pub fn integrate_preimages(
     timeslot: Timeslot,
 ) {
     for (service_id, data) in preimages {
-        if let Some(account) = services.get_mut(service_id)
-            && is_preimage_solicited(account, data)
-        {
-            let hash = grey_crypto::blake2b_256(data);
-            let len = data.len() as u32;
+        let hash = grey_crypto::blake2b_256(data);
+        let len = data.len() as u32;
 
+        if let Some(account) = services.get_mut(service_id)
+            && is_solicited_by_key(account, &hash, len)
+        {
             // Store the actual data
             account.preimage_lookup.insert(hash, data.clone());
 


### PR DESCRIPTION
## Summary

- Extract `is_solicited_by_key` helper that accepts a pre-computed hash and length
- Avoid redundant `blake2b_256` computation in `integrate_preimages` — the hash was computed once in `is_preimage_solicited` then immediately recomputed

Addresses #186.

## Scope

This PR addresses: eliminate redundant blake2b_256 hash computation in preimage integration.

Remaining sub-tasks in #186:
- stf_error! macro consolidation (complex due to as_str() compatibility)
- Further structural improvements in large files

## Test plan

- All 7 preimage-related tests pass (including proptest)
- `cargo clippy` and `cargo fmt` clean
- No behavioral change — same logic, fewer hash computations