### PR TITLE
refactor: reuse impl_crypto_common! macro for Hash type

### DIFF
--- a/grey/crates/grey-types/src/lib.rs
+++ b/grey/crates/grey-types/src/lib.rs
@@ -162,21 +162,13 @@ impl Hash {
         &self.0
     }
 
-    /// Encode the inner bytes as a bare hex string (no `0x` prefix).
-    pub fn to_hex(&self) -> String {
-        hex::encode(self.0)
-    }
-
     /// Encode the first 8 bytes as a hex string for log/debug output.
     pub fn short_hex(&self) -> String {
         hex::encode(&self.0[..8])
     }
-
-    /// Parse from a hex string (with optional 0x prefix). Panics on invalid input.
-    pub fn from_hex(s: &str) -> Self {
-        Self(decode_hex_fixed(s).expect("invalid hex for Hash"))
-    }
 }
+
+impl_crypto_common!(Hash, "Hash");
 
 impl fmt::Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -199,15 +191,6 @@ impl From<[u8; 32]> for Hash {
 impl AsRef<[u8]> for Hash {
     fn as_ref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Hash {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s: String = serde::Deserialize::deserialize(d)?;
-        Ok(Hash(
-            decode_hex_fixed(&s).map_err(serde::de::Error::custom)?,
-        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Contributes to #186 — eliminate code duplication across grey crates.

`Hash` manually implemented `to_hex`, `from_hex`, and `Deserialize` with identical logic to the `impl_crypto_common!` macro used by all other crypto types (`Ed25519PublicKey`, `BlsPublicKey`, etc.).

## Changes

- Replace manual `to_hex`/`from_hex` with `impl_crypto_common!(Hash, "Hash")`
- Remove duplicate `Deserialize` impl (now provided by macro)
- Keep Hash-specific methods (`short_hex`, `ZERO`, `as_bytes`) and custom `Debug`

## Testing

All 103 grey-types tests pass. No behavior changes — pure refactoring.