### PR TITLE
test(grey-transpiler): add blob hash stability regression tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,8 @@ dependencies = [
 name = "grey-transpiler"
 version = "0.1.0"
 dependencies = [
+ "blake2",
+ "hex",
  "javm",
  "proptest",
  "scale",
@@ -4252,9 +4254,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/grey/crates/grey-transpiler/Cargo.toml
+++ b/grey/crates/grey-transpiler/Cargo.toml
@@ -13,4 +13,6 @@ tracing = { workspace = true }
 tracing-test = { workspace = true }
 
 [dev-dependencies]
+blake2 = { workspace = true }
+hex = { workspace = true }
 proptest = { workspace = true }

--- a/grey/crates/grey-transpiler/src/assembler.rs
+++ b/grey/crates/grey-transpiler/src/assembler.rs
@@ -860,6 +860,47 @@ mod tests {
     }
 
     #[test]
+    fn test_trivial_authorizer_blob_hash_stability() {
+        // Regression test: the trivial authorizer blob must produce
+        // a deterministic blake2b hash. If this changes, the blob
+        // format or encoding has been unintentionally modified.
+        let blob = build_trivial_authorizer();
+        let hash = blake2b_256(&blob);
+        let expected = "33656ec3682cc9c9229d030b7cc1aa7d58b08e4403770b90908d6a8ddf7741fc";
+        assert_eq!(
+            hex::encode(hash),
+            expected,
+            "trivial authorizer blob hash changed — blob format regression?"
+        );
+    }
+
+    #[test]
+    fn test_sample_service_blob_hash_stability() {
+        // Regression test: the sample service blob must produce
+        // a deterministic blake2b hash across builds.
+        let blob = build_sample_service();
+        let hash = blake2b_256(&blob);
+        let expected = "883c430768add6fdbe6c58411fe8bb506bafec2450dde14c2be0ef94bddf6534";
+        assert_eq!(
+            hex::encode(hash),
+            expected,
+            "sample service blob hash changed — blob format regression?"
+        );
+    }
+
+    /// Compute blake2b-256 hash of a byte slice.
+    fn blake2b_256(data: &[u8]) -> [u8; 32] {
+        use blake2::digest::{Digest, consts::U32};
+        type Blake2b256 = blake2::Blake2b<U32>;
+        let mut hasher = Blake2b256::new();
+        hasher.update(data);
+        let result = hasher.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&result);
+        out
+    }
+
+    #[test]
     fn test_build_sample_service() {
         let blob = build_sample_service();
         assert!(!blob.is_empty());


### PR DESCRIPTION
## Summary
- Add two blake2b-256 hash pinning tests (`test_trivial_authorizer_blob_hash_stability` and `test_sample_service_blob_hash_stability`) that catch unintentional blob format or encoding changes across builds
- Add `blake2` and `hex` as dev-dependencies in grey-transpiler
- Pin rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

## Rationale
Blob output stability is critical for consensus — if the transpiler produces different blobs for the same input, deployed services would break. These tests act as canaries: if the hash changes, something in the encoding pipeline was unintentionally modified.

Related to #731 C5 (differential CI for interpreter vs recompiler) — hash pinning is a lightweight first step toward detecting output drift.