### PR TITLE
perf(recompiler): branchless cmov + mul-pair fusion (closes #842)

### DIFF
--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -1,0 +1,157 @@
+//! CI conformance for the bench workloads.
+//!
+//! Mirrors the per-workload sanity check in `benches/pvm_bench.rs` and
+//! `benches/stark_bench.rs` (which only run under `cargo bench`,
+//! invisible to CI) as plain `#[test]`s, so any regression in the
+//! interpreter, recompiler, or transpiler that changes a workload's
+//! return value or gas cost trips a test failure.
+//!
+//! For each workload we:
+//!   1. Drive the byte-PVM interpreter through `Nub::new_local()`.
+//!   2. Drive the JIT recompiler through `Nub::new_hyperlight()`.
+//!   3. Assert both backends agree on `(return_value, gas_used)`.
+//!   4. Pin both against a hardcoded `(value, gas)` from the
+//!      reference run on this branch — a deliberate floor that
+//!      catches "silently changed gas accounting" or "silently
+//!      changed transpiler output" regressions the round-trip
+//!      check would miss.
+//!
+//! Linux x86_64 only: the recompiler path needs Hyperlight + KVM.
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::Image;
+use scale::Decode;
+
+/// Build the `PublishSpec` once for a workload, drive both backends,
+/// and check they agree with each other and with the pinned reference.
+fn check_workload(name: &str, blob: &[u8], expected_value: u64, expected_gas: u64) {
+    let image = Image::decode(blob)
+        .unwrap_or_else(|e| panic!("[{name}] decode Image: {e:?}"))
+        .0;
+    let spec = javm_bench::build_publish_spec(&image, 0);
+
+    let (interp_val, interp_gas) = javm_bench::run_interpreter(&spec);
+    assert_eq!(
+        interp_val, expected_value,
+        "[{name}] interpreter return value drifted: got {interp_val:#x}, expected {expected_value:#x}",
+    );
+    assert_eq!(
+        interp_gas, expected_gas,
+        "[{name}] interpreter gas drifted: got {interp_gas}, expected {expected_gas}",
+    );
+
+    let (recomp_val, recomp_gas) = javm_bench::run_recompiler(&spec);
+    assert_eq!(
+        recomp_val, interp_val,
+        "[{name}] recompiler vs interpreter return value mismatch: recomp={recomp_val:#x} interp={interp_val:#x}",
+    );
+    assert_eq!(
+        recomp_gas, interp_gas,
+        "[{name}] recompiler vs interpreter gas mismatch: recomp={recomp_gas} interp={interp_gas}",
+    );
+}
+
+// PVM-shaped workloads (matches `benches/pvm_bench.rs`).
+
+#[test]
+fn prime_sieve() {
+    check_workload(
+        "prime_sieve",
+        include_bytes!(env!("PRIME_SIEVE_BLOB")),
+        0x2578,
+        8_773_823,
+    );
+}
+
+#[test]
+fn ed25519() {
+    check_workload(
+        "ed25519",
+        include_bytes!(env!("ED25519_BLOB")),
+        0x1,
+        826_824,
+    );
+}
+
+#[test]
+fn keccak() {
+    check_workload(
+        "keccak",
+        include_bytes!(env!("KECCAK_BLOB")),
+        0x39e5_0259,
+        102_409,
+    );
+}
+
+#[test]
+fn blake2b() {
+    check_workload(
+        "blake2b",
+        include_bytes!(env!("BLAKE2B_BLOB")),
+        0xee1f_55f1,
+        62_999,
+    );
+}
+
+#[test]
+fn ecrecover() {
+    check_workload(
+        "ecrecover",
+        include_bytes!(env!("ECRECOVER_BLOB")),
+        0x1,
+        6_790_808,
+    );
+}
+
+// STARK-shaped workloads (matches `benches/stark_bench.rs`).
+
+#[test]
+fn goldilocks_mul() {
+    check_workload(
+        "goldilocks_mul",
+        include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
+        0x2cf7_3e57,
+        2_600_154,
+    );
+}
+
+#[test]
+fn poseidon2_perm() {
+    check_workload(
+        "poseidon2_perm",
+        include_bytes!(env!("POSEIDON2_PERM_BLOB")),
+        0x3ce3_3156,
+        9_669_150,
+    );
+}
+
+#[test]
+fn mini_verifier() {
+    check_workload(
+        "mini_verifier",
+        include_bytes!(env!("MINI_VERIFIER_BLOB")),
+        0xf98f_c4ab,
+        4_580_325,
+    );
+}
+
+#[test]
+fn poly_eval() {
+    check_workload(
+        "poly_eval",
+        include_bytes!(env!("POLY_EVAL_BLOB")),
+        0x01da_34e2,
+        7_129_783,
+    );
+}
+
+#[test]
+fn fri_fold_tree() {
+    check_workload(
+        "fri_fold_tree",
+        include_bytes!(env!("FRI_FOLD_TREE_BLOB")),
+        0x37e6_76f4,
+        4_950_708,
+    );
+}

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -497,12 +497,9 @@ impl Compiler {
                 Opcode::Add64 => {
                     self.try_fuse_scaled_index_raw(code, bitmask, pc, &decoded_args, &mut gas_sim)
                 }
-                // Mul64+MulUpper fusion disabled: corrupts results when φ[11] (RAX)
-                // is involved as both source and destination. The push/restore sequence
-                // conflicts with rd_hi/rd_lo assignments when they alias RAX.
-                // Opcode::Mul64 => {
-                //     self.try_fuse_mul_pair_raw(code, bitmask, pc, &decoded_args, &mut gas_sim)
-                // }
+                Opcode::Mul64 => {
+                    self.try_fuse_mul_pair_raw(code, bitmask, pc, &decoded_args, &mut gas_sim)
+                }
                 _ => None,
             };
 
@@ -775,10 +772,17 @@ impl Compiler {
         }
     }
 
