### PR TITLE
chore: add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# EditorConfig - https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.toml]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.lean]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Adds EditorConfig file to maintain consistent coding style across different editors and IDEs.

## What's configured

| File type | Indent | Size | Other |
|-----------|--------|------|-------|
| Rust (.rs) | space | 4 | max_line_length=100 |
| TOML | space | 4 | |
| YAML/JSON | space | 2 | |
| Lean | space | 2 | |
| Makefile | tab | | |
| Python | space | 4 | |

Closes #735

## Benefits

- Consistent coding style across all contributors
- Works with most editors (VS Code, Vim, Emacs, JetBrains, etc.)
- No need for per-project editor settings
- Prevents whitespace-related diff noise