### PR TITLE
feat(grey-state): implement gas (Ω_1) host call in refine context

### DIFF
--- a/grey/crates/grey-state/src/refine.rs
+++ b/grey/crates/grey-state/src/refine.rs
@@ -142,6 +142,28 @@ pub struct RefineResult {
     pub expunge_requests: Vec<Hash>,
 }
 
+/// Handle a Ψ_R refine-context protocol call. jar1 slot numbering per
+/// `spec/Jar/Accumulation.lean:26-31`. Returns true to continue execution.
+///
+/// Spec: refine has access to gas (1), fetch (2), historical_lookup (7),
+/// export (8), machine (9) per `spec/Jar/Services.lean:84`. Anything else
+/// returns `WHAT`.
+fn handle_refine_host_call(slot: u8, pvm: &mut PvmInstance) -> bool {
+    const RESULT_WHAT: u64 = u64::MAX - 1;
+
+    tracing::trace!(slot, "handle_refine_host_call");
+    match slot {
+        1 => {
+            pvm.kernel_resume(pvm.gas(), 0);
+            true
+        }
+        _ => {
+            pvm.kernel_resume(RESULT_WHAT, 0);
+            true
+        }
+    }
+}
+
 /// Run the Refine invocation Ψ_R for a single work item.
 pub fn invoke_refine(
     _config: &Config,
@@ -199,8 +221,8 @@ pub fn invoke_refine(
                 let gas_used = initial_gas - pvm.gas();
                 return error_refine_result(item, WorkResult::Panic, gas_used);
             }
-            KernelResult::ProtocolCall { .. } => {
-                pvm.kernel_resume(u64::MAX - 1, 0);
+            KernelResult::ProtocolCall { slot } => {
+                handle_refine_host_call(slot, &mut pvm);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Refine (Ψ_R) had all protocol calls stubbed to `WHAT` (`refine.rs:202-204`), so service code in refinement could not even query its remaining gas.
- This PR adds a `handle_refine_host_call` dispatcher and wires slot 1 (gas) per `spec/Jar/Accumulation.lean:26-31`.
- `invoke_is_authorized` is intentionally left as-is — spec says Ψ_I runs **without host calls** (`spec/Jar/Services.lean:43-44`).

## Why now

#731 traced the actual host-call coverage across all four invocation contexts (Ψ_I, Ψ_R, Ψ_T, Ψ_A). Refine was at **0/5** implemented. This is the first slot landing in refine; the dispatcher pattern matches `accumulate.rs::handle_host_call` so subsequent slots are mechanical to add.

## Scope

- ✅ Slot 1 (gas) implemented for Ψ_R.
- ⛔ Slots 2 (fetch), 7 (historical_lookup), 8 (export), 9 (machine) still fall through to `WHAT`. Each will land in its own follow-up PR. `fetch` in particular needs the jar1 v2 mode codes for refine context, which the spec at `Services.lean:84-104` only documents in gp072 numbering — that needs spec clarification first.
- ⛔ No unit test added: the existing `make_halt_blob` helper is `#[cfg(test)]` private inside `javm/src/kernel.rs:2995` and not exposed. End-to-end test requires either (a) a `pub mod test_support` in javm exposing halt_blob, or (b) a conformance vector that exercises refine host calls (none exist today since refine has been a no-op). I'll file a follow-up to add the test infrastructure.

## Test plan

- [x] `cargo build -p grey-state` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p grey-state --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 501 tests pass, 0 failures
- [ ] Reviewer to confirm: should `fetch` (slot 2) be implemented in this PR after spec clarification, or kept as a follow-up?

## References

- Spec: `spec/Jar/Services.lean:43-44, 84` (Ψ_R host-call surface), `spec/Jar/Accumulation.lean:26-31` (jar1 slot numbering)
- Tracking: #731 (independent client readiness umbrella)
- Reconciliation comment: https://github.com/jarchain/jar/issues/731#issuecomment-4315527798

🤖 Generated with [Claude Code](https://claude.com/claude-code)