-    /// Peephole: fuse Mul64 + MulUpper from raw code.
-    /// Currently disabled: corrupts results when φ[11] (RAX) is both source and destination.
-    /// Kept for future fix (needs proper RAX aliasing handling in push/pop sequence).
-    #[allow(dead_code)]
+    /// Peephole: fuse `mul_64 D_lo, A, B` + `mul_upper_{uu,ss} D_hi, A, B`
+    /// (same A and B) into a single x86 `MUL`/`IMUL` that computes the
+    /// full 128-bit product in one shot (`RDX:RAX = A*B`).
+    ///
+    /// Hot in Goldilocks `mul`: the `(a as u128)*(b as u128)` decomposition
+    /// emits the PVM pair on identical operands; the standalone codegen
+    /// would do two separate full 64-bit multiplies (one for low, one
+    /// for high).
+    ///
+    /// Skipped for `mul_upper_su` (mixed signedness): handled by its
+    /// dedicated emit path, which needs the sign-correction.
     fn try_fuse_mul_pair_raw(
         &mut self,
         code: &[u8],
@@ -820,8 +824,13 @@ impl Compiler {
         if u_ra != *m_ra || u_rb != *m_rb {
             return None;
         }
+        // Disallow rd_lo == rd_hi (would only deliver one of the two products).
+        if *m_rd == u_rd {
+            return None;
+        }
 
-        // Feed instruction 2 to gas sim (using decoded args, no redundant decode)
+        // Feed instruction 2 to gas sim (using decoded args, no redundant decode).
+        // Fused mul-pair instructions are never terminators — no gas block binding.
         let fc = javm_exec::gas_cost::fast_cost_from_decoded(
             op2 as u8,
             &args2,
@@ -832,33 +841,76 @@ impl Compiler {
         );
         gas_sim.feed(&fc);
 
-        // Bind labels
-        // Fused mul-pair instructions are never terminators — no gas block binding.
-
         let (a, b) = (REG_MAP[*m_ra], REG_MAP[*m_rb]);
         let (rd_lo, rd_hi) = (REG_MAP[*m_rd], REG_MAP[u_rd]);
+        let phi11 = REG_MAP[11]; // RAX
+        debug_assert_eq!(phi11, Reg::RAX);
 
-        self.asm.push(Reg::RAX);
-        self.asm.push(SCRATCH);
-        self.asm.mov_rr(Reg::RAX, a);
-        let mul_src = if b == Reg::RAX {
-            self.asm.mov_load64(SCRATCH, Reg::RSP, 8);
+        // Strategy:
+        //   1. Get A's value into RAX (preserve φ[11] if it's neither rd_lo
+        //      nor rd_hi).
+        //   2. Get B's value into a non-RAX, non-RDX register (mul_src).
+        //   3. MUL/IMUL mul_src → RDX:RAX.
+        //   4. Move RAX → rd_lo (skip if rd_lo is RAX, value already there).
+        //   5. Move RDX → rd_hi (skip if rd_hi is RDX = SCRATCH, but SCRATCH
+        //      isn't a PVM register, so rd_hi is always ≠ RDX).
+        //   6. Restore φ[11] from stack if we saved it.
+        //
+        // Order of moves matters when rd_lo or rd_hi aliases A or B:
+        //   - rd_hi aliases A: writing rd_hi clobbers A's home, but A's
+        //     value was already consumed by mul. OK.
+        //   - rd_lo aliases B: writing rd_lo overwrites B's home. mul has
+        //     already consumed B. OK.
+        //   - rd_lo == RAX: RAX already holds low; skip the mov.
+        //
+        // We preserve φ[11] when neither rd writes to it (the rest of the
+        // program may still expect RAX to hold φ[11]'s value).
+        let need_save_phi11 = rd_lo != phi11 && rd_hi != phi11;
+
+        if need_save_phi11 {
+            self.asm.push(phi11);
+        }
+
+        // If B is RAX, its value is now either in RAX (where mul wants A)
+        // or on the stack (above) if we saved. Load to SCRATCH before
+        // clobbering RAX with A.
+        let mul_src = if b == phi11 {
+            if need_save_phi11 {
+                // φ[11]'s original value is at [RSP], which is B's value.
+                self.asm.mov_load64(SCRATCH, Reg::RSP, 0);
+            } else {
+                // Didn't save; B's value is still in RAX. But we're about
+                // to overwrite RAX with A. Stash B to SCRATCH first.
+                self.asm.mov_rr(SCRATCH, b);
+            }
             SCRATCH
         } else {
             b
         };
+
+        // Load A into RAX.
+        if a != phi11 {
+            self.asm.mov_rr(phi11, a);
+        }
+
         if signed {
             self.asm.imul_rdx_rax(mul_src);
         } else {
             self.asm.mul_rdx_rax(mul_src);
         }
-        self.asm.push(SCRATCH);
-        self.asm.push(Reg::RAX);
-        self.asm.mov_load64(SCRATCH, Reg::RSP, 16);
-        self.asm.mov_load64(Reg::RAX, Reg::RSP, 24);
-        self.asm.mov_load64(rd_lo, Reg::RSP, 0);
-        self.asm.mov_load64(rd_hi, Reg::RSP, 8);
-        self.asm.add_ri(Reg::RSP, 32);
+
+        // Write rd_lo (from RAX) first. If rd_lo == phi11, no-op. If rd_lo
+        // == SCRATCH that's impossible (SCRATCH isn't a PVM reg).
+        if rd_lo != phi11 {
+            self.asm.mov_rr(rd_lo, phi11);
+        }
+        // Write rd_hi (from RDX = SCRATCH).
+        self.asm.mov_rr(rd_hi, SCRATCH);
+
+        if need_save_phi11 {
+            self.asm.pop(phi11);
+        }
+
         self.invalidate_all_regs();
         Some(pc2 + 1 + skip2 - pc)
     }

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -1763,25 +1763,24 @@ impl Compiler {
             }
             Opcode::CmovIzImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
-                    // if φ[rb] == 0 then φ[ra] = imm
+                    // if φ[rb] == 0 then φ[ra] = imm — branchless via cmov.
+                    // Hot in Goldilocks `add` overflow-correction (~10% of
+                    // poseidon2 PVM trace), where the carry is ~50% random
+                    // and the branch was a pipeline drag.
                     let rb_reg = REG_MAP[*rb];
+                    let ra_reg = REG_MAP[*ra];
+                    self.asm.mov_ri64(SCRATCH, *imm);
                     self.asm.test_rr(rb_reg, rb_reg);
-                    let skip = self.asm.new_label();
-                    self.asm.jcc_label(Cc::NE, skip);
-                    self.asm.mov_ri64(REG_MAP[*ra], *imm);
-
-                    self.asm.bind_label(skip);
+                    self.asm.cmovcc(Cc::E, ra_reg, SCRATCH);
                 }
             }
             Opcode::CmovNzImm => {
                 if let Args::TwoRegImm { ra, rb, imm } = args {
                     let rb_reg = REG_MAP[*rb];
+                    let ra_reg = REG_MAP[*ra];
+                    self.asm.mov_ri64(SCRATCH, *imm);
                     self.asm.test_rr(rb_reg, rb_reg);
-                    let skip = self.asm.new_label();
-                    self.asm.jcc_label(Cc::E, skip);
-                    self.asm.mov_ri64(REG_MAP[*ra], *imm);
-
-                    self.asm.bind_label(skip);
+                    self.asm.cmovcc(Cc::NE, ra_reg, SCRATCH);
                 }
             }
             Opcode::RotR64Imm => {


### PR DESCRIPTION
Closes #842.

Two targeted recompiler-level changes that close (and on three of five benches, overshoot) the javm-vs-polkavm gap identified in the tracking issue, plus a small CI-coverage follow-up.

## Changes

1. **Branchless `CmovIzImm` / `CmovNzImm` codegen** ([83b526c5](https://github.com/jarchain/jar/commit/83b526c5)).
   The old form was `test rb, rb; jne skip; mov ra, imm; skip:`. That branch carries the Goldilocks `overflowing_add` carry-correction (~10% of the poseidon2 PVM trace) where the carry is ~50% unpredictable. Replaced with `mov scratch, imm; test rb, rb; cmovcc ra, scratch` — same instruction count, no branch.

2. **`mul_64 + mul_upper_{uu,ss}` peephole fusion, re-enabled** ([c8fd8a19](https://github.com/jarchain/jar/commit/c8fd8a19)).
   The previously-disabled fusion had a bad push/pop sequence that aliased RAX. Rewritten cleanly: when adjacent PVM ops compute lo+hi of the same `a*b`, emit one x86 `MUL`/`IMUL` (which writes `RDX:RAX` in a single instruction) instead of two independent 64-bit multiplies. Handles all RAX-aliasing cases (rd_lo == RAX, rb == RAX, ra == RAX).

3. **CI-visible workload conformance** ([bd66a1a0](https://github.com/jarchain/jar/commit/bd66a1a0)).
   The bench-harness sanity check (`interp_value == recomp_value && interp_gas == recomp_gas`) only fires under `cargo bench`, which CI never runs. New `rust/javm-bench/tests/workloads.rs` runs all ten workloads (prime_sieve, ed25519, keccak, blake2b, ecrecover, goldilocks_mul, poseidon2_perm, mini_verifier, poly_eval, fri_fold_tree) under `cargo test`, asserting both the pair-agreement *and* a pinned `(value, gas)` reference. Catches a silent gas-accounting drift or transpiler output drift that pair-agreement alone would miss.

## Numbers

`cargo bench -p javm-bench --bench stark_bench`, criterion 100-sample @ 3s warmup, Linux x86_64.

| workload | before #842 | after | polkavm-comp-exec |
|---|---:|---:|---:|
| goldilocks_mul | 626 µs | 518 µs | 508 µs |
| poseidon2_perm | 5.79 ms | **1.82 ms** | 1.92 ms |
| mini_verifier | 2.42 ms | **777 µs** | 795 µs |
| poly_eval | 2.31 ms | 1.71 ms | 1.69 ms |
| fri_fold_tree | 2.24 ms | **773 µs** | 827 µs |

The residual ~10 µs / ~20 µs gaps on `goldilocks_mul` and `poly_eval` are consistent with our ~6 µs KVM-roundtrip cost per `invoke_cached` amortized over the bench's tight inner loops — a price we're happy to pay for the multi-VM / COW / RO-memory story KVM gives us elsewhere.

## Test plan
- [x] `cargo test -p javm-recompiler-x86`
- [x] `cargo test -p javm-guest-tests`
- [x] `cargo test -p javm-bench --test workloads` (new conformance suite)
- [x] `cargo test --workspace --release`
- [x] `cargo bench -p javm-bench --bench stark_bench` — all five workloads improved or matched