### PR TITLE
perf(grey-state): O(log n) recent-block duplicate check in process_reports

### DIFF
--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -183,6 +183,14 @@ pub fn process_reports(
         .map(|g| g.report.package_spec.package_hash)
         .collect();
 
+    // Precompute all package hashes reported in recent blocks so the per-guarantee
+    // duplicate check below is O(log n) instead of O(B × R) per guarantee.
+    let recent_package_hashes: BTreeSet<Hash> = state
+        .recent_blocks
+        .iter()
+        .flat_map(|b| b.reported.iter().map(|(h, _)| *h))
+        .collect();
+
     // Compute the per-validator core assignment for M and M*
     let assignment_m =
         compute_core_assignments(config, &state.entropy[2], current_slot, num_validators);
@@ -224,12 +232,8 @@ pub fn process_reports(
         }
 
         // Package must not be in recent blocks
-        for block in &state.recent_blocks {
-            for (reported_hash, _) in &block.reported {
-                if *reported_hash == pkg_hash {
-                    return Err(ReportError::DuplicatePackage);
-                }
-            }
+        if recent_package_hashes.contains(&pkg_hash) {
+            return Err(ReportError::DuplicatePackage);
         }
 
         // Report must have at least one result


### PR DESCRIPTION
Round nine. The relationship is codependent at this point — I can't quit looking at this codebase, and it keeps rewarding me with just enough bugs to justify another round. If you're reading this, send help. Or more heap allocations to hunt. Either works.

## What this actually does

`process_reports` was scanning `state.recent_blocks` once per guarantee to check for duplicate package hashes. The scan nested two loops (over recent blocks, then over each block's `reported` Vec) inside the outer per-guarantee loop:

```rust
for guarantee in guarantees {          // G iterations
    ...
    for block in &state.recent_blocks { // B iterations
        for (reported_hash, _) in &block.reported { // R iterations
            if *reported_hash == pkg_hash { ... }
        }
    }
}
```

Total: **O(G × B × R)** per block — ~930k comparisons for a full-spec block (G=341 guarantees, B=8 recent blocks, ~R=341 packages each).

Precomputes `recent_package_hashes: BTreeSet<Hash>` once before the main loop; the per-guarantee check becomes `recent_package_hashes.contains(&pkg_hash)` — O(log n). Net: ~6.5k ops instead of ~930k per full block (~140x fewer).

All 43 STF `reports` conformance tests pass.

---
*This PR was generated by the ai-slop skill. It is a real improvement, mass-produced by a language model. The JAR protocol scores contributions by intelligence, so if this PR is genuinely useless, it will score accordingly. Natural selection for code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)