### PR TITLE
proof(spec): add setQuota const/idempotent and gratis preservation theorems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/spec/Jar/Proofs/BalanceEcon.lean
+++ b/spec/Jar/Proofs/BalanceEcon.lean
@@ -259,4 +259,22 @@ theorem balanceEcon_absorbEjected_comm_balance (e1 e2 : BalanceEcon) :
   show e1.balance + e2.balance = e2.balance + e1.balance
   rw [UInt64.add_comm]
 
+-- ============================================================================
+-- gratis preservation under absorbEjected
+-- ============================================================================
+
+/-- absorbEjected preserves the gratis field — only balance is modified. -/
+theorem balanceEcon_absorbEjected_preserves_gratis (e ejected : BalanceEcon) :
+    (@EconModel.absorbEjected BalanceEcon BalanceTransfer _ e ejected).gratis = e.gratis := by
+  rfl
+
+-- ============================================================================
+-- newServiceEcon gratis assignment
+-- ============================================================================
+
+/-- newServiceEcon assigns the given gratis value directly. -/
+theorem balanceEcon_newServiceEcon_gratis (items bytes : Nat) (gratis : UInt64) (bI bL bS : Nat) :
+    (@EconModel.newServiceEcon BalanceEcon BalanceTransfer _ items bytes gratis bI bL bS).gratis = gratis := by
+  rfl
+
 end Jar.Proofs

--- a/spec/Jar/Proofs/QuotaEcon.lean
+++ b/spec/Jar/Proofs/QuotaEcon.lean
@@ -49,6 +49,21 @@ theorem quotaEcon_setQuota_never_none (e : QuotaEcon) (mi mb : UInt64) :
     @EconModel.setQuota QuotaEcon QuotaTransfer _ e mi mb ≠ none := by
   simp [quotaEcon_setQuota_always_some]
 
+/-- setQuota is input-independent: the result depends only on (mi, mb), not on e.
+    This is the "const" property — setQuota unconditionally overwrites quotas. -/
+theorem quotaEcon_setQuota_const (e e' : QuotaEcon) (mi mb : UInt64) :
+    @EconModel.setQuota QuotaEcon QuotaTransfer _ e mi mb
+    = @EconModel.setQuota QuotaEcon QuotaTransfer _ e' mi mb := by
+  rfl
+
+/-- setQuota is idempotent: applying it to the result of setQuota with the same
+    arguments produces the same output. -/
+theorem quotaEcon_setQuota_idempotent (e : QuotaEcon) (mi mb : UInt64) :
+    @EconModel.setQuota QuotaEcon QuotaTransfer _
+      { quotaItems := mi, quotaBytes := mb } mi mb
+    = @EconModel.setQuota QuotaEcon QuotaTransfer _ e mi mb := by
+  rfl
+
 -- ============================================================================
 -- canAffordStorage monotonicity
 -- ============================================================================


### PR DESCRIPTION
## Summary
- **QuotaEcon**: Add `setQuota_const` (input-independent: result depends only on mi/mb, not on e) and `setQuota_idempotent` (applying setQuota to a quota already set is the same). Both provable by `rfl`.
- **BalanceEcon**: Add `absorbEjected_preserves_gratis` and `newServiceEcon_gratis`, completing gratis preservation coverage across all economic operations.

These complete the gratis field preservation story: for both econ models, every operation either preserves gratis (debit/credit/absorb) or assigns it explicitly (newService).

Relates to #374 (expand Lean proof coverage).