### PR TITLE
docs(spec): add docstrings to Types, Services, Notation, Accumulation, State, Codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/Accumulation.lean
+++ b/spec/Jar/Accumulation.lean
@@ -74,12 +74,19 @@ private def econEncodeInfo (e : JarConfig.EconType) (items bytes : Nat) : ByteAr
 
 /-- Combined work-digest/report operand for accumulation. GP §12. -/
 structure OperandTuple where
+  /-- Work-package hash. -/
   packageHash : Hash
+  /-- Segment root hash. -/
   segmentRoot : Hash
+  /-- Authorizer code hash. -/
   authorizerHash : Hash
+  /-- Work-item payload hash. -/
   payloadHash : Hash
+  /-- Gas limit for accumulation. -/
   gasLimit : Gas
+  /-- Authorization output/trace. -/
   authOutput : ByteArray
+  /-- Refinement result (output or error). -/
   result : WorkResult
 
 instance : Inhabited OperandTuple where
@@ -94,7 +101,9 @@ instance : Inhabited OperandTuple where
 
 /-- Input to a single-service accumulation: either an operand or a deferred transfer. -/
 inductive AccInput where
+  /-- Operand from a work-report result. -/
   | operand : OperandTuple → AccInput
+  /-- Deferred transfer from another service. -/
   | transfer : DeferredTransfer → AccInput
 
 -- ============================================================================
@@ -103,14 +112,23 @@ inductive AccInput where
 
 /-- Partial state threaded through accumulation. GP §12. -/
 structure PartialState where
+  /-- Service account dictionary. -/
   accounts : Dict ServiceId ServiceAccount
+  /-- Pending validator keys for next rotation. -/
   stagingKeys : Array ValidatorKey
+  /-- Per-core authorization queues. -/
   authQueue : Array (Array Hash)
+  /-- Manager service ID. -/
   manager : ServiceId
+  /-- Assigner service IDs. -/
   assigners : Array ServiceId
+  /-- Designator service ID. -/
   designator : ServiceId
+  /-- Registrar service ID. -/
   registrar : ServiceId
+  /-- Services that always accumulate regardless of operands. -/
   alwaysAccumulate : Dict ServiceId Gas
+  /-- Quota service ID (jar1). -/
   quotaService : ServiceId := 0
 
 /-- Extract partial state from full state. -/
@@ -131,10 +149,15 @@ def PartialState.fromState (s : State) : PartialState :=
 
 /-- Output of a single-service accumulation. GP §12. -/
 structure AccOneOutput where
+  /-- Partial state after accumulation. -/
   postState : PartialState
+  /-- Deferred transfers generated during accumulation. -/
   deferredTransfers : Array DeferredTransfer
+  /-- Accumulation output hash. -/
   yieldHash : Option Hash
+  /-- Gas consumed during accumulation. -/
   gasUsed : Gas
+  /-- Preimage provisions generated during accumulation. -/
   provisions : Array (ServiceId × ByteArray)
   /-- Updated opaque data (entries consumed during accumulation removed). -/
   opaqueData : Array (ByteArray × ByteArray) := #[]

--- a/spec/Jar/Codec.lean
+++ b/spec/Jar/Codec.lean
@@ -303,7 +303,9 @@ def encodeBlock (b : Block) : ByteArray :=
 
 /-- State for the decoder: a ByteArray and a current position. -/
 structure DecodeState where
+  /-- Byte array being decoded. -/
   data : ByteArray
+  /-- Current read position in the byte array. -/
   pos : Nat
 
 /-- Decoder monad: a function from state to an optional (result, new state). -/

--- a/spec/Jar/Notation.lean
+++ b/spec/Jar/Notation.lean
@@ -27,9 +27,12 @@ def substituteIfNone : List (Option α) → Option α
 /-- GP uses ∅ for "no specific value" (we use `Option.none`)
     and ∇ for "unexpected failure / invalid". We model ∇ explicitly. -/
 inductive Exceptional (α : Type) where
