### PR TITLE
Add docstrings to remaining instance declarations

### DIFF
--- a/spec/Jar/Types/Accounts.lean
+++ b/spec/Jar/Types/Accounts.lean
@@ -68,6 +68,7 @@ structure QuotaTransfer where
 -- EconModel Instances
 -- ============================================================================
 
+/-- EconModel instance for BalanceEcon: balance-based service accounting. -/
 instance : EconModel BalanceEcon BalanceTransfer where
   canAffordStorage e items bytes bI bL bS :=
     let minBal := bS + bI * items + bL * bytes
@@ -145,6 +146,7 @@ instance : EconModel BalanceEcon BalanceTransfer where
     let amtNat ← amtJson.getNat?
     return { amount := amtNat.toUInt64 }
 
+/-- EconModel instance for QuotaEcon: quota-based service accounting (coinless model). -/
 instance : EconModel QuotaEcon QuotaTransfer where
   canAffordStorage e items bytes _bI _bL _bS :=
     items ≤ e.quotaItems.toNat && bytes ≤ e.quotaBytes.toNat

--- a/spec/Jar/Types/Numerics.lean
+++ b/spec/Jar/Types/Numerics.lean
@@ -67,9 +67,11 @@ abbrev TicketEntryIndex [JarConfig] := Nat
 /-- Epoch slot index: ℕ_{E}. Bounded by config.E. -/
 abbrev EpochIndex [j : JarConfig] := Fin j.config.E
 
--- Inhabited instances for parameterized Fin types
+/-- Inhabited instance for CoreIndex: defaults to index 0. -/
 instance instInhabitedCoreIndex [j : JarConfig] : Inhabited (Fin j.config.C) := ⟨⟨0, j.valid.hC⟩⟩
+/-- Inhabited instance for ValidatorIndex: defaults to index 0. -/
 instance instInhabitedValidatorIndex [j : JarConfig] : Inhabited (Fin j.config.V) := ⟨⟨0, j.valid.hV⟩⟩
+/-- Inhabited instance for EpochIndex: defaults to index 0. -/
 instance instInhabitedEpochIndex [j : JarConfig] : Inhabited (Fin j.config.E) := ⟨⟨0, j.valid.hE⟩⟩
 
 end Jar

--- a/spec/Jar/Types/Validators.lean
+++ b/spec/Jar/Types/Validators.lean
@@ -43,6 +43,7 @@ structure Ticket where
   /-- a : Attempt/entry index ∈ {0, 1}. -/
   attempt : TicketEntryIndex
 
+/-- Default Ticket: zero hash, attempt 0. -/
 instance : Inhabited Ticket where
   default := { id := default, attempt := 0 }
 


### PR DESCRIPTION
## Summary
- Add `/-- ... -/` docstrings to the last 6 undocumented instances in the spec:
  - Numerics.lean: `instInhabitedCoreIndex`, `instInhabitedValidatorIndex`, `instInhabitedEpochIndex`
  - Accounts.lean: `EconModel BalanceEcon` and `EconModel QuotaEcon` instances
  - Validators.lean: `Inhabited Ticket` instance

With this PR, **all** instances, structures, inductives, and fields in `Jar.Types.*` now have proper docstrings.

Refs #402