### PR TITLE
refactor: consolidate hex decoding via grey_types::decode_hex

### DIFF
--- a/grey/crates/grey-crypto/src/bandersnatch.rs
+++ b/grey/crates/grey-crypto/src/bandersnatch.rs
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
 
     fn hex_to_bytes(s: &str) -> Vec<u8> {
-        hex::decode(s.strip_prefix("0x").unwrap_or(s)).unwrap()
+        grey_types::decode_hex(s).expect("bad hex")
     }
 
     #[test]

--- a/grey/crates/grey-state/tests/common/mod.rs
+++ b/grey/crates/grey-state/tests/common/mod.rs
@@ -47,7 +47,7 @@ pub fn load_json(path: &str) -> serde_json::Value {
 
 /// Decode a 0x-prefixed hex string to bytes. Panics on invalid input.
 pub fn decode_hex(s: &str) -> Vec<u8> {
-    hex::decode(s.strip_prefix("0x").unwrap_or(s)).expect("bad hex")
+    grey_types::decode_hex(s).expect("bad hex")
 }
 
 /// Parse a Hash from a hex string.

--- a/grey/crates/grey-types/src/serde_utils.rs
+++ b/grey/crates/grey-types/src/serde_utils.rs
@@ -3,8 +3,7 @@
 /// Deserialize a 0x-prefixed hex string as `Vec<u8>`.
 pub fn hex_bytes<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
     let s: String = serde::Deserialize::deserialize(d)?;
-    let stripped = s.strip_prefix("0x").unwrap_or(&s);
-    hex::decode(stripped).map_err(serde::de::Error::custom)
+    crate::decode_hex(&s).map_err(serde::de::Error::custom)
 }
 
 /// Deserialize a 0x-prefixed hex string as [u8; 128] (metadata field).


### PR DESCRIPTION
## Summary

Contributes to #186 — eliminate code duplication across grey crates.

The `strip_prefix("0x")` + `hex::decode()` pattern was duplicated in 3 locations outside of `grey_types::decode_hex`:

| Location | Before | After |
|---|---|---|
| `grey-types/serde_utils.rs` | Inline `strip_prefix` + `hex::decode` | `crate::decode_hex(&s)` |
| `grey-state/tests/common/mod.rs` | Local `decode_hex` wrapping `hex::decode` | `grey_types::decode_hex(s).expect(...)` |
| `grey-crypto/bandersnatch.rs` | Local `hex_to_bytes` with same pattern | `grey_types::decode_hex(s).expect(...)` |

## Testing

- All affected crates compile without warnings
- No behavior changes — pure refactoring