### PR TITLE
docs(spec): add docstrings to JAVM types and kernel structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/JAVM.lean
+++ b/spec/Jar/JAVM.lean
@@ -54,9 +54,12 @@ abbrev Registers := Array Reg
 
 /-- Page access mode. GP eq (4.17). -/
 inductive PageAccess where
-  | writable    -- W : page is readable and writable
-  | readable    -- R : page is readable only
-  | inaccessible -- ∅ : page is not accessible
+  /-- W : page is readable and writable. -/
+  | writable
+  /-- R : page is readable only. -/
+  | readable
+  /-- ∅ : page is not accessible. -/
+  | inaccessible
   deriving BEq, Inhabited
 
 /-- μ : RAM state. GP eq (4.17).
@@ -192,14 +195,22 @@ def HostCallHandler (ctx : Type) :=
 
 /-- PVM instruction categories (for documentation; not used in execution). -/
 inductive InstructionCategory where
-  | noArgs       -- trap, fallthrough
-  | oneImmediate -- ecalli (host call)
-  | regImm64     -- load_imm_64
-  | twoImm       -- store_imm_u8/u16/u32/u64
-  | offset       -- jump, branch_*
-  | regImm       -- ALU ops, load/store with immediate
-  | twoReg       -- register-register ops
-  | threeReg     -- three-register ALU ops
+  /-- No-argument instructions: trap, fallthrough. -/
+  | noArgs
+  /-- Single-immediate instructions: ecalli (host call). -/
+  | oneImmediate
+  /-- 64-bit immediate load: load_imm_64. -/
+  | regImm64
+  /-- Store with immediate value: store_imm_u8/u16/u32/u64. -/
+  | twoImm
+  /-- Offset-based control flow: jump, branch_*. -/
+  | offset
+  /-- Register + immediate: ALU ops, load/store with immediate. -/
+  | regImm
+  /-- Two-register operations: register-register ops. -/
+  | twoReg
+  /-- Three-register ALU operations. -/
+  | threeReg
 
 -- PVM opcodes (~141 instructions) are fully decoded and executed in
 -- Jar.JAVM.Decode, Jar.JAVM.Instructions, and Jar.JAVM.Interpreter.

--- a/spec/Jar/JAVM/Decode.lean
+++ b/spec/Jar/JAVM/Decode.lean
@@ -379,18 +379,28 @@ def jarMagic : Nat := decodeLEn ⟨#[0x4A, 0x41, 0x52, 0x02]⟩ 0 4
 
 /-- JAR header (10 bytes). -/
 structure JarHeader where
+  /-- Number of memory pages to allocate for the program. -/
   memoryPages : Nat
+  /-- Number of capability entries in the manifest. -/
   capCount : Nat
+  /-- Index of the initial invocation capability. -/
   invokeCap : Nat
 
 /-- JAR capability entry (19 bytes). -/
 structure JarCapEntry where
+  /-- Capability slot index in the cap table. -/
   capIndex : Nat
+  /-- true = CODE capability, false = DATA capability. -/
   isCode : Bool      -- true = CODE, false = DATA
+  /-- Starting page number for DATA capabilities. -/
   basePage : Nat     -- DATA only
+  /-- Number of pages spanned by this DATA capability. -/
   pageCount : Nat    -- DATA only
+  /-- true = read-write (RW), false = read-only (RO) for DATA capabilities. -/
   isRW : Bool        -- DATA only (true = RW, false = RO)
+  /-- Byte offset into the JAR data section for initial contents. -/
   dataOffset : Nat   -- offset into data section
+  /-- Length of initial data in bytes. -/
   dataLen : Nat      -- bytes of initial data
 
 /-- Parse a JAR header (11 bytes). Returns header + offset after header. -/

--- a/spec/Jar/JAVM/GasCost.lean
+++ b/spec/Jar/JAVM/GasCost.lean
@@ -16,10 +16,15 @@ namespace Jar.JAVM
 
 /-- Execution unit requirements for an instruction. -/
 structure ExecUnits where
+  /-- ALU (arithmetic logic unit) cycles required. -/
   alu  : Nat := 0
+  /-- Load unit cycles required. -/
   load : Nat := 0
+  /-- Store unit cycles required. -/
   store : Nat := 0
+  /-- Multiply unit cycles required. -/
   mul  : Nat := 0
+  /-- Divide unit cycles required. -/
   div  : Nat := 0
   deriving Inhabited, BEq
 
@@ -58,12 +63,19 @@ def branchCost (code bitmask : ByteArray) (targetPC : Nat) : Nat :=
 
 /-- Result of instruction cost analysis. -/
 structure InstrCost where
+  /-- Number of execution cycles this instruction requires. -/
   cycles     : Nat
+  /-- Number of decode slots consumed. -/
   decodeSlots : Nat
+  /-- Execution unit requirements (ALU, load, store, mul, div). -/
   execUnits  : ExecUnits
+  /-- Destination register indices written by this instruction. -/
   destRegs   : Array Nat
