### PR TITLE
refactor(grey): extract AUDIT_PRUNE_SLOTS constant, replace magic number 30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/grey/crates/grey/src/audit.rs
+++ b/grey/crates/grey/src/audit.rs
@@ -20,6 +20,10 @@ const TRANCHE_PERIOD_SECS: u64 = 8;
 /// Number of initial audit tranches before timeout.
 pub const MAX_TRANCHES: u32 = 30;
 
+/// Number of slots to retain audit state before pruning.
+/// Audits older than this are considered expired and removed.
+pub const AUDIT_PRUNE_SLOTS: Timeslot = 30;
+
 /// Announcement of an audit result.
 #[derive(Debug, Clone)]
 pub struct AuditAnnouncement {

--- a/grey/crates/grey/src/node.rs
+++ b/grey/crates/grey/src/node.rs
@@ -932,9 +932,9 @@ pub async fn run_node(config: NodeConfig) -> Result<(), Box<dyn std::error::Erro
                         }
                 }
 
-                // Prune old audits (older than 30 slots)
-                if state.timeslot > 30 {
-                    audit_state.prune_old_audits(state.timeslot - 30);
+                // Prune old audits (older than AUDIT_PRUNE_SLOTS)
+                if state.timeslot > audit::AUDIT_PRUNE_SLOTS {
+                    audit_state.prune_old_audits(state.timeslot - audit::AUDIT_PRUNE_SLOTS);
                 }
             }
 


### PR DESCRIPTION
## Summary

Replace the hardcoded `30` in `node.rs` audit pruning with a named constant `audit::AUDIT_PRUNE_SLOTS`.

### Changes
- Add `AUDIT_PRUNE_SLOTS: Timeslot = 30` constant to `audit.rs`
- Replace `state.timeslot > 30` / `state.timeslot - 30` with `audit::AUDIT_PRUNE_SLOTS`

### Before
```rust
// node.rs:936
if state.timeslot > 30 {
    audit_state.prune_old_audits(state.timeslot - 30);
}
```

### After
```rust
if state.timeslot > audit::AUDIT_PRUNE_SLOTS {
    audit_state.prune_old_audits(state.timeslot - audit::AUDIT_PRUNE_SLOTS);
}
```

## Test plan
- [x] `cargo check -p grey` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -p grey` passes

Refs: #186