### PR TITLE
refactor(grey): use Hash type in decode_guarantee return value

### DIFF
--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -272,7 +272,7 @@ pub fn decode_assurance(data: &[u8]) -> Option<Assurance> {
 ///
 /// Format: `[report_hash(32)][timeslot(4)][cred_count(2)][creds...][report_len(4)][report...]`
 /// Returns `(guarantee, claimed_report_hash)` on success.
-pub fn decode_guarantee(data: &[u8]) -> Option<(Guarantee, [u8; 32])> {
+pub fn decode_guarantee(data: &[u8]) -> Option<(Guarantee, Hash)> {
     if data.len() < 32 + 4 + 2 {
         return None;
     }
@@ -319,7 +319,7 @@ pub fn decode_guarantee(data: &[u8]) -> Option<(Guarantee, [u8; 32])> {
             timeslot,
             credentials,
         },
-        report_hash,
+        Hash(report_hash),
     ))
 }
 
@@ -340,11 +340,11 @@ pub fn handle_received_guarantee(
 
     // Verify report hash matches
     let computed_hash = grey_crypto::report_hash(&guarantee.report);
-    if computed_hash.0 != report_hash {
+    if computed_hash != report_hash {
         tracing::warn!(
             "Received guarantee: report hash mismatch (computed=0x{} vs claimed=0x{})",
             computed_hash.short_hex(),
-            hex::encode(&report_hash[..8])
+            report_hash.short_hex()
         );
         return;
     }
@@ -358,7 +358,7 @@ pub fn handle_received_guarantee(
 
     tracing::info!(
         "Received guarantee: report_hash=0x{}, timeslot={}, creds={}, core={}",
-        hex::encode(&report_hash[..8]),
+        report_hash.short_hex(),
         guarantee.timeslot,
         guarantee.credentials.len(),
         guarantee.report.core_index,
@@ -637,7 +637,7 @@ mod tests {
 
         // Verify the claimed hash matches the actual report hash
         let computed_hash = grey_crypto::report_hash(&decoded.report);
-        assert_eq!(claimed_hash, computed_hash.0);
+        assert_eq!(claimed_hash, computed_hash);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Change `decode_guarantee()` return type from `(Guarantee, [u8; 32])` to `(Guarantee, Hash)`
- Replace `hex::encode(&report_hash[..8])` with `report_hash.short_hex()` (2 call sites)
- Replace `computed_hash.0 != report_hash` with `computed_hash != report_hash` (direct Hash comparison)
- Simplify test assertion from `assert_eq!(claimed_hash, computed_hash.0)` to `assert_eq!(claimed_hash, computed_hash)`

Addresses #186.

## Scope

This PR addresses: replacing raw `[u8; 32]` with `Hash` type in decode_guarantee to enable idiomatic method usage

Remaining sub-tasks in #186:
- Further deduplication opportunities as identified

## Test plan

- `cargo test -p grey -- guarantor` — all 9 tests pass
- `cargo clippy -p grey --all-targets -- -D warnings` — clean