### PR TITLE
docs(spec): add module docstring to CryptoTest.lean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/CryptoTest.lean
+++ b/spec/Jar/CryptoTest.lean
@@ -1,5 +1,12 @@
 import Jar.Crypto
 
+/-!
+# Crypto Test Harness
+
+Smoke tests for cryptographic primitives: Blake2b, Keccak256, Ed25519,
+and Bandersnatch VRF. Run via `lake run cryptoTest`.
+-/
+
 def nibbleToHex (n : UInt8) : Char :=
   if n < 10 then Char.ofNat (48 + n.toNat)  -- '0' + n
   else Char.ofNat (87 + n.toNat)              -- 'a' + (n - 10)


### PR DESCRIPTION
## Summary
Add `/-!` module docstring to `Jar/CryptoTest.lean`, the only spec file missing one.

Relates to #402 (JarBook: fix inaccuracies and extend documentation).