### PR TITLE
proof(spec): add canAffordStorage monotonicity theorems for BalanceEcon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/Proofs/BalanceEcon.lean
+++ b/spec/Jar/Proofs/BalanceEcon.lean
@@ -259,4 +259,46 @@ theorem balanceEcon_absorbEjected_comm_balance (e1 e2 : BalanceEcon) :
   show e1.balance + e2.balance = e2.balance + e1.balance
   rw [UInt64.add_comm]
 
+-- ============================================================================
+-- canAffordStorage monotonicity (higher balance ⟹ still affordable)
+-- ============================================================================
+
+/-- canAffordStorage monotonicity for BalanceEcon: if storage is affordable under
+    econ state e1, and e2 has at least as high balance (with same gratis),
+    then storage is affordable under e2. This is the key safety property —
+    increasing a service's balance never revokes previously affordable storage.
+
+    The proof works because `canAffordStorage` checks `threshold ≤ balance`,
+    and increasing the balance preserves the inequality. -/
+theorem balanceEcon_canAffordStorage_mono
+    (e1 e2 : BalanceEcon) (items bytes bI bL bS : Nat)
+    (hGratis : e1.gratis = e2.gratis)
+    (hBal : e1.balance.toNat ≤ e2.balance.toNat)
+    (h : @EconModel.canAffordStorage BalanceEcon BalanceTransfer _ e1 items bytes bI bL bS = true) :
+    @EconModel.canAffordStorage BalanceEcon BalanceTransfer _ e2 items bytes bI bL bS = true := by
+  simp only [EconModel.canAffordStorage, decide_eq_true_eq] at h ⊢
+  rw [hGratis] at h
+  exact Nat.le_trans h hBal
+
+/-- canAffordStorage is monotone in gratis: increasing gratis (which decreases
+    the threshold `minBal - min gratis minBal`) preserves affordability.
+    If e2 has greater or equal gratis than e1 (with same balance), then
+    storage affordable under e1 is also affordable under e2. -/
+theorem balanceEcon_canAffordStorage_mono_gratis
+    (e1 e2 : BalanceEcon) (items bytes bI bL bS : Nat)
+    (hBal : e1.balance = e2.balance)
+    (hGratis : e1.gratis.toNat ≤ e2.gratis.toNat)
+    (h : @EconModel.canAffordStorage BalanceEcon BalanceTransfer _ e1 items bytes bI bL bS = true) :
+    @EconModel.canAffordStorage BalanceEcon BalanceTransfer _ e2 items bytes bI bL bS = true := by
+  simp only [EconModel.canAffordStorage, decide_eq_true_eq] at h ⊢
+  -- threshold2 ≤ threshold1 (more gratis ⟹ smaller threshold)
+  calc bS + bI * items + bL * bytes - min e2.gratis.toNat (bS + bI * items + bL * bytes)
+      ≤ bS + bI * items + bL * bytes - min e1.gratis.toNat (bS + bI * items + bL * bytes) := by
+        -- min e2.gratis ≥ min e1.gratis since e2.gratis ≥ e1.gratis
+        have : min e1.gratis.toNat (bS + bI * items + bL * bytes)
+             ≤ min e2.gratis.toNat (bS + bI * items + bL * bytes) := by omega
+        omega
+    _ ≤ UInt64.toNat e1.balance := h
+    _ = UInt64.toNat e2.balance := by rw [hBal]
+
 end Jar.Proofs


### PR DESCRIPTION
## Summary

Adds two Lean 4 theorems proving that `BalanceEcon.canAffordStorage` is monotone — increasing either balance or gratis never revokes previously affordable storage.

### New theorems

1. **`balanceEcon_canAffordStorage_mono`** — If storage is affordable under e1, and e2 has ≥ balance (same gratis), then affordable under e2. Key safety guarantee: increasing balance never revokes storage rights.

2. **`balanceEcon_canAffordStorage_mono_gratis`** — If storage is affordable under e1, and e2 has ≥ gratis (same balance), then affordable under e2. More gratis ⟹ smaller threshold ⟹ easier to afford.

### Proof technique

Both theorems use `calc` chains with `omega` for the `min`-subtraction monotonicity step:
```
threshold(e2) ≤ threshold(e1) ≤ e1.balance = e2.balance
```

### Context

These complement the existing `quotaEcon_canAffordStorage_mono` and the `creditTransfer`/`absorbEjected` preservation theorems, completing the monotonicity story for both economic models.

## Test plan
- [x] `lake build` passes in `spec/`
- [x] Full build (187 jobs) passes

Refs: #374