### PR TITLE
refactor(spec): expose Codec.lengthClass and add boundary size proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/Codec.lean
+++ b/spec/Jar/Codec.lean
@@ -41,8 +41,9 @@ def decodeFixedNat (bs : ByteArray) : Nat :=
 -- §C.1 — Variable-length Natural Encoding
 -- ============================================================================
 
-/-- Compute l such that 2^{7l} ≤ x < 2^{7(l+1)}, or 8 if x ≥ 2^{56}. -/
-private def lengthClass (x : Nat) : Nat :=
+/-- Compute l such that 2^{7l} ≤ x < 2^{7(l+1)}, or 8 if x ≥ 2^{56}.
+    Exposed for use in proof code (Jar.Proofs.Codec). -/
+def lengthClass (x : Nat) : Nat :=
   if x < 2^7  then 0
   else if x < 2^14 then 1
   else if x < 2^21 then 2

--- a/spec/Jar/Proofs/Codec.lean
+++ b/spec/Jar/Proofs/Codec.lean
@@ -130,4 +130,12 @@ theorem encodeNat_small_size [JarConfig] :
 theorem encodeNat_128_size [JarConfig] :
     (Codec.encodeNat 128).size = 2 := by decide
 
+/-- encodeNat for 2^56 - 1 produces 8 bytes — l=7 path (largest l < 8). -/
+theorem encodeNat_2p56m1_size [JarConfig] :
+    (Codec.encodeNat (2^56 - 1)).size = 8 := by decide
+
+/-- encodeNat for 2^56 produces 9 bytes — l=8 path (0xFF prefix mode). -/
+theorem encodeNat_2p56_size [JarConfig] :
+    (Codec.encodeNat (2^56)).size = 9 := by decide
+
 end Jar.Proofs


### PR DESCRIPTION
## Summary
- Remove `private` from `Codec.lengthClass` to make it accessible from proof code (`Jar.Proofs.Codec`). This is a prerequisite for proving general `encodeNat` size bounds.
- Add two boundary-value size theorems:
  - `encodeNat_2p56m1_size`: `(2^56 - 1)` encodes to 8 bytes (largest `l < 8` case)
  - `encodeNat_2p56_size`: `2^56` encodes to 9 bytes (0xFF prefix mode)
- These complement existing `encodeNat_zero/small/128` tests, covering all three structural paths of the variable-length encoder.
- Pin rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

## Why expose lengthClass?
The `lengthClass` function is a pure total function that determines the encoding length category of a natural number. Making it public allows proof code to case-split on its value, which is essential for proving properties like `encodeNat_size_pos` (output always > 0 bytes) and `encodeNat_size_le_9` (output always ≤ 9 bytes). These general proofs are listed as targets in #374.

Relates to #374 (expand Lean proof coverage) and #731 (spec readiness).