### PR TITLE
refactor: add missing Copy derive to small value types

### DIFF
--- a/grey/crates/grey-state/src/reports.rs
+++ b/grey/crates/grey-state/src/reports.rs
@@ -75,14 +75,14 @@ pub struct AvailAssignment {
 }
 
 /// Service account info needed for validation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ServiceInfo {
     pub code_hash: Hash,
     pub min_item_gas: Gas,
 }
 
 /// Per-core statistics.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CoreStats {
     pub da_load: u64,
     pub popularity: u64,
@@ -133,7 +133,7 @@ impl ServiceStats {
 }
 
 /// Reported package output.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReportedPackage {
     pub work_package_hash: Hash,
     pub segment_tree_root: Hash,

--- a/grey/crates/javm/src/lib.rs
+++ b/grey/crates/javm/src/lib.rs
@@ -40,7 +40,7 @@ pub use kernel::CodeCache;
 // --- PVM types ---
 
 /// Exit reason for PVM execution (ε values, eq A.1).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExitReason {
     /// ∎: Normal halt.
     Halt,


### PR DESCRIPTION
## Summary

Contributes to #186 — eliminate code duplication and improve type ergonomics.

Several structs and enums have all-Copy fields but only derive `Clone`, forcing unnecessary clones when `Copy` semantics would suffice.

## Changes

| Type | Crate | Fields | Added |
|---|---|---|---|
| `ExitReason` | javm | Halt/Trap/Panic/OutOfGas/PageFault(u32)/HostCall(u32)/Ecall | `Copy` |
| `ServiceInfo` | grey-state | `Hash` + `Gas` (both Copy) | `Copy` |
| `CoreStats` | grey-state | eight `u64` fields | `Copy` |
| `ReportedPackage` | grey-state | two `Hash` fields | `Copy` |

## Testing

Compiles cleanly. No behavior changes — pure refactoring.