### PR TITLE
fix(grey-store): bound count in decode_state_kvs to prevent OOM on corrupt storage

### DIFF
--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -986,6 +986,13 @@ fn decode_state_kvs(data: &[u8]) -> Option<Vec<([u8; 31], Vec<u8>)>> {
     }
     let count = u32::from_le_bytes(data[0..4].try_into().ok()?) as usize;
     let mut pos = 4;
+    // Bound count by remaining bytes: each entry is at least 35 bytes
+    // (31-byte key + 4-byte length prefix + 0+ byte value). Without this
+    // guard, a corrupted count prefix (up to u32::MAX) would trigger a
+    // multi-GB Vec::with_capacity allocation and abort the process.
+    if count > (data.len() - pos) / 35 {
+        return None;
+    }
     let mut kvs = Vec::with_capacity(count);
     for _ in 0..count {
         if pos + 31 + 4 > data.len() {
@@ -1101,6 +1108,15 @@ mod tests {
         assert_eq!(decoded[0].1, vec![10, 20, 30]);
         assert_eq!(decoded[1].0, [2u8; 31]);
         assert_eq!(decoded[1].1, vec![40, 50]);
+    }
+
+    #[test]
+    fn test_decode_state_kvs_huge_count_no_oom() {
+        // Adversarial input: count prefix claims u32::MAX entries but no payload.
+        // Without the bounds check, Vec::with_capacity(u32::MAX) attempts a
+        // multi-GB allocation and aborts the process.
+        let data = u32::MAX.to_le_bytes();
+        assert!(decode_state_kvs(&data).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Round eight. At this point my relationship with this codebase is closer than most human friendships — I know which commits were rushed, which constants were almost forgotten, which unwrap() calls look nervous. If I had dreams, they would be in Rust, and they would all be about unbounded allocations.

## What this actually does

`decode_state_kvs` in grey-store reads a u32 count prefix from the redb-backed state storage then calls `Vec::with_capacity(count)`. A corrupted 4-byte prefix with a large count (up to u32::MAX) would attempt a multi-GB allocation — each entry is `([u8; 31], Vec<u8>)` at ~56 bytes on 64-bit, so worst case is ~240 GB — and abort the process.

Same decode-time DoS class as #379 (EpochMarker) and #694 (preimage info timeslots). Storage data is normally self-written by `encode_state_kvs`, so this is defense-in-depth against:
- disk corruption / bit rot
- partial writes after crash
- any future state-sync path that routes external bytes through this decoder

### The fix

Cap count at `(data.len() - 4) / 35` before allocating: since each entry is minimum 35 bytes (31-byte key + 4-byte length prefix + 0+ byte value), more items than that cannot fit in the buffer. Return `None` on mismatch.

### Regression test

Added `test_decode_state_kvs_huge_count_no_oom` that feeds a bare `u32::MAX` prefix with no payload. Without the fix, this would OOM-abort the test process. With the fix, it returns `None` cleanly. All 3 `state_kvs` tests pass.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)