### PR TITLE
Eliminate from_le_bytes().try_into().unwrap() pattern

### DIFF
--- a/grey/crates/grey-merkle/src/state_serial.rs
+++ b/grey/crates/grey-merkle/src/state_serial.rs
@@ -13,7 +13,7 @@ fn decode_u32_le_at(data: &[u8], pos: &mut usize) -> Result<u32, ()> {
     if *pos + 4 > data.len() {
         return Err(());
     }
-    let val = u32::from_le_bytes(data[*pos..*pos + 4].try_into().unwrap());
+    let val = u32::from_le_bytes([data[*pos], data[*pos + 1], data[*pos + 2], data[*pos + 3]]);
     *pos += 4;
     Ok(val)
 }

--- a/grey/crates/grey-state/src/accumulate.rs
+++ b/grey/crates/grey-state/src/accumulate.rs
@@ -21,7 +21,7 @@ pub fn decode_preimage_info_timeslots(data: &[u8]) -> Vec<Timeslot> {
     if pos + 4 > data.len() {
         return vec![];
     }
-    let count = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+    let count = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
     pos += 4;
     // Bound count by remaining bytes: each Timeslot is 4 bytes, so count cannot
     // exceed (data.len() - pos) / 4. Without this guard, a crafted count prefix
@@ -1898,9 +1898,9 @@ mod tests {
     fn test_encode_accumulate_args() {
         let result = encode_accumulate_args(100, 42, 3);
         assert_eq!(result.len(), 12); // 4 + 4 + 4
-        assert_eq!(u32::from_le_bytes(result[0..4].try_into().unwrap()), 100);
-        assert_eq!(u32::from_le_bytes(result[4..8].try_into().unwrap()), 42);
-        assert_eq!(u32::from_le_bytes(result[8..12].try_into().unwrap()), 3);
+        assert_eq!(u32::from_le_bytes([result[0], result[1], result[2], result[3]]), 100);
+        assert_eq!(u32::from_le_bytes([result[4], result[5], result[6], result[7]]), 42);
+        assert_eq!(u32::from_le_bytes([result[8], result[9], result[10], result[11]]), 3);
     }
 
     // --- keccak_merkle_root ---

--- a/grey/crates/grey-store/src/lib.rs
+++ b/grey/crates/grey-store/src/lib.rs
@@ -14,6 +14,29 @@ use grey_types::state::State;
 use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition};
 use std::path::{Path, PathBuf};
 
+/// Read a u32 from a little-endian byte slice at the given offset.
+/// Returns the value and advances the offset by 4.
+///
+/// # Panics
+/// Panics if `data[pos..pos+4]` is out of bounds — caller must ensure length.
+#[inline]
+fn read_u32_le(data: &[u8], pos: usize) -> u32 {
+    u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]])
+}
+
+/// Read a u64 from a little-endian byte slice at the given offset.
+/// Returns the value and advances the offset by 8.
+///
+/// # Panics
+/// Panics if `data[pos..pos+8]` is out of bounds — caller must ensure length.
+#[inline]
+fn read_u64_le(data: &[u8], pos: usize) -> u64 {
+    u64::from_le_bytes([
+        data[pos], data[pos + 1], data[pos + 2], data[pos + 3],
+        data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7],
+    ])
+}
+
 /// Current schema version. Bump this when table layouts change.
 /// The store refuses to open a database with a different version.
 pub const SCHEMA_VERSION: u32 = 1;