+  /-- Successful value. GP: no exceptional case. -/
   | ok    : α → Exceptional α
-  | none  : Exceptional α       -- GP: ∅
-  | error : Exceptional α       -- GP: ∇
+  /-- No value / empty. GP: ∅. -/
+  | none  : Exceptional α
+  /-- Error / invalid. GP: ∇. -/
+  | error : Exceptional α
 
 -- GP: `A?` ≡ A ∪ {∅}. We use Lean's built-in `Option α` throughout.
 
@@ -50,12 +53,14 @@ def IntRange (a b : Int) : Type := { x : Int // a ≤ x ∧ x < b }
 /-- A dictionary ⟨K→V⟩ : partial mapping with enumerable key-value pairs.
     GP §3.5. Represented as sorted association list with unique keys. -/
 structure Dict (K : Type) (V : Type) [BEq K] where
+  /-- Key-value pairs in insertion order. -/
   entries : List (K × V)
 
 namespace Dict
 
 variable {K V : Type} [BEq K]
 
+/-- Empty dictionary. -/
 def empty : Dict K V := ⟨[]⟩
 
 /-- Lookup: d[k]. GP §3.5. -/
@@ -138,7 +143,9 @@ abbrev Blob := ByteArray
 
 /-- 𝔹_n : octet strings of exactly n bytes. GP §3.7.4. -/
 structure OctetSeq (n : Nat) where
+  /-- Underlying byte array. -/
   data : ByteArray
+  /-- Proof that the byte array has exactly n bytes. -/
   size_eq : data.size = n
 
 instance (n : Nat) : BEq (OctetSeq n) where
@@ -164,14 +171,20 @@ def OctetSeq.mk! (ba : ByteArray) (n : Nat) : OctetSeq n :=
 /-- Construct Hash with runtime size check, falling back to zero on mismatch. -/
 def Hash.mk! (ba : ByteArray) : Hash := OctetSeq.mk! ba 32
 
--- Signing key types. GP §3.8.2.
-abbrev Ed25519PublicKey       := OctetSeq 32   -- H̄ ⊂ 𝔹_32
-abbrev BandersnatchPublicKey  := OctetSeq 32   -- H̃ ⊂ 𝔹_32
-abbrev BlsPublicKey           := OctetSeq 144  -- B^BLS ⊂ 𝔹_144
-abbrev BandersnatchRingRoot   := OctetSeq 144  -- B° ⊂ 𝔹_144
+/-- Ed25519 public key (32 bytes). GP §3.8.2: H̄ ⊂ 𝔹_32. -/
+abbrev Ed25519PublicKey       := OctetSeq 32
+/-- Bandersnatch public key (32 bytes). GP §3.8.2: H̃ ⊂ 𝔹_32. -/
+abbrev BandersnatchPublicKey  := OctetSeq 32
+/-- BLS public key (144 bytes). GP §3.8.2: B^BLS ⊂ 𝔹_144. -/
+abbrev BlsPublicKey           := OctetSeq 144
+/-- Bandersnatch ring root (144 bytes). GP §3.8.2: B° ⊂ 𝔹_144. -/
+abbrev BandersnatchRingRoot   := OctetSeq 144
 
--- Signature types. GP §3.8.2.
-abbrev Ed25519Signature           := OctetSeq 64   -- V̄_k⟨m⟩ ⊂ 𝔹_64
-abbrev BandersnatchSignature      := OctetSeq 96   -- Ṽ_k^m⟨x⟩ ⊂ 𝔹_96
-abbrev BandersnatchRingVrfProof   := OctetSeq 784  -- V°_r^m⟨x⟩ ⊂ 𝔹_784
+/-- Ed25519 signature (64 bytes). GP §3.8.2. -/
+abbrev Ed25519Signature           := OctetSeq 64
+/-- Bandersnatch signature (96 bytes). GP §3.8.2. -/
+abbrev BandersnatchSignature      := OctetSeq 96
+/-- Bandersnatch ring VRF proof (784 bytes). GP §3.8.2. -/
+abbrev BandersnatchRingVrfProof   := OctetSeq 784
+/-- BLS signature (48 bytes). GP §3.8.2. -/
 abbrev BlsSignature               := OctetSeq 48

--- a/spec/Jar/Services.lean
+++ b/spec/Jar/Services.lean
@@ -335,26 +335,46 @@ opaque auditWorkReport
 
 /-- Host-call identifiers available during accumulation. GP §12. -/
 inductive HostCall where
-  | gas          -- Ω_G : Query remaining gas
-  | lookup       -- Ω_L : Lookup value in service storage
-  | read         -- Ω_R : Read from own storage
-  | write        -- Ω_W : Write to own storage
-  | info         -- Ω_I : Service info query
-  | bless        -- Ω_B : Set privileged services (manager only)
-  | assign       -- Ω_A : Assign core authorization
-  | designate    -- Ω_D : Designate validator keys
-  | checkpoint   -- Ω_C : Checkpoint gas
-  | newService   -- Ω_N : Create new service
-  | upgrade      -- Ω_U : Upgrade service code
-  | transfer     -- Ω_T : Transfer balance
-  | quit         -- Ω_Q : Remove service
-  | solicit      -- Ω_S : Solicit preimage
-  | forget       -- Ω_F : Forget preimage
-  | historicalLookup -- Ω_H : Historical state lookup
-  | fetch        -- Ω_E : Fetch preimage data
-  | yield        -- Ω_Y : Yield accumulation output
-  | provide      -- Ω_P : Provide preimage data
-  | empower      -- Ω_M : Empower (privileged operations)
+  /-- Ω_G: Query remaining gas. Host call slot 1. -/
+  | gas
+  /-- Ω_L: Lookup value in another service's storage. Host call slot 3. -/
+  | lookup
+  /-- Ω_R: Read from own service storage. Host call slot 4. -/
+  | read
+  /-- Ω_W: Write to own service storage. Host call slot 5. -/
+  | write
+  /-- Ω_I: Query own service info. Host call slot 6. -/
+  | info
+  /-- Ω_B: Set privileged services (manager only). Host call slot 15. -/
+  | bless
+  /-- Ω_A: Assign core authorization. Host call slot 16. -/
+  | assign
+  /-- Ω_D: Designate validator keys. Host call slot 17. -/
+  | designate
+  /-- Ω_C: Checkpoint gas for potential rollback. Host call slot 18. -/
+  | checkpoint
+  /-- Ω_N: Create a new service. Host call slot 19. -/
+  | newService
+  /-- Ω_U: Upgrade service code. Host call slot 20. -/
+  | upgrade
+  /-- Ω_T: Transfer balance to another service. Host call slot 21. -/
+  | transfer
+  /-- Ω_Q: Remove (quit) own service. Host call slot 22. -/
+  | quit
+  /-- Ω_S: Solicit a preimage. Host call slot 24. -/
+  | solicit
+  /-- Ω_F: Forget a preimage. Host call slot 25. -/
+  | forget
+  /-- Ω_H: Historical state lookup. Host call slot 7. -/
+  | historicalLookup
+  /-- Ω_E: Fetch preimage data. Host call slot 2. -/
+  | fetch
+  /-- Ω_Y: Yield accumulation output. Host call slot 26. -/
+  | yield
+  /-- Ω_P: Provide preimage data. Host call slot 27. -/
+  | provide
+  /-- Ω_M: Empower privileged operations. Host call slot 28. -/
+  | empower
   deriving BEq
 
 end Jar.Services

--- a/spec/Jar/State.lean
+++ b/spec/Jar/State.lean
@@ -350,15 +350,25 @@ def updateAuthPool
 
 /-- Accumulation result: the combined outputs of processing available work reports. -/
 structure AccumulationResult where
+  /-- Updated service accounts after accumulation. -/
   services : Dict ServiceId ServiceAccount
+  /-- Updated privileged service configuration. -/
   privileged : PrivilegedServices
+  /-- Updated pending validator keys. -/
   pendingValidators : Array ValidatorKey
+  /-- Updated per-core authorization queues. -/
   authQueue : Array (Array Hash)
+  /-- Accumulation output pairs (service ID, hash). -/
   outputs : AccumulationOutputs
+  /-- Updated accumulation queue. -/
   accQueue : Array (Array (WorkReport × Array Hash))
+  /-- Updated accumulation history. -/
   accHistory : Array (Array Hash)
+  /-- Per-service accumulation statistics. -/
   accStats : Dict ServiceId ServiceStatistics
+  /-- Opaque data entries not consumed during accumulation. -/
   remainingOpaqueData : Array (ByteArray × ByteArray) := #[]
+  /-- Per-service exit reasons for debugging. -/
   exitReasons : Array (ServiceId × String) := #[]
 
 /-- Compute dependency set for a work report (GP eq 12.6).

--- a/spec/Jar/Types/Config.lean
+++ b/spec/Jar/Types/Config.lean
@@ -90,9 +90,13 @@ def Params.isValidValCount (cfg : Params) (z : Nat) : Bool :=
 
 /-- Positivity proofs required for Fin types to be inhabited. -/
 structure Params.Valid (cfg : Params) : Prop where
+  /-- Positivity proof: validator count V > 0. -/
   hV : 0 < cfg.V
+  /-- Positivity proof: core count C > 0. -/
   hC : 0 < cfg.C
+  /-- Positivity proof: epoch length E > 0. -/
   hE : 0 < cfg.E
+  /-- Positivity proof: ticket count N > 0. -/
   hN : 0 < cfg.N_TICKETS
 
 -- ============================================================================
@@ -184,7 +188,9 @@ class EconModel (econ : Type) (xfer : Type) where
 class JarConfig where
   /-- Variant name, e.g. "gp072_tiny", "gp072_full". -/
   name : String
+  /-- Protocol parameter set for this variant. -/
   config : Params
+  /-- Positivity proofs for the parameter set. -/
   valid : Params.Valid config
   /-- PVM memory layout for program initialization. -/
   memoryModel : MemoryModel := .segmented

--- a/spec/Jar/Types/Header.lean
+++ b/spec/Jar/Types/Header.lean
@@ -62,33 +62,49 @@ structure Header where
 
 /-- A single judgment by a validator on a work-report. -/
 structure Judgment where
+  /-- Whether the validator judges the report as valid. -/
   isValid : Bool
+  /-- Index of the judging validator in the validator set. -/
   validatorIndex : ValidatorIndex
+  /-- Ed25519 signature attesting to the judgment. -/
   signature : Ed25519Signature
 
 /-- A verdict on a work-report, composed of multiple judgments. -/
 structure Verdict where
+  /-- Hash of the work-report being judged. -/
   reportHash : Hash
+  /-- Timeslot age of the judgment. -/
   age : UInt32
+  /-- Individual validator judgments composing the verdict. -/
   judgments : Array Judgment
 
 /-- Culprit: a validator who guaranteed an invalid work-report. -/
 structure Culprit where
+  /-- Hash of the invalid work-report. -/
   reportHash : Hash
+  /-- Ed25519 public key of the offending guarantor. -/
   validatorKey : Ed25519PublicKey
+  /-- Ed25519 signature proving guilt. -/
   signature : Ed25519Signature
 
 /-- Fault: a validator who made an incorrect judgment. -/
 structure Fault where
+  /-- Hash of the work-report in question. -/
   reportHash : Hash
+  /-- Whether the faulting validator judged correctly. -/
   isValid : Bool
+  /-- Ed25519 public key of the faulting validator. -/
   validatorKey : Ed25519PublicKey
+  /-- Ed25519 signature proving the fault. -/
   signature : Ed25519Signature
 
 /-- E_D : Disputes extrinsic. GP §10.2. -/
 structure DisputesExtrinsic where
+  /-- Super-majority verdicts on work-reports. -/
   verdicts : Array Verdict
+  /-- Validators who guaranteed invalid work-reports. -/
   culprits : Array Culprit
+  /-- Validators who made incorrect judgments. -/
   faults : Array Fault
 
 -- ============================================================================

--- a/spec/Jar/Types/Work.lean
+++ b/spec/Jar/Types/Work.lean
@@ -20,12 +20,18 @@ variable [JarConfig]
 /-- 𝔼 : Work execution error. GP eq (109–111).
     Possible outcomes when refinement fails. -/
 inductive WorkError where
-  | outOfGas    -- ∞ : gas exhaustion
-  | panic       -- ☇ : exceptional halt
-  | badExports  -- invalid exports
-  | oversize    -- code too large
-  | badCode     -- BAD : code not available
-  | bigCode     -- BIG : code exceeds limit
+  /-- Gas exhaustion (∞). GP eq (110). -/
+  | outOfGas
+  /-- Exceptional halt (☇). GP eq (110). -/
+  | panic
+  /-- Invalid exports. GP eq (110). -/
+  | badExports
+  /-- Code too large. GP eq (110). -/
+  | oversize
+  /-- Code not available (BAD). GP eq (110). -/
+  | badCode
+  /-- Code exceeds limit (BIG). GP eq (110). -/
+  | bigCode
   deriving BEq
 
 -- ============================================================================
@@ -34,7 +40,9 @@ inductive WorkError where
 
 /-- Work result: either successful output blob or an error. GP eq (109). -/
 inductive WorkResult where
+  /-- Successful refinement output. -/
   | ok : ByteArray → WorkResult
+  /-- Refinement failed with error. -/
   | err : WorkError → WorkResult
 
 /-- 𝔻 : Work digest — the on-chain summary of a single refined work-item.


### PR DESCRIPTION
## Summary

Adds docstrings to 7 Lean 4 source modules, eliminating all non-JAVM/Capability/Kernel JarBook documentation warnings (249 → 147).

### Files modified

| Module | Declarations documented | Count |
|--------|------------------------|-------|
| `Types/Work.lean` | WorkError constructors (6), WorkResult constructors (2) | 8 |
| `Types/Header.lean` | Judgment fields (3), Verdict fields (3), Culprit fields (3), Fault fields (4), DisputesExtrinsic fields (3) | 16 |
| `Types/Config.lean` | Params.Valid fields (4), JarConfig fields (2) | 6 |
| `Notation.lean` | Exceptional constructors (3), Dict fields (2), OctetSeq fields (2), crypto key types (4), signature types (4) | 15 |
| `Services.lean` | All HostCall constructors with Ω identifiers and slot numbers | 20 |
| `Accumulation.lean` | OperandTuple fields (7), AccInput constructors (2), PartialState fields (9), AccOneOutput fields (5) | 23 |
| `State.lean` | AccumulationResult fields (10) | 10 |
| `Codec.lean` | DecodeState fields (2) | 2 |
| **Total** | | **102** |

### CI fix

Includes `rustls-webpki` 0.103.13 update to pass Security audit (RUSTSEC-2026-0104).

### Related

- Issue #402 (JarBook documentation)
- PR #751 (Capability docstrings) and #756 (JAVM docstrings) cover the remaining 147 warnings

## Test plan

- [x] `lake build` passes in `spec/`
- [x] JarBook warnings reduced from 249 to 147 (remaining are in PR #751/#756)
- [x] CI Security audit passes (rustls-webpki fix included)