### PR TITLE
Add docstrings to Memory, Interpreter, Codec, and Variant proofs

### DIFF
--- a/spec/Jar/Codec.lean
+++ b/spec/Jar/Codec.lean
@@ -303,7 +303,9 @@ def encodeBlock (b : Block) : ByteArray :=
 
 /-- State for the decoder: a ByteArray and a current position. -/
 structure DecodeState where
+  /-- Remaining bytes to decode. -/
   data : ByteArray
+  /-- Current read position. -/
   pos : Nat
 
 /-- Decoder monad: a function from state to an optional (result, new state). -/

--- a/spec/Jar/JAVM/Interpreter.lean
+++ b/spec/Jar/JAVM/Interpreter.lean
@@ -471,9 +471,12 @@ def runTracePCs (prog : ProgramBlob) (pc : Nat) (regs : Registers) (mem : Memory
 
 /-- Single instruction trace entry: PC, opcode number, register snapshot. -/
 structure InstrTraceEntry where
+  /-- Program counter at trace point. -/
   pc : Nat
+  /-- Opcode number executed. -/
   opcode : Nat
-  regs : Array UInt64  -- snapshot of all 13 registers before execution
+  /-- Snapshot of all 13 registers before execution. -/
+  regs : Array UInt64
   deriving Inhabited
 
 /-- Format a trace entry as a compact string. -/

--- a/spec/Jar/JAVM/Memory.lean
+++ b/spec/Jar/JAVM/Memory.lean
@@ -16,9 +16,12 @@ namespace Jar.JAVM
 
 /-- Result of a memory access: success or fault. -/
 inductive MemResult (α : Type) where
+  /-- Successful memory access. -/
   | ok : α → MemResult α
-  | panic : MemResult α         -- Address < 2^16: always inaccessible
-  | fault : UInt64 → MemResult α  -- Page fault with page-aligned address
+  /-- Address < 2^16: always inaccessible. -/
+  | panic : MemResult α
+  /-- Page fault with page-aligned address. -/
+  | fault : UInt64 → MemResult α
 
 -- ============================================================================
 -- Page Calculations — GP eq (4.17-4.19)

--- a/spec/Jar/Proofs/Variant.lean
+++ b/spec/Jar/Proofs/Variant.lean
@@ -14,15 +14,19 @@ namespace Jar.Proofs
 -- jar1 config assertions (v2 capability model)
 -- ============================================================================
 
+/-- jar1 uses the v2 capability model. -/
 theorem jar1_capabilityModel_v2 :
     @JarConfig.capabilityModel JarVariant.jar1.toJarConfig = .v2 := by rfl
 
+/-- jar1 uses linear memory layout. -/
 theorem jar1_memoryModel_linear :
     @JarConfig.memoryModel JarVariant.jar1.toJarConfig = .linear := by rfl
 
+/-- jar1 uses single-pass basic-block gas model. -/
 theorem jar1_gasModel_singlePass :
     @JarConfig.gasModel JarVariant.jar1.toJarConfig = .basicBlockSinglePass := by rfl
 
+/-- jar1 has variable validator set size enabled. -/
 theorem jar1_variableValidators :
     @JarConfig.variableValidators JarVariant.jar1.toJarConfig = true := by rfl
 
@@ -30,12 +34,15 @@ theorem jar1_variableValidators :
 -- gp072_tiny config assertions (contrast)
 -- ============================================================================
 
+/-- gp072_tiny uses segmented memory layout. -/
 theorem gp072_tiny_memoryModel_segmented :
     @JarConfig.memoryModel JarVariant.gp072_tiny.toJarConfig = .segmented := by rfl
 
+/-- gp072_tiny uses per-instruction gas model. -/
 theorem gp072_tiny_gasModel_perInstruction :
     @JarConfig.gasModel JarVariant.gp072_tiny.toJarConfig = .perInstruction := by rfl
 
+/-- gp072_tiny does not have variable validator set size. -/
 theorem gp072_tiny_variableValidators_false :
     @JarConfig.variableValidators JarVariant.gp072_tiny.toJarConfig = false := by rfl
 


### PR DESCRIPTION
## Summary
- **JAVM/Memory.lean**: MemResult constructors (ok, panic, fault) — promote inline `--` to `/-- ... -/`
- **JAVM/Interpreter.lean**: InstrTraceEntry fields (pc, opcode, regs)
- **Codec.lean**: DecodeState fields (data, pos)
- **Proofs/Variant.lean**: 7 theorem docstrings for jar1 and gp072_tiny config assertions

Refs #402