### PR TITLE
refactor(grey): remove dead threshold parameter from reports_needing_escalation

### DIFF
--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -115,22 +115,23 @@ impl AuditState {
     }
 
     /// Check if any report has conflicting announcements (escalation needed).
-    pub fn reports_needing_escalation(&self, threshold: usize) -> Vec<Hash> {
+    pub fn reports_needing_escalation(&self) -> Vec<Hash> {
         let mut escalations = Vec::new();
         for (hash, announcements) in &self.announcements {
-            let valid_count = announcements.iter().filter(|a| a.is_valid).count();
-            let invalid_count = announcements.iter().filter(|a| !a.is_valid).count();
-            // Escalate if there are both valid and invalid announcements
-            if valid_count > 0 && invalid_count > 0 {
-                escalations.push(*hash);
-            }
-            // Also escalate if enough announcements to trigger it
-            if valid_count + invalid_count >= threshold && valid_count > 0 && invalid_count > 0 {
-                escalations.push(*hash);
+            let mut has_valid = false;
+            let mut has_invalid = false;
+            for a in announcements {
+                if a.is_valid {
+                    has_valid = true;
+                } else {
+                    has_invalid = true;
+                }
+                if has_valid && has_invalid {
+                    escalations.push(*hash);
+                    break;
+                }
             }
         }
-        escalations.sort();
-        escalations.dedup();
         escalations
     }
 
@@ -420,7 +421,7 @@ mod tests {
         });
 
         // No escalation with only valid announcements
-        assert!(state.reports_needing_escalation(3).is_empty());
+        assert!(state.reports_needing_escalation().is_empty());
 
         // Add conflicting invalid announcement
         state.add_announcement(AuditAnnouncement {
@@ -431,7 +432,7 @@ mod tests {
         });
 
         // Should now trigger escalation
-        let escalations = state.reports_needing_escalation(3);
+        let escalations = state.reports_needing_escalation();
         assert_eq!(escalations.len(), 1);
         assert_eq!(escalations[0], hash);
     }

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1229,9 +1229,8 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                 audit_state.add_announcement(ann);
 
                                 // Check for escalations
-                                let escalations = audit_state.reports_needing_escalation(
-                                    protocol.validators_count as usize / 3,
-                                );
+                                let escalations =
+                                    audit_state.reports_needing_escalation();
                                 for hash in &escalations {
                                     tracing::warn!(
                                         "Validator {} ESCALATION needed for report 0x{}",


### PR DESCRIPTION
## Summary

- Remove redundant second `if` block in `reports_needing_escalation` — it was always a strict subset of the first condition (both required `valid_count > 0 && invalid_count > 0`), making the `threshold` parameter dead
- Remove the dead `threshold` parameter and update all 3 call sites
- Replace two `.filter().count()` passes with a single early-exit loop
- Remove now-unnecessary `sort()`/`dedup()` (no duplicates possible with single push)

Addresses #186.

## Scope

This PR addresses: remove dead code in audit escalation check.

Remaining sub-tasks in #186:
- stf_error! macro consolidation (complex due to as_str() compatibility)
- Further structural improvements in large files

## Test plan

- Existing `test_escalation_on_conflict` passes (updated to match new signature)
- `cargo clippy -p grey -- -D warnings` clean
- Logic unchanged: escalation still triggers on any conflict (both valid and invalid announcements for same report)