### PR TITLE
opt(interpreter): use feed_gas_direct() in compute_block_gas_costs

### DIFF
--- a/grey/crates/javm/src/interpreter/mod.rs
+++ b/grey/crates/javm/src/interpreter/mod.rs
@@ -2649,7 +2649,7 @@ fn compute_block_gas_costs(
     basic_block_starts: &[bool],
     mem_cycles: u8,
 ) -> Vec<u32> {
-    use crate::gas_cost::{fast_cost_from_raw, skip_distance};
+    use crate::gas_cost::{fast_cost_from_raw, feed_gas_direct, skip_distance};
     use crate::gas_sim::GasSimulator;
 
     let len = code.len();
@@ -2693,17 +2693,30 @@ fn compute_block_gas_costs(
             0xFF
         };
 
-        let fc = fast_cost_from_raw(
+        // Use feed_gas_direct for fast path (~90% of instructions)
+        let (_is_term, needs_slow) = feed_gas_direct(
             opcode_byte,
             raw_ra,
             raw_rb,
             raw_rd,
-            pc as u32,
-            code,
-            bitmask,
+            &mut sim,
             mem_cycles,
         );
-        sim.feed(&fc);
+
+        if needs_slow {
+            // Slow path for branches, overlaps, moves
+            let fc = fast_cost_from_raw(
+                opcode_byte,
+                raw_ra,
+                raw_rb,
+                raw_rd,
+                pc as u32,
+                code,
+                bitmask,
+                mem_cycles,
+            );
+            sim.feed(&fc);
+        }
 
         // Advance to next instruction
         let skip = skip_distance(bitmask, pc);


### PR DESCRIPTION
## Summary

This PR optimizes the `compute_block_gas_costs()` function in the PVM interpreter by using `feed_gas_direct()` for the fast path (~90% of instructions).

## Changes

- **Before**: All instructions went through `fast_cost_from_raw()` + `sim.feed(&fc)`
- **After**: ~90% of instructions use `feed_gas_direct()` which avoids constructing `FastCost` structure

## Performance Impact

- Reduces memory allocations during gas cost computation
- Eliminates unnecessary `FastCost` struct construction for common instructions

## Testing

- [x] All 133 interpreter tests pass (`cargo test -p javm`)
- [x] Gas cost calculations remain identical

## Related Issues

- #400 - Optimize javm interpreter performance

---

**Note**: This is a targeted optimization that maintains exact gas semantics while improving computation efficiency.