### PR TITLE
refactor(grey): deduplicate make_seed between genesis.rs and node.rs

### DIFF
--- a/grey/crates/grey-consensus/src/genesis.rs
+++ b/grey/crates/grey-consensus/src/genesis.rs
@@ -20,10 +20,9 @@ pub struct ValidatorSecrets {
 /// Build a deterministic 32-byte seed from a validator index and a key-type marker.
 ///
 /// Layout: `[index_lo, index_hi, 0, …, 0, marker]`.
-fn make_seed(index: u16, marker: u8) -> [u8; 32] {
+pub fn make_seed(index: u16, marker: u8) -> [u8; 32] {
     let mut seed = [0u8; 32];
-    seed[0] = index as u8;
-    seed[1] = (index >> 8) as u8;
+    seed[0..2].copy_from_slice(&index.to_le_bytes());
     seed[31] = marker;
     seed
 }
@@ -49,16 +48,14 @@ pub fn make_validator_key(secrets: &ValidatorSecrets) -> ValidatorKey {
     // Uses loopback (127.0.0.1) for local testnets; production genesis
     // would use actual public addresses.
     let mut metadata = [0u8; 128];
-    metadata[0] = secrets.index as u8;
-    metadata[1] = (secrets.index >> 8) as u8;
+    metadata[0..2].copy_from_slice(&secrets.index.to_le_bytes());
     // Bytes 2..6: IP address (loopback for testnet)
     metadata[2] = 127;
     metadata[3] = 0;
     metadata[4] = 0;
     metadata[5] = 1;
     let port = 9000u16 + secrets.index;
-    metadata[6] = port as u8;
-    metadata[7] = (port >> 8) as u8;
+    metadata[6..8].copy_from_slice(&port.to_le_bytes());
 
     ValidatorKey {
         bandersnatch,

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -212,9 +212,9 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
             crate::keystore::Keystore::open(ks_path).map_err(|e| format!("keystore error: {e}"))?;
         if !ks.has_keys(config.validator_index) {
             // Derive seeds for persistence (same deterministic derivation as genesis)
-            let ed_seed = make_validator_seed(config.validator_index, 0xED);
-            let band_seed = make_validator_seed(config.validator_index, 0xBA);
-            let bls_seed = make_validator_seed(config.validator_index, 0xBB);
+            let ed_seed = grey_consensus::genesis::make_seed(config.validator_index, 0xED);
+            let band_seed = grey_consensus::genesis::make_seed(config.validator_index, 0xBA);
+            let bls_seed = grey_consensus::genesis::make_seed(config.validator_index, 0xBB);
             let ed_public = my_secrets.ed25519.public_key().0;
             ks.save_seeds(
                 config.validator_index,
@@ -1456,15 +1456,6 @@ fn broadcast_equivocation(
     let _ = net_commands.try_send(NetworkCommand::BroadcastEquivocation {
         data: countersig.encode(),
     });
-}
-
-/// Build a deterministic 32-byte seed from a validator index and a key-type tag.
-fn make_validator_seed(index: u16, tag: u8) -> [u8; 32] {
-    let mut seed = [0u8; 32];
-    seed[0] = index as u8;
-    seed[1] = (index >> 8) as u8;
-    seed[31] = tag;
-    seed
 }
 
 fn insert_bounded(set: &mut std::collections::HashSet<Hash>, item: Hash, cap: usize) {


### PR DESCRIPTION
## Summary

- Make `genesis::make_seed()` public and remove the identical `make_validator_seed()` from node.rs
- Replace 3 instances of manual u16 byte splitting (`x as u8` / `(x >> 8) as u8`) with `to_le_bytes()` in genesis.rs
- Net reduction: 12 lines removed

Addresses #186.

## Scope

This PR addresses: removing duplicated seed construction function between genesis.rs and node.rs

Remaining sub-tasks in #186:
- Further deduplication opportunities as identified

## Test plan

- `cargo test -p grey-consensus` — all tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean