### PR TITLE
test(harness): verify RPC submissions reach block inclusion

### DIFF
--- a/grey/crates/grey/src/seq_testnet.rs
+++ b/grey/crates/grey/src/seq_testnet.rs
@@ -225,6 +225,8 @@ pub async fn run_seq_testnet(
                         transition_times.push(transition_us);
                         let header_hash = grey_crypto::header_hash(&block.header);
 
+                        rpc_state.record_accumulation_metrics(&block.extrinsic.guarantees);
+
                         // Update store for RPC (order matters: block+state first, then head)
                         let _ = store.put_block(&block);
                         let _ = store.put_state(&header_hash, &new_state, &config);

--- a/grey/harness/src/poll.rs
+++ b/grey/harness/src/poll.rs
@@ -14,6 +14,13 @@ pub struct TimeoutError {
     timeout: Duration,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MetricsSnapshot {
+    head_slot: u32,
+    work_packages_submitted: u64,
+    work_packages_accumulated: u64,
+}
+
 /// Poll `predicate` every `interval` until it returns `true`, or fail after `timeout`.
 pub async fn wait_until<F, Fut>(
     predicate: F,
@@ -68,6 +75,71 @@ pub async fn wait_for_service(
         &format!("service {service_id} ready"),
     )
     .await
+}
+
+fn parse_metric_u64(body: &str, name: &str) -> Result<u64, String> {
+    let line = body
+        .lines()
+        .find(|line| line.split_whitespace().next() == Some(name))
+        .ok_or_else(|| format!("missing metric: {name}"))?;
+    let value = line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| format!("missing value for metric: {name}"))?;
+    value
+        .parse::<u64>()
+        .map_err(|e| format!("invalid metric {name}: {e}"))
+}
+
+async fn fetch_metrics_snapshot(
+    client: &RpcClient,
+) -> Result<MetricsSnapshot, Box<dyn std::error::Error>> {
+    let body = client.get_metrics().await?;
+    Ok(MetricsSnapshot {
+        head_slot: parse_metric_u64(&body, "grey_block_height")? as u32,
+        work_packages_submitted: parse_metric_u64(&body, "grey_work_packages_submitted_total")?,
+        work_packages_accumulated: parse_metric_u64(&body, "grey_work_packages_accumulated_total")?,
+    })
+}
+
+async fn wait_for_metrics_progress(
+    client: &RpcClient,
+    before: MetricsSnapshot,
+    timeout: Duration,
+) -> Result<MetricsSnapshot, TimeoutError> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(snapshot) = fetch_metrics_snapshot(client).await
+            && snapshot.work_packages_submitted > before.work_packages_submitted
+            && snapshot.work_packages_accumulated > before.work_packages_accumulated
+        {
+            return Ok(snapshot);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Err(TimeoutError {
+        label: "RPC submission + accumulation metrics".to_string(),
+        timeout,
+    })
+}
+
+async fn find_guarantee_block(
+    client: &RpcClient,
+    from_slot: u32,
+    to_slot: u32,
+) -> Result<Option<u32>, Box<dyn std::error::Error>> {
+    if from_slot > to_slot {
+        return Ok(None);
+    }
+
+    let blocks = client.get_block_range(from_slot, to_slot).await?;
+    for entry in blocks.blocks {
+        let block = client.get_block(&entry.hash).await?;
+        if block.guarantees_count > 0 {
+            return Ok(Some(entry.slot));
+        }
+    }
+    Ok(None)
 }
 
 /// Check if a pixel at (x,y) with color (r,g,b) is written in storage.
@@ -161,11 +233,51 @@ pub async fn submit_and_verify_pixel(
     b: u8,
     timeout: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let before_metrics = fetch_metrics_snapshot(client).await?;
     submit_pixel_work_package(client, service_id, x, y, r, g, b).await?;
+    let after_metrics = wait_for_metrics_progress(client, before_metrics, timeout).await?;
+    let guarantee_slot = find_guarantee_block(
+        client,
+        before_metrics.head_slot.saturating_add(1),
+        after_metrics.head_slot,
+    )
+    .await?
+    .ok_or_else(|| {
+        format!(
+            "metrics advanced from slot {} to {} but no guarantee block was found",
+            before_metrics.head_slot, after_metrics.head_slot
+        )
+    })?;
     wait_for_pixel(client, service_id, x, y, r, g, b, timeout).await?;
 
     let storage = client.read_storage(service_id, "00").await?;
     let color_hex = format!("#{r:02x}{g:02x}{b:02x}");
-    info!("({x},{y}) {color_hex} ok (slot {})", storage.slot);
+    info!(
+        "({x},{y}) {color_hex} ok (included at slot {guarantee_slot}, visible at head slot {})",
+        storage.slot
+    );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_metric_u64;
+
+    #[test]
+    fn parse_metric_u64_reads_plain_counter_lines() {
+        let body = "\
+# HELP grey_work_packages_accumulated_total Work packages accumulated.\n\
+# TYPE grey_work_packages_accumulated_total counter\n\
+grey_work_packages_accumulated_total 7\n";
+        assert_eq!(
+            parse_metric_u64(body, "grey_work_packages_accumulated_total").unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn parse_metric_u64_errors_when_metric_missing() {
+        let err = parse_metric_u64("grey_block_height 12\n", "grey_missing_metric").unwrap_err();
+        assert!(err.contains("missing metric"));
+    }
 }

--- a/grey/harness/src/rpc.rs
+++ b/grey/harness/src/rpc.rs
@@ -72,6 +72,35 @@ pub struct SubmitResult {
     pub status: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct BlockSummaryResult {
+    pub timeslot: u32,
+    pub author_index: u16,
+    pub parent_hash: String,
+    pub state_root: String,
+    pub extrinsic_hash: String,
+    pub tickets_count: u32,
+    pub guarantees_count: u32,
+    pub assurances_count: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct BlockRangeEntry {
+    pub slot: u32,
+    pub hash: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct BlockRangeResult {
+    pub from_slot: u32,
+    pub to_slot: u32,
+    pub count: usize,
+    pub blocks: Vec<BlockRangeEntry>,
+}
+
 pub struct RpcClient {
     http: reqwest::Client,
     endpoint: String,
@@ -204,6 +233,20 @@ impl RpcClient {
 
     pub async fn submit_work_package(&self, data_hex: &str) -> Result<SubmitResult, RpcError> {
         self.call("jam_submitWorkPackage", serde_json::json!([data_hex]))
+            .await
+    }
+
+    pub async fn get_block(&self, hash_hex: &str) -> Result<BlockSummaryResult, RpcError> {
+        self.call("jam_getBlock", serde_json::json!([hash_hex]))
+            .await
+    }
+
+    pub async fn get_block_range(
+        &self,
+        from_slot: u32,
+        to_slot: u32,
+    ) -> Result<BlockRangeResult, RpcError> {
+        self.call("jam_getBlockRange", serde_json::json!([from_slot, to_slot]))
             .await
     }
 

--- a/grey/harness/src/scenarios/metrics.rs
+++ b/grey/harness/src/scenarios/metrics.rs
@@ -20,6 +20,8 @@ const REQUIRED_METRICS: &[&str] = &[
     "grey_peer_count",
     "grey_stored_blocks",
     "grey_grandpa_round",
+    "grey_work_packages_submitted_total",
+    "grey_work_packages_accumulated_total",
 ];
 
 pub async fn run(client: &RpcClient) -> ScenarioResult {


### PR DESCRIPTION
## Summary

- strengthen the harness pixel-submission flow to wait for RPC submission plus accumulation metrics
- verify a post-submission block in the new slot range actually carries guarantees before treating storage mutation as success
- update the seq-testnet metrics path and metrics scenario so accumulated work packages are observable in the integration environment

## Scope

This PR addresses: integration tests that start a node/seq-testnet, submit a work package via RPC, and verify inclusion.

Remaining sub-tasks in #179:
- WebSocket subscription support for new blocks and finality events
- Optional API key authentication

Addresses #179.

## Test plan

- cargo test -p harness
- cargo test -p grey-rpc
- cargo run --release -p harness -- --seq-testnet --scenario serial
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
