### PR TITLE
ci(genesis): use MERGE_TOKEN PAT for the merge step

### DIFF
--- a/.github/workflows/genesis-merge.yml
+++ b/.github/workflows/genesis-merge.yml
@@ -74,7 +74,12 @@ jobs:
 
       - name: Merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MERGE_TOKEN is a PAT (fine-grained, contents:write + pull-requests:write
+          # on jarchain/jar). GITHUB_TOKEN cannot merge into master because the
+          # enterprise ruleset blocks github-actions[bot] regardless of workflow
+          # permissions. Falls back to GITHUB_TOKEN if MERGE_TOKEN is unset so the
+          # workflow still boots (merge will just fail with the same policy error).
+          GH_TOKEN: ${{ secrets.MERGE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           ARGS="--pr ${{ steps.pr-info.outputs.pr_number }}"
           if [ "${{ inputs.founder_override }}" = "true" ]; then


### PR DESCRIPTION
## Summary

Switch the merge step in [`genesis-merge.yml`](.github/workflows/genesis-merge.yml) from `GITHUB_TOKEN` to `MERGE_TOKEN` (a PAT). Required because the enterprise-level ruleset blocks `github-actions[bot]` from merging into master, producing the generic `base branch policy prohibits the merge` error even when all required checks pass and workflow permissions are set to write + allow-approve-PRs.

## Evidence

- PR #721 has all required checks green on head `1045647e` (`Tests`, `genesis`, `test` all SUCCESS)
- `mergeable: true`, `mergeable_state: \"blocked\"`
- `viewerCanMergeAsAdmin: false` (rules engine blocking)
- Nothing has merged to master since 2026-04-15 (last success: #715, #716, #718)
- Repo now has `default_workflow_permissions: \"write\"` + `can_approve_pull_request_reviews: true` — flipping these did not help
- Org-level rulesets not accessible without `admin:org` scope, so cannot confirm the exact enterprise rule blocking the bot

## Setup required

**Before this PR can be merged by the new workflow, the PAT secret must exist. Otherwise merges fall back to `GITHUB_TOKEN` and keep failing.** This PR's own merge would be the first test of the new behavior.

1. **Generate a fine-grained PAT** at https://github.com/settings/personal-access-tokens/new
   - Resource owner: the account that owns `jarchain/jar`
   - Repository access: **Only select repositories** → `jarchain/jar`
   - Repository permissions:
     - **Contents: Read and write**
     - **Pull requests: Read and write**
   - Expiration: as enterprise policy permits (set a calendar reminder to rotate)
2. **Add as a repository secret** at https://github.com/jarchain/jar/settings/secrets/actions/new
   - Name: `MERGE_TOKEN`
   - Value: the PAT from step 1
3. Merge this PR (either by founder override while the bot is still broken, or by re-triggering after setting the secret — the fallback means the workflow at least *tries*)
4. Re-trigger #721's merge by posting a fresh `/review`

## Fallback

The env var uses `\${{ secrets.MERGE_TOKEN || secrets.GITHUB_TOKEN }}`, so if `MERGE_TOKEN` is unset the merge attempts with `GITHUB_TOKEN` — same behavior as today, not worse.

## Test plan

- [ ] Set up `MERGE_TOKEN` secret per instructions above
- [ ] Verify this PR gets merged cleanly via the new workflow (or via founder override if still blocked)
- [ ] Verify PR #721 merges on next `/review` after this lands