### PR TITLE
refactor(grey): use Assurance::has_bit() instead of inline bitfield check

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -666,11 +666,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                         let mut assurance_counts = vec![0u32; num_cores];
                         for a in &assurances {
                             for (core, count) in assurance_counts.iter_mut().enumerate() {
-                                let byte_idx = core / 8;
-                                let bit_idx = core % 8;
-                                if byte_idx < a.bitfield.len()
-                                    && (a.bitfield[byte_idx] >> bit_idx) & 1 == 1
-                                {
+                                if a.has_bit(core) {
                                     *count += 1;
                                 }
                             }


### PR DESCRIPTION
## Summary

- Replace manually inlined bitfield bit-check logic in node.rs with the existing `Assurance::has_bit()` method
- Removes 5 lines of duplicated bit manipulation code

Addresses #186.

## Scope

This PR addresses: inline bitfield check duplicating `Assurance::has_bit()` in node.rs.

Remaining sub-tasks in #186:
- Further duplication patterns across grey crates

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` passes
- No behavioral change — `has_bit()` implements the same logic