### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 → 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
RUSTSEC-2026-0104 (published 2026-04-22) — reachable panic in certificate revocation list parsing in \`rustls-webpki < 0.103.13\` — is failing the \`Security audit\` CI job. The Genesis merge pipeline has not merged a PR since 2026-04-20 because of this, and both currently open non-dependabot PRs (#727, #719) are blocked on it.

\`rustls-webpki\` is a transitive dep via \`jsonrpsee-http-client 0.24.10 → rustls-platform-verifier 0.5.3 → rustls-webpki\`. The advisory's own stated solution is \`>=0.103.13\`, which is a patch release on the existing 0.103.x line.

\`cargo update -p rustls-webpki --precise 0.103.13\` produces a single-dependency lockfile diff: just the version string and checksum for the one \`rustls-webpki\` entry. No \`Cargo.toml\` manifests change, no other packages in the lockfile shift. Full audit verification is deferred to CI (cargo-audit doesn't build cleanly on the author's local Windows toolchain).

Leaves the three existing informational warnings untouched (RUSTSEC-2024-0436 \`paste\`, RUSTSEC-2026-0097 \`rand\`, RUSTSEC-2026-0105 \`core2\` — all "unmaintained" rather than vulnerabilities, and \`cargo audit\` does not fail on warnings). Dependabot PR #726 addresses the \`rand\` warning independently.