### PR TITLE
fix(spec): remove unused variable srcOff in Kernel.lean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/JAVM/Kernel.lean
+++ b/spec/Jar/JAVM/Kernel.lean
@@ -449,7 +449,6 @@ def handleMap (state : KernelState) (vmIdx : Nat) (slot : Nat) : KernelState × 
         let state := Id.run do
           let mut s := state
           for p in [pageOffset:pageOffset + pgCount] do
-            let srcOff := (d.backingOffset + p) * pageSize
             let dstAddr := (baseOffset + p) * pageSize
             let pageData := s.backing.read (d.backingOffset + p) 0 pageSize
             -- Write page into PVM memory


### PR DESCRIPTION
## Summary
Remove unused `let srcOff := ...` binding in `Jar/JAVM/Kernel.lean:452`. The variable was computed but never referenced — the backing store read on the next line uses `(d.backingOffset + p)` directly.

Relates to #402 (JarBook code quality).