### PR TITLE
Add docstrings to Types submodules

### DIFF
--- a/spec/Jar/Types/Config.lean
+++ b/spec/Jar/Types/Config.lean
@@ -90,9 +90,13 @@ def Params.isValidValCount (cfg : Params) (z : Nat) : Bool :=
 
 /-- Positivity proofs required for Fin types to be inhabited. -/
 structure Params.Valid (cfg : Params) : Prop where
+  /-- V > 0 : positive validator count. -/
   hV : 0 < cfg.V
+  /-- C > 0 : positive core count. -/
   hC : 0 < cfg.C
+  /-- E > 0 : positive epoch length. -/
   hE : 0 < cfg.E
+  /-- N_TICKETS > 0 : positive ticket count. -/
   hN : 0 < cfg.N_TICKETS
 
 -- ============================================================================
@@ -184,7 +188,9 @@ class EconModel (econ : Type) (xfer : Type) where
 class JarConfig where
   /-- Variant name, e.g. "gp072_tiny", "gp072_full". -/
   name : String
+  /-- Protocol parameter set. -/
   config : Params
+  /-- Proof that the parameter set is valid. -/
   valid : Params.Valid config
   /-- PVM memory layout for program initialization. -/
   memoryModel : MemoryModel := .segmented
@@ -218,12 +224,19 @@ class JarConfig where
   [econModel : EconModel EconType TransferType]
 
 -- Forward typeclass instances from JarConfig fields
+/-- Forward BEq for EconType from JarConfig. -/
 instance [j : JarConfig] : BEq j.EconType := j.econBEq
+/-- Forward Inhabited for EconType from JarConfig. -/
 instance [j : JarConfig] : Inhabited j.EconType := j.econInhabited
+/-- Forward BEq for TransferType from JarConfig. -/
 instance [j : JarConfig] : BEq j.TransferType := j.xferBEq
+/-- Forward Inhabited for TransferType from JarConfig. -/
 instance [j : JarConfig] : Inhabited j.TransferType := j.xferInhabited
+/-- Forward Repr for EconType from JarConfig. -/
 instance [j : JarConfig] : Repr j.EconType := j.econRepr
+/-- Forward Repr for TransferType from JarConfig. -/
 instance [j : JarConfig] : Repr j.TransferType := j.xferRepr
+/-- Forward EconModel instance from JarConfig. -/
 instance [j : JarConfig] : EconModel j.EconType j.TransferType := j.econModel
 
 -- ============================================================================
@@ -257,12 +270,14 @@ def Params.tiny : Params where
 -- Validity Proofs
 -- ============================================================================
 
+/-- Full configuration satisfies validity constraints. -/
 theorem Params.full_valid : Params.Valid Params.full where
   hV := by decide
   hC := by decide
   hE := by decide
   hN := by decide
 
+/-- Tiny configuration satisfies validity constraints. -/
 theorem Params.tiny_valid : Params.Valid Params.tiny where
   hV := by decide
   hC := by decide

--- a/spec/Jar/Types/Header.lean
+++ b/spec/Jar/Types/Header.lean
@@ -62,33 +62,49 @@ structure Header where
 
 /-- A single judgment by a validator on a work-report. -/
 structure Judgment where
+  /-- Whether the validator judges the work-report as valid. -/
   isValid : Bool
+  /-- Index of the judging validator in the validator set. -/
   validatorIndex : ValidatorIndex
+  /-- Ed25519 signature over the judgment. -/
   signature : Ed25519Signature
 
 /-- A verdict on a work-report, composed of multiple judgments. -/
 structure Verdict where
+  /-- Hash of the work-report being judged. -/
   reportHash : Hash
+  /-- Age of the report in timeslots since it was reported. -/
   age : UInt32
+  /-- Individual validator judgments composing this verdict. -/
   judgments : Array Judgment
 
 /-- Culprit: a validator who guaranteed an invalid work-report. -/
 structure Culprit where
+  /-- Hash of the invalid work-report that was guaranteed. -/
   reportHash : Hash
+  /-- Ed25519 public key of the culpable validator. -/
   validatorKey : Ed25519PublicKey
+  /-- Ed25519 signature proving the guarantee. -/
   signature : Ed25519Signature
 
 /-- Fault: a validator who made an incorrect judgment. -/
 structure Fault where
+  /-- Hash of the work-report that was incorrectly judged. -/
   reportHash : Hash
+  /-- Whether the faulty validator judged it as valid. -/
   isValid : Bool
+  /-- Ed25519 public key of the faulty validator. -/
   validatorKey : Ed25519PublicKey
+  /-- Ed25519 signature proving the incorrect judgment. -/
   signature : Ed25519Signature
 
 /-- E_D : Disputes extrinsic. GP §10.2. -/
 structure DisputesExtrinsic where
+  /-- Verdicts: valid or invalid judgments on work-reports. -/
   verdicts : Array Verdict
+  /-- Culprits: validators who guaranteed invalid work-reports. -/
   culprits : Array Culprit
+  /-- Faults: validators who made incorrect judgments. -/
   faults : Array Fault
 
 -- ============================================================================

--- a/spec/Jar/Types/Work.lean
+++ b/spec/Jar/Types/Work.lean
@@ -20,12 +20,18 @@ variable [JarConfig]
 /-- 𝔼 : Work execution error. GP eq (109–111).
     Possible outcomes when refinement fails. -/
 inductive WorkError where
-  | outOfGas    -- ∞ : gas exhaustion
-  | panic       -- ☇ : exceptional halt
-  | badExports  -- invalid exports
-  | oversize    -- code too large
-  | badCode     -- BAD : code not available
-  | bigCode     -- BIG : code exceeds limit
+  /-- ∞ : Gas exhaustion. -/
+  | outOfGas
+  /-- ☇ : Exceptional halt. -/
+  | panic
+  /-- Invalid exports produced. -/
+  | badExports
+  /-- Code too large. -/
+  | oversize
+  /-- BAD : Code not available. -/
+  | badCode
+  /-- BIG : Code exceeds limit. -/
+  | bigCode
   deriving BEq
 
 -- ============================================================================
@@ -34,7 +40,9 @@ inductive WorkError where
 
 /-- Work result: either successful output blob or an error. GP eq (109). -/
 inductive WorkResult where
+  /-- Successful output blob. -/
   | ok : ByteArray → WorkResult
+  /-- Refinement error. -/
   | err : WorkError → WorkResult
 
 /-- 𝔻 : Work digest — the on-chain summary of a single refined work-item.


### PR DESCRIPTION
## Summary
- Add proper `/-- ... -/` docstrings to 38 items across Types submodules:

**Work.lean (8):**
- WorkError constructors: outOfGas (∞), panic (☇), badExports, oversize, badCode (BAD), bigCode (BIG)
- WorkResult constructors: ok, err

**Header.lean (16):**
- Judgment fields (3): isValid, validatorIndex, signature
- Verdict fields (3): reportHash, age, judgments
- Culprit fields (3): reportHash, validatorKey, signature
- Fault fields (4): reportHash, isValid, validatorKey, signature
- DisputesExtrinsic fields (3): verdicts, culprits, faults

**Config.lean (14):**
- Params.Valid fields (4): hV, hC, hE, hN
- JarConfig.config and JarConfig.valid (2)
- Forwarding instances (7)
- Validity theorems (2): full_valid, tiny_valid

Refs #402