### PR TITLE
refactor(grey-types): add short_hex() to crypto macro, eliminate inline hex encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/grey/crates/grey-state/tests/stf_blocks.rs
+++ b/grey/crates/grey-state/tests/stf_blocks.rs
@@ -204,7 +204,7 @@ fn run_independent_trace(trace_name: &str) {
                                     eprintln!(
                                         "  DIFF key[0]={} key={}...: exp={}B act={}B",
                                         k[0],
-                                        hex::encode(&k[..8]),
+                                        hex::encode(&k[..8.min(k.len())]),
                                         ev.len(),
                                         av.len()
                                     );
@@ -213,7 +213,7 @@ fn run_independent_trace(trace_name: &str) {
                                     eprintln!(
                                         "  MISSING key[0]={} key={}...: exp={}B",
                                         k[0],
-                                        hex::encode(&k[..8]),
+                                        hex::encode(&k[..8.min(k.len())]),
                                         ev.len()
                                     );
                                 }
@@ -225,7 +225,7 @@ fn run_independent_trace(trace_name: &str) {
                                 eprintln!(
                                     "  EXTRA key[0]={} key={}...: act={}B",
                                     k[0],
-                                    hex::encode(&k[..8]),
+                                    hex::encode(&k[..8.min(k.len())]),
                                     av.len()
                                 );
                             }

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -104,6 +104,10 @@ macro_rules! impl_crypto_common {
             pub fn to_hex(&self) -> String {
                 hex::encode(self.0)
             }
+            /// Encode the first 8 bytes as a hex string for log/debug output.
+            pub fn short_hex(&self) -> String {
+                hex::encode(&self.0[..8])
+            }
             /// Parse from a hex string (with optional 0x prefix). Panics on invalid input.
             pub fn from_hex(s: &str) -> Self {
                 Self(decode_hex_fixed(s).expect(concat!("invalid hex for ", $debug_name)))
@@ -141,7 +145,7 @@ macro_rules! impl_crypto_type {
         }
         impl fmt::Debug for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}({}...)", $debug_name, hex::encode(&self.0[..8]))
+                write!(f, "{}({}...)", $debug_name, self.short_hex())
             }
         }
     };


### PR DESCRIPTION
## Summary

Eliminates inline `hex::encode(&self.0[..8])` duplication by promoting `short_hex()` from a `Hash`-only method to a shared method in the `impl_crypto_common` macro.

### Changes

1. **`impl_crypto_common` macro** — Add `short_hex()` method so all crypto types (Hash, BlsPublicKey, Ed25519Signature, BandersnatchSignature, etc.) get consistent truncated hex output
2. **`impl_crypto_type` macro (large variant)** — Replace `hex::encode(&self.0[..8])` with `self.short_hex()`
3. **`stf_blocks.rs` test** — Use bounds-checked `8.min(k.len())` for potentially short `Vec<u8>` storage keys

### Before
```rust
// In macro:
write!(f, "{}({}...)", $debug_name, hex::encode(&self.0[..8]))
// Only Hash had short_hex(), other crypto types had to inline
```

### After
```rust
// In macro:
write!(f, "{}({}...)", $debug_name, self.short_hex())
// All crypto types now have short_hex() via impl_crypto_common
```

## Test plan
- [x] `cargo check -p grey-types -p grey-state --tests` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy` passes

Refs: #186