### PR TITLE
refactor(grey-types): make super_majority() delegate to super_majority_of()

### DIFF
--- a/grey/crates/grey-types/src/config.rs
+++ b/grey/crates/grey-types/src/config.rs
@@ -84,7 +84,7 @@ impl Config {
 
     /// Validators super-majority threshold: floor(2V/3) + 1.
     pub fn super_majority(&self) -> u16 {
-        (self.validators_count * 2 / 3) + 1
+        Self::super_majority_of(self.validators_count as usize) as u16
     }
 
     /// Supermajority threshold for a given validator count. GP#514.


### PR DESCRIPTION
## Summary

- Make `Config::super_majority()` delegate to `Config::super_majority_of()` instead of reimplementing the same `floor(2V/3)+1` formula
- Single canonical implementation of the supermajority threshold calculation

Addresses #186.

## Scope

This PR addresses: duplicated supermajority formula in Config methods.

Remaining sub-tasks in #186:
- Further duplication patterns across grey crates

## Test plan

- `cargo test -p grey-types -- test_super_majority` — both tests pass (values unchanged)
- `cargo clippy --workspace --all-targets -- -D warnings` passes