### PR TITLE
extend Assembler API; add primes workload showcase

### DIFF
--- a/grey/crates/grey-bench/src/lib.rs
+++ b/grey/crates/grey-bench/src/lib.rs
@@ -558,6 +558,138 @@ pub fn polkavm_hostcall_blob(n: u64) -> Vec<u8> {
 }
 
 // ---------------------------------------------------------------------------
+// Naive prime counting (trial division). Hand-assembled showcase for the
+// extended Assembler API (mul_64, rem_unsigned_64, set_less_than_unsigned,
+// branch_less_unsigned). Complements the pre-built `sieve` blobs further
+// down — different algorithm (O(N²) vs O(N log log N)) and different
+// construction path (hand-assembled vs Rust→RISC-V via build-script).
+// ---------------------------------------------------------------------------
+
+/// Build a naive-trial-division prime-count program as a grey-pvm blob.
+///
+/// Counts primes in `[2, N)` and returns the count in A0.
+///
+/// Algorithm (no early-exit; no forward branches anywhere):
+///   count = (2 < N) ? 1 : 0          // pre-count i=2 (always prime if in range)
+///   for i in 3..(N+1):                // i ranges over i ∈ [3, N]
+///     is_prime = 1
+///     for j in 2..i:                  // do-while is OK here since i ≥ 3
+///       rem = i %u j
+///       is_prime *= (0 <u rem)        // stays 1 only if all rems nonzero
+///     in_range = (i < N) ? 1 : 0      // masks the final overshoot iteration
+///     count += is_prime * in_range
+///   return count
+///
+/// Uses the extended Assembler methods: `rem_unsigned_64`,
+/// `set_less_than_unsigned`, `mul_64`, `branch_less_unsigned`. The
+/// `mul *= flag` pattern replaces early-exit forward branches — keeps
+/// all branches backward-only and dodges javm's basic-block boundary
+/// requirement on forward branch targets.
+pub fn grey_primes_blob(n: u64) -> Vec<u8> {
+    let mut asm = Assembler::new();
+    asm.set_stack_pages(1);
+    asm.set_heap_pages(0);
+
+    asm.load_imm_64(Reg::A3, n); // A3 = N (original, for in_range check)
+    asm.load_imm_64(Reg::T0, n.wrapping_add(1)); // T0 = N+1 (outer loop limit)
+    asm.load_imm_64(Reg::A1, 0); // const 0 for set_lt
+    asm.load_imm_64(Reg::A2, 2); // const 2 for initial count check
+
+    // count = (2 < N) ? 1 : 0 — pre-count the prime "2" when N > 2.
+    asm.set_less_than_unsigned(Reg::T1, Reg::A2, Reg::A3);
+
+    asm.load_imm_64(Reg::T2, 3); // i = 3
+
+    // Outer loop entry — jump forward to create a BB boundary at outer_pc.
+    let outer_pre = asm.current_offset();
+    asm.jump(5);
+    let outer_pc = asm.current_offset();
+    assert_eq!(outer_pc, outer_pre + 5);
+
+    // Inner setup: is_prime = 1, j = 2.
+    asm.load_imm_64(Reg::S0, 1);
+    asm.load_imm_64(Reg::S1, 2);
+
+    // Inner loop entry.
+    let inner_pre = asm.current_offset();
+    asm.jump(5);
+    let inner_pc = asm.current_offset();
+    assert_eq!(inner_pc, inner_pre + 5);
+
+    // rem = i %u j ; nonzero_flag = (0 <u rem) ; is_prime *= nonzero_flag
+    asm.move_reg(Reg::A0, Reg::T2);
+    asm.rem_unsigned_64(Reg::A0, Reg::A0, Reg::S1);
+    asm.set_less_than_unsigned(Reg::A2, Reg::A1, Reg::A0);
+    asm.mul_64(Reg::S0, Reg::S0, Reg::A2);
+
+    // j++ ; if j < i, loop.
+    asm.add_imm_64(Reg::S1, Reg::S1, 1);
+    let inner_branch_pc = asm.current_offset();
+    let inner_rel = (inner_pc as i64) - (inner_branch_pc as i64);
+    asm.branch_less_unsigned(Reg::S1, Reg::T2, inner_rel as i32);
+
+    // Post-inner BB (after branch terminator).
+    // in_range = (i < N) ? 1 : 0 ; is_prime *= in_range ; count += is_prime
+    asm.set_less_than_unsigned(Reg::A2, Reg::T2, Reg::A3);
+    asm.mul_64(Reg::S0, Reg::S0, Reg::A2);
+    asm.add_64(Reg::T1, Reg::T1, Reg::S0);
+
+    // i++ ; if i < N+1, loop outer.
+    asm.add_imm_64(Reg::T2, Reg::T2, 1);
+    let outer_branch_pc = asm.current_offset();
+    let outer_rel = (outer_pc as i64) - (outer_branch_pc as i64);
+    asm.branch_less_unsigned(Reg::T2, Reg::T0, outer_rel as i32);
+
+    // Post-outer: A0 = count ; ecalli REPLY.
+    asm.move_reg(Reg::A0, Reg::T1);
+    asm.ecalli(0);
+
+    asm.build()
+}
+
+/// Build the same prime-count program as a polkavm blob.
+pub fn polkavm_primes_blob(n: u64) -> Vec<u8> {
+    let isa = polkavm_common::program::InstructionSetKind::JamV1;
+    let mut builder = ProgramBlobBuilder::new(isa);
+    builder.set_stack_size(4096);
+
+    let code = vec![
+        // BB0: init constants + pre-count i=2 if in range
+        PInst::load_imm64(pr(PReg::A3), n),
+        PInst::load_imm64(pr(PReg::T0), n.wrapping_add(1)),
+        PInst::load_imm64(pr(PReg::A1), 0),
+        PInst::load_imm64(pr(PReg::A2), 2),
+        PInst::set_less_than_unsigned(pr(PReg::T1), pr(PReg::A2), pr(PReg::A3)),
+        PInst::load_imm64(pr(PReg::T2), 3),
+        PInst::jump(1),
+        // BB1: inner setup
+        PInst::load_imm64(pr(PReg::S0), 1),
+        PInst::load_imm64(pr(PReg::S1), 2),
+        PInst::jump(2),
+        // BB2: inner body (loop back to self while j < i)
+        PInst::move_reg(pr(PReg::A0), pr(PReg::T2)),
+        PInst::rem_unsigned_64(pr(PReg::A0), pr(PReg::A0), pr(PReg::S1)),
+        PInst::set_less_than_unsigned(pr(PReg::A2), pr(PReg::A1), pr(PReg::A0)),
+        PInst::mul_64(pr(PReg::S0), pr(PReg::S0), pr(PReg::A2)),
+        PInst::add_imm_64(pr(PReg::S1), pr(PReg::S1), 1),
+        PInst::branch_less_unsigned(pr(PReg::S1), pr(PReg::T2), 2),
+        // BB3: post-inner — mask by in_range, accumulate, advance i
+        PInst::set_less_than_unsigned(pr(PReg::A2), pr(PReg::T2), pr(PReg::A3)),
+        PInst::mul_64(pr(PReg::S0), pr(PReg::S0), pr(PReg::A2)),
+        PInst::add_64(pr(PReg::T1), pr(PReg::T1), pr(PReg::S0)),
+        PInst::add_imm_64(pr(PReg::T2), pr(PReg::T2), 1),
+        PInst::branch_less_unsigned(pr(PReg::T2), pr(PReg::T0), 1),
+        // BB4: halt
+        PInst::move_reg(pr(PReg::A0), pr(PReg::T1)),
+        PInst::jump_indirect(pr(PReg::RA), 0),
+    ];
+
+    builder.set_code(&code, &[]);
+    builder.add_export_by_basic_block(0, b"main");
+    builder.to_vec().expect("failed to build polkavm primes blob")
+}
+
+// ---------------------------------------------------------------------------
 // Ecrecover benchmark: secp256k1 ECDSA public key recovery (k256 crate)
 // ELFs are auto-built by build.rs via build-javm and build-pvm crates.
 // ---------------------------------------------------------------------------
