### PR TITLE
refactor(grey): deduplicate get_code to delegate to get_preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/grey/crates/grey/src/guarantor.rs
+++ b/grey/crates/grey/src/guarantor.rs
@@ -411,7 +411,7 @@ impl<'a> StateRefineContext<'a> {
 
 impl<'a> RefineContext for StateRefineContext<'a> {
     fn get_code(&self, code_hash: &Hash) -> Option<Vec<u8>> {
-        self.lookup_preimage(code_hash)
+        self.get_preimage(code_hash)
     }
 
     fn get_storage(&self, service_id: u32, key: &[u8]) -> Option<Vec<u8>> {


### PR DESCRIPTION
## Summary
- `RefineContext::get_code` and `RefineContext::get_preimage` in `guarantor.rs` had identical implementations (both calling `self.lookup_preimage`). Delegate `get_code` to `self.get_preimage()` to eliminate the duplication while preserving the distinct semantic names of the trait methods.
- Pin rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

## Before
```rust
fn get_code(&self, code_hash: &Hash) -> Option<Vec<u8>> {
    self.lookup_preimage(code_hash)
}
fn get_preimage(&self, hash: &Hash) -> Option<Vec<u8>> {
    self.lookup_preimage(hash)
}
```

## After
```rust
fn get_code(&self, code_hash: &Hash) -> Option<Vec<u8>> {
    self.get_preimage(code_hash)
}
fn get_preimage(&self, hash: &Hash) -> Option<Vec<u8>> {
    self.lookup_preimage(hash)
}
```

Addresses #186 (eliminate code duplication across grey crates).