### PR TITLE
fix(deps): bump rustls-webpki 0.103.12 → 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Bumps `rustls-webpki` from `0.103.12` to `0.103.13` to resolve two RUSTSEC advisories that are currently blocking all PR merges.

### Fixed advisories

| Advisory | Description |
|----------|-------------|
| RUSTSEC-2026-0098 | Name constraints for URI names were incorrectly accepted |
| RUSTSEC-2026-0099 | Wildcard name bypasses permitted subtree name constraints |

Both vulnerabilities require a misissued certificate to exploit (low practical risk), but the name-constraint bypass could allow acceptance of certificates that should be rejected.

### Impact

- `cargo audit` has been failing on master since 2026-04-10
- All PRs are blocked from merging (genesis-merge.yml requires CI to pass)
- This is a transitive dependency via `rustls` → `libp2p-tls` → `libp2p` — no API changes, drop-in patch version bump

Closes #722