### PR TITLE
feat(grey): add monitoring stack and CI Docker build (fixes #231)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "grey/**"
+      - "Dockerfile"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: jarchain/grey
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: grey/Dockerfile
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke test
+        run: |
+          docker run --rm $(echo "${{ steps.meta.outputs.tags }}" | head -1) \
+            grey --test --test-blocks 1
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: grey/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/grey/docker-compose.monitoring.yml
+++ b/grey/docker-compose.monitoring.yml
@@ -1,0 +1,36 @@
+# Monitoring overlay — run with:
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+#
+# Adds Prometheus + Grafana, pre-configured to scrape all 6 validators.
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: grey-prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prom-data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - testnet
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grey-grafana
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+    ports:
+      - "3000:3000"
+    networks:
+      - testnet
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+
+volumes:
+  prom-data:
+  grafana-data:

--- a/grey/monitoring/grafana/dashboards/grey.json
+++ b/grey/monitoring/grafana/dashboards/grey.json
@@ -1,0 +1,92 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "grey_block_height", "legendFormat": "{{instance}}" }
+      ],
+      "title": "Block Height",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "grey_finality_lag", "legendFormat": "{{instance}}" }
+      ],
+      "title": "Finality Lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "grey_peer_count", "legendFormat": "{{instance}}" }
+      ],
+      "title": "Peer Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "grey_work_packages_per_epoch", "legendFormat": "{{instance}}" }
+      ],
+      "title": "Work Packages / Epoch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "grey_rpc_latency_seconds", "legendFormat": "{{instance}} {{method}}" }
+      ],
+      "title": "RPC Latency",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["grey", "jarchain"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "name": "DS_PROMETHEUS",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Grey Validators",
+  "uid": "grey-validators",
+  "version": 1
+}

--- a/grey/monitoring/grafana/datasources/datasources.yml
+++ b/grey/monitoring/grafana/datasources/datasources.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/grey/monitoring/prometheus.yml
+++ b/grey/monitoring/prometheus.yml
@@ -1,0 +1,19 @@
+# Prometheus scrape configuration for Grey testnet
+# Scrapes metrics from all 6 validators via Docker internal network.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "grey-validators"
+    static_configs:
+      - targets:
+          - "validator-0:9615"
+          - "validator-1:9615"
+          - "validator-2:9615"
+          - "validator-3:9615"
+          - "validator-4:9615"
+          - "validator-5:9615"
+    metrics_path: /metrics
+    scrape_interval: 5s


### PR DESCRIPTION
## Summary

Adds the missing parts of #231 (Docker monitoring + CI build):

- `grey/monitoring/prometheus.yml` — scrape config for all 6 validators
- `grey/monitoring/grafana/dashboards/grey.json` — Grafana dashboard (block height, finality lag, peer count, work packages/epoch, RPC latency)
- `grey/monitoring/grafana/datasources/datasources.yml` — auto-provision Prometheus datasource
- `grey/docker-compose.monitoring.yml` — overlay to launch Prometheus + Grafana alongside the 6-validator testnet
- `.github/workflows/docker.yml` — CI workflow to build/push image to GHCR with smoke test

## Usage

```bash
# Launch full stack (6 validators + Prometheus + Grafana)
docker compose -f grey/docker-compose.yml -f grey/docker-compose.monitoring.yml up -d

# Open Grafana
open http://localhost:3000   # admin/admin
```

## Verification

- [x] Prometheus config valid (scrapes `validator-0:9615` through `validator-5:9615`)
- [x] Grafana dashboard JSON well-formed
- [x] CI workflow builds image and runs `grey --test --test-blocks 1`

## Related Issues

Fixes #231