+  /-- Source register indices read by this instruction. -/
   srcRegs    : Array Nat
+  /-- Whether this instruction terminates the basic block (sets ι := none). -/
   isTerminator : Bool   -- if true, sets ι := none after adding to ROB
+  /-- Whether this is a move_reg handled in the frontend only (no ROB entry). -/
   isMoveReg  : Bool     -- if true, handled in frontend only (no ROB entry)
 
 /-- Check if destination overlaps any source register (for ifdstoverlap). -/

--- a/spec/Jar/JAVM/GasCostFull.lean
+++ b/spec/Jar/JAVM/GasCostFull.lean
@@ -21,28 +21,43 @@ namespace Jar.JAVM
 
 /-- ROB entry state. -/
 inductive RobState where
-  | dec   -- decoded, waiting for dependencies
-  | wait  -- dependencies resolved, waiting for dispatch
-  | exe   -- executing
-  | fin   -- finished
+  /-- Decoded, waiting for dependencies. -/
+  | dec
+  /-- Dependencies resolved, waiting for dispatch. -/
+  | wait
+  /-- Executing on functional units. -/
+  | exe
+  /-- Finished execution. -/
+  | fin
   deriving BEq, Inhabited
 
 /-- Reorder buffer entry. -/
 structure RobEntry where
+  /-- Current state of this ROB entry. -/
   state     : RobState
+  /-- Remaining execution cycles. -/
   cyclesLeft : Nat
+  /-- ROB indices this entry depends on. -/
   deps      : Array Nat       -- ROB indices this depends on
+  /-- Register indices written by this instruction. -/
   destRegs  : Array Nat       -- registers written
+  /-- Execution units required to start. -/
   execUnits : ExecUnits       -- units required to start execution
   deriving Inhabited
 
 /-- Pipeline simulation state. -/
 structure GasSimState where
+  /-- Current instruction PC (none when done decoding). -/
   ι                    : Option Nat       -- current instruction counter (none = done decoding)
+  /-- Elapsed pipeline cycles. -/
   cycles               : Nat              -- cycle counter
+  /-- Decode slots remaining this cycle (reset to 4). -/
   remainingDecodeSlots : Nat              -- reset to 4 each cycle
+  /-- Dispatch slots remaining this cycle (reset to 5). -/
   remainingStartSlots  : Nat              -- reset to 5 each cycle
+  /-- Execution units remaining this cycle (reset to ALU:4, LOAD:4, STORE:4, MUL:1, DIV:1). -/
   remainingExecUnits   : ExecUnits        -- reset to (4,4,4,1,1) each cycle
+  /-- Reorder buffer entries. -/
   rob                  : Array RobEntry   -- reorder buffer
   deriving Inhabited
 

--- a/spec/Jar/JAVM/GasCostSinglePass.lean
+++ b/spec/Jar/JAVM/GasCostSinglePass.lean
@@ -59,10 +59,15 @@ namespace Jar.JAVM
 
 /-- Single-pass simulation state. -/
 structure GasSimStateSP where
+  /-- Current instruction PC (none when done decoding). -/
   ι         : Option Nat    -- current instruction PC (none = done)
+  /-- Current decode cycle counter. -/
   cycle     : Nat           -- current decode cycle
+  /-- Decode slots consumed this cycle (max 4 per cycle). -/
   decodeUsed : Nat          -- decode slots consumed this cycle
+  /-- Cycle when each register's value is ready (13 entries, one per register). -/
   regDone   : Array Nat     -- cycle when each register's value is ready (13 entries)
+  /-- Maximum completion cycle across all instructions in the block. -/
   maxDone   : Nat           -- max completion cycle across all instructions
 
 /-- Single-pass gas simulation: process one instruction at a time. -/

