### PR TITLE
fix(ci): update rustls-webpki to 0.103.13 to fix RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- **Fixes RUSTSEC-2026-0104**: Reachable panic in certificate revocation list parsing
- **Upgrades `rustls-webpki`** from 0.103.12 to 0.103.13
- **Unblocks CI merges** (cargo-audit now passes with no errors)

## Changes
- Updated `Cargo.lock` to use `rustls-webpki` v0.103.13
- Verified with `cargo audit`: no vulnerabilities found (only warnings remain)

## Test plan
- [x] `cargo audit` passes with no errors
- [ ] CI checks should now pass (audit job no longer fails)

## References
- RUSTSEC-2026-0104: https://rustsec.org/advisories/RUSTSEC-2026-0104
- Related Issue: #722 (cargo-audit failing on new 2026 RUSTSEC advisories)