### PR TITLE
chore: add CODEOWNERS file for code review routing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,39 @@
+# CODEOWNERS - Define code ownership for the JAR project
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# The following users will be automatically requested for review
+# when a pull request changes files in the matching paths.
+
+# Default - all files
+* @jarchain
+
+# Core protocol
+/spec/ @sorpaas
+/grey/crates/grey-state/ @sorpaas
+/grey/crates/grey-consensus/ @sorpaas
+/grey/crates/javm/ @sorpaas
+
+# Cryptography
+/grey/crates/grey-crypto/ @sorpaas
+
+# Networking
+/grey/crates/grey-network/ @sorpaas
+
+# Storage
+/grey/crates/grey-store/ @sorpaas
+
+# RPC
+/grey/crates/grey-rpc/ @sorpaas
+
+# Documentation
+/docs/ @sorpaas
+/README.md @sorpaas
+/grey/README.md @sorpaas
+/GENESIS.md @sorpaas
+
+# CI/CD
+/.github/ @sorpaas
+
+# Build configuration
+/Cargo.toml @sorpaas
+/Cargo.lock @sorpaas


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file to automatically route pull request reviews to the appropriate maintainers based on which files are changed.

## Ownership Structure

| Path | Owner |
|------|-------|
|  (default) | @jarchain |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |
|  | @sorpaas |

## Benefits

- Automatic reviewer assignment on PRs
- Clear ownership boundaries for each module
- Helps new contributors know who to ask for help
- Enforces review from domain experts