--- a/spec/Jar/JAVM/Interpreter.lean
+++ b/spec/Jar/JAVM/Interpreter.lean
@@ -471,8 +471,11 @@ def runTracePCs (prog : ProgramBlob) (pc : Nat) (regs : Registers) (mem : Memory
 
 /-- Single instruction trace entry: PC, opcode number, register snapshot. -/
 structure InstrTraceEntry where
+  /-- Program counter at time of execution. -/
   pc : Nat
+  /-- Opcode number of the instruction. -/
   opcode : Nat
+  /-- Snapshot of all 13 registers before execution. -/
   regs : Array UInt64  -- snapshot of all 13 registers before execution
   deriving Inhabited
 

--- a/spec/Jar/JAVM/Kernel.lean
+++ b/spec/Jar/JAVM/Kernel.lean
@@ -23,8 +23,11 @@ open Jar.JAVM.Cap
 
 /-- Compiled code data associated with a CODE cap. -/
 structure CodeCapData where
+  /-- Unique identifier for this code capability. -/
   id : Nat
+  /-- Decoded program blob (code + bitmask). -/
   program : JAVM.ProgramBlob
+  /-- Jump table for dynamic jump resolution. -/
   jumpTable : Array Nat
 
 instance : Inhabited CodeCapData where
@@ -32,7 +35,9 @@ instance : Inhabited CodeCapData where
 
 /-- Backing store: flat byte array representing all physical pages. -/
 structure BackingStore where
+  /-- Raw byte data backing all physical pages. -/
   data : ByteArray
+  /-- Total number of pages in the backing store. -/
   totalPages : Nat
 
 /-- PVM run function type (selects gas model). -/
@@ -40,34 +45,53 @@ def PvmRunFn := JAVM.ProgramBlob → Nat → JAVM.Registers → JAVM.Memory → 
 
 /-- Kernel state: VM pool + call stack + backing store + memory. -/
 structure KernelState where
+  /-- Pool of VM instances. -/
   vms : Array VmInstance
+  /-- Call stack for CALL/REPLY semantics. -/
   callStack : Array CallFrame
+  /-- Code capabilities (compiled programs). -/
   codeCaps : Array CodeCapData
+  /-- Index of the currently active VM. -/
   activeVm : Nat
+  /-- Untyped capability allocator for retype operations. -/
   untyped : UntypedCap
+  /-- Backing store for DATA cap pages. -/
   backing : BackingStore
   /-- Flat PVM memory shared by all VMs (simplified model). -/
   memory : JAVM.Memory
   /-- PVM execution function (gas model dependent). -/
   pvmRun : PvmRunFn
+  /-- Memory access cycle cost for gas simulation. -/
   memCycles : Nat
 
 /-- Result of running the kernel. -/
 inductive KernelResult where
+  /-- Root VM halted with exit value. -/
   | halt (value : Nat)
+  /-- Root VM panicked. -/
   | panic
+  /-- Gas exhausted. -/
   | outOfGas
+  /-- Page fault at address. -/
   | pageFault (addr : Nat)
+  /-- Protocol cap invoked, requesting host interaction. -/
   | protocolCall (slot : Nat)
 
 /-- Internal dispatch result. -/
 inductive DispatchResult where
+  /-- Continue execution (dispatch handled internally). -/
   | continue_
+  /-- Protocol cap invoked, needs host interaction. -/
   | protocolCall (slot : Nat)
+  /-- Root VM halted with exit value. -/
   | rootHalt (value : Nat)
+  /-- Root VM panicked. -/
   | rootPanic
+  /-- Root VM out of gas. -/
   | rootOutOfGas
+  /-- Root VM page fault. -/
   | rootPageFault (addr : Nat)
+  /-- Fault was handled by parent VM (resume parent). -/
   | faultHandled
 
 -- ============================================================================

--- a/spec/Jar/JAVM/Memory.lean
+++ b/spec/Jar/JAVM/Memory.lean
@@ -16,9 +16,12 @@ namespace Jar.JAVM
 
 /-- Result of a memory access: success or fault. -/
 inductive MemResult (α : Type) where
+  /-- Access succeeded, returning the value. -/
   | ok : α → MemResult α
-  | panic : MemResult α         -- Address < 2^16: always inaccessible
-  | fault : UInt64 → MemResult α  -- Page fault with page-aligned address
+  /-- Address below guard zone (2^16): always inaccessible. -/
+  | panic : MemResult α
+  /-- Page fault with page-aligned address. -/
+  | fault : UInt64 → MemResult α
 
 -- ============================================================================
 -- Page Calculations — GP eq (4.17-4.19)


### PR DESCRIPTION
## Summary

Addresses Issue #402 (JarBook documentation gaps) for the JAVM module.

Adds docstrings to 8 Lean 4 source files, eliminating **all non-Capability JAVM docstring warnings** in JarBook (previously 59+ warnings, now 0 for non-Cap JAVM types).

### Files changed

| File | Docstrings added |
|------|-----------------|
| `Jar/JAVM.lean` | `PageAccess` constructors (writable, readable, inaccessible), `InstructionCategory` constructors (8) |
| `Jar/JAVM/Memory.lean` | `MemResult` constructors (ok, panic, fault) |
| `Jar/JAVM/Decode.lean` | `JarHeader` fields (3), `JarCapEntry` fields (7) |
| `Jar/JAVM/GasCost.lean` | `ExecUnits` fields (5), `InstrCost` fields (7) |
| `Jar/JAVM/GasCostFull.lean` | `RobState` constructors (4), `RobEntry` fields (5), `GasSimState` fields (6) |
| `Jar/JAVM/GasCostSinglePass.lean` | `GasSimStateSP` fields (5) |
| `Jar/JAVM/Kernel.lean` | `CodeCapData` fields (3), `BackingStore` fields (2), `KernelState` fields (7+1), `KernelResult` constructors (5), `DispatchResult` constructors (7) |
| `Jar/JAVM/Interpreter.lean` | `InstrTraceEntry` fields (3) |

### Verification
- [x] `lake build` passes (187 jobs, 0 failures)
- [x] `lake build JarBookMain` — 0 non-Capability JAVM docstring warnings remaining

## Test plan
- [x] Lean 4 spec builds successfully
- [ ] JarBook documentation renders correctly with new docstrings

Contributes to #402