### PR TITLE
feat(grey): add Grafana dashboard and Prometheus config for node monitoring

### DIFF
--- a/grey/grafana/README.md
+++ b/grey/grafana/README.md
@@ -1,0 +1,105 @@
+# Grey Grafana Dashboard
+
+Prometheus dashboard for monitoring Grey JAM node metrics.
+
+## Dashboard Panels
+
+### Block Production
+- **Head / Finalized Slot** — Current block height and finality progress
+- **Finality Lag** — Slots between head and last finalized block (thresholds: green < 10, yellow < 50, red ≥ 50)
+- **Blocks Authored / Imported** — Block production rate
+
+### Consensus
+- **GRANDPA Round** — Current finality round
+- **Validator Index** — This node's validator index
+- **State Transitions** — STF application rate
+- **State Transition Duration** — Last STF and block authoring times
+
+### Networking
+- **Connected Peers** — P2P peer count
+- **Gossip Messages by Topic** — blocks, finality, guarantees, assurances, announcements, tickets
+- **Queue Depths** — Event, command, RPC, and pending block queues
+
+### RPC
+- **RPC Requests / sec** — Total and per-method request rate
+- **RPC Latency (p99)** — 99th percentile latency per method
+- **Work Packages** — Submitted and accumulated work packages
+
+### Storage
+- **Database Entries** — Blocks, states, DA chunks, GRANDPA votes
+- **Store Read / Write Latency** — Storage operation times
+
+### PVM
+- **PVM Gas Used** — Gas consumption for accumulation
+
+## Quick Start with Docker Compose
+
+Add the following to your `docker-compose.yml`:
+
+```yaml
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/dashboard.json:/var/lib/grafana/dashboards/dashboard.json
+      - ./grafana/dashboards-provider.yaml:/etc/grafana/provisioning/dashboards/dashboards-provider.yaml
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+```
+
+## Prometheus Configuration
+
+Create `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'grey'
+    static_configs:
+      - targets: ['validator-0:9615']  # Grey metrics port
+```
+
+## Import Manually
+
+1. Open Grafana → Dashboards → Import
+2. Upload `dashboard.json` or paste JSON
+3. Select Prometheus datasource
+4. Click Import
+
+## Metrics Reference
+
+The dashboard uses the following metrics exported by Grey:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `grey_block_height` | gauge | Current head slot |
+| `grey_finalized_height` | gauge | Last finalized slot |
+| `grey_finality_lag` | gauge | Slots between head and finalized |
+| `grey_blocks_produced_total` | counter | Blocks authored by this node |
+| `grey_blocks_imported_total` | counter | Blocks received and imported |
+| `grey_grandpa_round` | gauge | Current GRANDPA round |
+| `grey_validator_index` | gauge | This node's validator index |
+| `grey_peer_count` | gauge | Connected peers |
+| `grey_state_transitions_total` | counter | STF applications |
+| `grey_state_transition_last_seconds` | gauge | Last STF duration |
+| `grey_block_author_last_seconds` | gauge | Last block authoring duration |
+| `grey_store_write_last_seconds` | gauge | Last store write duration |
+| `grey_store_read_last_seconds` | gauge | Last store read duration |
+| `grey_rpc_requests_total` | counter | Total RPC requests |
+| `grey_rpc_requests_by_method` | counter | RPC requests per method |
+| `grey_rpc_request_seconds` | histogram | RPC latency histogram |
+| `grey_gossipsub_messages_total` | counter | Gossip messages by topic |
+| `grey_queue_depth_*` | gauge | Queue depths |
+| `grey_pvm_gas_used_total` | counter | PVM gas consumed |
+| `grey_work_packages_*` | counter | Work package metrics |
+| `grey_stored_*` | gauge | Database entry counts |

