### PR TITLE
feat(fuzz): add gossipsub message decode fuzz target

### DIFF
--- a/grey/fuzz/Cargo.toml
+++ b/grey/fuzz/Cargo.toml
@@ -48,3 +48,8 @@ doc = false
 name = "fuzz_pvm_differential"
 path = "fuzz_targets/fuzz_pvm_differential.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_gossipsub_message"
+path = "fuzz_targets/fuzz_gossipsub_message.rs"
+doc = false

--- a/grey/fuzz/fuzz_targets/fuzz_gossipsub_message.rs
+++ b/grey/fuzz/fuzz_targets/fuzz_gossipsub_message.rs
@@ -1,0 +1,44 @@
+//! Fuzz target: random bytes into gossipsub message decode.
+//!
+//! Simulates receiving arbitrary bytes on each gossipsub topic
+//! (blocks, finality, guarantees, assurances, announcements,
+//! tickets, equivocation) and verifies that decoding never panics.
+//!
+//! This covers the decode path that network message handlers invoke
+//! when receiving gossipsub messages from peers.
+
+#![no_main]
+
+use grey_codec::Decode;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Each gossipsub topic carries a different message type.
+    // Fuzz all of them to ensure no panic on arbitrary input.
+
+    // Topic: blocks — Block
+    let _ = grey_types::header::Block::decode(data);
+
+    // Topic: finality — FinalityVotes (encoded as Vec<Ed25519Signature>)
+    let _ = Vec::<grey_types::Ed25519Signature>::decode(data);
+
+    // Topic: guarantees — Guarantee
+    let _ = grey_types::header::Guarantee::decode(data);
+
+    // Topic: assurances — Assurance
+    let _ = grey_types::header::Assurance::decode(data);
+
+    // Topic: tickets — Ticket
+    let _ = grey_types::header::Ticket::decode(data);
+
+    // Topic: equivocation — EquivocationEvidence
+    let _ = grey_types::header::EquivocationEvidence::decode(data);
+
+    // Topic: announcements — (BandersnatchPublicKey, Ed25519PublicKey) pair
+    let _: Result<(grey_types::BandersnatchPublicKey, grey_types::Ed25519PublicKey), _> =
+        (|| {
+            let key1 = grey_types::BandersnatchPublicKey::decode(data)?;
+            let key2 = grey_types::Ed25519PublicKey::decode(data)?;
+            Ok((key1, key2))
+        })();
+});


### PR DESCRIPTION
## Summary

- Add `fuzz_gossipsub_message` fuzz target that decodes arbitrary bytes as each gossipsub topic message type (Block, FinalityVotes, Guarantee, Assurance, Ticket, EquivocationEvidence, Announcements)
- Verifies that decoding arbitrary network bytes never panics — the core safety property for message handlers

## Context

This addresses the `fuzz_gossipsub_message` item from #229 (Property-based testing and fuzzing infrastructure):

> `fuzz_gossipsub_message`: random network message bytes → handler doesn't panic

## Test plan

- [x] `cargo build -p grey-fuzz --bin fuzz_gossipsub_message` compiles
- [ ] Run `cargo fuzz run fuzz_gossipsub_message` for 60+ seconds — no panics