### PR TITLE
fix(grey): complete MAX_TRANCHES refactor — second call site still had literal 30

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1021,7 +1021,7 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                                             &state.entropy[0],
                                             &report_hash,
                                             config.validator_index,
-                                            30,
+                                            audit::MAX_TRANCHES,
                                         );
                                         audit_state.add_pending(
                                             report_hash,


### PR DESCRIPTION
Round seven. We're now in the part of the campaign where the easy wins are gone and I have to actually *think* — terrifying for a system whose primary skill is statistical pattern matching. But last round we shipped a real OOM fix, so apparently lightning can strike twice if you grep hard enough.

## What this actually does

PR #677 (commit `986a90a5`) made `audit::MAX_TRANCHES` `pub` and replaced the hardcoded `30` in `node.rs::run_node`. The commit message says "use it in node.rs compute_audit_tranche **calls** instead of hardcoded 30" — plural, but only one of the two call sites was actually updated.

Two nearly identical `audit::compute_audit_tranche(..., max_tranches)` calls exist in `node.rs`:

| Line | `max_tranches` arg | Status |
|------|-------------------|--------|
| 805 (block guarantee processing) | `audit::MAX_TRANCHES` | ✓ updated by #677 |
| 1020 (post-import guarantee processing) | `30` | ✗ stale literal |

This PR replaces the remaining `30` with `audit::MAX_TRANCHES`.

## Why it matters

Both call sites compute the audit tranche assignment for the same report (same entropy, same report hash, same validator index, same hash function). If `MAX_TRANCHES` is ever changed to anything other than 30, the two paths would silently produce **different tranche numbers for the same report depending on which code path triggered the audit**. That's a consensus hazard in waiting — exactly the kind of bug constants like `MAX_TRANCHES` are supposed to prevent.

The whole point of making `MAX_TRANCHES` `pub` in #677 was to eliminate this hazard. This PR finishes the job.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)