### PR TITLE
ci: add dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      rust-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "ring"
+        versions: ["0.16.x"]
+        # RUSTSEC-2025-0009, RUSTSEC-2025-0010: ring 0.16.x issues
+        # blocked by libp2p-tls -> rcgen -> ring chain


### PR DESCRIPTION
Adds weekly automated dependency updates with grouped minor/patch updates, limit of 10 open PRs, and ignored ring 0.16.x (blocked by RUSTSEC-2025-0009/0010).