@@ -158,7 +181,7 @@ impl Store {
             let stored_version = meta.get(META_SCHEMA_VERSION)?.and_then(|val| {
                 let bytes = val.value();
                 if bytes.len() == 4 {
-                    Some(u32::from_le_bytes(bytes.try_into().unwrap()))
+                    Some(read_u32_le(bytes, 0))
                 } else {
                     None
                 }
@@ -204,7 +227,7 @@ impl Store {
             Some(val) => {
                 let bytes = val.value();
                 if bytes.len() == 4 {
-                    Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
+                    Ok(read_u32_le(bytes, 0))
                 } else {
                     Err(StoreError::Codec("invalid schema version bytes".into()))
                 }
@@ -469,23 +492,23 @@ impl Store {
         let mut code_hash = [0u8; 32];
         code_hash.copy_from_slice(&v[pos..pos + 32]);
         pos += 32;
-        let quota_items = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+        let quota_items = read_u64_le(v, pos);
         pos += 8;
-        let min_accumulate_gas = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+        let min_accumulate_gas = read_u64_le(v, pos);
         pos += 8;
-        let min_on_transfer_gas = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+        let min_on_transfer_gas = read_u64_le(v, pos);
         pos += 8;
-        let total_footprint = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+        let total_footprint = read_u64_le(v, pos);
         pos += 8;
-        let quota_bytes = u64::from_le_bytes(v[pos..pos + 8].try_into().unwrap());
+        let quota_bytes = read_u64_le(v, pos);
         pos += 8;
-        let accumulation_counter = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+        let accumulation_counter = read_u32_le(v, pos);
         pos += 4;
-        let last_accumulation = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+        let last_accumulation = read_u32_le(v, pos);
         pos += 4;
-        let last_activity = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+        let last_activity = read_u32_le(v, pos);
         pos += 4;
-        let preimage_count = u32::from_le_bytes(v[pos..pos + 4].try_into().unwrap());
+        let preimage_count = read_u32_le(v, pos);
 
         Ok(Some(ServiceMetadata {
             code_hash: Hash(code_hash),
@@ -910,7 +933,7 @@ impl Store {
             Some(entry) => {
                 let key = entry.0.value();
                 if key.len() >= 8 {
-                    Ok(u64::from_le_bytes(key[0..8].try_into().unwrap()))
+                    Ok(read_u64_le(key, 0))
                 } else {
                     Ok(0)
                 }

--- a/grey/crates/scale/src/lib.rs
+++ b/grey/crates/scale/src/lib.rs
@@ -90,7 +90,7 @@ impl Decode for u16 {
         if data.len() < 2 {
             return Err(DecodeError::UnexpectedEof);
         }
-        Ok((u16::from_le_bytes(data[..2].try_into().unwrap()), 2))
+        Ok((u16::from_le_bytes([data[0], data[1]]), 2))
     }
 }
 
@@ -99,7 +99,7 @@ impl Decode for u32 {
         if data.len() < 4 {
             return Err(DecodeError::UnexpectedEof);
         }
-        Ok((u32::from_le_bytes(data[..4].try_into().unwrap()), 4))
+        Ok((u32::from_le_bytes([data[0], data[1], data[2], data[3]]), 4))
     }
 }
 
@@ -108,7 +108,7 @@ impl Decode for u64 {
         if data.len() < 8 {
             return Err(DecodeError::UnexpectedEof);
         }
-        Ok((u64::from_le_bytes(data[..8].try_into().unwrap()), 8))
+        Ok((u64::from_le_bytes([data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]]), 8))
     }
 }
 


### PR DESCRIPTION
## Summary
Replace the `T::from_le_bytes(slice.try_into().unwrap())` pattern across 4 crates with safer alternatives, eliminating the unreachable `unwrap()` panic paths. All call sites already have length guards making the `try_into()` infallible, but the direct construction is more explicit and avoids the panic codegen.

**scale/src/lib.rs (3):** u16/u32/u64 `Decode` impls — use direct array literals instead of `data[..N].try_into().unwrap()`

**grey-store/src/lib.rs (11):** Add `read_u32_le`/`read_u64_le` helper functions; replace 11 occurrences in schema version reading and `decode_service_account_state`

**grey-merkle/src/state_serial.rs (1):** Replace `decode_u32_le_at`'s `try_into().unwrap()` with direct array construction

**grey-state/src/accumulate.rs (4):** Replace 1 production + 3 test occurrences with direct array construction

Refs #186