### PR TITLE
fix(grey): bound count in decode_guarantee to prevent OOM on malformed gossip

### DIFF
--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -286,6 +286,16 @@ pub fn decode_guarantee(data: &[u8]) -> Option<(Guarantee, Hash)> {
     let cred_count = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
     pos += 2;
 
+    // Bound `cred_count` by the bytes remaining before allocating. Each
+    // credential is 66 bytes on the wire (2-byte validator_index + 64-byte
+    // Ed25519 signature). Without this guard a peer can broadcast a 38-byte
+    // gossip message with `cred_count = u16::MAX` and force every receiver
+    // subscribed to the `guarantees` topic to pre-allocate ~4.3 MiB before
+    // the per-iteration bounds check rejects the message.
+    if cred_count > data.len().saturating_sub(pos) / 66 {
+        return None;
+    }
+
     let mut credentials = Vec::with_capacity(cred_count);
     for _ in 0..cred_count {
         if pos + 2 + 64 > data.len() {
@@ -673,6 +683,25 @@ mod tests {
             fn decode_guarantee_never_panics(data in prop::collection::vec(any::<u8>(), 0..2048)) {
                 let _ = decode_guarantee(&data);
             }
+        }
+
+        /// Targeted regression test for the bound check on `cred_count`.
+        ///
+        /// The existing proptest above generates random bytes up to 2048 in
+        /// length, but does not specifically explore the adversarial shape
+        /// of a 38-byte message with `cred_count = u16::MAX`: the random
+        /// search would need to land exactly on a 38-byte length AND on
+        /// `0xFFFF` in the cred_count field, which has effectively zero
+        /// probability under uniform sampling. This test exercises that
+        /// shape directly.
+        #[test]
+        fn decode_guarantee_rejects_oversized_cred_count() {
+            // [report_hash(32)] + [timeslot(4)] + [cred_count = u16::MAX]
+            // and nothing else.
+            let mut data = vec![0u8; 32 + 4 + 2];
+            data[32 + 4] = 0xff;
+            data[32 + 4 + 1] = 0xff;
+            assert!(decode_guarantee(&data).is_none());
         }
     }
 }


### PR DESCRIPTION
# fix(grey): bound count in decode_guarantee to prevent OOM on malformed gossip

## Problem

`grey::guarantor::decode_guarantee` reads a 16-bit credential count from
untrusted gossip bytes and pre-allocates a `Vec` of that size before the
per-iteration bounds check runs:

```rust
// grey/crates/grey/src/guarantor.rs:286-300
let cred_count = u16::from_le_bytes([data[pos], data[pos + 1]]) as usize;
pos += 2;

let mut credentials = Vec::with_capacity(cred_count);   // ← unbounded
for _ in 0..cred_count {
    if pos + 2 + 64 > data.len() {
        return None;
    }
    ...
}
```

Each credential entry is `(u16, Ed25519Signature)` = 66 bytes on the wire,
so a peer broadcasting a 38-byte message with `cred_count = 0xFFFF` forces
every receiver subscribed to the `guarantees` gossipsub topic to allocate
~4.1 MiB before the loop's bounds check rejects the message and the `Vec`
is dropped. The decode runs *before* any signature verification — anyone
on the network can do this.

This is the same class of bug fixed by:
- #720 — `decode_state_kvs`
- #694 — `decode_preimage_info_timeslots`

## Reachability

`handle_received_guarantee` (same file, line 326) is the gossipsub handler
for the `guarantees` topic. Decode happens before any auth check, so the
attacker is the network — no validator key required.

## Fix

Bound `cred_count` by the bytes remaining in `data` before any allocation:

```rust
if cred_count > data.len().saturating_sub(pos) / 66 {
    return None;
}
let mut credentials = Vec::with_capacity(cred_count);
```

Each credential is exactly 66 bytes on the wire (2-byte validator index +
64-byte Ed25519 signature, per the format docstring on `decode_guarantee`),
so any `cred_count` larger than `(remaining_bytes) / 66` is necessarily
malformed and can be rejected before allocation.

## Reproducer (peak-allocation measurement)

A standalone reproducer that vendors the decode logic with and without the
fix, run with `cargo run --release` on macOS (Apple Silicon):

```
Adversarial input: 38 bytes, claimed cred_count = 65535

current (vulnerable)    iters=    1  peak_delta=  4_325_310 bytes (4.12 MB)  returned_Some=0
with proposed fix       iters=    1  peak_delta=          0 bytes (0.00 MB)  returned_Some=0

--- amplification at gossip rates (1000 messages/sec scenario) ---
current x1000           iters= 1000  peak_delta=  4_325_310 bytes (4.12 MB)  returned_Some=0
fixed x1000             iters= 1000  peak_delta=          0 bytes (0.00 MB)  returned_Some=0
```

Per-call peak allocation: **4.12 MiB → 0 bytes** for the same input that
both implementations correctly reject. Reproducer source available on
request.

## Tests

`cargo test -p grey decode_guarantee --release`:

```
test guarantor::tests::proptests::decode_guarantee_rejects_oversized_cred_count ... ok
test guarantor::tests::proptests::decode_guarantee_never_panics ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 102 filtered out
```

The existing `decode_guarantee_never_panics` proptest generates random
bytes 0..2048 in length, but uniform-random sampling effectively never
lands on the adversarial shape (a 38-byte input with `cred_count = 0xFFFF`).
The new `decode_guarantee_rejects_oversized_cred_count` test exercises
that shape directly as a regression guard.

## Future work (not in this PR)

A libfuzzer target `fuzz_guarantee_decode` is staged locally; it requires
adding `grey` as a path dependency in `grey/fuzz/Cargo.toml`. Happy to
fold it into this PR or split it out — let me know preference.

---

## Checklist

- [x] `cargo fmt --check -p grey`
- [x] `cargo clippy -p grey --all-targets -- -D warnings`
- [x] `cargo test -p grey decode_guarantee --release`
- [x] No public API change
- [x] No spec change (network-input hardening only)