--- a/grey/grafana/dashboard.json
+++ b/grey/grafana/dashboard.json
@@ -1,0 +1,363 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Grey JAM node monitoring dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Block Production",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "title": "Head / Finalized Slot",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_block_height", "legendFormat": "Head Slot", "refId": "A" },
+        { "expr": "grey_finalized_height", "legendFormat": "Finalized Slot", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Finality Lag",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "slots"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_finality_lag", "legendFormat": "Lag (head - finalized)", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Blocks Authored / Imported",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_blocks_produced_total[5m])", "legendFormat": "Authored/s", "refId": "A" },
+        { "expr": "rate(grey_blocks_imported_total[5m])", "legendFormat": "Imported/s", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+
+    {
+      "title": "Consensus",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "collapsed": false
+    },
+    {
+      "title": "GRANDPA Round",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_grandpa_round", "legendFormat": "Round", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Validator Index",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 10 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_validator_index", "legendFormat": "Index", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "State Transitions",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_state_transitions_total[5m])", "legendFormat": "STF/s", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "State Transition Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_state_transition_last_seconds", "legendFormat": "Last STF", "refId": "A" },
+        { "expr": "grey_block_author_last_seconds", "legendFormat": "Last Block Author", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+
+    {
+      "title": "Networking",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "collapsed": false
+    },
+    {
+      "title": "Connected Peers",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_peer_count", "legendFormat": "Peers", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Gossip Messages by Topic",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_gossipsub_messages_total[5m])", "legendFormat": "{{topic}}", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Queue Depths",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_queue_depth_events", "legendFormat": "Events", "refId": "A" },
+        { "expr": "grey_queue_depth_commands", "legendFormat": "Commands", "refId": "B" },
+        { "expr": "grey_queue_depth_rpc", "legendFormat": "RPC", "refId": "C" },
+        { "expr": "grey_pending_blocks", "legendFormat": "Pending Blocks", "refId": "D" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+
+    {
+      "title": "RPC",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "collapsed": false
+    },
+    {
+      "title": "RPC Requests / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_rpc_requests_total[5m])", "legendFormat": "Total", "refId": "A" },
+        { "expr": "rate(grey_rpc_requests_by_method[5m])", "legendFormat": "{{method}}", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "RPC Latency (p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "histogram_quantile(0.99, rate(grey_rpc_request_seconds_bucket[5m]))", "legendFormat": "{{method}} p99", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Work Packages",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_work_packages_submitted_total[5m])", "legendFormat": "Submitted/s", "refId": "A" },
+        { "expr": "rate(grey_work_packages_accumulated_total[5m])", "legendFormat": "Accumulated/s", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+
+    {
+      "title": "Storage",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "collapsed": false
+    },
+    {
+      "title": "Database Entries",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_stored_blocks", "legendFormat": "Blocks", "refId": "A" },
+        { "expr": "grey_stored_states", "legendFormat": "States", "refId": "B" },
+        { "expr": "grey_stored_chunks", "legendFormat": "DA Chunks", "refId": "C" },
+        { "expr": "grey_stored_votes", "legendFormat": "GRANDPA Votes", "refId": "D" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+    {
+      "title": "Store Read / Write Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "grey_store_write_last_seconds", "legendFormat": "Write", "refId": "A" },
+        { "expr": "grey_store_read_last_seconds", "legendFormat": "Read", "refId": "B" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    },
+
+    {
+      "title": "PVM",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "collapsed": false
+    },
+    {
+      "title": "PVM Gas Used",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "rate(grey_pvm_gas_used_total[5m])", "legendFormat": "Gas/s", "refId": "A" }
+      ],
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["grey", "jam", "blockchain"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Grey — JAM Node",
+  "uid": "grey-jam-node",
+  "version": 1
+}

--- a/grey/grafana/dashboards-provider.yaml
+++ b/grey/grafana/dashboards-provider.yaml
@@ -1,0 +1,18 @@
+# Grafana provisioning configuration for Grey JAM node dashboard
+# Place this file in /etc/grafana/provisioning/dashboards/ when running Grafana
+# Or mount it as a volume when running Grafana in Docker
+
+apiVersion: 1
+
+providers:
+  - name: 'Grey JAM Node'
+    orgId: 1
+    folder: ''
+    folderUid: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grey/grafana/prometheus.yml
+++ b/grey/grafana/prometheus.yml
@@ -1,0 +1,32 @@
+# Prometheus scrape configuration for Grey JAM node
+#
+# Usage:
+#   1. Copy to prometheus.yml
+#   2. Run: prometheus --config.file=prometheus.yml
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Grey node metrics (exposed on port 9615 by default)
+  - job_name: 'grey'
+    static_configs:
+      # Single validator
+      - targets: ['localhost:9615']
+        labels:
+          instance: 'grey-validator-0'
+
+      # For a multi-validator testnet, add all validators:
+      # - targets:
+      #   - '172.28.0.10:9615'  # validator-0
+      #   - '172.28.0.11:9615'  # validator-1
+      #   - '172.28.0.12:9615'  # validator-2
+      # etc.
+
+    # Metric relabeling (optional)
+    metric_relabel_configs:
+      # Drop histogram buckets to reduce storage (optional)
+      # - source_labels: [__name__]
+      #   regex: 'grey_rpc_request_seconds_bucket'
+      #   action: drop


### PR DESCRIPTION
## Summary

Add a pre-configured Grafana dashboard, Prometheus scrape config, and provisioning setup for monitoring Grey JAM nodes. This addresses the "infrastructure" tier (P3) task from CONTRIBUTING.md.

## What's included

| File | Purpose |
|------|---------|
| `grey/grafana/dashboard.json` | Full Grafana dashboard with 6 row groups (Block Production, Consensus, Networking, RPC, Storage, PVM) |
| `grey/grafana/prometheus.yml` | Example Prometheus scrape config for single/multi-validator setups |
| `grey/grafana/dashboards-provider.yaml` | Grafana provisioning config for auto-loading the dashboard |
| `grey/grafana/README.md` | Usage docs with Docker Compose example and complete metrics reference table |

## Dashboard panels

1. **Block Production** — head/finalized slot, finality lag (with thresholds), block rate
2. **Consensus** — GRANDPA round, validator index, STF rate & duration
3. **Networking** — peer count, gossip messages by topic, queue depths
4. **RPC** — request rate (total + per-method), p99 latency histogram, work packages
5. **Storage** — DB entry counts (blocks/states/chunks/votes), read/write latency
6. **PVM** — gas consumption rate

## How to test

```bash
# 1. Start Grey with metrics enabled
grey --metrics-port 9615

# 2. Verify metrics endpoint
curl http://localhost:9615/metrics

# 3. Import dashboard.json into Grafana
#    Dashboards → Import → Upload JSON file → Select Prometheus datasource
```