### PR TITLE
test(grey-rpc): add websocket subscription coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
 name = "grey-rpc"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "grey-consensus",
  "grey-crypto",
  "grey-merkle",

--- a/grey/crates/grey-rpc/Cargo.toml
+++ b/grey/crates/grey-rpc/Cargo.toml
@@ -22,8 +22,9 @@ serde_json = { workspace = true }
 hex = { workspace = true }
 
 [dev-dependencies]
-jsonrpsee = { version = "0.24", features = ["client"] }
+jsonrpsee = { version = "0.24", features = ["client", "ws-client"] }
 reqwest = { version = "0.12", default-features = false }
 tempfile = "3"
 grey-consensus = { workspace = true }
 proptest = { workspace = true }
+futures-util = "0.3"

--- a/grey/crates/grey-rpc/src/lib.rs
+++ b/grey/crates/grey-rpc/src/lib.rs
@@ -1370,11 +1370,13 @@ pub fn create_rpc_channel(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use grey_types::BandersnatchSignature;
     use grey_types::header::{Block, Extrinsic, Header, UnsignedHeader};
-    use jsonrpsee::core::client::ClientT;
+    use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
     use jsonrpsee::http_client::HttpClientBuilder;
     use jsonrpsee::rpc_params;
+    use jsonrpsee::ws_client::WsClientBuilder;
 
     /// Create a temp store, RPC state, and start an ephemeral server.
     /// Returns (client_url, rpc_state, command_rx, store, _tempdir).
@@ -1392,6 +1394,10 @@ mod tests {
         let (addr, _handle) = start_rpc_server_ephemeral(state.clone()).await.unwrap();
         let url = format!("http://{}", addr);
         (url, state, rx, store, dir)
+    }
+
+    fn ws_url(http_url: &str) -> String {
+        http_url.replacen("http://", "ws://", 1)
     }
 
     fn test_block(slot: u32) -> Block {
@@ -1432,6 +1438,61 @@ mod tests {
         assert_eq!(result["head_hash"], "abc123");
         assert_eq!(result["blocks_authored"], 10);
         assert_eq!(result["validator_index"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_new_blocks_receives_notifications() {
+        let (url, state, _rx, _store, _dir) = setup().await;
+        let client = WsClientBuilder::default()
+            .build(&ws_url(&url))
+            .await
+            .unwrap();
+
+        let mut sub = client
+            .subscribe::<serde_json::Value, _>(
+                "subscribeNewBlocks",
+                rpc_params![],
+                "unsubscribeNewBlocks",
+            )
+            .await
+            .unwrap();
+
+        let expected = serde_json::json!({
+            "slot": 42,
+            "hash": "0xfeedbeef",
+        });
+        state.block_notifications.send(expected.clone()).unwrap();
+
+        let received = sub.next().await.unwrap().unwrap();
+        assert_eq!(received, expected);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_finalized_receives_notifications() {
+        let (url, state, _rx, _store, _dir) = setup().await;
+        let client = WsClientBuilder::default()
+            .build(&ws_url(&url))
+            .await
+            .unwrap();
+
+        let mut sub = client
+            .subscribe::<serde_json::Value, _>(
+                "subscribeFinalized",
+                rpc_params![],
+                "unsubscribeFinalized",
+            )
+            .await
+            .unwrap();
+
+        let expected = serde_json::json!({
+            "slot": 40,
+            "hash": "0xdeadbeef",
+            "finalized": true,
+        });
+        state.finality_notifications.send(expected.clone()).unwrap();
+
+        let received = sub.next().await.unwrap().unwrap();
+        assert_eq!(received, expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

This patch adds end-to-end WebSocket subscription coverage for `grey-rpc`.

## What changed

- enabled the `ws-client` feature for `jsonrpsee` in dev-dependencies
- added a small `ws_url` helper for test setup
- added an end-to-end test for `subscribeNewBlocks`
- added an end-to-end test for `subscribeFinalized`
- added the minimal stream/client imports needed for subscription assertions

## Why

`grey-rpc` already exposes WebSocket subscription methods for new blocks and finalized notifications, but these paths were not covered by dedicated tests. This patch makes that behavior explicit and helps protect against regressions in subscription wiring, notification delivery, and payload shape.

## Notes

This changes tests only and does not affect protocol behavior.
