### PR TITLE
refactor(grey): remove stale #[allow(dead_code)] from five modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,9 +4252,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/grey/crates/grey/src/main.rs
+++ b/grey/crates/grey/src/main.rs
@@ -3,20 +3,15 @@
 //! This is the main entry point for the Grey node implementation.
 //! See the Gray Paper v0.7.2 for the full specification.
 
-#[allow(dead_code)]
 mod audit;
 mod chainspec;
 mod config;
-#[allow(dead_code)]
 mod disputes;
-#[allow(dead_code)]
 mod finality;
 mod guarantor;
-#[allow(dead_code)]
 mod keystore;
 mod node;
 mod seq_testnet;
-#[allow(dead_code)]
 mod testnet;
 mod tickets;
 


### PR DESCRIPTION
## Summary
Remove `#[allow(dead_code)]` from five modules in `grey/src/main.rs`: audit, disputes, finality, keystore, testnet. All now have sufficient callers that the annotation is no longer needed.

Verified with `cargo check -p grey` — no dead_code warnings.

Relates to #186 (eliminate code duplication and improve code quality).