### PR TITLE
refactor: deduplicate arb_hash() proptest strategy into grey-types

### DIFF
--- a/grey/crates/grey-state/Cargo.toml
+++ b/grey/crates/grey-state/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 hex = { workspace = true }
 
 [dev-dependencies]
+grey-types = { workspace = true, features = ["testing"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/grey/crates/grey-state/src/authorizations.rs
+++ b/grey/crates/grey-state/src/authorizations.rs
@@ -146,11 +146,8 @@ mod proptests {
     use super::*;
     use grey_types::Hash;
     use grey_types::config::Config;
+    use grey_types::testing::arb_hash;
     use proptest::prelude::*;
-
-    fn arb_hash() -> impl Strategy<Value = Hash> {
-        prop::array::uniform32(any::<u8>()).prop_map(Hash)
-    }
 
     proptest! {
         /// Pool size never exceeds auth_pool_size (O) after any update.

--- a/grey/crates/grey-state/src/history.rs
+++ b/grey/crates/grey-state/src/history.rs
@@ -240,11 +240,8 @@ mod proptests {
     use grey_types::Hash;
     use grey_types::constants::RECENT_HISTORY_SIZE;
     use grey_types::state::RecentBlocks;
+    use grey_types::testing::arb_hash;
     use proptest::prelude::*;
-
-    fn arb_hash() -> impl Strategy<Value = Hash> {
-        prop::array::uniform32(any::<u8>()).prop_map(Hash)
-    }
 
     proptest! {
         /// Headers length never exceeds RECENT_HISTORY_SIZE.

--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -571,12 +571,9 @@ mod proptests {
     use super::*;
     use grey_types::Hash;
     use grey_types::config::Config;
+    use grey_types::testing::arb_hash;
     use grey_types::work::WorkReport;
     use proptest::prelude::*;
-
-    fn arb_hash() -> impl Strategy<Value = Hash> {
-        prop::array::uniform32(any::<u8>()).prop_map(Hash)
-    }
 
     fn make_reports_state(config: &Config) -> ReportsState {
         let v = config.validators_count as usize;

--- a/grey/crates/grey-state/src/safrole.rs
+++ b/grey/crates/grey-state/src/safrole.rs
@@ -545,11 +545,8 @@ mod proptests {
     use super::*;
     use crate::test_helpers::{make_hash, make_validator};
     use grey_types::header::Ticket;
+    use grey_types::testing::arb_hash;
     use proptest::prelude::*;
-
-    fn arb_hash() -> impl Strategy<Value = Hash> {
-        prop::array::uniform32(any::<u8>()).prop_map(Hash)
-    }
 
     proptest! {
         /// outside_in_sequence preserves length and all elements.

--- a/grey/crates/grey-store/Cargo.toml
+++ b/grey/crates/grey-store/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+grey-types = { workspace = true, features = ["testing"] }
 grey-consensus = { workspace = true }
 proptest = { workspace = true }
 tempfile = "3"

--- a/grey/crates/grey-store/tests/proptest_store.rs
+++ b/grey/crates/grey-store/tests/proptest_store.rs
@@ -1,6 +1,7 @@
 //! Property-based roundtrip tests for grey-store.
 
 use grey_types::header::{Block, Extrinsic, Header, UnsignedHeader};
+use grey_types::testing::arb_hash;
 use grey_types::{BandersnatchSignature, Hash};
 use proptest::prelude::*;
 
@@ -8,11 +9,6 @@ fn temp_store() -> (grey_store::Store, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let store = grey_store::Store::open(dir.path().join("test.redb")).unwrap();
     (store, dir)
-}
-
-/// Strategy for an arbitrary 32-byte Hash.
-fn arb_hash() -> impl Strategy<Value = Hash> {
-    prop::array::uniform32(any::<u8>()).prop_map(Hash)
 }
 
 /// Strategy for a minimal Block with arbitrary header fields.

--- a/grey/crates/grey-types/Cargo.toml
+++ b/grey/crates/grey-types/Cargo.toml
@@ -5,8 +5,12 @@ edition.workspace = true
 license.workspace = true
 description = "Core types, constants, and data structures for the JAM protocol."
 
+[features]
+testing = ["proptest"]
+
 [dependencies]
 hex = { workspace = true }
+proptest = { workspace = true, optional = true }
 serde = { workspace = true }
 scale = { workspace = true }
 

--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -96,6 +96,27 @@ pub fn decode_hex_fixed<const N: usize>(s: &str) -> Result<[u8; N], String> {
     Ok(arr)
 }
 
+/// Proptest strategies and test utilities.
+///
+/// Enable with the `testing` feature flag. Other crates should add
+/// `grey-types = { workspace = true, features = ["testing"] }` to their
+/// **dev-dependencies** to use these helpers in tests.
+#[cfg(feature = "testing")]
+pub mod testing {
+    use crate::Hash;
+    use proptest::prop_compose;
+
+    // Strategy for generating an arbitrary Hash.
+    //
+    // Usage: `use grey_types::testing::arb_hash;`
+    //        `proptest! { | h in arb_hash() | { ... } }`
+    prop_compose! {
+        pub fn arb_hash()(bytes in proptest::array::uniform32(proptest::arbitrary::any::<u8>())) -> Hash {
+            Hash(bytes)
+        }
+    }
+}
+
 /// Shared to_hex, from_hex and Deserialize for all crypto types.
 macro_rules! impl_crypto_common {
     ($name:ident, $debug_name:expr) => {


### PR DESCRIPTION
## Summary

Contributes to #186 — identify and eliminate code duplication across grey crates.

The `arb_hash()` proptest strategy was identically defined in **5 places**:

| Location | File |
|---|---|
| grey-state | `src/safrole.rs` |
| grey-state | `src/reports.rs` |
| grey-state | `src/history.rs` |
| grey-state | `src/authorizations.rs` |
| grey-store | `tests/proptest_store.rs` |

All 5 copies had the exact same implementation:
```rust
fn arb_hash() -> impl Strategy<Value = Hash> {
    prop::array::uniform32(any::<u8>()).prop_map(Hash)
}
```

## Changes

- Add `testing` feature to `grey-types` with `grey_types::testing::arb_hash()`
- Replace all 5 local `arb_hash()` definitions with `use grey_types::testing::arb_hash`
- Add `grey-types = { workspace = true, features = ["testing"] }` to dev-dependencies of `grey-state` and `grey-store`

## Testing

- All proptests continue to pass
- No behavior changes — pure refactoring