### PR TITLE
refactor(grey): add Hash::short_hex() to deduplicate truncated hex formatting

### DIFF
--- a/grey/crates/grey-state/src/refine.rs
+++ b/grey/crates/grey-state/src/refine.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 #[derive(Debug, thiserror::Error)]
 pub enum RefineError {
     /// Service code not found for the given code hash.
-    #[error("code not found: 0x{}", hex::encode(&.0.0[..8]))]
+    #[error("code not found: 0x{}", .0.short_hex())]
     CodeNotFound(Hash),
     /// Authorization failed.
     #[error("authorization failed: {0}")]

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -167,6 +167,11 @@ impl Hash {
         hex::encode(self.0)
     }
 
+    /// Encode the first 8 bytes as a hex string for log/debug output.
+    pub fn short_hex(&self) -> String {
+        hex::encode(&self.0[..8])
+    }
+
     /// Parse from a hex string (with optional 0x prefix). Panics on invalid input.
     pub fn from_hex(s: &str) -> Self {
         Self(decode_hex_fixed(s).expect("invalid hex for Hash"))
@@ -367,6 +372,20 @@ mod tests {
         let encoded = h.encode();
         let (decoded, _) = Hash::decode(&encoded).unwrap();
         assert_eq!(decoded, h);
+    }
+
+    #[test]
+    fn test_hash_short_hex() {
+        let h = Hash([
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert_eq!(h.short_hex(), "0123456789abcdef");
+        assert_eq!(h.short_hex().len(), 16); // 8 bytes = 16 hex chars
+
+        // Zero hash
+        assert_eq!(Hash::ZERO.short_hex(), "0000000000000000");
     }
 
     #[test]

--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -195,7 +195,7 @@ pub fn audit_work_report(_config: &Config, report: &WorkReport, _ctx: &dyn Refin
                 // (the guarantor may have had access to code we don't)
                 tracing::warn!(
                     "Audit: code not found for hash 0x{}, skipping item",
-                    hex::encode(&digest.code_hash.0[..8])
+                    digest.code_hash.short_hex()
                 );
                 continue;
             }

--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -187,7 +187,7 @@ pub fn process_work_package(
         chunks.len(),
         chunks.first().map(|c| c.len()).unwrap_or(0),
         bundle_len,
-        hex::encode(&report_hash.0[..8])
+        report_hash.short_hex()
     );
 
     // 5. Sign the guarantee
@@ -205,7 +205,7 @@ pub fn process_work_package(
         "Validator {} created guarantee for core {}, report_hash=0x{}",
         validator_index,
         core_index,
-        hex::encode(&report_hash.0[..8])
+        report_hash.short_hex()
     );
 
     Ok(report_hash)
@@ -343,7 +343,7 @@ pub fn handle_received_guarantee(
     if computed_hash.0 != report_hash {
         tracing::warn!(
             "Received guarantee: report hash mismatch (computed=0x{} vs claimed=0x{})",
-            hex::encode(&computed_hash.0[..8]),
+            computed_hash.short_hex(),
             hex::encode(&report_hash[..8])
         );
         return;
@@ -382,7 +382,7 @@ pub fn handle_received_assurance(data: &[u8], collected_assurances: &mut Vec<Ass
         tracing::info!(
             "Received assurance from validator {}, anchor=0x{}",
             assurance.validator_index,
-            hex::encode(&assurance.anchor.0[..8])
+            assurance.anchor.short_hex()
         );
         collected_assurances.push(assurance);
     } else {

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -80,10 +80,7 @@ fn handle_guarantee_result(
                 all_secrets,
             );
             broadcast_last_guarantee(guarantor_state, net_commands);
-            tracing::info!(
-                "{context}, report_hash=0x{}",
-                hex::encode(&report_hash.0[..8])
-            );
+            tracing::info!("{context}, report_hash=0x{}", report_hash.short_hex());
             Some(report_hash)
         }
         Err(e) => {
@@ -414,7 +411,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                     .recent_blocks
                     .headers
                     .last()
-                    .map(|h| hex::encode(&h.header_hash.0[..8]))
+                    .map(|h| h.header_hash.short_hex())
                     .unwrap_or_else(|| "none".into());
                 tracing::info!(
                     "=== SIGUSR1 debug dump (validator {}) ===\n\
@@ -653,7 +650,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                 if !fresh {
                                     tracing::warn!(
                                         "Pruning stale guarantee: anchor=0x{} not in recent blocks",
-                                        hex::encode(&g.report.context.anchor.0[..8])
+                                        g.report.context.anchor.short_hex()
                                     );
                                 }
                                 fresh
@@ -801,7 +798,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     config.validator_index,
                                     blocks_authored,
                                     current_slot,
-                                    hex::encode(&header_hash.0[..8])
+                                    header_hash.short_hex()
                                 );
 
                                 // Register guarantees from this block for auditing
@@ -905,7 +902,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                 tracing::info!(
                                     "Validator {} audited report 0x{}: {}",
                                     config.validator_index,
-                                    hex::encode(&report_hash.0[..8]),
+                                    report_hash.short_hex(),
                                     if is_valid { "VALID" } else { "INVALID" }
                                 );
                                 let ann_data = audit::encode_announcement(&ann);
@@ -1157,7 +1154,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                                 "Validator {} GRANDPA FINALIZED slot {} hash=0x{}",
                                                 config.validator_index,
                                                 fin_slot,
-                                                hex::encode(&fin_hash.0[..8])
+                                                fin_hash.short_hex()
                                             );
                                             let _ = store.set_finalized(&fin_hash, fin_slot);
 
@@ -1223,7 +1220,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     "Validator {} received valid audit announcement from {} for report 0x{}: {}",
                                     config.validator_index,
                                     source,
-                                    hex::encode(&ann.report_hash.0[..8]),
+                                    ann.report_hash.short_hex(),
                                     if ann.is_valid { "VALID" } else { "INVALID" }
                                 );
                                 audit_state.add_announcement(ann);
@@ -1235,7 +1232,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                     tracing::warn!(
                                         "Validator {} ESCALATION needed for report 0x{}",
                                         config.validator_index,
-                                        hex::encode(&hash.0[..8])
+                                        hash.short_hex()
                                     );
                                 }
                             } else {
@@ -1362,7 +1359,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                             tracing::info!(
                                 "Validator {} received work package via RPC, hash=0x{}",
                                 config.validator_index,
-                                hex::encode(&hash.0[..8])
+                                hash.short_hex()
                             );
 
                             // Decode work package from JAM codec and process it

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -264,7 +264,7 @@ pub async fn run_seq_testnet(
                             let rss_mb = get_rss_mb();
                             tracing::info!(
                                 "Slot {slot}: block #{blocks_produced} by v{author_idx}, hash=0x{}, rss={rss_mb:.1}MB",
-                                hex::encode(&header_hash.0[..8])
+                                header_hash.short_hex()
                             );
                         }
 

--- a/grey/crates/grey/src/testnet.rs
+++ b/grey/crates/grey/src/testnet.rs
@@ -47,7 +47,7 @@ pub async fn run_testnet(
     tracing::info!(
         "Testnet: installed pixels service {} (code_hash=0x{})",
         pixels_service_id,
-        hex::encode(&pixels_code_hash.0[..8])
+        pixels_code_hash.short_hex()
     );
 
     // Populate auth_pool and auth_queue so guarantees pass the authorizer check
@@ -219,7 +219,7 @@ pub fn run_sequential_test(num_blocks: u32) -> Result<SequentialTestResult, Stri
     tracing::info!(
         "Installed PVM service {} with code_hash=0x{}",
         service_id,
-        hex::encode(&code_hash.0[..8])
+        code_hash.short_hex()
     );
 
     // --- Install the pixels service (ID 2000) ---
@@ -231,7 +231,7 @@ pub fn run_sequential_test(num_blocks: u32) -> Result<SequentialTestResult, Stri
     tracing::info!(
         "Installed pixels service {} with code_hash=0x{}",
         pixels_service_id,
-        hex::encode(&pixels_code_hash.0[..8])
+        pixels_code_hash.short_hex()
     );
 
     // Populate auth_pool so guarantees pass the authorizer check.
@@ -321,7 +321,7 @@ pub fn run_sequential_test(num_blocks: u32) -> Result<SequentialTestResult, Stri
                             "  [WP] Submitting {} guarantee at slot {}, core=0, pkg=0x{}",
                             target_label,
                             slot,
-                            hex::encode(&pkg_hash.0[..8])
+                            pkg_hash.short_hex()
                         );
                         wp_phase = WpPhase::GuaranteeSubmitted {
                             slot,
@@ -427,7 +427,7 @@ pub fn run_sequential_test(num_blocks: u32) -> Result<SequentialTestResult, Stri
                             blocks_produced,
                             slot,
                             author_idx,
-                            hex::encode(&header_hash.0[..8]),
+                            header_hash.short_hex(),
                             state.services.len(),
                         );
 


### PR DESCRIPTION
## Summary

- Add `Hash::short_hex()` method that encodes the first 8 bytes as hex, replacing 21 inline `hex::encode(&x.0[..8])` calls across 7 files
- Reduces boilerplate in log/tracing statements throughout the codebase
- Add unit test for `short_hex()` covering normal and zero hash cases

Addresses #186.

## Scope

This PR addresses: repeated inline `hex::encode(&x.0[..8])` pattern for truncated hash display in log output.

Remaining sub-tasks in #186:
- Further duplication patterns across grey crates (e.g. dual SafroleError enums, request-decode arms in grey-network)

## Test plan

- `cargo test -p grey-types -- test_hash_short_hex` passes
- `cargo check --workspace` compiles cleanly
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- All existing tests pass (no behavioral change — output is identical)