### PR TITLE
test(grey-state): add proptest properties for preimages sub-transition

### DIFF
--- a/grey/crates/grey-state/src/preimages.rs
+++ b/grey/crates/grey-state/src/preimages.rs
@@ -197,3 +197,103 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Empty preimages always succeed regardless of account state.
+        #[test]
+        fn empty_preimages_always_ok(timeslot in 0u32..10000) {
+            let mut accounts = BTreeMap::new();
+            let result = process_preimages(&mut accounts, &[], timeslot);
+            prop_assert!(result.is_ok());
+            prop_assert!(result.unwrap().is_empty());
+        }
+
+        /// Unknown service always returns PreimageUnneeded.
+        #[test]
+        fn unknown_service_rejected(
+            service_id in 0u32..1000,
+            blob in proptest::collection::vec(any::<u8>(), 1..50),
+            timeslot in 0u32..10000,
+        ) {
+            let mut accounts = BTreeMap::new();
+            // No accounts at all
+            let result = process_preimages(&mut accounts, &[(service_id, blob)], timeslot);
+            prop_assert_eq!(result, Err(PreimageError::PreimageUnneeded));
+        }
+
+        /// A valid preimage stores the blob and returns correct stats.
+        #[test]
+        fn valid_preimage_stored_and_counted(
+            service_id in 0u32..100,
+            blob in proptest::collection::vec(any::<u8>(), 1..100),
+            timeslot in 1u32..10000,
+        ) {
+            let hash = grey_crypto::blake2b_256(&blob);
+            let len = blob.len() as u32;
+            let mut requests = BTreeMap::new();
+            requests.insert((hash, len), vec![0]);
+            let account = PreimageAccountData {
+                blobs: BTreeMap::new(),
+                requests,
+            };
+            let mut accounts = BTreeMap::new();
+            accounts.insert(service_id, account);
+
+            let blob_len = blob.len() as u64;
+            let result = process_preimages(&mut accounts, &[(service_id, blob.clone())], timeslot);
+            prop_assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            prop_assert_eq!(stats[&service_id].provided_count, 1);
+            prop_assert_eq!(stats[&service_id].provided_size, blob_len);
+
+            // Blob should be stored in account
+            prop_assert!(accounts[&service_id].blobs.contains_key(&hash));
+            prop_assert_eq!(&accounts[&service_id].blobs[&hash], &blob);
+        }
+
+        /// Already-stored blob returns PreimageUnneeded.
+        #[test]
+        fn already_stored_rejected(
+            service_id in 0u32..100,
+            blob in proptest::collection::vec(any::<u8>(), 1..50),
+            timeslot in 0u32..10000,
+        ) {
+            let hash = grey_crypto::blake2b_256(&blob);
+            let len = blob.len() as u32;
+            let mut requests = BTreeMap::new();
+            requests.insert((hash, len), vec![0]);
+            let mut blobs = BTreeMap::new();
+            blobs.insert(hash, blob.clone()); // already stored
+            let account = PreimageAccountData { blobs, requests };
+            let mut accounts = BTreeMap::new();
+            accounts.insert(service_id, account);
+
+            let result = process_preimages(&mut accounts, &[(service_id, blob)], timeslot);
+            prop_assert_eq!(result, Err(PreimageError::PreimageUnneeded));
+        }
+
+        /// No request for the blob's hash → PreimageUnneeded.
+        #[test]
+        fn no_request_rejected(
+            service_id in 0u32..100,
+            blob in proptest::collection::vec(any::<u8>(), 1..50),
+            timeslot in 0u32..10000,
+        ) {
+            let account = PreimageAccountData {
+                blobs: BTreeMap::new(),
+                requests: BTreeMap::new(), // no requests
+            };
+            let mut accounts = BTreeMap::new();
+            accounts.insert(service_id, account);
+
+            let result = process_preimages(&mut accounts, &[(service_id, blob)], timeslot);
+            prop_assert_eq!(result, Err(PreimageError::PreimageUnneeded));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add 5 property-based tests for the `process_preimages` function in grey-state:
  - `empty_preimages_always_ok`: empty input always succeeds
  - `unknown_service_rejected`: non-existent service returns `PreimageUnneeded`
  - `valid_preimage_stored_and_counted`: valid preimage stores blob and stats match input
  - `already_stored_rejected`: duplicate blob returns `PreimageUnneeded`
  - `no_request_rejected`: unrequested preimage returns `PreimageUnneeded`

Addresses #229.

## Scope

This PR addresses: property-based tests for the preimages sub-transition (grey-state/src/preimages.rs).

Remaining sub-tasks in #229:
- Proptests for remaining grey-state sub-transitions (safrole, reports)
- Fuzzing infrastructure setup
- CI fuzz smoke test job

## Test plan

- `cargo test -p grey-state --lib preimages::proptests` — all 5 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean