### PR TITLE
refactor(grey-state): consolidate duplicated make_validator test helpers

### DIFF
--- a/grey/crates/grey-state/src/disputes.rs
+++ b/grey/crates/grey-state/src/disputes.rs
@@ -290,28 +290,12 @@ pub fn process_disputes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_hash;
+    use crate::test_helpers::{make_hash, make_validators};
     use grey_types::config::Config;
     use grey_types::header::{DisputesExtrinsic, Judgment, Verdict};
-    use grey_types::validator::ValidatorKey;
 
     fn test_config() -> Config {
         Config::tiny()
-    }
-
-    fn make_ed25519_key(byte: u8) -> Ed25519PublicKey {
-        Ed25519PublicKey([byte; 32])
-    }
-
-    fn make_validators(n: usize) -> Vec<ValidatorKey> {
-        (0..n)
-            .map(|i| ValidatorKey {
-                ed25519: make_ed25519_key(i as u8),
-                bandersnatch: grey_types::BandersnatchPublicKey([i as u8; 32]),
-                bls: grey_types::BlsPublicKey([i as u8; 144]),
-                metadata: [i as u8; 128],
-            })
-            .collect()
     }
 
     fn empty_disputes() -> DisputesExtrinsic {

--- a/grey/crates/grey-state/src/lib.rs
+++ b/grey/crates/grey-state/src/lib.rs
@@ -43,10 +43,24 @@ pub mod transition;
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use grey_types::Hash;
+    use grey_types::validator::ValidatorKey;
+    use grey_types::{BandersnatchPublicKey, BlsPublicKey, Ed25519PublicKey, Hash};
 
     pub fn make_hash(byte: u8) -> Hash {
         Hash([byte; 32])
+    }
+
+    pub fn make_validator(byte: u8) -> ValidatorKey {
+        ValidatorKey {
+            ed25519: Ed25519PublicKey([byte; 32]),
+            bandersnatch: BandersnatchPublicKey([byte; 32]),
+            bls: BlsPublicKey([byte; 144]),
+            metadata: [byte; 128],
+        }
+    }
+
+    pub fn make_validators(n: usize) -> Vec<ValidatorKey> {
+        (0..n).map(|i| make_validator(i as u8)).collect()
     }
 }
 

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -390,17 +390,8 @@ pub fn compute_ring_root(keys: &[ValidatorKey]) -> BandersnatchRingRoot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_hash;
+    use crate::test_helpers::{make_hash, make_validator};
     use grey_types::header::Ticket;
-
-    fn make_validator(i: u8) -> ValidatorKey {
-        ValidatorKey {
-            ed25519: Ed25519PublicKey([i; 32]),
-            bandersnatch: BandersnatchPublicKey([i; 32]),
-            bls: grey_types::BlsPublicKey([i; 144]),
-            metadata: [i; 128],
-        }
-    }
 
     fn make_ticket(id_byte: u8, attempt: u8) -> Ticket {
         Ticket {


### PR DESCRIPTION
## Summary

- Add shared `make_validator(byte)` and `make_validators(n)` helpers to the `test_helpers` module in grey-state
- Remove identical local `make_validator` from `safrole.rs` and `make_validators`/`make_ed25519_key` from `disputes.rs`
- Net reduction: 11 lines removed

Addresses #186.

## Scope

This PR addresses: consolidating duplicated ValidatorKey construction helpers in grey-state test code

Remaining sub-tasks in #186:
- Further deduplication opportunities as identified

## Test plan

- `cargo test -p grey-state` — all 66 tests pass
- `cargo clippy -p grey-state --all-targets -- -D warnings` — clean