### PR TITLE
refactor(grey): replace magic number 30 with audit::MAX_TRANCHES

### DIFF
--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 const TRANCHE_PERIOD_SECS: u64 = 8;
 
 /// Number of initial audit tranches before timeout.
-const MAX_TRANCHES: u32 = 30;
+pub const MAX_TRANCHES: u32 = 30;
 
 /// Announcement of an audit result.
 #[derive(Debug, Clone)]

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -810,7 +810,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                         &state.entropy[0],
                                         &report_hash,
                                         config.validator_index,
-                                        30,
+                                        audit::MAX_TRANCHES,
                                     );
                                     audit_state.add_pending(
                                         report_hash,


### PR DESCRIPTION
## Summary

- Replace hardcoded magic number `30` with the existing `audit::MAX_TRANCHES` constant in `compute_audit_tranche` calls in `node.rs`
- Make `MAX_TRANCHES` pub so it can be used outside the audit module
- Leave the prune window `30` (different concept: audit age in slots) unchanged

Addresses #186.

## Scope

This PR addresses: replacing magic number 30 with named constant for audit tranche computation

Remaining sub-tasks in #186:
- Further deduplication opportunities as they are identified

## Test plan

- `cargo test --workspace` passes (no behavioral change, just constant substitution)
- `cargo clippy --workspace --all-targets -- -D warnings` passes