### PR TITLE
fix(grey): handle raw EquivocationEvidence in receiver — relay countersig to peers

### DIFF
--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1313,19 +1313,29 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                     }
                     NetworkEvent::EquivocationReceived { data, source: _ } => {
                         use scale::Decode;
-                        let Ok((countersig, _)) = grey_types::EquivocationCountersig::decode(data.as_slice()) else {
-                            tracing::warn!("failed to decode EquivocationCountersig");
-                            continue;
-                        };
-                        let validator_keys: Vec<_> = state
-                            .current_validators
-                            .iter()
-                            .map(|v| v.ed25519)
-                            .collect();
-                        if let Some(loser) =
-                            grandpa.add_equivocation_countersig(&countersig, &validator_keys)
-                        {
-                            crate::disputes::report_loser(loser, &mut grandpa);
+                        if let Ok((countersig, _)) = grey_types::EquivocationCountersig::decode(data.as_slice()) {
+                            // Countersig path: accumulate toward quorum.
+                            let validator_keys: Vec<_> = state
+                                .current_validators
+                                .iter()
+                                .map(|v| v.ed25519)
+                                .collect();
+                            if let Some(loser) =
+                                grandpa.add_equivocation_countersig(&countersig, &validator_keys)
+                            {
+                                crate::disputes::report_loser(loser, &mut grandpa);
+                            }
+                        } else if let Ok((evidence, _)) = grey_types::EquivocationEvidence::decode(data.as_slice()) {
+                            // Raw evidence relay path: a peer detected an equivocation we
+                            // didn't witness locally. Sign and broadcast our own countersig
+                            // so we contribute to quorum. Do NOT re-broadcast raw evidence.
+                            tracing::warn!(
+                                slot = evidence.slot,
+                                "equivocation evidence received from peer: relaying countersig"
+                            );
+                            broadcast_countersig(evidence, my_secrets, config.validator_index, &net_commands);
+                        } else {
+                            tracing::warn!("failed to decode equivocation message");
                         }
                     }
                     NetworkEvent::PeerIdentified { peer_id, validator_index: vi } => {

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -1430,6 +1430,28 @@ fn head_hash(state: &State) -> Hash {
         .unwrap_or(Hash::ZERO)
 }
 
+/// Sign equivocation evidence and broadcast only the countersig (relay path).
+///
+/// Used when this validator received raw evidence from a peer — it must not
+/// re-broadcast the raw evidence (that would loop), only add its own countersig.
+fn broadcast_countersig(
+    evidence: grey_types::EquivocationEvidence,
+    secrets: &grey_consensus::genesis::ValidatorSecrets,
+    validator_index: grey_types::ValidatorIndex,
+    net_commands: &tokio::sync::mpsc::Sender<NetworkCommand>,
+) {
+    use scale::Encode;
+    let sig = secrets.ed25519.sign(&evidence.signing_message());
+    let countersig = grey_types::EquivocationCountersig {
+        evidence,
+        validator_index,
+        signature: sig,
+    };
+    let _ = net_commands.try_send(NetworkCommand::BroadcastEquivocation {
+        data: countersig.encode(),
+    });
+}
+
 /// Sign equivocation evidence and broadcast both raw evidence and countersig.
 fn broadcast_equivocation(
     evidence: grey_types::EquivocationEvidence,
@@ -1442,20 +1464,12 @@ fn broadcast_equivocation(
         slot = evidence.slot,
         "equivocation detected: broadcasting evidence and countersig"
     );
-    // Broadcast raw evidence so peers learn about it
+    // Broadcast raw evidence so peers that missed one block can relay a countersig.
     let _ = net_commands.try_send(NetworkCommand::BroadcastEquivocation {
         data: evidence.encode(),
     });
-    // Sign and broadcast our own countersig
-    let sig = secrets.ed25519.sign(&evidence.signing_message());
-    let countersig = grey_types::EquivocationCountersig {
-        evidence,
-        validator_index,
-        signature: sig,
-    };
-    let _ = net_commands.try_send(NetworkCommand::BroadcastEquivocation {
-        data: countersig.encode(),
-    });
+    // Sign and broadcast our own countersig.
+    broadcast_countersig(evidence, secrets, validator_index, net_commands);
 }
 
 fn insert_bounded(set: &mut std::collections::HashSet<Hash>, item: Hash, cap: usize) {


### PR DESCRIPTION
Replaces #653. Fixes #645. Part of #221.

## Summary
- Extract `broadcast_countersig` helper from `broadcast_equivocation` so the relay path can sign+broadcast a countersig without re-sending raw evidence (which would loop)
- Extend `EquivocationReceived` handler with a fallback decode branch: try `EquivocationCountersig` first, fall back to `EquivocationEvidence` and call `broadcast_countersig`
- Validators that never witnessed both conflicting blocks locally can now contribute to §17 quorum

## Test Plan
- [x] `cargo build -p grey` — clean
- [x] `cargo test -p grey` — 103 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all passed
- [x] `cargo fmt --all -- --check` — no changes