### PR TITLE
refactor(grey): use to_hex() instead of hex::encode(x.0)

### DIFF
--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -2487,7 +2487,7 @@ mod tests {
         let mut handles = Vec::new();
         for i in 0..100u32 {
             let url = url.clone();
-            let hash_hex = hex::encode(hash.0);
+            let hash_hex = hash.to_hex();
             handles.push(tokio::spawn(async move {
                 let client = HttpClientBuilder::default().build(&url).unwrap();
                 let result: Result<serde_json::Value, _> = match i % 4 {

--- a/grey/crates/grey/src/chainspec.rs
+++ b/grey/crates/grey/src/chainspec.rs
@@ -55,7 +55,7 @@ impl ChainSpec {
         Self {
             name: "Grey JAM".to_string(),
             protocol_version: "0.7.2".to_string(),
-            genesis_hash: hex::encode(genesis_hash.0),
+            genesis_hash: genesis_hash.to_hex(),
             boot_peers,
             config: ChainSpecConfig {
                 validators_count: config.validators_count,
@@ -127,7 +127,7 @@ pub fn print_genesis_info(config: &Config) {
         config.ticket_submission_end()
     );
     println!();
-    println!("Genesis config hash: 0x{}", hex::encode(genesis_hash.0));
+    println!("Genesis config hash: 0x{}", genesis_hash.to_hex());
     println!("Genesis seed hash: {seed_hash}");
 }
 

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -170,10 +170,10 @@ fn persist_and_notify_block(
     }
     if let Some(rpc_st) = rpc_state {
         let _ = rpc_st.block_notifications.send(serde_json::json!({
-            "hash": hex::encode(hash.0),
+            "hash": hash.to_hex(),
             "slot": slot,
             "author_index": block.header.author_index,
-            "parent_hash": hex::encode(block.header.parent_hash.0),
+            "parent_hash": block.header.parent_hash.to_hex(),
             "guarantees": block.extrinsic.guarantees.len(),
             "assurances": block.extrinsic.assurances.len(),
         }));
@@ -236,7 +236,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
     tracing::info!(
         "Validator {} bandersnatch key: 0x{}",
         config.validator_index,
-        hex::encode(my_bandersnatch.0)
+        my_bandersnatch.to_hex()
     );
 
     // Start the network
@@ -1157,7 +1157,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                             // Push finality notification to WebSocket subscribers
                                             if let Some(ref rpc_st) = rpc_state {
                                                 let _ = rpc_st.finality_notifications.send(serde_json::json!({
-                                                    "hash": hex::encode(fin_hash.0),
+                                                    "hash": fin_hash.to_hex(),
                                                     "slot": fin_slot,
                                                     "round": grandpa.round,
                                                 }));
@@ -1409,10 +1409,10 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
             status.finalized_slot = grandpa.finalized_slot;
             status.grandpa_round = grandpa.round;
             if let Ok((h, _)) = store.get_head() {
-                status.head_hash = hex::encode(h.0);
+                status.head_hash = h.to_hex();
             }
             if let Ok((h, _)) = store.get_finalized() {
-                status.finalized_hash = hex::encode(h.0);
+                status.finalized_hash = h.to_hex();
             }
         }
     }

--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -236,7 +236,7 @@ pub async fn run_seq_testnet(
                         // Update RPC status (use try_write to avoid blocking)
                         if let Ok(mut status) = rpc_state.status.try_write() {
                             status.head_slot = slot;
-                            status.head_hash = hex::encode(header_hash.0);
+                            status.head_hash = header_hash.to_hex();
                             status.finalized_slot = finalized_slot;
                             status.blocks_authored = blocks_produced as u64 + 1;
                             status.blocks_imported = blocks_produced as u64 + 1;


### PR DESCRIPTION
## Summary

- Replace 9 instances of `hex::encode(x.0)` with the existing `.to_hex()` method on `Hash` and `BandersnatchPublicKey` types
- Covers node.rs (6), chainspec.rs (2), seq_testnet.rs (1), and grey-rpc (1)
- No behavioral change — `to_hex()` calls `hex::encode(self.0)` internally

Addresses #186.

## Scope

This PR addresses: replacing raw `hex::encode(x.0)` calls with the type's own `to_hex()` method

Remaining sub-tasks in #186:
- Further deduplication opportunities as identified

## Test plan

- `cargo check --workspace` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo fmt --all -- --check` passes
- No behavioral change (to_hex wraps hex::encode internally)