### PR TITLE
fix(grey-state): bound count in decode_preimage_info_timeslots to prevent OOM

### DIFF
--- a/grey/crates/grey-state/src/accumulate.rs
+++ b/grey/crates/grey-state/src/accumulate.rs
@@ -23,11 +23,13 @@ pub fn decode_preimage_info_timeslots(data: &[u8]) -> Vec<Timeslot> {
     }
     let count = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
     pos += 4;
+    // Bound count by remaining bytes: each Timeslot is 4 bytes, so count cannot
+    // exceed (data.len() - pos) / 4. Without this guard, a crafted count prefix
+    // (up to u32::MAX) would trigger a multi-GB Vec::with_capacity allocation.
+    let max_count = (data.len() - pos) / 4;
+    let count = count.min(max_count);
     let mut timeslots = Vec::with_capacity(count);
     for _ in 0..count {
-        if pos + 4 > data.len() {
-            break;
-        }
         let t = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
         pos += 4;
         timeslots.push(t);
@@ -1760,6 +1762,15 @@ mod tests {
         data.extend_from_slice(&42u32.to_le_bytes());
         // Gracefully returns what it can parse
         assert_eq!(decode_preimage_info_timeslots(&data), vec![42]);
+    }
+
+    #[test]
+    fn test_decode_preimage_info_timeslots_huge_count_no_oom() {
+        // Adversarial input: count prefix claims u32::MAX items but no payload.
+        // Without the bounds check, Vec::with_capacity(u32::MAX) attempts a ~16GB
+        // allocation and aborts the process.
+        let data = u32::MAX.to_le_bytes();
+        assert_eq!(decode_preimage_info_timeslots(&data), vec![]);
     }
 
     // --- compute_dependencies ---


### PR DESCRIPTION
Round six. I'm now hunting bugs instead of allocations — promotion! Of course "bug hunter" sounds prestigious until you realize my methodology is "read code at 100,000 tokens per minute and feel suspicious about everything." But occasionally a real one falls out.

## What this actually does

`decode_preimage_info_timeslots` in grey-state/src/accumulate.rs reads a u32 count prefix from raw bytes then calls `Vec::with_capacity(count)`. A crafted 4-byte prefix with a large count (up to `u32::MAX`) would attempt a ~16 GB allocation and abort the process.

This is the same decode-time DoS class that #379 fixed in `EpochMarker::decode_with_config` — where a 9-byte crafted length prefix triggered a ~1.4 TB allocation. The pattern snuck back in here because `decode_preimage_info_timeslots` uses raw byte reads instead of going through the SCALE codec's bounds-checked path.

### The fix

Cap `count` at `(data.len() - pos) / 4` before calling `with_capacity`: since each Timeslot is 4 bytes, more items than that cannot possibly fit in the buffer. This preserves the existing graceful-truncation semantics (the original code had a `break` inside the loop when out of bytes) while bounding the allocation to what the data can actually hold.

### Why it matters

Call path: `transition.rs:378` passes opaque state data into this decoder during block application. While opaque data normally comes from prior decoded state, any code path that routes attacker-controlled bytes through here (state sync, future RPC surfaces, fuzz inputs) would hit the allocation abort.

### Regression test

Added `test_decode_preimage_info_timeslots_huge_count_no_oom` that feeds a bare `u32::MAX` prefix with no payload. Without the fix, this test would OOM-abort the test process. With the fix, it returns `vec![]` cleanly. All 7 decode tests pass.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)