### PR TITLE
refactor: deduplicate package_hashes by reusing grey_state version

### DIFF
--- a/grey/crates/grey-services/src/accumulation.rs
+++ b/grey/crates/grey-services/src/accumulation.rs
@@ -382,13 +382,11 @@ pub fn integrate_preimages(
     }
 }
 
-/// Collect the set of work-package hashes from accumulated reports (P function).
+/// Collect the set of work-package hashes from the first `count` reports (P function).
+///
+/// Delegates to [`grey_state::accumulate::package_hashes`] after truncating to `count`.
 pub fn accumulated_package_hashes(reports: &[WorkReport], count: usize) -> BTreeSet<Hash> {
-    reports
-        .iter()
-        .take(count)
-        .map(|r| r.package_spec.package_hash)
-        .collect()
+    grey_state::accumulate::package_hashes(&reports[..count.min(reports.len())])
 }
 
 #[cfg(test)]

--- a/grey/crates/grey-state/src/accumulate.rs
+++ b/grey/crates/grey-state/src/accumulate.rs
@@ -220,7 +220,7 @@ fn partition_reports(reports: &[WorkReport]) -> (Vec<WorkReport>, Vec<ReadyRecor
 }
 
 /// Extract work-package hashes from reports (eq 12.9).
-fn package_hashes(reports: &[WorkReport]) -> BTreeSet<Hash> {
+pub fn package_hashes(reports: &[WorkReport]) -> BTreeSet<Hash> {
     reports
         .iter()
         .map(|r| r.package_spec.package_hash)


### PR DESCRIPTION
## Summary

Contributes to #186 — eliminate code duplication across grey crates.

Two functions with identical core logic existed in separate crates:

| Crate | Function | Difference |
|---|---|---|
| grey-state | package_hashes(reports) | Extract all hashes |
| grey-services | accumulated_package_hashes(reports, count) | Extract hashes from first count reports |

## Changes

- Make grey_state::accumulate::package_hashes public
- grey_services::accumulation::accumulated_package_hashes now delegates to grey_state::accumulate::package_hashes with a truncated slice

## Testing

All existing tests pass. No behavior changes — pure refactoring.