@@ -851,6 +983,52 @@ pub fn run_fib_recur_with_backend(
         KernelResult::ProtocolCall { slot } => {
             panic!("fib_recur unexpected protocol call slot={slot}")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_primes {
+    use super::*;
+
+    /// Native reference: naive trial division. Counts primes in `[2, n)`.
+    /// Mirrors the algorithm shape used by both blob builders so the
+    /// comparison is direct (no algorithmic divergence).
+    fn primes_count(n: u64) -> u64 {
+        let mut count = 0u64;
+        for i in 2..n {
+            let mut is_prime = 1u64;
+            let mut j = 2u64;
+            while j < i {
+                if i % j == 0 {
+                    is_prime = 0;
+                }
+                j += 1;
+            }
+            count += is_prime;
+        }
+        count
+    }
+
+    #[test]
+    fn test_grey_primes_matches_native_reference() {
+        for &n in &[2u64, 5, 10, 30] {
+            let blob = grey_primes_blob(n);
+            let (result, _gas) = run_kernel(&blob, 1_000_000_000);
+            assert_eq!(
+                result,
+                primes_count(n),
+                "grey_primes({n}) should be {}, got {result}",
+                primes_count(n),
+            );
+        }
+    }
+
+    /// primes(30) — primes in [2, 30) are {2,3,5,7,11,13,17,19,23,29} = 10.
+    #[test]
+    fn test_grey_primes_30_is_10() {
+        let blob = grey_primes_blob(30);
+        let (result, _gas) = run_kernel(&blob, 1_000_000_000);
+        assert_eq!(result, 10, "10 primes in [2, 30)");
     }
 }
 

--- a/grey/crates/grey-bench/src/lib.rs
+++ b/grey/crates/grey-bench/src/lib.rs
@@ -686,7 +686,9 @@ pub fn polkavm_primes_blob(n: u64) -> Vec<u8> {
 
     builder.set_code(&code, &[]);
     builder.add_export_by_basic_block(0, b"main");
-    builder.to_vec().expect("failed to build polkavm primes blob")
+    builder
+        .to_vec()
+        .expect("failed to build polkavm primes blob")
 }
 
 // ---------------------------------------------------------------------------

--- a/grey/crates/grey-transpiler/src/assembler.rs
+++ b/grey/crates/grey-transpiler/src/assembler.rs
@@ -331,6 +331,54 @@ impl Assembler {
         self
     }
 
+    /// Opcode 150: mul_imm_64 (rD = rA * imm, 64-bit)
+    pub fn mul_imm_64(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(150, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
+    /// Opcode 132: and_imm (rD = rA & imm)
+    pub fn and_imm(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(132, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
+    /// Opcode 133: xor_imm (rD = rA ^ imm)
+    pub fn xor_imm(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(133, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
+    /// Opcode 134: or_imm (rD = rA | imm)
+    pub fn or_imm(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(134, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
+    /// Opcode 136: set_less_than_unsigned_imm (rD = (rA <u imm) ? 1 : 0)
+    pub fn set_less_than_unsigned_imm(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(136, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
+    /// Opcode 137: set_less_than_signed_imm (rD = (rA <s imm) ? 1 : 0)
+    pub fn set_less_than_signed_imm(&mut self, rd: Reg, ra: Reg, imm: i32) -> &mut Self {
+        self.emit_byte(137, true);
+        self.emit_byte((rd as u8) | ((ra as u8) << 4), false);
+        self.emit_imm(imm as i64, 4);
+        self
+    }
+
     // ===== Three register instructions =====
 
     /// Opcode 200: add_64 (rD = rA + rB)
@@ -346,6 +394,150 @@ impl Assembler {
         self.emit_byte(201, true);
         self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
         self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 202: mul_64 (rD = rA * rB)
+    pub fn mul_64(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(202, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 203: div_unsigned_64 (rD = rA /u rB)
+    pub fn div_unsigned_64(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(203, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 204: div_signed_64 (rD = rA /s rB)
+    pub fn div_signed_64(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(204, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 205: rem_unsigned_64 (rD = rA %u rB)
+    pub fn rem_unsigned_64(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(205, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 206: rem_signed_64 (rD = rA %s rB)
+    pub fn rem_signed_64(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(206, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 210: and (rD = rA & rB)
+    pub fn and(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(210, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 211: xor (rD = rA ^ rB)
+    pub fn xor(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(211, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 212: or (rD = rA | rB)
+    pub fn or(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(212, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 216: set_less_than_unsigned (rD = (rA <u rB) ? 1 : 0)
+    pub fn set_less_than_unsigned(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(216, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    /// Opcode 217: set_less_than_signed (rD = (rA <s rB) ? 1 : 0)
+    pub fn set_less_than_signed(&mut self, rd: Reg, ra: Reg, rb: Reg) -> &mut Self {
+        self.emit_byte(217, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_byte(rd as u8, false);
+        self
+    }
+
+    // ===== Register-register branches =====
+    //
+    // Encoding: opcode + (rA | rB<<4) + 4-byte signed relative offset.
+    // Offset is relative to the branch instruction's own PC. Use a
+    // negative offset for backward jumps (loops); positive for forward.
+
+    /// Opcode 170: branch_eq (branch if rA == rB)
+    pub fn branch_eq(&mut self, ra: Reg, rb: Reg, rel_offset: i32) -> &mut Self {
+        self.emit_byte(170, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
+        self
+    }
+
+    /// Opcode 171: branch_not_eq (branch if rA != rB)
+    pub fn branch_not_eq(&mut self, ra: Reg, rb: Reg, rel_offset: i32) -> &mut Self {
+        self.emit_byte(171, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
+        self
+    }
+
+    /// Opcode 172: branch_less_unsigned (branch if rA <u rB)
+    pub fn branch_less_unsigned(&mut self, ra: Reg, rb: Reg, rel_offset: i32) -> &mut Self {
+        self.emit_byte(172, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
+        self
+    }
+
+    /// Opcode 173: branch_less_signed (branch if rA <s rB)
+    pub fn branch_less_signed(&mut self, ra: Reg, rb: Reg, rel_offset: i32) -> &mut Self {
+        self.emit_byte(173, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
+        self
+    }
+
+    /// Opcode 174: branch_greater_or_equal_unsigned (branch if rA >=u rB)
+    pub fn branch_greater_or_equal_unsigned(
+        &mut self,
+        ra: Reg,
+        rb: Reg,
+        rel_offset: i32,
+    ) -> &mut Self {
+        self.emit_byte(174, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
+        self
+    }
+
+    /// Opcode 175: branch_greater_or_equal_signed (branch if rA >=s rB)
+    pub fn branch_greater_or_equal_signed(
+        &mut self,
+        ra: Reg,
+        rb: Reg,
+        rel_offset: i32,
+    ) -> &mut Self {
+        self.emit_byte(175, true);
+        self.emit_byte((ra as u8) | ((rb as u8) << 4), false);
+        self.emit_imm(rel_offset as i64, 4);
         self
     }
 
@@ -887,5 +1079,173 @@ mod tests {
             javm::kernel::KernelResult::Halt(_) | javm::kernel::KernelResult::Panic => {}
             other => panic!("Expected Halt or Panic, got {:?}", other),
         }
+    }
+
+    // ===== Extended ALU + branch ops =====
+    //
+    // Each test verifies the emitted bytes match the documented opcode + the
+    // encoding shape used by the surrounding methods in this file.
+
+    #[test]
+    fn test_mul_imm_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.mul_imm_64(Reg::A0, Reg::A1, 7);
+        assert_eq!(asm.code[0], 150); // opcode
+        assert_eq!(asm.code[1], (Reg::A0 as u8) | ((Reg::A1 as u8) << 4));
+        assert_eq!(asm.code[2], 7); // imm LE byte 0
+        assert_eq!(asm.code.len(), 6); // 1 opcode + 1 reg_byte + 4 imm
+        assert_eq!(asm.bitmask[0], 1);
+        assert!(asm.bitmask[1..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_set_less_than_unsigned_imm_encoding() {
+        let mut asm = Assembler::new();
+        asm.set_less_than_unsigned_imm(Reg::T0, Reg::T1, 100);
+        assert_eq!(asm.code[0], 136);
+        assert_eq!(asm.code[1], (Reg::T0 as u8) | ((Reg::T1 as u8) << 4));
+        assert_eq!(asm.code.len(), 6);
+    }
+
+    #[test]
+    fn test_mul_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.mul_64(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 202); // opcode
+        assert_eq!(asm.code[1], (Reg::A1 as u8) | ((Reg::A2 as u8) << 4));
+        assert_eq!(asm.code[2], Reg::A0 as u8);
+        assert_eq!(asm.code.len(), 3);
+        assert_eq!(asm.bitmask, vec![1, 0, 0]);
+    }
+
+    #[test]
+    fn test_div_unsigned_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.div_unsigned_64(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 203);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_div_signed_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.div_signed_64(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 204);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_rem_unsigned_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.rem_unsigned_64(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 205);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_rem_signed_64_encoding() {
+        let mut asm = Assembler::new();
+        asm.rem_signed_64(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 206);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_and_or_xor_encoding() {
+        let mut asm = Assembler::new();
+        asm.and(Reg::A0, Reg::A1, Reg::A2);
+        asm.or(Reg::A0, Reg::A1, Reg::A2);
+        asm.xor(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 210); // and
+        assert_eq!(asm.code[3], 212); // or
+        assert_eq!(asm.code[6], 211); // xor
+        assert_eq!(asm.code.len(), 9);
+    }
+
+    #[test]
+    fn test_set_less_than_unsigned_encoding() {
+        let mut asm = Assembler::new();
+        asm.set_less_than_unsigned(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 216);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_set_less_than_signed_encoding() {
+        let mut asm = Assembler::new();
+        asm.set_less_than_signed(Reg::A0, Reg::A1, Reg::A2);
+        assert_eq!(asm.code[0], 217);
+        assert_eq!(asm.code.len(), 3);
+    }
+
+    #[test]
+    fn test_branch_less_unsigned_encoding() {
+        // The canonical case: this is the encoding `grey-bench`'s
+        // `emit_branch_lt_u` helper has been hand-rolling. Verify the
+        // typed helper produces identical bytes.
+        let mut asm = Assembler::new();
+        asm.branch_less_unsigned(Reg::T2, Reg::S1, -5);
+        assert_eq!(asm.code[0], 172);
+        assert_eq!(asm.code[1], (Reg::T2 as u8) | ((Reg::S1 as u8) << 4));
+        // -5 as i32 LE: 0xFB, 0xFF, 0xFF, 0xFF
+        assert_eq!(&asm.code[2..6], &[0xFB, 0xFF, 0xFF, 0xFF]);
+        assert_eq!(asm.code.len(), 6);
+        assert_eq!(asm.bitmask, vec![1, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_branch_eq_encoding() {
+        let mut asm = Assembler::new();
+        asm.branch_eq(Reg::T0, Reg::T1, 16);
+        assert_eq!(asm.code[0], 170);
+        assert_eq!(&asm.code[2..6], &16i32.to_le_bytes());
+    }
+
+    #[test]
+    fn test_branch_not_eq_encoding() {
+        let mut asm = Assembler::new();
+        asm.branch_not_eq(Reg::T0, Reg::T1, 16);
+        assert_eq!(asm.code[0], 171);
+    }
+
+    #[test]
+    fn test_branch_less_signed_encoding() {
+        let mut asm = Assembler::new();
+        asm.branch_less_signed(Reg::T0, Reg::T1, 16);
+        assert_eq!(asm.code[0], 173);
+    }
+
+    #[test]
+    fn test_branch_greater_or_equal_unsigned_encoding() {
+        let mut asm = Assembler::new();
+        asm.branch_greater_or_equal_unsigned(Reg::T0, Reg::T1, 16);
+        assert_eq!(asm.code[0], 174);
+    }
+
+    #[test]
+    fn test_branch_greater_or_equal_signed_encoding() {
+        let mut asm = Assembler::new();
+        asm.branch_greater_or_equal_signed(Reg::T0, Reg::T1, 16);
+        assert_eq!(asm.code[0], 175);
+    }
+
+    #[test]
+    fn test_and_imm_xor_imm_or_imm_encoding() {
+        let mut asm = Assembler::new();
+        asm.and_imm(Reg::A0, Reg::A1, 5);
+        asm.xor_imm(Reg::A0, Reg::A1, 5);
+        asm.or_imm(Reg::A0, Reg::A1, 5);
+        assert_eq!(asm.code[0], 132); // and_imm
+        assert_eq!(asm.code[6], 133); // xor_imm
+        assert_eq!(asm.code[12], 134); // or_imm
+        assert_eq!(asm.code.len(), 18); // 3 × 6 bytes each
+    }
+
+    #[test]
+    fn test_set_less_than_signed_imm_encoding() {
+        let mut asm = Assembler::new();
+        asm.set_less_than_signed_imm(Reg::T0, Reg::T1, -1);
+        assert_eq!(asm.code[0], 137);
+        assert_eq!(&asm.code[2..6], &(-1i32).to_le_bytes());
     }
 }


### PR DESCRIPTION
## Summary

Two commits, both motivated by hand-rolling non-trivial workloads against
`grey-transpiler::Assembler`:

1. **grey-transpiler:** extend the `Assembler` API with 22 typed helpers
   for opcodes the existing surface didn't cover — multiplication, division,
   remainder, bitwise ALU, set-less-than, and register-register branches.
   The encoding patterns mirror what `grey-bench`'s local `emit_branch_lt_u`
   helper has been doing via `emit_raw` — formalizing it as typed methods.
   17 byte-encoding unit tests; 65 → 82 total tests pass.

2. **grey-bench:** add `grey_primes_blob(n)` + `polkavm_primes_blob(n)` —
   hand-assembled naive trial-division prime counter. Showcase consumer
   for the extended API (uses `rem_unsigned_64`, `set_less_than_unsigned`,
   `mul_64`, `branch_less_unsigned`). Complements the pre-built sieve blobs;
   different algorithm (O(N²) vs O(N log log N)) and different construction
   path (hand-assembled vs build-script). 2 new tests verifying correctness
   against a native-Rust reference; 21 / 21 grey-bench tests pass.



## Verification

- `cargo test -p grey-transpiler --lib` — 82 pass (existing 65 + 17 new)
- `cargo test -p grey-bench --lib` — 21 pass (existing 19 + 2 new)
- `cargo check -p grey-bench` — clean (no downstream regressions)
