### PR TITLE
docs: import minimum-kernel v3 spec into docs/spec/

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,2556 @@
+# Minimum kernel v3 — top-level spec
+
+A redesign of the JAR kernel as a content-addressed, by-value, capability-
+threaded VM kernel. The discipline: **state is content-addressed values,
+caps are typed forgery-resistant references, conservation is bytecode
+arithmetic in canonical authorities, and snapshot/revert is universal
+via MGMT_COPY.**
+
+This document promotes the v3 design from discussion to top-level spec.
+The discussion-level exploration with linearity remains at
+[../minimum/discussions/minimal-kernel-v3.md](../minimum/discussions/minimal-kernel-v3.md)
+for reference if we want to revisit linearity later.
+
+## The shape, in one paragraph
+
+An Instance holds an Image (its current spec) and a 256-slot cnode (its
+mutable state). Image is a structured cap kind (`Cap::Image`)
+containing code, endpoints, memory mappings, and pinned ro caps.
+Instances evolve their Image via **`set_image`** — atomically swapping
+pinned slots and extending the cumulative `image_hash` chain. The
+canonical formula: at genesis `image_hash = hash(initial_image)`;
+after `set_image(new)`, `image_hash = hash(image_hash_before ||
+hash(new))`. All five cap kinds (Instance, Image, Data, CNode, Type) are
+**uniformly copyable** (content-addressed; MGMT_COPY shares content
+hash; mutations diverge). Conservation of resources lives in
+**authority bytecode** (ChainOrchestrator's ledgers); structural
+forgery resistance comes from the **image_hash chain rooted at the
+genesis Kernel Instance** plus cap-flow + cap-runtime integrity. New
+Instances are produced via **`MGMT_COPY`** of an existing Cap::Instance
+(same-type sibling; image_hash preserved) or **`host_derive_spawn`**
+(new image; image_hash chain extends; sub-type creation).
+Snapshot/revert is universal:
+MGMT_COPY of any Instance produces a content-shared reference;
+mutations diverge per §9 case (b).
+
+## Key design properties
+
+- **No kernel-level linearity.** All caps are copyable. Conservation
+  is bytecode-enforced in authority Instances; forgery resistance is
+  structural via image_hash chain. Linearity is not just dropped
+  for snapshot/revert convenience — it has no structural use case in
+  v3 that other mechanisms (ledger arithmetic, image_hash, MGMT_MOVE,
+  bytecode discipline) don't already cover. See §8 "Why no
+  linearity".
+- **Cap::Instance is uniformly copyable.** No `image.copyable` field.
+  Snapshot/revert works on any Instance.
+- **No KernelInstance category — kernel-assisted Instances instead.**
+  Instances whose image is well-known to the kernel (YieldCatcher,
+  GasMeter, StorageQuota, Gas{meter_id}, Quota{quota_id},
+  AttestationAuthority) are still Cap::Instance; the kernel may
+  direct-access their state for hot-path metering, but they share
+  the cap kind with everything else. See §22 and
+  [discussions/kernel-assisted-instances.md](discussions/kernel-assisted-instances.md).
+- **By-value with content-addressed slot references.** Slots only
+  update at apply termination. Sub-tree atomicity is structural:
+  faulted apply leaves no observable side effect outside its working
+  memory.
+- **Forgery resistance via image_hash chain.** Adversary cannot
+  construct Cap::Instance with canonical image_hash without legitimate
+  derive_spawn / set_image descent from genesis.
+- **Pure-function apply.** `(input, state, scratchpad) → outputs |
+  yield | fault`. No side effects during execution; effects encoded
+  as outputs.
+- **Instance creation:** `MGMT_COPY` of a Cap::Instance for same-type
+  siblings (image_hash preserved; content-shared with mutations
+  diverging per §9 case (b)); `host_derive_spawn(image, cnode)` for
+  sub-types (image_hash chain extends).
+- **Instance copy is universal.** MGMT_COPY of any Cap::Instance produces
+  a content-shared copy. For copies that need different initial state
+  than the source, the Image declares a setup endpoint the caller
+  CALLs into after MGMT_COPY.
+- **Image's pinned slots accept Cap::Data and Cap::Image.** Both are
+  content-addressed copyable kinds suitable for "ro spec content".
+- **Resource caps are not separate kinds.** Gas and StorageQuota
+  are kernel-assisted Cap::Instances (§22): per-Instance unit handles
+  (`Cap::Instance[Gas{meter_id}]` in `gas_slots`,
+  `Cap::Instance[Quota{quota_id}]` in `quota_slots`) into kernel-
+  internal `GasMeter` / `StorageQuota` tables. Chain accesses the
+  tables only via kernel-issued `SetGasMeter` / `SetStorageQuota`
+  caps. Custom resources are typed handles into authority ledgers.
+- **Authority is conveyed by capabilities.** Cap possession is the
+  right to invoke. Unforgeability via image_hash chain; unappropriability
+  via cnode ownership. No per-user ACL tables; no bearer tokens (in
+  the secrecy sense); no σ-resident signing keys; no Cap::Authority
+  kind. See §14 for the EndpointRefCap pattern and
+  [userspace/generic-authority-pattern.md](userspace/generic-authority-pattern.md)
+  for the broader authority cap spec.
+
+## 0. Foundational principles
+
+```
+1.  Data flow direction is structural.
+    Forward data flow defines scope; faults propagate against it.
+
+2.  Instance is the unit of state.
+    Always Image-bound. Persistent state = cnode contents.
+    Image (Cap::Image) is the spec; cnode contents are the state.
+
+3.  Caps are values; cnode is a table of values.
+    Slots reference Instance values by hash. Slots only update at apply
+    termination.
+
+4.  Caps are uniformly copyable.
+    All five cap kinds (Instance, Image, Data, CNode, Type) are
+    content-addressed copyable. No kernel-level linearity. Conservation
+    of resources lives in authority bytecode; structural forgery
+    resistance comes from image_hash chain.
+
+5.  Memory is static, declared by Image.
+    Two purposes: ro reference data (Image-baked or pinned cnode
+    DataCaps) and rw working/persistent areas (mapped via cnode
+    DataCap slots). No dynamic mapping; no lazy paging.
+
+6.  Apply is a pure function.
+    apply : (input, state, scratchpad) → (new_state, reply, emits)
+            | yield(slot, reason)
+            | fault.
+    No side effects during execution. Effects are encoded as outputs.
+
+7.  Sub-tree atomicity is structural.
+    A's HALT commits everything A did including changes to sub-Instances
+    A owns. A's fault discards all of it. By-value with slot-only-
+    updates-at-termination.
+
+8.  CALL is the only invocation primitive.
+    CALL_RESUME and DROP_PAUSED handle Paused Instances. No CALL_TO.
+
+9.  slot[0] is the universal scratchpad channel.
+    All inbound/outbound payload between instances flows through slot[0].
+    CALL/CALL_RESUME move caller's slot[0] into target's slot[0]
+    (down). HALT/yield/fault reflect target's slot[0] back to caller's
+    slot[0] (up). host_yield takes only a marker reference (a
+    Cap::Instance whose instance_hash is the routing key — see §14); the
+    marker's payload reflects via slot[0]. Apply discipline: keep
+    slot[0] in a safe-to-reflect state at all times (OOG can yield
+    at any instruction; mid-mutation states would expose partial
+    data).
+
+10. OOG is just kernel-triggered host_yield with the kernel-issued
+    OOGMarker (§4). Captures continuation; reflects a
+    Cap::Instance[Gas{meter_id}] payload to caller; caller typically
+    SetGasMeter's a topup and CALL_RESUMEs.
+
+11. Saga is for peer coordination only.
+    Sub-Instance ownership is structurally atomic. Saga (emit +
+    on_failure) covers the case where A doesn't own B.
+
+12. Gas accounting is STM-exempt.
+    Debited at every termination (HALT, yield, fault) regardless.
+    Validators are paid for compute they performed.
+
+13. Encapsulation = data-flow isolation + trusted apply.
+    Two related properties; they apply at different levels.
+
+    (a) Data-flow isolation. An Instance can only access caps that have
+        flowed to it via legitimate cap-flow. Siblings, parents, and
+        unrelated Instances are structurally unreachable.
+
+    (b) Trusted apply. An Instance's state changes only via running its
+        Image's bytecode. Kernel-enforced; no ABI op writes content
+        into another Instance's state. Load-bearing at levels where
+        state encodes authorization (orchestrators).
+
+    INTEGRITY, not confidentiality (σ is public). What makes
+    sandbox, replay, trustless composition, and the orchestrator-
+    mediated authority pattern (§14) work.
+
+14. Image is mutated as a unit; set_image is a "push".
+    The only on-self spec-changing primitive is
+    set_image(new_image: Cap::Image). Each set_image:
+      - swaps pinned slots (from old image's to new image's),
+      - installs new_image as current,
+      - updates image_hash = hash(self.image_hash || hash(new_image)).
+    Lineage chain extends; it does not contract.
+    No host_set_code / host_set_endpoints / etc. — those would let
+    userspace mutate spec piecewise, breaking atomicity.
+    Sub-type Instance creation uses host_derive_spawn (spawning a fresh
+    Instance with chosen image), which extends the chain on the *spawned*
+    Instance, not self. Same-type Instance creation uses MGMT_COPY (preserves
+    image_hash; content-shared copy).
+
+15. Pinned slots are per-Image, not per-Instance.
+    Image.pinned_slots declares which cnode slots hold pinned ro caps
+    (Cap::Data or Cap::Image — content-addressed copyable kinds).
+    They're part of the program's spec: LLVM jump tables, baked-in
+    constants, Cap::Image references for derive_spawn, etc.
+    set_image swaps pinned slots atomically with the rest of the spec.
+
+16. image_hash captures lineage as a cumulative chain hash.
+    Canonical formulae:
+      genesis:                  image_hash = hash(initial_image)
+      after set_image(new):     image_hash = hash(image_hash_before
+                                                   || hash(new))
+      via derive_spawn(new):    spawned.image_hash =
+                                  hash(spawner.image_hash || hash(new))
+      via MGMT_COPY:            copy.image_hash = source.image_hash
+                                  (preserved, not extended)
+    Forgery resistance: post-extension hashes are recursive and never
+    equal hash(any single Image). Only genesis Instances have image_hash
+    of the form hash(Image). Cap-flow on the genesis Kernel Instance +
+    cap-runtime integrity prevent adversary from producing Instances with
+    canonical image_hash chains.
+
+17. Type query is semantic, not raw; types are identification, not
+    authorization.
+    Userspace cannot read raw image_hash. Two type-query host calls:
+      host_same_type(a, b)
+                  — image_hash equality between two caps the caller
+                    holds.
+      host_same_type_as(comparer, comparee, [images])
+                  — relative-chain comparison: returns true iff
+                    comparer's image_hash equals the hash chain
+                    extension of comparee's image_hash through the
+                    given Cap::Image derivation steps.
+    Plus the Cap::Type primitives (host_type_of, host_subtype,
+    host_type_eq) for working with types as caps. See §8.
+    
+    **Type queries identify; possession authorizes.** Two Instances
+    being "the same type" doesn't grant authority. Authority requires
+    possession of Cap::Instance (the actual instance) used per the
+    yield-marker pattern (§14, userspace/generic-authority-pattern.md).
+    Raw image_hash and full lineage walking are not exposed; if
+    needed, chains track
+    ancestors in their own state.
+
+18. Authority within σ is conveyed by capabilities.
+    σ is public, but caps in v3 are not bearer tokens whose security
+    depends on secrecy — their unforgeability is structural via
+    image_hash chain (§16 principle) plus cnode ownership discipline
+    (§13). Authority is expressed by minting EndpointRefCap-style
+    caps and granting them via cap-flow (§14). Possession = right
+    to invoke; intermediates can route but cannot inspect endpoints
+    that gate on caller-witness image_hash. No σ-resident signing
+    keys; no per-user ACL tables.
+
+19. Instance creation is via MGMT_COPY (for siblings) and host_derive_spawn
+    (for sub-types).
+    Cap::Instance is uniformly copyable; new Instances are produced by:
+      - MGMT_COPY of a Cap::Instance:   content-shared copy with the
+                                     same image_hash. Mutations to
+                                     either ref diverge per §9 case
+                                     (b). For "same type with fresh
+                                     state", caller follows MGMT_COPY
+                                     with a CALL into an image-defined
+                                     setup endpoint.
+      - host_derive_spawn(image, cnode):
+                                     new image; image_hash chain
+                                     extends from self. For sub-type
+                                     creation (user contract
+                                     instantiation, authority chains,
+                                     etc.). Only callable from within
+                                     self's apply; consumes the cnode
+                                     arg.
+
+20. Instance's root cnode is fixed at 256 slots.
+    Variable-size storage uses Cap::CNode (size = 2^k slots; minted
+    via host_mint_cnode). Cap::CNode is uniformly copyable; copying a
+    populated Cap::CNode produces a content-addressed share.
+
+21. Authority + Subject pattern for issued resources.
+    Authority Instances (Kernel, MintInstances, chain-defined issuers) are
+    held by the chain orchestrator. They mint Subject Instances via
+    host_derive_spawn or by issuing typed handles. Subjects can be
+    cloned via MGMT_COPY (content-shared) where applicable; for
+    resource splitting, the operation routes to the authority's
+    bytecode (or kernel, for kernel-assisted resources) which
+    allocates a new ledger entry and constructs the new handle.
+    Conservation is enforced by the authority's bytecode + ledger
+    (or by kernel-internal tables for kernel-assisted resources, per
+    principle 22).
+
+22. Kernel resources are exposed via the kernel-assisted Instance
+    pattern.
+    Where the kernel needs to maintain state that userspace interacts
+    with (yield routing, gas accounting, storage accounting, future
+    kernel-mediated operations), that state lives in an Instance whose
+    Image is in a kernel-reserved namespace (e.g.,
+    `kernel:yieldcatcher`, `kernel:gasmeter`). Properties:
+      - Userspace sees a regular Cap::Instance; cap-flow works uniformly.
+      - The Image is kernel-implemented in native code (no userspace
+        bytecode runs); the state layout is a kernel-known struct.
+      - The kernel may short-circuit access to the state during the
+        fast path (e.g., per-instruction gas debit) — but the
+        abstraction at the user-facing level is plain Instance.
+      - Some kernel-assisted Instances live in user Instances' cnodes
+        (e.g., YieldCatcher held in an Instance's `yield_marker_slot`);
+        others are kernel-internal and never appear in chain hands
+        (e.g., GasMeter, StorageQuota — accessed only via kernel-
+        issued caps like SetGasMeter).
+      - Unit handles into kernel-internal tables (Gas{meter_id},
+        Quota{quota_id}) are regular Cap::Instance; conservation lives
+        in the kernel-internal table, so cap copies don't multiply
+        balance.
+    See [discussions/kernel-assisted-instances.md](discussions/kernel-assisted-instances.md)
+    for the full design and rationale.
+```
+
+## 1. Instance and Image
+
+```
+Instance {
+  image_id:    ImageHash      -- hash of current Image
+  cnode:       RootCNode      -- fixed 256 slots; caps as values;
+                              --   persistent state (pinned slots are
+                              --   populated from Image.pinned_slots;
+                              --   non-pinned slots are mutable state)
+  status:      Idle
+             | Paused {
+                 regs:           ...
+                 pc:             u64
+                 yield_marker:   Cap::Instance  -- the marker yielded with
+               }
+             | Faulted { fault_info }
+
+  -- derived (kernel-attested):
+  image_hash:    Hash         -- canonical formulae:
+                              --   genesis: hash(initial_image)
+                              --   after set_image(new):
+                              --     hash(image_hash_before || hash(new))
+                              --   via derive_spawn(new, cnode):
+                              --     spawned.image_hash =
+                              --       hash(spawner.image_hash || hash(new))
+                              --   via MGMT_COPY of Cap::Instance:
+                              --     copy.image_hash = source.image_hash
+                              --       (preserved; not a chain extension)
+}
+
+RootCNode {                   -- the Instance's root cnode (fixed 256 slots).
+  slots:         [Option<Cap>; 256]
+}
+
+CNode {                       -- variable size in Cap::CNode (2^k slots).
+  slots:         [Option<Cap>; SIZE]
+}
+
+Image {                        -- content-addressed; Cap::Image kind
+                               -- the smallest unit of program specification
+  code:            Bytes            -- bytecode embedded directly
+                                    -- (validated at Image construction:
+                                    --  parseable; no malformed instructions)
+  memory_mappings: [MemoryMapping]
+  endpoints:       [Option<EndpointDef>; 256]
+  gas_slots:       [SlotIdx]        -- slots that hold Cap::Instance[Gas{meter_id}]
+                                    -- (kernel-assisted Instances; see §22).
+                                    -- Kernel debits the meter named by the
+                                    -- active gas slot while this Instance runs.
+                                    -- Convention: gas_slots[0] = primary
+                                    --  meter; subsequent entries are
+                                    --  fallback reserves (chain-spec policy).
+  quota_slots:     [SlotIdx]        -- slots that hold Cap::Instance[Quota{quota_id}]
+                                    -- (kernel-assisted Instances; see §22).
+                                    -- Kernel debits the named quota when
+                                    -- pages are dirtied by this Instance.
+                                    -- Convention same as gas_slots: [0] is
+                                    --  primary; rest are fallback reserves.
+  pinned_slots:    Map<SlotIdx, ContentAddressedCap>
+                                    -- pinned ro caps that the program
+                                    -- needs. ContentAddressedCap ∈
+                                    -- { Cap::Data, Cap::Image }:
+                                    --   Cap::Data: LLVM jump tables,
+                                    --     baked-in constants, etc.
+                                    --   Cap::Image: derive_spawn target
+                                    --     images for authority Instances.
+                                    -- All slot indices in [0, 256).
+  yield_marker_slot: Option<SlotIdx>
+                                    -- The slot in the Instance's cnode that
+                                    -- holds Cap::Instance[YieldCatcher] — a
+                                    -- kernel-assisted Instance (see §22)
+                                    -- whose state is the list of markers
+                                    -- this Instance catches. On YIELD, kernel
+                                    -- walks the call stack and consults each
+                                    -- Instance's YieldCatcher via short-circuit
+                                    -- (no endpoint dispatch), matching by
+                                    -- instance_hash equality.
+                                    -- See §4 (host_yield) and §14 (yield-
+                                    -- marker authority pattern).
+                                    -- None = this Instance catches no yields.
+}
+
+MemoryMapping {
+  start:   u64                  -- virtual address
+  size:    u64                  -- bytes (any size; not page-aligned)
+  source:  Persistent(SlotPath) -- cnode-DataCap-backed; mutations COW'd
+        |  Ephemeral            -- kernel-allocated per-apply; not in cnode;
+                                --   captured into Paused on yield
+}
+
+EndpointDef {
+  entry_pc:          u64
+  initial_registers: ...
+  arg_registers:     ...
+  arg_cnode_size:    u8
+}
+```
+
+Notes:
+
+- **No `rw_bytes` field.** Persistent rw memory lives as DataCaps in
+  cnode, loaded into the address space via memory_mappings at apply
+  start.
+- **No `volatile` mode.** Stack/scratch live in Ephemeral mappings
+  (kernel-allocated, captured into Paused on yield).
+- **No `host_set_*` for spec.** Image is mutated as a unit via
+  `set_image` (§4).
+- **No `image.copyable` field.** All Cap::Instance is copyable at the
+  kernel level. MGMT_COPY produces content-shared copy; for
+  initialization with different state, the Image declares a setup
+  endpoint the caller CALLs into after MGMT_COPY.
+- **No `linear_count`.** No linearity, no copy gating.
+- **No prev_instance field.** Lineage is captured as a cumulative chain
+  hash in `image_hash`.
+- **`image_id` is the hash of the current Image.** Different from
+  `image_hash` (the lineage-derived chain hash).
+- **Pinned slots are determined by Image, not Instance.** Different
+  Images have different pinned slot configurations. set_image swaps
+  them atomically (§4).
+
+### All Instances are Image-bound
+
+Every Instance is bound to an Image. There are no Image-free Instances.
+The Image is referenced by `image_id` (the hash of the current
+Cap::Image).
+
+### Cap::Image is a structured cap kind
+
+Cap::Image is a copyable, content-addressed value. Its content is
+the Image structure (code, endpoints, mappings, pinned_slots). The
+kernel parses Cap::Image at apply boundary to set up working memory
+and endpoint dispatch.
+
+Cap::Image instances can be passed via cap-flow, stored in cnode
+slots, or constructed by chains as needed for `set_image` /
+`host_derive_spawn` calls.
+
+### `set_image` is the only on-self spec-mutation primitive
+
+`set_image` swaps an Instance's Image atomically, including pinned slots:
+
+```
+set_image(new_image: Cap::Image) → ()
+  Pre: caller is running an apply on self.
+
+  Kernel:
+    1. Pinned-slot diff:
+       old_pinned = self.image.pinned_slots.keys()
+       new_pinned = new_image.pinned_slots.keys()
+
+    2. Clear old pinned slots:
+       For each idx in old_pinned:
+         self.cnode[idx] = (empty)
+
+    3. Install new pinned slots:
+       For each (idx, ro_cap) in new_image.pinned_slots:
+         if self.cnode[idx] is non-empty:
+           FAIL — collision (caller has non-pinned content where
+                  new image needs pinned).
+         else:
+           self.cnode[idx] = ro_cap
+           (kernel may optimize as content-shared reference)
+
+    4. Update image:
+       self.image_id = hash(new_image)
+
+    5. Update image_hash chain:
+       self.image_hash = hash(self.image_hash_before || hash(new_image))
+       (kernel-attested; chain extends)
+
+    6. New image's spec takes effect at next CALL.
+```
+
+Each `set_image` is a "push" — image_hash chain extends. Pinned
+content is swapped (old image's pinned data goes; new image's pinned
+data comes in). Cap-flow on the new image determines who can call
+set_image with what; cap-runtime integrity prevents synthesis.
+
+The collision check at step 3 keeps userspace honest: if a caller
+has populated a non-pinned slot at an index that the new image needs
+pinned, set_image fails.
+
+### Genesis-seeded Instance
+
+At genesis, the chain spec seeds a single root Instance: `Kernel`. Its
+image_hash is the hash of its initial Image:
+
+```
+Kernel: image_id = hash(KernelImage), image_hash = hash(KernelImage)
+```
+
+All other Instances (authority Instances, user contracts, resource Instances)
+are derived from `Kernel` via `host_derive_spawn`, which extends the
+image_hash chain. The chain spec doesn't seed a roster of templates;
+just `Kernel`, plus the Cap::Image references (in `Kernel`'s pinned
+slots or initial cnode) for the authorities the chain wants to
+derive.
+
+### Forgery resistance
+
+The unforgeability argument is structural:
+
+```
+Property A: image_hash = hash(Image_X) for some Image X
+  ⟺ this is THE genesis Instance for Image X
+    (or a MGMT_COPY descendant that preserved hash(Image_X)).
+
+Property B: image_hash = hash(some_image_hash || hash(Image_X))
+  ⟺ this Instance was produced via set_image(Image_X) on an Instance with
+    image_hash = some_image_hash, OR via host_derive_spawn(Image_X, ...)
+    by a spawner with image_hash = some_image_hash, OR is a MGMT_COPY
+    descendant of either.
+
+Property C: image_hash chain rooted at hash(KernelImage)
+  ⟺ at some point, this Instance's lineage traced through the genesis
+    Kernel Instance.
+```
+
+Adversary cannot:
+
+- Synthesize Cap::Instance with target image_hash (cap-runtime integrity).
+- Apply Kernel (cap-flow gates; only the kernel/orchestrator has the cap).
+- Produce image_hash = hash(KernelImage) via set_image or derive_spawn
+  (post-extension image_hash is recursive, not equal to hash(any single
+  Image) modulo cryptographic collisions).
+- Derive-spawn from canonical Instances without holding a Cap::Instance to
+  one (host_derive_spawn is only callable from within self's apply,
+  which requires having self as a cap to CALL into).
+- MGMT_COPY from a canonical Instance without holding a Cap::Instance to it
+  in some accessible slot (cap-flow gates).
+
+Forgery resistance comes from:
+
+1. **Cap-runtime integrity**: caps not synthesizable from bytes.
+2. **Cap-flow on the genesis Kernel Instance**: Kernel's Cap::Instance is
+   exclusive to the chain orchestrator; authority Instances derived from
+   it are similarly held by the orchestrator.
+3. **Kernel-attested image_hash formula**: kernel computes the chain
+   hash on every set_image / derive_spawn; MGMT_COPY preserves it;
+   userspace cannot influence.
+
+### Type queries
+
+Userspace cannot read raw image_hash. Two type-query host calls:
+
+```
+host_same_type(a: SlotPath, b: SlotPath) → bool
+  Returns true iff a.image_hash == b.image_hash.
+
+host_same_type_as(
+    comparer: SlotPath,
+    comparee: SlotPath,
+    images:   [SlotPath of Cap::Image]
+) → bool
+  Returns true iff:
+    comparer.image_hash == fold_left(
+      images, comparee.image_hash,
+      (acc, img) -> hash(acc || hash(img))
+    )
+  i.e., comparer is what you'd get by deriving comparee through the
+  given Image steps. Relative-chain comparison; comparee must be a
+  Cap::Instance (anchor relative to known reference); absolute Cap::Image
+  anchors are deliberately not supported.
+```
+
+For "is this a canonical Gas Instance?": chain pins a reference Gas
+template; compare via `host_same_type`. For "is this Instance of a
+specific subtype?": use `host_same_type_as`. **For authority
+routing, do NOT use type queries — use possession of Cap::Instance
+combined with the yield-marker mechanism (§14). Type matching is
+identification, not authorization.** Lineage walking and raw hash
+inspection are not exposed.
+
+## 2. Memory model
+
+### Static layout, declared by Image
+
+`memory_mappings` is a list of regions; each maps one cnode slot's
+DataCap into the address space:
+
+```
+Image declares:
+  memory_mappings: [
+    {start: 0x10000, size: 64KB,  source: MainCnode[3]}    -- pinned (ro)
+    {start: 0x20000, size: 1MB,   source: Persistent(MainCnode[5])}  -- unpinned (rw)
+    {start: 0x120000,size: 16MB,  source: Persistent(Scratchpad[5])} -- caller-provided
+    {start: 0x800000,size: 8MB,   source: Ephemeral}                 -- stack/scratch
+  ]
+  cnode initial state (at construction):
+    [3] = Cap::Data(BAKED_RO_BYTES)           -- baked-in ro data
+    [5] = Cap::Data(EMPTY)                     -- mutable working area
+    ...
+  pinned_slots = {3: Cap::Data(...), ...}
+```
+
+At apply start: for Persistent mappings, kernel reads each source
+slot's DataCap and lays its bytes at the declared start..start+size
+in the apply's address space. Pinned source slots → mapped
+read-only. Unpinned → mapped read-write with copy-on-write per page.
+Ephemeral mappings are kernel-allocated zeroed at apply start.
+
+### DataCap canonical form: trailing-zero-stripped
+
+```
+DataCap.content has size N (the "stripped size" — no trailing zeros).
+hash(DataCap("Hello\0\0\0")) ≡ hash(DataCap("Hello"))
+DataCap.size = position of last non-zero byte + 1; or 0 if all zero.
+```
+
+Kernel strips trailing zeros at every mint operation. The
+content_hash and size both reflect the stripped representation.
+
+### Size handling at map time
+
+```
+DataCap.size = N
+region.size = S
+
+if N == S:  direct mapping.
+if N <  S:  map bytes 0..N from DataCap; zero-fill bytes N..S in
+            address space.
+if N >  S:  CALL faults. Caller is responsible for ensuring DataCaps
+            fit the regions they'll be mapped into.
+```
+
+Zero-padding small DataCaps lets callers pass variable-size args
+without explicit length encoding.
+
+### Persistence of mapped regions at HALT
+
+For each rw mapping (source slot is unpinned):
+
+```
+At HALT:
+  If apply explicitly replaced the source slot via cap-table ops:
+    Use the replaced cap. Discard memory modifications from this region.
+  Else if any pages in the region are dirty:
+    Mint a new DataCap from the modified region content (trailing
+      zeros stripped). Place at source slot.
+  Else:
+    Source slot unchanged.
+```
+
+Apply has full control: explicit slot replacement wins over auto-mint.
+
+### Volatile-style memory: a userspace pattern
+
+The kernel does not provide a "volatile" memory mode. Programs that
+want a memory region zeroed at every CALL implement it themselves:
+
+```
+Apply:
+  ... uses scratch region during execution ...
+
+  -- Before HALT:
+  reset(VOLATILE_SLOT, empty_DataCap)
+  HALT
+```
+
+At HALT: source slot now holds the empty DataCap. At next CALL:
+kernel maps empty DataCap → zero-pad → apply sees a zeroed region.
+
+### Page-merkleized DataCap
+
+DataCaps used as backing for mapped regions are stored as
+balanced-merkle trees of page-sized chunks. At HALT:
+
+- Modified pages get new chunk hashes.
+- Unchanged pages reuse existing chunk hashes.
+- Merkle paths from modified leaves to root are recomputed.
+- Cost: O(modified_pages × log num_pages), not O(total size).
+
+**Page size: 4 KiB**, matching the underlying JAVM page size.
+
+### Storage cost via dirty-page tracking
+
+Mutation of mapped DataCaps dirties pages; kernel charges each
+dirty page to the StorageQuota referenced by the Instance's active
+quota_slot (the quota_id named there; see §22). Properties:
+
+- **Copy is free.** Content-addressed values can be referenced from
+  multiple slots / mappings at zero cost.
+- **Write costs per page.** Each dirty page = one page-cost unit
+  charged to the active quota.
+- **Stack-leave reset.** An Instance's dirty set persists while it
+  remains on the kernel call stack (across nested CALL / yield /
+  resume), and is finalized + charged when the Instance leaves the
+  stack entirely. This matches "dirty until commit" intuition: a
+  Instance that yields and resumes is still mid-invocation, so its
+  dirty set is not yet finalized.
+
+If the active quota is exhausted mid-mutation, the kernel yields
+with the chain-issued `StorageExhaustedMarker` (per §4); the chain
+typically tops up via SetStorageQuota and CALL_RESUMEs.
+
+### Memory and caps are mostly decoupled
+
+Cnode holds caps as values. Most caps (Instance, Image, CNode) are
+never mapped into the address space. The single exception: DataCaps
+in source slots of memory mappings have their content laid into
+memory at apply start.
+
+For ad-hoc data flow:
+
+```
+host_read_data_cap(cap, dst_offset, len) → actual_len
+  -- copy bytes from a DataCap into a writable mapped region.
+
+host_mint_data_cap(src_offset, len) → DataCap
+  -- read bytes from any region; strip trailing zeros; mint a fresh
+  -- DataCap; debit StorageQuota ledger entry of self's quota slot.
+```
+
+### Rust heap
+
+The Rust heap is a regular Ephemeral mapped region:
+
+```
+Apply:
+  At apply start: HEAP region zeroed.
+  Allocator operates over the region.
+  At HALT/fault: heap discarded.
+  At yield: heap captured into Paused.volatile_bytes.
+```
+
+For programs that want the heap to persist across CALLs, use a
+Persistent mapping with a cnode DataCap. OOM is a fault; for
+graceful OOM handling, programs use try-* allocator APIs or yield
+via a chain-defined `NeedHeapSpace` marker.
+
+## 3. The Instance status state machine and kernel call stack
+
+### Instance states (σ-resident)
+
+```
+            spawn          CALL @ endpoint        HALT
+   ────────────────► Idle ─────────────────► [apply runs] ──► Idle (new value)
+                        ▲    ▲                   │  (target.slot[0]
+                        │    │                   │   reflects to caller)
+                        │    │                   │
+                        │    │                   │ host_yield(marker)
+                        │    │                   │   OR kernel OOG (= yield
+                        │    │                   │   to OOG-marker)
+                        │    │                   │ (target.slot[0] reflects
+                        │    │                   │   to caller-handler; per
+                        │    │                   │   discipline, slot[0]
+                        │    │                   │   is in a safe state)
+                        │    └───────────────────┤
+                        │   CALL_RESUME(target): │  capture continuation
+                        │   caller's slot[0]     │  (regs, pc, marker)
+                        │   moves into target's  │
+                        │   slot[0]              │
+                        │                        ┴
+                        │                     Paused
+                        │                        │
+                        │                        │ panic / illegal access /
+                        │                        │ memory fault / etc.
+                        │                        │ (target.slot[0] reflects
+                        │                        │  to caller; then target
+                        │                        │  dropped)
+                        │                        ▼
+                        │                   Faulted (dead)
+                        │                        │
+                        │                        │ MGMT_DROP
+                        ▼                        ▼
+                     [N/A]                    [removed]
+```
+
+- **Idle**: ready to be invoked at any Image endpoint.
+- **Paused**: continuation captured (regs, pc, marker). Resumable via
+  CALL_RESUME (caller's slot[0] becomes target's new slot[0]).
+- **Faulted**: dead from a hard fault. Cannot be invoked further.
+
+### Kernel call stack (kernel-internal)
+
+While the kernel is executing apply, it maintains an ordered call
+stack. The stack drives control transfer (CALL/YIELD/HALT) and
+provides the structural invocation boundary that gives v3 its fault
+atomicity and yield-resume linearity.
+
+Stack entries are one of:
+
+- **InstanceEntry(instance, pc, slot_state, status)** — pushed by
+  CALL. Introduces a fresh invocation of an Instance.
+- **ReferenceEntry(target_position, status)** — pushed by YIELD.
+  Refers to an InstanceEntry at an earlier stack position. Same Instance
+  instance, same PC as the target; PC advances together when active.
+
+Invariants:
+
+- **Exactly one entry is Running at any moment** — the top of the
+  stack. All others are Waiting.
+- **Same-instance entries share PC.** If A appears multiple times on
+  the stack (once as InstanceEntry from CALL, once as ReferenceEntry
+  from a yield routed to A), they all reflect A's single PC.
+- **Instance state machine is σ-visible only.** Running and Waiting are
+  kernel-internal call-stack accounting, not Instance states. From
+  outside the kernel, an Instance in flight just shows as "not Idle yet."
+- **An Instance is snapshottable iff it has zero entries on the call
+  stack.** Idle Instances are snapshottable; Instances mid-invocation are
+  not. (Paused Instances are snapshottable because their continuation
+  lives in σ, not on the stack.)
+
+### Pause and the call stack
+
+When an Instance yields voluntarily, it transitions to Paused state (its
+continuation captured in σ-resident Paused state) — OR — its
+continuation stays on the call stack as a ReferenceEntry waiting for
+resumption from below, depending on whether the yield is "persistent"
+(stays across blocks) or "in-flight" (stays in the call stack until
+resolved this block).
+
+In practice, all routine yields stay in the kernel call stack
+(ReferenceEntry). Paused-persistent is the special case when DROP_RESUME
+is invoked or the chain explicitly preserves an in-flight invocation
+across blocks.
+
+### Why hierarchy is the invocation boundary
+
+The hierarchical call stack provides three structural properties at
+one mechanism cost:
+
+1. **Sub-tree atomicity (§10).** An Instance's HALT/fault commits/discards
+   everything in its subtree atomically. Sub-Instances called during
+   this invocation are part of the parent's atomic scope.
+2. **Yield-resume linearity (§14).** A instance in Waiting has a
+   structurally unique resumer — whatever's directly above it on the
+   stack. Cap-authority routing relies on this.
+3. **Reentry protection (free side effect).** Same Instance can't have
+   two concurrent activations because the stack is sequential.
+
+See [discussions/data-flow-principle.md](discussions/data-flow-principle.md)
+for the architectural derivation: single-mutator-per-state-unit forces
+single-activation; per-context fault isolation + single-activation
+forces hierarchical structure; hierarchical structure forces orchestrator
+mediation for cross-contract calls. The chain orchestrator pattern is
+structurally required, not just a convention.
+
+**OOG = kernel-triggered yield, not a fault.** Same continuation
+mechanism as voluntary yield (reflects slot[0]; marker = kernel's
+canonical OOG marker).
+
+**Hard faults are deterministic and permanent.** Same Instance + same
+input → same fault.
+
+**Pause is opaque.** Verbs are CALL_RESUME (sends caller's slot[0] as
+the new target slot[0]) and DROP_PAUSED.
+
+**slot[0] discipline.** Apply must keep slot[0] in a "safe to reflect"
+state at all times: empty, the input scratchpad, or a complete output
+Cap::CNode atomically MGMT_MOVE'd in. Never leave slot[0] mid-mutation,
+because OOG yield (or fault) can reflect at any instruction boundary.
+The canonical pattern: at apply entry, MGMT_MOVE slot[0] (input) into
+a working slot; do work in working slots; just before HALT/yield,
+atomically MGMT_MOVE the output Cap::CNode into slot[0].
+
+## 4. The kernel ABI
+
+### CALL — invoke an Idle Instance at an endpoint
+
+```
+CALL(target: SlotPath, endpoint_idx: u8) → result
+  Pre: target Instance is Idle.
+  Effect:
+    Caller's slot[0] moves into target's slot[0] (the scratchpad).
+    Kernel pushes an InstanceEntry for target on the call stack.
+    Kernel materializes mapped regions from cnode DataCaps.
+    Apply runs; per-instruction gas debit comes from the meter
+      named by target's active gas slot (see §22 and "Gas
+      accounting" below).
+  On HALT:    target ← Idle (new value); target's slot[0] reflects
+              to caller's slot[0].
+  On yield:   target enters Waiting on the call stack (or Paused if
+              the yield is preserved across blocks); target's
+              slot[0] reflects to caller's slot[0]; phi[7] holds the
+              yield payload reference (typically a marker / unit
+              cap copy).
+  On fault:   target ← Faulted, then dropped; target's slot[0]
+              reflects to caller's slot[0]; phi[7] = fault info.
+  Return: phi[7] = (return value | yield payload ref | fault info);
+          phi[8] = status.
+```
+
+CALL takes no gas_budget. Gas is metered against the meter named by
+the target Instance's active gas slot (Image-declared `gas_slots[0]`).
+The caller controls the available gas by ensuring the target's gas
+slot points to a meter with sufficient balance — typically by
+populating the target's gas slot before CALL (cap-flow or
+host_derive_spawn-time initialization).
+
+### CALL_RESUME — resume a Paused or Waiting Instance
+
+```
+CALL_RESUME(target: SlotPath) → result
+  Pre: target Instance is Paused, or target is at the top of a Waiting
+       chain on the call stack expecting resumption.
+  Effect:
+    Caller's slot[0] moves into target's slot[0] (same as CALL).
+    Continuation restored; apply resumes from saved pc.
+    Apply reads the response (caller's prepared scratchpad) from slot[0].
+  Termination semantics same as CALL.
+```
+
+### DROP_PAUSED — give up on a Paused Instance
+
+```
+DROP_PAUSED(target: SlotPath)
+  Pre: target Instance is Paused.
+  target slot becomes empty (Instance and its cnode discarded).
+  Caller's slot[0] unchanged (no reflection).
+```
+
+### host_yield — voluntary yield with marker routing
+
+```
+host_yield(marker: SlotPath)   -- does not return to apply
+  Pre: marker holds a Cap::Instance (the yield marker; see §14).
+  Effect:
+    Read marker; compute marker.instance_hash.
+    Walk kernel call stack from top (yielder) toward bottom (root).
+    For each InstanceEntry F encountered:
+      If F.image.yield_marker_slot is set, F's cnode at that slot
+      holds a Cap::Instance[YieldCatcher] (a kernel-assisted Instance;
+      §22). Kernel short-circuits into the YieldCatcher's state —
+      its marker list — and tests each entry:
+        If entry is Cap::Instance and entry.instance_hash == marker.instance_hash:
+          Match. Push ReferenceEntry pointing to F. F resumes at its
+          post-CALL continuation with the marker payload reflected
+          into slot[0].
+          Return; control transfers to F.
+    No match found: fault yielder with "unhandled marker."
+
+    Per slot[0] discipline: the yielder's slot[0] should be in a safe
+    state before calling host_yield, since on resume it will hold the
+    handler's response.
+
+  Capture continuation (regs, pc) for the yielder.
+  Yielder transitions to Waiting on the kernel stack.
+  Gas debited for the yielder (STM-exempt; debited from the meter
+    named by yielder's active gas slot).
+
+  On CALL_RESUME from the handler:
+    Caller-handler's slot[0] reflects to yielder's slot[0].
+    Yielder's apply resumes from saved pc.
+    Returns: phi[7..] = registered args; phi[8] = status.
+
+Kernel-issued markers (placed in chain's initial YieldCatcher at
+boot; see §12):
+  OOGMarker             -- kernel-injected on gas exhaustion. Payload:
+                           a Cap::Instance[Gas{meter_id}] copy naming
+                           the meter that ran out. Nothing else (no
+                           caller context — see "OOG payload" below).
+  StorageExhaustedMarker
+                        -- kernel-injected on quota exhaustion.
+                           Payload: Cap::Instance[Quota{quota_id}] copy.
+
+Chain-defined markers: per chain spec; minted by chain orchestrator
+via host_derive_spawn and distributed via cap-flow.
+```
+
+The yield marker mechanism replaces the old "yield reason code." A
+yield is routed to a specific handler in the call stack based on the
+marker's `instance_hash`. The handler must have a matching marker in its
+YieldCatcher's marker list.
+
+**OOG payload — just the Gas cap, nothing else.** The OOG yield
+payload is *only* the `Cap::Instance[Gas{meter_id}]` copy. No "which
+call was running," no caller instance_hash, no stack context.
+Encoding "which call ran out" would reintroduce CALLER information
+into a capability-only system — which is precisely what v3 avoids.
+The meter_id alone is sufficient: chain looks meter_id up in its
+own ledger to find the owning user; that's all the context needed
+to decide topup vs fail. Same shape for StorageExhausted.
+
+See §14 for the canonical authority pattern that uses this mechanism.
+
+### host_read_data_cap / host_mint_data_cap
+
+```
+host_read_data_cap(cap: SlotPath, dst_offset: u64, len: u64) → actual_len
+  Copy bytes from the DataCap at `cap` into a writable region at
+  dst_offset. Returns actual bytes copied (may be less than len if
+  cap.size is smaller).
+
+host_mint_data_cap(src_offset: u64, len: u64, quota_slot: SlotPath,
+                   dst: SlotPath) → ()
+  Read len bytes from any region starting at src_offset.
+  Strip trailing zeros to get canonical content.
+  Read quota_slot (holds Cap::Instance[Quota{quota_id}]); debit
+    kernel-internal StorageQuota[quota_id] by stripped size.
+  Mint a fresh Cap::Data; place at dst.
+```
+
+### Image / spawn / type-related host calls
+
+```
+set_image(new_image: SlotPath) → ()
+  Pre: caller is running self's apply.
+       new_image at SlotPath holds a Cap::Image.
+  Atomically swaps Image; updates image_hash chain (see §1).
+
+host_derive_spawn(image: SlotPath, cnode: SlotPath, dst: SlotPath) → ()
+  Pre: caller is running self's apply.
+       image holds a Cap::Image.
+       cnode holds a Cap::CNode of size 256.
+       dst is empty.
+  Effect:
+    Constructs a fresh Instance:
+      image:       (the Cap::Image at `image`)
+      image_hash:  hash(self.image_hash || hash(image))   (chain extends)
+      cnode:       initialized from input cnode's slots, with the
+                   spawned image's pinned slots overlaid.
+      status:      Idle
+    Consumes the input Cap::CNode (Cap::Image is content-addressed
+    copyable; reading it doesn't consume).
+    Places Cap::Instance at dst.
+
+host_same_type(a: SlotPath, b: SlotPath) → bool
+  Returns true iff a.image_hash == b.image_hash.
+  
+  USE FOR IDENTIFICATION ONLY. Two Instances being "the same type" does
+  not grant authority — possession of a Cap::Instance is what grants
+  authority. See §14 for the proper authority pattern.
+
+host_same_type_as(
+    comparer: SlotPath,
+    comparee: SlotPath,
+    images:   [SlotPath of Cap::Image]
+) → bool
+  Returns true iff comparer.image_hash equals the chain extension
+  of comparee.image_hash through the given Image derivation steps.
+  
+  USE FOR IDENTIFICATION ONLY. Same caveat as host_same_type: type
+  matching is not an authority proof. Use Cap::Instance possession for
+  authority.
+
+-- Cap::Type ops (see §8 for Cap::Type definition):
+
+host_type_of(instance: SlotPath, dst: SlotPath) → ()
+  Pre: instance holds a Cap::Instance; dst is empty.
+  Effect: extract the Instance's image_hash; place Cap::Type{image_hash}
+  at dst.
+  
+  USE FOR IDENTIFICATION ONLY. Possession of Cap::Type does not grant
+  authority equivalent to possession of Cap::Instance. See §8 and §14.
+
+host_subtype(
+    base: SlotPath,
+    images: [SlotPath of Cap::Image],
+    dst: SlotPath
+) → ()
+  Pre: base holds a Cap::Type; dst is empty; images are Cap::Images.
+  Effect: compute the chain-extended image_hash:
+    result_hash = fold(base.image_hash, hashes(images),
+                       (acc, h) -> hash(acc || h))
+  Place Cap::Type{result_hash} at dst.
+  
+  Pure computation. No Instance derivation. No authority granted.
+
+host_type_eq(a: SlotPath, b: SlotPath) → bool
+  Pre: a, b hold Cap::Type.
+  Returns true iff a.image_hash == b.image_hash.
+```
+
+For **same-type Instance creation** (siblings of self's type), use
+`MGMT_COPY` on a Cap::Instance whose image_hash matches the target type.
+Content-shared copy; mutations diverge per §9 case (b). If the
+sibling needs a different state than self at construction, the
+Image declares a setup endpoint that the caller CALLs into after
+MGMT_COPY to initialize it.
+
+For **sub-type Instance creation** (different image, new image_hash
+chain), use `host_derive_spawn`. The image_hash chain extends from
+self; this is how authority Instances create their subjects.
+
+There is **no** `host_set_code` / `host_set_endpoints` /
+`host_set_memory_mappings` — Image is mutated as a unit.
+
+There is **no** `host_set_pinned` — pinning is determined by
+`Image.pinned_slots`.
+
+There is **no** `host_is_template_of` — lineage walking is off-chain
+or userspace.
+
+There is **no** raw image_hash exposure — the only type query is
+`host_same_type`.
+
+### Cap-table operations
+
+```
+MGMT_COPY(src: SlotPath, dst: SlotPath) → Result
+  Clone source cap into dst slot. All cap kinds are copyable.
+  Rejects if source slot is `pinned`.
+  Cost: O(1) (content-addressed; both slots reference the same hash).
+
+MGMT_MOVE(src: SlotPath, dst: SlotPath) → Result
+  Move source cap to dst slot. Rejects if source slot is `pinned`.
+
+MGMT_DROP(src: SlotPath) → Result
+  Remove cap from slot. Rejects if `pinned`.
+
+host_mint_cnode(slot: SlotPath, cnode_size_log: u8, quota_slot: SlotPath)
+  -- Mints a fresh empty Cap::CNode of size 2^cnode_size_log slots.
+  -- Places at the given slot in self's cnode (slot must be empty).
+  -- Debits StorageQuota[quota_slot's quota_id] by metadata size.
+
+MGMT_CNODE_SWAP(a: SlotPath, b: SlotPath)
+  -- Swap contents of two slots. Both slots must be either both in
+  -- self's root cnode, or both in the same Cap::CNode reachable from
+  -- self. Useful for atomic batch operations.
+```
+
+### Calling convention
+
+Endpoint invocation is **process spawn + IPC**, not a SysV-style
+function call. Caller and target have separate register files; the
+kernel mediates the boundary. Target's bootstrap state comes from
+two sources merged in order:
+
+1. **Snapshot** (callee-declared): `endpoint.initial_regs` from the
+   target's Image table — typically `phi[1] = stack_top` and any
+   other constants the program wants at entry. All unset GPRs are 0.
+   PC is set to `endpoint.entry_pc`.
+2. **Args overlay** (caller-supplied): `phi[7..10]` are written last
+   from the four u64 arg slots in the CALL site.
+
+The kernel does *not* write the endpoint selector or the target slot
+into any callee register. The endpoint is fully encoded by PC (each
+endpoint has its own `entry_pc` in the Image table — there is no
+in-bytecode dispatcher reading a selector). The target slot is the
+caller's private namespace and isn't meaningful inside the target.
+An Image author that wants either value can declare it in
+`initial_regs` for the specific endpoint.
+
+```
+On CALL entry (target's apply starts at endpoint.entry_pc):
+  phi[i]      = endpoint.initial_regs[i]  for each i (snapshot)
+  phi[7..10]  = register args (4 u64 args supplied by caller; overlay)
+  all other phi = 0
+  slot[0]     = scratchpad (moved from caller's slot[0])
+
+On CALL_RESUME entry (target's apply resumes from saved pc):
+  slot[0]     = scratchpad (moved from caller's slot[0]; the response)
+  -- no register args: target's registers are restored from the saved
+     continuation (regs, pc captured at host_yield).
+
+On apply termination, return registers (kernel writes into CALLER):
+  caller's phi[7]  = on HALT:    u64 return value
+                     on Paused:  yield payload reference
+                     on Faulted: fault info pointer
+  caller's phi[8]  = system status (Ok | Paused | Faulted)
+  caller's slot[0] = reflected from target's slot[0]
+```
+
+Caller's other registers are untouched across the CALL boundary —
+they're preserved by the kernel in the caller's continuation while
+the target runs, not by any callee-side discipline.
+
+### Gas accounting (STM-exempt)
+
+Gas is accounted via the kernel-assisted GasMeter pattern (§22):
+
+```
+GasMeter (kernel-internal, kernel-assisted Instance):
+  Image: kernel:gasmeter
+  State: meters: Map<MeterId, RemainingGas>
+  Lifecycle: kernel initializes at block start with
+    { root_meter_id: <chain-spec block budget> }; all other meters
+    are populated lazily by chain via SetGasMeter; kernel discards
+    GasMeter at block end (kernel is stateless across blocks).
+
+Gas{meter_id} (per-Instance unit handle, kernel-assisted Instance):
+  Image: kernel:gas
+  State: meter_id: u64
+  Created via Cap::Instance[MintGas].mint(meter_id) — caller supplies
+    the meter_id (chain-chosen; kernel cannot assign uniquely
+    without persistent state).
+  Conservation lives in GasMeter, not in the cap — cap copies all
+    name the same meter; debiting any copy debits the same meter.
+```
+
+During execution of an Instance:
+- Kernel reads the meter_id from the Instance's active gas slot
+  (`gas_slots[0]`).
+- Per-instruction metering decrements `GasMeter[meter_id]` directly
+  via kernel short-circuit (no endpoint dispatch).
+- When the meter reaches 0 mid-execution, kernel triggers a yield
+  with the well-known `OOGMarker` (kernel-issued at chain init;
+  placed in chain's initial YieldCatcher). Payload: a
+  `Cap::Instance[Gas{meter_id}]` copy.
+
+Per-instruction metering is invisible to userspace; debits don't
+go through the CALL/yield mechanism. STM-exempt: gas already
+consumed by a faulted apply is not refunded.
+
+### Kernel-issued caps for resource management
+
+The kernel injects a small set of caps into the top-level chain
+Instance at chain init. These are how userspace interacts with
+kernel-internal kernel-assisted Instances (GasMeter, StorageQuota)
+and how userspace creates per-Instance YieldCatchers.
+
+Each is a regular Cap::Instance (kernel-assisted); userspace invokes
+its endpoints via CALL.
+
+```
+Cap::Instance[SetGasMeter] (kernel-internal access):
+  endpoint set(meter_id: u64, value: u64) → u64
+    Atomically GasMeter[meter_id] := value; return previous value.
+    If no entry exists, "previous" is 0 and the entry is created.
+    The atomic set+read enables the "harvest remaining" idiom.
+
+Cap::Instance[SetStorageQuota] (kernel-internal access):
+  endpoint set(quota_id: u64, value: u64) → u64
+    Same semantics as SetGasMeter for StorageQuota.
+
+Cap::Instance[MintGas] (factory):
+  endpoint mint(meter_id: u64) → Cap::Instance[Gas{meter_id}]
+    Constructs a fresh Gas unit handle naming the given meter_id.
+    Chain is responsible for meter_id uniqueness (collisions
+    silently alias).
+
+Cap::Instance[MintQuota] (factory):
+  endpoint mint(quota_id: u64) → Cap::Instance[Quota{quota_id}]
+    Symmetric.
+
+Cap::Instance[CreateYieldCatcher] (factory):
+  endpoint create() → Cap::Instance[YieldCatcher]
+    Constructs a fresh empty YieldCatcher (no markers).
+
+Cap::Instance[YieldCatcher] (per-Instance, kernel-assisted):
+  endpoint add(marker: Cap::Instance) → ()
+    Add a marker template to the catch list.
+  endpoint remove(marker: Cap::Instance) → ()
+    Remove a marker template.
+  endpoint read() → Cap::Data
+    Serialize the marker list as a DataCap for inspection.
+```
+
+For the full design and rationale (lazy-load OOG-catch, why no
+narrow linearity, etc.), see
+[discussions/kernel-assisted-instances.md](discussions/kernel-assisted-instances.md).
+
+## 5. Apply terminations
+
+```
+HALT(phi[7] = return_value)
+  → Instance becomes Idle with new value.
+  → Target's slot[0] reflects to caller's slot[0] (apply's chosen
+    output, atomically placed via MGMT_MOVE just before HALT).
+  → Emits returned for orchestrator processing.
+  → Caller: phi[8] = Ok.
+  → Gas debited.
+
+host_yield(marker)              -- includes kernel-triggered OOG
+  → Instance becomes Waiting on the call stack (or Paused if the yield
+    is preserved across blocks).
+  → Target's slot[0] reflects to caller's slot[0] (carrying the
+    marker's payload — typically a unit cap copy like
+    Cap::Instance[Gas{meter_id}] for OOG, per §4).
+  → Emits returned for orchestrator processing.
+  → Caller: phi[8] = Paused; phi[7] = yield payload reference.
+  → Caller may CALL_RESUME (with new scratchpad in caller's slot[0])
+    or DROP_PAUSED.
+  → Gas debited (from the active gas meter).
+
+panic / illegal access / memory fault / write to pinned region / ...
+  → Instance becomes Faulted.
+  → Target's slot[0] reflects to caller's slot[0]
+    (whatever was there at fault; per discipline, safe-to-reflect).
+  → Target then dropped (cnode discarded except for the reflected slot[0]).
+  → Emits discarded.
+  → Caller: phi[8] = Faulted.
+  → Instance cannot be invoked further.
+  → Gas debited.
+```
+
+| Outcome | Instance.status after | Re-CALL OK? | Caller's slot[0] |
+|---|---|---|---|
+| HALT  | Idle    | Yes (new state) | reflected from target |
+| Paused (yield/OOG) | Waiting on call stack (or Paused if preserved) | No (must RESUME) | reflected from target (marker payload) |
+| Fault | Faulted, then dropped | No | reflected from target at fault point |
+
+## 6. Operation patterns
+
+### Pattern A — state-apply loop
+
+Orchestrator (chain Instance's apply) processes events:
+
+```
+for event in block_body:
+  -- prepare scratchpad in self.slot[0]
+  build event-specific Cap::CNode into self.slot[0]
+  -- ensure target's gas_slots[0] names a meter with enough balance
+  -- (typically chain has already done SetGasMeter for this user's
+  -- meter_id; see §22 lazy-load OOG-catch pattern).
+  match CALL(target_slot, endpoint):
+    Ok:
+      target updated; self.slot[0] now has target's reply.
+      proceed.
+    Paused via OOGMarker:
+      -- payload (slot[0]) holds Cap::Instance[Gas{meter_id}].
+      -- Chain looks meter_id up in its GasLedger.
+      record / decide topup-or-fail; if topup:
+        SetGasMeter(meter_id, more); CALL_RESUME.
+      else DROP_PAUSED (fault propagation).
+    Paused via StorageExhaustedMarker:
+      -- payload holds Cap::Instance[Quota{quota_id}].
+      analogous; SetStorageQuota then CALL_RESUME, or fail.
+    Paused via chain-defined marker:
+      marker-specific handling per chain spec.
+      (self.slot[0] has the marker's payload from yield.)
+    Faulted:
+      drop target; chain-spec policy decides (log, governance, etc.).
+      (self.slot[0] has whatever target had at fault.)
+```
+
+### Pattern B — state-read (explicit copy + CALL)
+
+For queries that shouldn't mutate target's persistent state:
+
+```
+MGMT_COPY(T_slot, T_copy_slot)
+  -- content-shared copy; same image_hash; mutations to T_copy or T
+  -- will diverge per §9 case (b).
+build query args into self.slot[0]
+match CALL(T_copy_slot, query_endpoint):
+  Ok:    self.slot[0] has reply; use it; MGMT_DROP T_copy.
+  ...:   handle; MGMT_DROP T_copy.
+```
+
+Available universally because Cap::Instance is copyable. The original
+T is unaffected — query runs against the divergent copy.
+
+### Pattern C — snapshot/revert
+
+```
+let backup = MGMT_COPY(target_slot)   -- O(1); content-shared
+do_risky_work_on_target()
+if bad_outcome:
+  MGMT_COPY(backup, target_slot)      -- restore
+else:
+  MGMT_DROP(backup)                    -- discard backup
+```
+
+Available universally because all caps are copyable.
+
+## 7. Pure-function apply
+
+apply is `(input, state, scratchpad) → outputs | yield | fault`. No
+side effects. Effects are encoded as outputs:
+
+- **Instance state mutations** (cnode, mapped DataCap content) — committed
+  on HALT.
+- **Emits** — `Emit{target, args, arg_caps, on_failure}` returned for
+  the orchestrator.
+- **Intent records in well-known-Image Instances** — for things like
+  attestation, publishing, scheduling: apply mutates state in a known
+  userspace Instance (e.g., AttestationAuthority); the kernel post-HALT
+  reads that state and performs hardware ops.
+
+Anything that "looks like" a side effect — sign, verify, publish,
+attest, log, BLS aggregate — is encoded as a record in such a
+well-known Instance, not as in-apply mutation. The kernel handles
+crypto and hardware post-HALT (§15).
+
+## 8. Cap kinds
+
+```
+Cap::Instance   — Instance value reference. Content-addressed copyable.
+               MGMT_COPY produces a content-shared reference;
+               mutations diverge per §9 case (b).
+               AUTHORITY-BEARING. Possession is structural proof of
+               authority. Use this for authority routing.
+Cap::Image   — Image (spec, including bytecode) reference.
+               Content-addressed copyable.
+Cap::Data    — Bytes (trailing-zero-stripped). Content-addressed
+               copyable.
+Cap::CNode   — Variable-size cnode (size = 2^k slots).
+               Content-addressed copyable.
+Cap::Type    — Cumulative image_hash chain identifier.
+               Content-addressed copyable. Opaque to bytecode reads;
+               equality-comparable via host calls; composable via
+               host_subtype.
+               IDENTIFICATION-ONLY. NOT an authority credential.
+               See "Cap::Type vs Cap::Instance" below.
+```
+
+Five cap kinds. All uniformly copyable. No conditional linearity.
+No `linear_count`. No drop endpoints.
+
+### Why these five
+
+- **Cap::Instance**: the unit of state. Copyable; MGMT_COPY produces a
+  content-shared reference. Mutations via CALL into the Instance's
+  apply produce a divergent value (per §9 case (b)). **Possession of
+  Cap::Instance is the authority-bearing primitive.**
+- **Cap::Image**: the unit of program specification. Content-
+  addressed; copyable. Image embeds bytecode directly. Multiple
+  Instances can share an Image via the content-addressed hash.
+- **Cap::Data**: arbitrary bytes. The general data carrier.
+- **Cap::CNode**: variable-size cnode (size = 2^k slots). Used by
+  Instances that need more than 256 slots, for nested storage, and as
+  the **constructor argument** for `host_derive_spawn`.
+- **Cap::Type**: a type identifier — a Cap holding a single
+  `image_hash` value (the cumulative chain hash). Used for runtime
+  type-checking and type-based dispatch. **Never used standalone for
+  authority.**
+
+### Cap::Type vs Cap::Instance — identification vs authorization
+
+This distinction is load-bearing and must be understood clearly:
+
+> **Cap::Type identifies an Instance's type.**
+> **Cap::Instance authorizes invocation of a specific Instance.**
+>
+> These are NOT interchangeable. Cap::Type is derivable from any
+> Cap::Instance whose chain is a prefix (via host_type_of + host_subtype);
+> Cap::Instance can only be obtained via legitimate cap-flow originating
+> from an Instance's actual derivation.
+
+**Forgery resistance for Cap::Instance:** An Instance with image_hash X can
+only be produced by derivation through the kernel-mediated
+`host_derive_spawn`, which extends the deriver's chain. Adversary
+cannot fabricate a Cap::Instance with a chain that doesn't include
+their own derivation history. The image_hash chain is forgery-
+resistant.
+
+**Cap::Type is NOT forgery-resistant in the same sense.** Anyone
+holding a Cap::Instance whose chain prefix is X can compute
+Cap::Type{X} via host_type_of. They can further compute
+Cap::Type{X + derive_steps} via host_subtype. The Cap::Type
+"identifies the type" but doesn't prove the holder has the
+corresponding Cap::Instance.
+
+**Authority must use Cap::Instance, not Cap::Type.** A pattern like
+"if I hold Cap::Type{X}, I have authority X" is WRONG. The correct
+pattern is "if I hold Cap::Instance whose type is X, I have authority X"
+— and this is what §14 (yield-marker authority pattern) uses.
+
+**When to use Cap::Type:**
+- Runtime type-checking (e.g., "is this Instance of type X?").
+- Type-based dispatch in bytecode logic.
+- Composing types abstractly without materializing Instances.
+
+**When NOT to use Cap::Type:**
+- As a routing key for authority operations (use Cap::Instance).
+- As a stand-in for an actual Instance.
+- As proof of identity (it's only proof of *knowing the type*).
+
+### Resource caps as kernel-assisted Instances or userspace patterns
+
+Earlier drafts had Cap::Gas, Cap::StorageQuota as separate cap kinds.
+In v3, these are NOT cap kinds. They split into two families:
+
+**Kernel-assisted resources (kernel-mediated, see §22):**
+
+- **Gas**: tracked in a kernel-internal `GasMeter` (kernel-assisted
+  Instance, never in chain hands). Each Instance holds
+  `Cap::Instance[Gas{meter_id}]` in its `gas_slots`; per-instruction
+  metering decrements `GasMeter[meter_id]` directly via kernel
+  short-circuit. Conservation lives in GasMeter, not in the Gas
+  cap, so copies all name the same meter (no narrow linearity
+  needed). OOG triggers a yield with `OOGMarker`.
+- **StorageQuota**: symmetric — kernel-internal `StorageQuota`
+  table, `Cap::Instance[Quota{quota_id}]` unit handles held in
+  `quota_slots`, dirty-page tracking debits per Pattern 4 (§2).
+  Exhaustion triggers a yield with `StorageExhaustedMarker`.
+
+Chain interacts with kernel-internal tables via the kernel-issued
+caps `SetGasMeter` / `SetStorageQuota` (set+return-previous);
+mints unit handles via `MintGas` / `MintQuota` (chain-chosen ids).
+See §4 for the cap endpoints.
+
+**Userspace resources (chain-bytecode-managed):**
+
+- **Persistent fee balance (tokens)**: ledger entries in chain
+  orchestrator's σ (`O.account_balances[user]` as Cap::Data
+  integers).
+- **Custom resources (tokens, NFTs, etc.)**: typed handles
+  (Cap::Instance[ResourceImage]) into authority-managed ledgers. The
+  Instance's state names the ledger entry (e.g., session_id); the
+  balance lives in O.
+
+Conservation in the userspace case is bytecode-arithmetic in
+authorities. Forgery resistance via image_hash chain.
+
+### MGMT_COPY uniformly succeeds
+
+```
+MGMT_COPY(src, dst):
+  cap = read(src)
+  copy share into dst (content-addressed; both refs point to same hash)
+```
+
+No copyability checks. No linear_count. No conditional gating.
+
+For Instance cloning: MGMT_COPY produces a content-shared reference;
+mutations diverge per §9 case (b). The result has the same
+image_hash as the source (same type).
+
+If the resulting clone should have a *different state* from the
+source (e.g., resetting some slots, populating new values), the
+caller follows MGMT_COPY with a CALL into an image-defined setup
+endpoint:
+
+```
+A.apply:
+  MGMT_COPY(template_slot, clone_slot)
+  build init_args Cap::CNode into self.slot[0]
+  CALL(clone_slot, setup_endpoint)
+  -- clone is now mutated per the image's setup logic
+```
+
+The image author decides what the setup endpoint does (reset slots,
+write new state, etc.). MGMT_COPY plus image-defined initialization
+gives full flexibility without requiring a special kernel primitive.
+
+### Why no linearity
+
+Earlier drafts considered making certain caps (or all Cap::Instance)
+linear at the kernel level, with kernel-tracked exclusivity. v3
+explicitly rejects this. The argument:
+
+**Linearity is needed only for the "Delegate" pattern.** Delegate
+means: the cap **contains** a resource (e.g., `Untyped{remaining:
+100}`); operations on the cap mutate its internal balance and
+produce sub-resources; conservation requires no aliasing.
+
+In v3's by-value, copyable-cap model, Delegate cannot work. With
+copies of a balance-bearing cap, each clone tracks its own copy of
+the balance; mutating one doesn't affect the other; total spend
+across clones can exceed initial balance. Conservation breaks.
+
+The seL4 mitigation is structural linearity (kernel rejects
+MGMT_COPY of linear caps). But this introduces a kernel privilege
+that goes beyond "running mechanism" — the kernel becomes an
+enforcer of structural exclusivity, asymmetric with what userspace
+can do.
+
+**More importantly, even with linearity, userspace can't implement
+Delegate.** If ChainOrchestrator gives a user contract a linear
+`Cap::Instance[Counter{count: 100}]`, the user contract's invocation
+of `counter.consume(50)` mutates the *local* Counter Instance's count
+to 50. But CO's *canonical* counter (in CO's σ-state) is unchanged
+— there's no structural way for Counter's apply to mutate CO's
+state from inside Counter's own apply (principle 13b: trusted
+apply). So the actual conservation effect can only happen when
+Counter yields up to CO, CO's apply runs, CO mutates its state.
+That's not Delegate; that's managed cap with yield-to-issuer.
+
+So Delegate, in seL4 itself, is "managed cap accessed via syscall"
+— not actually different from our managed cap pattern in functional
+terms. seL4's syntactic veneer (`untyped.retype(...)` looking like
+a method call) hides the syscall. The kernel does the work; the cap
+is the authority handle.
+
+**Linearity has no other structural use case in v3** that other
+mechanisms don't already cover:
+
+| Use case for linearity | v3 alternative |
+|---|---|
+| Delegate (cap = resource) | Managed cap (cap = handle into ledger) + ledger arithmetic in issuer |
+| Singleton/identity enforcement | image_hash chain canonical pattern + chain-author discipline |
+| One-shot tickets | Ledger entry marked consumed; bytecode rejects re-use |
+| Atomic transfer | MGMT_MOVE empties source; receiver gets cap |
+| Linear protocol verification | Bytecode tracks step state; rejects out-of-order calls |
+| Capability secrecy / non-aliasing | Doesn't apply: σ is public regardless |
+| Affine/relevant resource accounting | Bytecode discipline + tooling |
+
+Each row has a v3 mechanism that achieves the same property without
+requiring kernel linearity tracking. The kernel stays minimal
+(running mechanism only); conservation invariants live in authority
+bytecode (small, chain-spec-defined, formally verifiable).
+
+So **linearity earns no place in v3**. Cap::Instance, Cap::Image,
+Cap::Data, Cap::CNode are uniformly copyable. Conservation is
+ledger arithmetic. Identity is image_hash chain. Atomic transfer
+is MGMT_MOVE. There is no kernel privilege beyond running the VM,
+computing image_hash, and direct-accessing canonical-image state.
+
+### Why no σ-resident signing primitive
+
+The kernel does **not** provide an in-σ signing primitive, and it
+does not provide an in-apply verification cap either. Both signing
+and verification happen **kernel-side, post-HALT**, against an
+AttestationAuthority Instance the apply produces (§15).
+
+- **σ is public.** Any "secret" in σ is exposed to all validators.
+- **Hardware-rooted per-validator signing breaks determinism in
+  apply.** Each validator's hardware would produce different
+  signatures.
+- **Kernel post-HALT is the right boundary.** Apply records intent;
+  kernel does the crypto.
+
+### Pinned cnode slots
+
+Pinning is determined by the Instance's current `Image.pinned_slots` —
+a Map<SlotIdx, ContentAddressedCap> declaring which slots hold
+pinned ro caps. ContentAddressedCap ∈ { Cap::Data, Cap::Image }.
+
+A pinned slot:
+
+- Cannot be MGMT_MOVE'd out.
+- Cannot be MGMT_COPY'd out (rejected — pinned status doesn't
+  propagate).
+- Cannot be MGMT_DROP'd.
+- Cannot be replaced by writing a different cap.
+- For Cap::Data: memory mappings sourcing from the slot are
+  implicitly ro (writes to the mapped address range fault).
+
+`set_image` swaps the pinned set atomically with the rest of the
+Image (§4).
+
+Use cases:
+- **Cap::Data**: ro reference data baked into the program.
+- **Cap::Image**: target images for `host_derive_spawn` calls.
+  Authority Instances pin the Cap::Image references for the subject
+  types they mint.
+
+## 9. By-value semantics with content-addressed slot references
+
+```
+Slot's cap = reference (by hash) to a specific Instance or Data value.
+
+Apply runs:
+  Kernel materializes Instance value into apply's working memory.
+  Apply mutates working memory (with COW per page for mapped DataCaps).
+  Slot is NOT updated yet.
+
+At termination:
+  HALT  → kernel computes hash of new Instance value (with new mapped
+          DataCaps); slot updates to that hash.
+  yield → kernel computes hash of Paused Instance value (with continuation);
+          slot updates.
+  fault → slot was never updated; outer's view of pre-call value is
+          preserved structurally.
+
+No explicit STM buffer; no merge-or-discard ceremony. Atomicity comes
+from "slots only update at termination."
+```
+
+### The two-condition hashing property
+
+The kernel only needs to compute new hashes ("persist the value")
+in exactly two situations:
+
+**(a) At the *outermost* apply's termination** (HALT, yield, or
+fault). At that boundary the kernel computes hashes for everything
+that was modified (the whole sub-tree). Modified mapped DataCaps
+get hashed incrementally via page-merkle.
+
+**Sub-applies within the outermost invocation do NOT trigger
+hashing.** When A's apply CALLs B, B's apply runs to HALT, and A
+continues — the new B value lives in A's working memory; A's cnode
+reference to B is updated in working memory; no hash is computed.
+
+**(b) When an apply explicitly creates a second reference to a
+value whose hash isn't yet materialized.** This is the divergence
+moment: a singleton in working memory is being duplicated, and the
+two references must remain stable independently from this point on.
+
+- MGMT_COPY of a cap whose value lives in working memory.
+- An Image's `copy` endpoint producing a Cap::Instance for an Instance
+  value that's currently being mutated.
+
+For caps whose hashes are already known (loaded from cnode at apply
+start, etc.), MGMT_COPY is free — just duplicates the (hash, size)
+tuple.
+
+### Cost model
+
+```
+Per-block hashing = O(modified pages × log(num pages))
+                      [paid at outermost termination, once per block]
+                  + Σ O(divergence event sizes)
+                      [paid per explicit copy of a working-memory
+                       singleton, mid-block]
+```
+
+The crucial property: **sub-CALL chains within a block don't pay
+per-level hashing.**
+
+## 10. Sub-tree atomicity
+
+When A.apply CALLs sub-Instances it owns:
+
+```
+A → B → C, all sync CALLs:
+
+If C HALTs and B HALTs and A HALTs: all changes commit to σ.
+If C HALTs but B faults: B's working state (including the new C
+   value) discarded. A sees pre-call B and pre-call C.
+If A faults: no changes commit; σ unchanged.
+
+Automatic transactional rollback for sync CALL chains. Each apply's
+cap-reference updates live in working memory until that apply HALTs.
+Failures unwind everything below.
+```
+
+For peer coordination (A doesn't own B), use the saga pattern (§11).
+
+## 11. Sync CALL + emits + saga
+
+### Sync CALL — direct invocation of owned sub-Instances
+
+A CALLs B from A's cnode. B's apply mutates B's working state in
+A's working cnode. Sub-tree atomicity is automatic.
+
+### emit — cross-Instance canonical mutation via orchestrator
+
+When A doesn't own B:
+
+```
+A.apply HALTs with emit{target=B, args, on_failure=A.refund}.
+  → A's new state committed to orchestrator's cnode.
+
+Orchestrator processes emit (sync CALL to B):
+  B HALTs   → both A and B committed.
+  B Paused  → orchestrator handles per reason.
+  B faults  → orchestrator invokes A's refund (compensating action).
+```
+
+### Why both
+
+Sync CALL atomicity is structural for owned sub-trees. Saga is for
+peer coordination where A's apply terminates before B's CALL begins.
+
+## 12. Per-block kernel + chain Instance
+
+The chain Instance's value IS the chain state.
+
+```
+Hardware → Kernel: (parent chain Instance value, block_body)
+Kernel:
+  Materialize chain Instance from parent state.
+  Initialize per-block kernel-assisted Instances (§22):
+    GasMeter      := { root_meter_id: <chain-spec block budget> }
+    StorageQuota  := { root_quota_id: <chain-spec block budget> }
+  Place block_body Cap::CNode into kernel's slot[0].
+  CALL(chain_Frame, process_endpoint).
+  Apply runs; processes events; sub-CALLs and emits chain.
+  HALT.
+  state_root = hash(new chain Instance value); commit in block header.
+  Discard per-block kernel state (GasMeter, StorageQuota); kernel
+    is stateless across blocks.
+```
+
+If chain Instance's apply HALTs: block commits; new state-root.
+If chain Instance faults: block rejected; no σ change.
+If chain Instance yields: chain Instance is now Paused; resumable next
+  block.
+
+### Chain init: kernel-issued caps
+
+At first block (genesis) — or at every block, depending on chain
+spec — the kernel injects these caps into the top-level chain
+Instance's cnode (see §4 for endpoint specs):
+
+```
+Gas / storage management:
+  Cap::Instance[Gas{root_meter_id}]      -- initial root gas budget
+  Cap::Instance[Quota{root_quota_id}]    -- initial root storage budget
+  Cap::Instance[SetGasMeter]             -- modify GasMeter (returns prev)
+  Cap::Instance[SetStorageQuota]         -- modify StorageQuota
+  Cap::Instance[MintGas]                 -- factory for Gas unit handles
+  Cap::Instance[MintQuota]               -- factory for Quota unit handles
+
+Yield routing:
+  Cap::Instance[CreateYieldCatcher]      -- factory for per-Instance catchers
+  
+  Pre-placed in chain's initial YieldCatcher
+  (chain.cnode[yield_marker_slot]):
+    OOGMarker                         -- caught when any meter hits 0
+    StorageExhaustedMarker            -- caught when any quota hits 0
+    (others as chain spec requires)
+```
+
+This is the entire kernel ABI for chain orchestration. Kernel
+internals (GasMeter, StorageQuota) are opaque from userspace; only
+the cap-mediated operations are visible. Persistence of gas/quota
+balances across blocks (e.g., per-user budgets) lives in chain σ,
+not in kernel state; chain repopulates kernel tables lazily via
+`SetGasMeter` / `SetStorageQuota` in response to OOG /
+StorageExhausted yields. See
+[discussions/kernel-assisted-instances.md](discussions/kernel-assisted-instances.md)
+for the lazy-load OOG-catch pattern.
+
+## 13. Off-chain Dispatch — ephemeral per block
+
+Off-chain Dispatch Instances are fresh per block:
+
+```
+Block N: spawn fresh Dispatch Instance; first message is
+  aggregate_{N-1}; produce aggregate_N; sign; submit; destroy.
+```
+
+The aggregate carries state across blocks. No off-chain storage.
+
+## 14. Authority via capability flow
+
+σ is public. Earlier drafts of this design treated that as an obstacle
+to capability-based authority and fell back on per-user ACLs ("auth
+tables") maintained by orchestrators. **That was a mistake.** Public
+σ does not preclude capability authority — it only precludes
+*secrecy-based* authority (signatures, bearer tokens). Capability
+authority depends on **unforgeability**, which v3 provides
+structurally via image_hash chain plus cnode ownership discipline.
+With both in place, possession of a cap *is* the authorization. No
+parallel ACL is needed.
+
+### The properties that make caps work in public σ
+
+- **Visibility of a cap in σ does not grant access to it.** Anyone
+  can read σ and see that A holds Cap::Instance[X]; nothing follows.
+- **Fabrication is structurally prevented.** An Instance whose
+  `image_hash` chain doesn't show legitimate derivation from the
+  expected parent is rejected on use; the chain extension is kernel-
+  mediated and cannot be synthesized in userspace.
+- **Cap transfer is gated by ownership.** B cannot reach into A's
+  cnode to take a cap; moves require the source's cooperation.
+  Mutation of A's cnode is bytecode-mediated by A's apply alone
+  (Encapsulation, §0 principle 13).
+
+So a cap held in σ is forgery-resistant *and* unappropriable. That is
+exactly the unforgeability seL4 caps provide via kernel mediation;
+v3 reproduces it via image_hash chain plus ownership discipline.
+
+### The kernel yield-marker mechanism
+
+Authority caps are implemented via the kernel's yield-marker
+mechanism: a instance catches yields routed to it by holding matching
+marker Instances in its **YieldCatcher** (a kernel-assisted Instance
+referenced from the catcher's `yield_marker_slot`; see §22).
+Yielding bytecode places a marker Instance in a scratchpad slot; the
+kernel walks the call stack from top down, consulting each instance's
+YieldCatcher via kernel short-circuit, and routes the yield to the
+first matching instance.
+
+```
+Yield routing:
+  yielder.bytecode places Cap::Instance[marker_M] in scratchpad
+  yielder.bytecode invokes host_yield(scratchpad_slot)
+  Kernel:
+    target_hash := marker_M.instance_hash
+    for each InstanceEntry F on stack from top down:
+      if F.image.yield_marker_slot is set:
+        let YC = F.cnode[F.yield_marker_slot]
+                 (a Cap::Instance[YieldCatcher])
+        for each marker template in YC.state.markers:
+          if marker.instance_hash == target_hash:
+            push ReferenceEntry(F); transfer control to F.
+            return.
+    fault yielder with "unhandled marker"
+```
+
+The marker Instance's `instance_hash` (which incorporates its full
+image_hash chain via §1) is the routing key. Adversaries cannot
+fabricate matching markers because the chain extension is kernel-
+mediated.
+
+A YieldCatcher's marker list is mutated via the catcher's
+`add(marker)` / `remove(marker)` endpoints (see §4). To revoke an
+authority, the holder removes the marker template — outstanding
+authority caps holding that marker fail to match on yield.
+
+### The pattern
+
+A chain Orchestrator `O` mints **authority caps** for the operations
+it's willing to expose, and grants them to user contracts that should
+be able to invoke them. Each authority cap holds a marker Instance
+internally; the marker is opaque from outside the authority cap.
+Only the cap's own bytecode (defined by its Image) can extract the
+marker to yield with it.
+
+```
+Setup phase (Chain init):
+
+  -- Chain mints a marker for each authority type:
+  marker_invoke = host_derive_spawn(InvokeMarkerImage, init={})
+  
+  -- Chain adds the marker to its YieldCatcher
+  -- (chain.cnode[yield_marker_slot] holds Cap::Instance[YieldCatcher],
+  --  pre-populated at chain init per §12 with OOGMarker etc.):
+  CALL(chain.cnode[yield_marker_slot], add, marker=Cap::Instance[marker_invoke])
+
+Image EndpointRefCap (well-known image):
+  state:
+    marker:         Cap::Instance[marker_invoke]    -- in self.cnode slot
+    target_address: ContractId                   -- which contract
+    endpoint_idx:   u8                           -- which endpoint
+  endpoints:
+    invoke(args)
+      -- 1. Compose payload from self.state + args:
+      --     payload = { target_address, endpoint_idx, args }
+      -- 2. Place payload in arg slot (slot for handler to read).
+      -- 3. Place self.cnode[marker_slot] (Cap::Instance[marker_invoke])
+      --    into yield-scratchpad slot.
+      -- 4. host_yield(yield-scratchpad).
+      -- 5. On resume, slot[0] holds the handler's response. HALT.
+
+Chain mints these:
+
+O.endpoint grant_endpoint_access(target, endpoint_idx) → Cap::Instance[EndpointRefCap]:
+  cap = host_derive_spawn(EndpointRefCapImage,
+                          init = { marker: Cap::Instance[marker_invoke],
+                                   target_address: target,
+                                   endpoint_idx: endpoint_idx })
+  return cap
+```
+
+A user contract `A` that holds the cap invokes it directly:
+
+```
+A.endpoint do_something():
+  ref_cap = self.slot[7]   -- holds Cap::Instance[EndpointRefCap(B, 5)]
+  slot[0] := args
+  CALL(ref_cap, "invoke")
+  -- ref_cap's invoke endpoint runs; yields with marker; kernel
+  --   routes to Chain; Chain dispatches to B; response returns.
+  result = slot[0]
+  ...
+```
+
+### Why this works
+
+**1. Forgery resistance is structural.** Marker instances are derived
+via `host_derive_spawn` from Chain's bytecode; their `instance_hash`
+includes Chain's image_hash chain. An adversary cannot fabricate a
+matching marker (would require Chain's chain in the derivation
+history, which kernel-mediation prevents).
+
+**2. Authorization is possession of the AuthorityCap, not the
+marker.** The marker is opaque inside AuthorityCap's state (only
+AuthorityCap's bytecode reads it). User contracts hold
+`Cap::Instance[EndpointRefCap]`, not the marker directly. They invoke
+EndpointRefCap; EndpointRefCap's bytecode yields with the marker on
+their behalf.
+
+**3. Cap::Type vs Cap::Instance distinction matters.** Holding a
+Cap::Type that *identifies* the marker's type does NOT grant the
+ability to yield with the marker. Only holding an actual
+`Cap::Instance[marker]` (i.e., the marker Instance) does. The
+yield-marker routing uses instance_hash equality on real Cap::Instance
+values, never Cap::Type. See §8.
+
+**4. Delegation is automatic.** A can MGMT_COPY the EndpointRefCap
+and pass to another contract. Whoever ends up holding it can invoke.
+Non-delegable authority would require additional discipline at the
+AuthorityCap Image level.
+
+**5. Public σ is fine.** Anyone can read that A holds the cap.
+Nothing follows from reading. Only A can move the cap out of A's
+cnode; only the cap holder can invoke through it; the marker stays
+opaque inside AuthorityCap.
+
+**6. No per-user table at O.** O's state is the contracts themselves
+plus O's own facets and YieldCatcher marker list. Per-user
+authorization lives in *which caps A holds*, which is A's own cnode
+contents.
+
+**7. Revocation via marker rotation.** Chain can remove the marker
+from its YieldCatcher via `YieldCatcher.remove(marker)` (or replace
+it with a new marker by minting a fresh one and adding it). All
+outstanding AuthorityCaps holding the old marker fail to match.
+Mint new AuthorityCaps with the new marker if needed. Structural
+revocation without per-cap tracking.
+
+### Where policy attaches
+
+Some operations need policy beyond "permitted to invoke" — rate
+limits, arg filters, quota deductions per call. Two patterns:
+
+**(a) Bake policy into cap variants.** Mint different EndpointRefCaps
+for different policies. A "rate-limited" variant carries its own
+limit; an "unlimited" variant doesn't. The cap encodes the policy.
+Self-contained; preferred default.
+
+**(b) Sidecar policy table keyed by cap identity.** O maintains a
+small map keyed by cap-identity (e.g., a monotonic mint-id captured
+in the cap's state at grant time) → policy. On dispatch, O looks up.
+This is *not* an auth_table — it's not keyed by user, it doesn't
+gate "who can invoke," it only refines "how each cap behaves." Use
+when policy must be dynamically adjusted post-grant.
+
+The choice depends on whether the policy is fixed at grant or
+dynamic afterwards. Both are capability-pure; neither re-introduces
+the ACL anti-pattern.
+
+### Hierarchical orchestration
+
+ChainOrchestrator can decompose:
+
+```
+Kernel
+  └── ChainRoot (handles chain-wide policy)
+       ├── DomainOrch_DeFi
+       │    ├── ProtocolOrch_AMM
+       │    │    └── ...
+       │    └── ProtocolOrch_Lending
+       │         └── ...
+       ├── DomainOrch_NFT
+       │    └── ...
+       └── DomainOrch_Identity
+```
+
+User contracts that interact with the AMM hold EndpointRefCaps
+minted by ProtocolOrch_AMM (delegated through their parent domain
+orchestrator). They invoke endpoints directly via cap-flow — same
+mechanism at every layer. Possession of the cap is the authority.
+
+For operations spanning domains, the user contract holds an
+EndpointRefCap minted by the higher-level orchestrator (e.g., a
+ChainRoot-minted cap that targets a cross-domain coordination
+endpoint). The cascade reaches the appropriate level structurally;
+each cap embeds the level that minted it via image_hash chain.
+Capability flow at every layer; no ACLs at any layer.
+
+## 15. Attestation as a yield-mediated authority
+
+Attestation — verifying signatures on inputs and producing
+signatures on outputs — is exposed as an **AttestationAuthority (AA)
+cap**. AA is a userspace Instance minted by the kernel and granted to
+chain code; possession is the authority to request attestations.
+The actual crypto runs kernel-side via per-attest yield, with mode
+(verify vs sign) determined by whether the block carries
+attestation_traces. AA follows the generic authority pattern
+documented in [userspace/generic-authority-pattern.md](userspace/generic-authority-pattern.md).
+
+### The shape
+
+```
+Image AttestationAuthority (well-known image; minted by kernel):
+  state:
+    marker: Cap::Instance[attest_marker]    -- in self.cnode
+  endpoints:
+    attest(key, blob) → AttestStatus
+      -- 1. Compose payload: { key, blob }, place in arg slot.
+      -- 2. Place Cap::Instance[attest_marker] in yield-scratchpad.
+      -- 3. host_yield(yield-scratchpad).
+      -- 4. On resume, slot[0] holds the kernel's response (status).
+      -- 5. HALT returning status to caller.
+
+Setup (kernel/chain init):
+  attest_marker = host_derive_spawn(AttestMarkerImage, init={})
+  -- Add to the kernel handler instance's YieldCatcher
+  -- (kernel's handler is a kernel-internal instance whose
+  --  yield_marker_slot points to its own YieldCatcher):
+  CALL(kernel_handler.YieldCatcher, add,
+       marker=Cap::Instance[attest_marker])
+  -- Now kernel catches yields with this marker.
+
+  -- AA caps are minted with marker in their state:
+  aa_cap = host_derive_spawn(AAImage, init={ marker: Cap::Instance[attest_marker] })
+  -- Distribute aa_cap to chain code that needs to attest.
+
+enum AttestStatus {
+  Recorded,         -- request was recorded; kernel will sign at
+                    -- termination (sign mode) or has verified
+                    -- (verify mode). Userspace sees the same value.
+  InvalidKey,
+  MalformedBlob,
+  QuotaExceeded,
+  ... (mode-invariant failure modes)
+}
+```
+
+The mechanism follows the canonical authority pattern (§14, §17):
+attest_marker's image_hash chain is rooted in the kernel; user code
+holding Cap::Instance[AA] can invoke AA which yields with the marker;
+kernel catches via yield_marker_slot match; kernel processes mode-
+aware and returns mode-invariant status. The marker is opaque inside
+AA — only AA's bytecode reads it.
+
+Userspace never sees a signature. The return value of `AA.attest` is
+a status enum, identical in produce and verify modes for the same
+input. This is the consensus-safety guarantee: there is nothing
+userspace can observe that depends on mode.
+
+### Why a status enum (not the signature)
+
+If `AA.attest` returned a signature:
+
+- **In sign mode**, the kernel would have to produce a signature
+  visible to userspace. Userspace could then branch on its bytes,
+  leak it, or compose it into σ in ways the kernel can't constrain.
+- **In verify mode**, there is no live signing key. The kernel
+  would have to fabricate something; userspace could distinguish
+  fabricated from real and diverge from sign-mode behavior.
+  Consensus breaks.
+
+Returning only a status enum makes userspace's observable behavior
+**identical** in both modes. The actual signature exists only at the
+block level (in attestation_traces), where consensus mediates it.
+
+### Tx / block flow
+
+```
+Block carries an optional sidecar attestation_traces:
+  None         → sign mode (this validator is the proposer).
+  Some(sigs)   → verify mode (this validator is a verifier).
+
+Kernel injects a Cap::Instance[AA] at apply start, in scratchpad of
+the top-level apply. AA's image_hash_chain extends from the kernel-
+bridge image, structurally proving "minted by this kernel."
+
+Apply (or downstream Instances receiving AA via cap-flow) calls
+AA.attest(key, blob) at every signature obligation.
+
+Per-attest yield handling:
+  - AA's bytecode yields with attest_marker; kernel walks the call
+    stack and consults each InstanceEntry's YieldCatcher (via short-
+    circuit). Match found at kernel handler instance.
+  - Intermediates don't catch (their YieldCatcher's marker list
+    doesn't contain attest_marker). They have no access to the
+    yielded payload — it never lands in their slot[0].
+  - The kernel reads the payload (key, blob) from the yield's arg
+    slot — these are part of AA's payload composition, not part of
+    AA's identity.
+  - The kernel performs the mode-appropriate work:
+      Verify mode: hw_verify(key, blob, traces[next_slot]).
+                   Status = Recorded on success; else mode-invariant
+                   failure or block-fault (see attestation-authority.md).
+      Sign mode:   if validator has authority to sign with key,
+                     hw_sign(key, blob) → sig; append to outgoing
+                     attestation_traces; Status = Recorded.
+                   else: mode-invariant failure (consensus safe
+                     because failure conditions are deterministic
+                     functions of apply-visible state).
+  - The kernel places status in slot[0]; CALL_RESUME returns control
+    to AA's bytecode.
+
+Apply HALTs. At HALT, kernel knows:
+  Verify mode: did every required position in traces get consumed?
+               If not, block invalid (apply produced fewer attestations
+               than the block claims).
+  Sign mode:   are all hw_sign calls done? Block is finalized with
+               the attestation_traces sidecar.
+```
+
+### Why this obviates a σ-resident sig primitive
+
+- **No signing key in σ.** The signing key is per-node hardware
+  state, never on-chain.
+- **No Cap::SigVerify needed.** Verification is kernel-side, per-
+  attest, against block-supplied traces.
+- **No SigningCap as a userspace cap.** Authority to sign with a
+  given key is per-node config; userspace gets only the AA cap, which
+  grants "request attestations" not "see signatures."
+- **Determinism preserved.** Userspace observes only mode-invariant
+  status. The signature itself lives at the block layer.
+
+### AA presence and chain integrity
+
+Kernel verifies on receipt of every Attest yield that the request's
+`image_hash_chain` extends from a kernel-minted AA. A fabricated
+Attest from userspace would have a chain that doesn't match; rejected
+structurally. This is what forgery resistance buys; no presence-check
+machinery beyond chain validation is required.
+
+The chain orchestrator's bytecode is responsible for ensuring AA
+flows through cap-flow to the Instances that need to attest. If the
+orchestrator's bytecode is incorrect (drops AA), the relevant
+attestations don't happen, and the block fails consensus. Strong
+incentive to author correctly.
+
+### BLS aggregation
+
+A separate AA endpoint follows the same yield-mediated pattern:
+
+```
+AA.aggregate(group_key, partial_sig) → AggregateStatus
+  -- builds an Aggregate request Instance (state: { group_key, partial_sig });
+  -- yields up; kernel collects partials per group;
+  -- at block finalization, kernel BLS-aggregates and appends final
+  -- sig to block sidecar.
+  -- Returns mode-invariant status.
+```
+
+### Cross-chain proofs
+
+External-chain attestations use the same AA cap. The verifier on
+this chain calls `AA.attest(external_chain_pubkey, header_hash)`.
+The block carries the external sig in attestation_traces; kernel
+verifies per-yield. No new mechanism.
+
+## 16. MintInstance as a capability-mediated pattern
+
+MintInstance (issuance authority for typed values) is owned by the
+chain Orchestrator. User contracts that should be able to mint hold
+**MintRefCap** — a capability minted by O that, on invocation, yields
+a Mint request up the cascade to O. Same yield-mediated authority
+pattern as AA; same forgery resistance via image_hash chain. No
+auth_table lookup; no user-keyed ACL.
+
+```
+Image MintInstance (owned by O, well-known image):
+  state:
+    issued:  Map<MintHandle, Issuance>,
+    policy:  ...
+  endpoints:
+    mint(domain, content) → Issuance       -- only callable from O.apply
+    burn(handle)                           -- only callable from O.apply
+    transfer(handle, from, to)             -- only callable from O.apply
+
+Image MintRefCap (granted by O to user contracts that may mint):
+  state:
+    domain: DomainId                       -- which mint domain this cap is for
+    marker: Cap::Instance[mint_marker]        -- in self.cnode
+    -- possibly: policy fields (rate limits, etc.) baked in per §14
+  endpoints:
+    mint(content) → MintStatus
+      -- Per the canonical authority pattern (§14, §17):
+      -- 1. Compose payload from { domain, content } + args.
+      -- 2. Place Cap::Instance[mint_marker] in yield-scratchpad.
+      -- 3. host_yield(yield-scratchpad).
+      -- 4. Kernel routes to O (which has mint_marker in its
+      --    yield_marker_slot). O invokes MintInstance.mint internally
+      --    and returns status via CALL_RESUME.
+      -- 5. On resume, slot[0] holds status (and any new Issuance cap).
+      -- 6. HALT to caller.
+    burn(handle) → BurnStatus    -- symmetric pattern
+    transfer(...) → TransferStatus
+```
+
+Setup: O derives mint_marker via `host_derive_spawn(MintMarkerImage)`
+and adds it to its YieldCatcher via
+`CALL(O.YieldCatcher, add, marker=Cap::Instance[mint_marker])`. Then
+mints MintRefCaps with the marker embedded. See
+`userspace/generic-authority-pattern.md` for the full pattern.
+
+### Flow
+
+```
+Alice's tx (off-chain, signed):
+  "Alice transfers 10 to Bob."
+
+Chain Orchestrator's apply:
+  1. Record Alice's signature into AttestationAuthority:
+       AA.attest(alice_pubkey, tx_payload_hash).
+  2. Look up Alice's user contract A (just a contract registry
+     lookup — no auth_table).
+  3. Update Alice's account state (decrement) and Bob's (increment).
+  4. If a typed stamp is needed, O calls MintInstance.mint directly
+     (O holds the cap to MintInstance, intra-O cap-flow).
+
+Cross-contract case (A invokes an operation that mints):
+  1. A holds Cap::Instance[MintRefCap(domain_X)] in its cnode (granted
+     by O earlier via O's grant endpoint).
+  2. A.apply calls MintRefCap.mint(content).
+  3. MintRefCap's bytecode yields with mint_marker; kernel walks
+     the call stack; finds O's YieldCatcher contains a matching
+     marker template; routes to O.
+  4. O's bytecode reads payload (domain_X, content), invokes
+     MintInstance.mint(domain_X, content) → Issuance.
+  5. O places result in slot[0]; CALL_RESUME. MintRefCap resumes,
+     HALTs with status to A.
+
+Forgery resistance: a malicious A cannot yield with mint_marker
+without holding a real MintRefCap (the marker is in MintRefCap's
+state, opaque from outside). And A can't fabricate a MintRefCap
+because Chain's chain prefix can't be replicated.
+```
+
+## 17. Footgun reduction
+
+Structurally eliminated:
+
+- **Reentrancy attacks** — by-value snapshots; nested calls operate
+  on separate instances.
+- **Mid-update state observation** — apply runs on its own working
+  state; only termination publishes to outer.
+- **Cap-as-value confusion** — caps are content-addressed copyable;
+  MGMT_COPY produces explicit shared references; mutations diverge
+  per §9 case (b).
+- **Bytecode validation at Image construction** — kernel validates
+  Image's embedded bytecode for parseability when the Image is
+  constructed. Malformed bytecode rejected at construction.
+- **Memory exhaustion mid-apply** — static memory; allocation only
+  via the heap-region pattern with bounded size.
+- **Page-fault nondeterminism** — no page faults; access to undeclared
+  addresses Faults the Instance deterministically.
+- **Lazy paging consensus footguns** — no lazy paging.
+- **Lost continuation** — yield captures continuation in Instance value.
+- **Pinned data corruption** — kernel rejects writes to pinned regions
+  and modifications to pinned cnode entries.
+- **Surprise gas refunds on fault** — gas STM-exempt; debited regardless.
+- **Bearer-token forgery in public σ** — there are no bearer tokens
+  in the secrecy sense. Caps in σ are visible but unforgeable
+  (image_hash chain) and unappropriable (cnode ownership). Authority
+  flows via capability grant (§14); off-chain → on-chain authority
+  uses AttestationAuthority verified kernel-side via per-attest yield
+  against block-supplied traces (§15).
+- **`caller()`-style identity introspection** — not exposed. Instances
+  identify their callers structurally (orchestrator's own dispatch
+  loop tracking which child it just CALLed).
+- **Spec-mutation forgery (image_hash collision via spec replication)** —
+  prevented structurally. image_hash is a kernel-attested chain;
+  genesis Instances have image_hash = hash(initial_image); post-set_image
+  / post-derive_spawn image_hashes are recursive.
+- **Raw image_hash inspection footguns** — userspace cannot read raw
+  image_hash. The only type queries are semantic (`host_same_type`,
+  `host_same_type_as`).
+- **Piecewise spec mutation inconsistency** — Image is mutated as a
+  unit via `set_image`. No `host_set_code` / `host_set_endpoints`.
+- **Conservation violations via cap copying** — conservation lives
+  either in kernel-internal tables (for kernel-assisted resources
+  like Gas/Quota: copies of `Cap::Instance[Gas{meter_id}]` all name
+  the same meter; debiting any copy debits the same row) or in
+  authority bytecode (for userspace resources: typed handle copies
+  reference the same ledger row). Either way, copying doesn't
+  multiply balance — no kernel-level linearity required.
+
+## 18. Open questions
+
+1. **Chain-defined yield markers**: canonical patterns for chain-
+   defined markers (CooperativeCheckpoint, NeedHeapSpace, etc.)
+   and how chains extend the kernel-issued set (OOGMarker,
+   StorageExhaustedMarker).
+
+2. **EndpointRefCap variants and dispatch-side policy**: which
+   policy fields (rate limit, arg filter, etc.) bake into the cap
+   itself vs. live in a sidecar policy table keyed by cap identity
+   at the dispatcher (§14, "Where policy attaches").
+
+3. **Cap::Image construction**: how chain authors construct
+   Cap::Image values. Probably via a `host_make_image(code: Bytes,
+   endpoints: ..., mappings: ..., pinned_slots: ...) → Cap::Image`
+   host call. Bytecode validation at construction.
+
+4. **gas_slots / quota_slots fallback policies**: standard
+   combinations chain authors should know — single primary meter
+   vs. primary + caller-reserve fallback vs. multi-reserve. Likely
+   chain-spec-specific.
+
+5. **State-root computation**: chain-spec choice of merkle scheme;
+   canonical serialization for hashing.
+
+6. **Per-block kernel ABI**: exact inputs/outputs at the
+   (parent state, block_body) → (new state, header) boundary.
+
+7. **Recursion depth limit**: sync CALL has bounded stack; what's
+   the limit?
+
+8. **Long-running computation patterns**: best practices for chain
+   authors using the yield/Paused mechanism for compile, ZK proof
+   generation, etc.
+
+9. **Genesis seed**: what initial cnode contents does Kernel hold?
+   Chains likely pin Cap::Image references for the authorities the
+   chain wants to derive at bootstrap, plus the kernel-issued caps
+   listed in §12.
+
+10. **Pinned-slot collision policy**: when `set_image` finds a
+    target pinned slot is already occupied by non-pinned content,
+    we currently FAIL. Should there be a "force" variant?
+
+11. **MGMT_CNODE_SWAP semantics**: pinned-slot rules, cross-cnode
+    behavior.
+
+12. **set_image / derive_spawn validation timing for memory_mappings
+    against slot types**: at the spawn/transition moment, or at next
+    CALL?
+
+13. **`image_id`-equal but `image_hash`-different Instances**: same code,
+    different lineage — `host_same_type` returns false. Document so
+    chain authors don't conflate "same Image content" with "same
+    type".
+
+14. **Off-chain Dispatch Instance's image_hash**: derived per the
+    canonical formula, or absent (ephemeral, never hashed)?
+
+15. **Cap::CNode size constraints for spawn**: host_derive_spawn
+    requires a Cap::CNode of size 256. Should kernel auto-pad
+    smaller Cap::CNodes, or require exact-size?
+
+16. **Hierarchical orchestrator patterns**: when does decomposition
+    pay off? What's the minimal canonical set of orchestrators per
+    chain?
+
+Resolved decisions on the kernel-assisted Instance design (gas / quota
+/ yield routing — page size, dirty-page tracking lifetime, id
+assignment policy, OOG payload shape, etc.) are captured in
+[discussions/kernel-assisted-instances.md](discussions/kernel-assisted-instances.md).
+
+## 19. Summary
+
+```
+Instance (always Image-bound):
+  image_id:     ImageHash
+  cnode:        256 slots; pinned slots per Image; non-pinned mutable
+  status:       Idle | Paused {...} | Faulted
+  image_hash:   derived; kernel-attested chain hash:
+                  genesis:                  hash(initial_image)
+                  after set_image(new):     hash(image_hash_before
+                                                  || hash(new))
+                  via derive_spawn(new):    hash(spawner.image_hash
+                                                  || hash(new))
+                  via MGMT_COPY:            preserved
+
+Cap::Image (content-addressed, copyable):
+  - code:            Bytes  (bytecode embedded; validated at construction)
+  - memory_mappings: [{start, size, source}]
+  - endpoints:       [Option<EndpointDef>; 256]
+  - gas_slots:       [SlotIdx]    -- slots holding Cap::Instance[Gas{meter_id}]
+  - quota_slots:     [SlotIdx]    -- slots holding Cap::Instance[Quota{quota_id}]
+  - pinned_slots:    Map<SlotIdx, ContentAddressedCap>
+                       (ContentAddressedCap ∈ { Cap::Data, Cap::Image })
+  - yield_marker_slot: Option<SlotIdx>
+                       -- slot holding Cap::Instance[YieldCatcher]
+
+Cap::CNode (uniformly copyable; mintable):
+  - size: 2^k slots
+  - slots: [Option<Cap>; size]
+  - Used for storage exceeding 256-slot Instance root cnode, for
+    state-snapshot/revert patterns, and as the cnode argument to
+    host_derive_spawn.
+
+Memory model:
+  - Static layout per Image; no dynamic mapping; no lazy paging.
+  - Persistent mapping = backed by cnode DataCap; mutations COW'd.
+  - Ephemeral mapping = kernel-allocated; per-apply.
+  - DataCap canonical form: trailing-zero-stripped.
+  - Size-mismatch: small DataCap zero-padded; large DataCap faults.
+
+Apply terminations (all reflect target.slot[0] to caller.slot[0]):
+  HALT  → Idle (new value)
+  yield → Waiting on call stack (Paused if preserved across blocks);
+          continuation is regs+pc; yield payload (typically a marker
+          / unit cap) reflects to caller via slot[0].
+          (kernel OOG = host_yield with kernel-issued OOGMarker;
+           payload is Cap::Instance[Gas{meter_id}].)
+  fault → Faulted, then dropped
+  Gas debited STM-exempt: from the meter named by the active Instance's
+    gas slot; debits are per-instruction; no per-CALL budget.
+  Apply discipline: keep slot[0] in a safe-to-reflect state at all
+    times (input scratchpad, empty, or complete output Cap::CNode
+    atomically MGMT_MOVE'd in). OOG and fault can happen at any
+    instruction; partial slot[0] would expose mid-mutation state.
+
+Kernel ABI:
+  Invocation:           CALL, CALL_RESUME, DROP_PAUSED
+                        (no gas_budget — gas via gas_slots)
+  Yield:                host_yield (YieldCatcher-routed marker)
+  Data:                 host_read_data_cap, host_mint_data_cap
+  Cap-table:            MGMT_COPY/MOVE/DROP/CNODE_SWAP
+  Image / spawn:        set_image, host_derive_spawn
+  Type-query:           host_same_type, host_same_type_as,
+                        host_type_of, host_subtype, host_type_eq
+  CNode:                host_mint_cnode
+
+Kernel-issued caps at chain init (see §4, §12):
+  Gas/storage:          SetGasMeter, SetStorageQuota, MintGas,
+                        MintQuota, root Gas/Quota unit handles.
+  Yield routing:        CreateYieldCatcher; chain's initial
+                        YieldCatcher pre-populated with OOGMarker,
+                        StorageExhaustedMarker.
+
+Cap kinds (five; all copyable):
+  Cap::Instance   — Instance value reference. AUTHORITY-BEARING.
+                 Includes kernel-assisted Instances (§22): YieldCatcher,
+                 Gas{meter_id}, Quota{quota_id}, etc.
+  Cap::Image   — spec including embedded bytecode.
+  Cap::Data    — arbitrary bytes.
+  Cap::CNode   — variable-size cnode (mintable).
+  Cap::Type    — image_hash chain identifier. IDENTIFICATION-ONLY;
+                 NOT for authority routing (see §8).
+
+  Resource caps (Gas, StorageQuota) are NOT separate cap kinds —
+  they are kernel-assisted Cap::Instances:
+    Gas{meter_id}   — per-Instance unit handle naming a meter in the
+                      kernel-internal GasMeter table. Conservation
+                      lives in the table; cap copies all name the
+                      same meter; no narrow linearity needed.
+    Quota{quota_id} — symmetric for StorageQuota.
+  Chain accesses kernel-internal GasMeter/StorageQuota only via
+  the kernel-issued SetGasMeter/SetStorageQuota caps.
+  Custom (non-kernel-assisted) resources are typed handles into
+  authority ledgers.
+
+  No σ-resident signing primitive. Signing/verification happen
+  kernel-side post-HALT against AttestationAuthority records (§15).
+
+Image mutation:
+  set_image(new_image: Cap::Image) is the only on-self spec-changing
+  primitive.
+
+Instance creation:
+  MGMT_COPY of Cap::Instance:
+    content-shared copy; same image_hash. Mutations diverge per §9
+    case (b). For "same type with fresh state": follow MGMT_COPY
+    with CALL into image-defined setup endpoint.
+  host_derive_spawn(image, cnode):
+    new image; image_hash = hash(self.image_hash || hash(image));
+    consumes cnode. For sub-type creation (authority Instances creating
+    subjects, etc.). Only callable from within self's apply.
+
+Authority + Subject pattern:
+  Authority Instances: held by chain orchestrator (Kernel, MintInstances,
+    chain-defined issuers). They mint Subject Instances via
+    host_derive_spawn or issue typed handles.
+  Subject Instances: e.g., user contracts, custom token handles.
+  Conservation enforced by authority bytecode (ledger arithmetic)
+    for userspace resources, or by the kernel-internal table for
+    kernel-assisted resources (Gas/Quota, §22).
+  Forgery resistance via image_hash chain.
+
+Type query:
+  host_same_type(a, b)  → image_hash equality
+  host_same_type_as(comparer, comparee, [images])
+                        → comparer is comparee derived through images
+  Lineage walking and raw image_hash are not exposed.
+
+Forgery resistance (structural):
+  Genesis Kernel Instance has image_hash = hash(KernelImage).
+  Post-set_image / post-derive_spawn image_hashes are recursive;
+    never equal hash(any single Image).
+  Cap-flow on the genesis Kernel Instance gates entry.
+  Cap-runtime integrity: caps not synthesizable from bytes.
+
+By-value with content-addressed slot references:
+  Slots only update at apply termination.
+  Sub-tree atomicity structural.
+  No STM buffer required.
+
+Snapshot/revert universal:
+  MGMT_COPY of any Cap::Instance produces a content-shared reference.
+  Mutations diverge per §9 case (b).
+  Always available; always works.
+
+Pinned cnode slots: kernel-locked, declared by current Image's
+  `pinned_slots`. Holds Cap::Data (baked-in ro bytes) or Cap::Image
+  (derive_spawn targets).
+
+Pure-function apply; effects as outputs.
+Saga pattern for peer coordination via emit + on_failure.
+Per-block kernel as top orchestrator.
+Off-chain Dispatch ephemeral per block.
+
+Authority model:
+  In-σ authority is conveyed by capabilities; possession = right to
+  invoke. Caps are unforgeable (image_hash chain) and unappropriable
+  (cnode ownership); secrecy of σ is unnecessary. Orchestrators mint
+  EndpointRefCap-style caps and grant them via cap-flow; no per-user
+  ACL tables. No σ-resident signing keys; no Cap::Authority cap kind.
+  Off-chain → on-chain authority via AttestationAuthority cap (status-
+  only return; per-attest yield mediated by kernel against block-
+  supplied traces). Hierarchical orchestrators compose by minting and
+  granting caps at each layer.
+```
+
+This is the consolidated v3 design without linearity.
+
+For a side-by-side comparison with seL4's verified security
+properties, see [discussions/sel4-mapping.md](discussions/sel4-mapping.md).
+
+For the discussion-level exploration that includes the linearity
+alternative, see
+[../minimum/discussions/minimal-kernel-v3.md](../minimum/discussions/minimal-kernel-v3.md).

--- a/docs/spec/discussions/attestation-authority.md
+++ b/docs/spec/discussions/attestation-authority.md
@@ -1,0 +1,438 @@
+# AttestationAuthority — design
+
+AttestationAuthority (AA) is the v3 mechanism by which userspace
+declares signing / verifying obligations, while the kernel performs
+all mode-aware processing (sign vs verify, local vs remote, seen-rule
+enforcement). The design preserves consensus by keeping the apply's
+visible state independent of mode.
+
+## Why AA exists
+
+Three orthogonal concerns require it:
+
+1. **Determinism**. apply bytecode must produce the same outputs
+   across all validators given the same visible inputs. So
+   "should this validator sign this blob?" can't be apply-visible —
+   it depends on per-validator hardware authority. Apply just
+   declares the (key, blob) need; kernel decides.
+
+2. **Aggregation deferral**. Crypto operations (hw_sign, hw_verify,
+   BLS aggregate) are slow. Doing them in-line during apply would
+   force the kernel to schedule crypto in the middle of pure-function
+   apply. Recording obligations and processing them post-HALT
+   (per-attest yield in v3) lets crypto happen at clean boundaries.
+
+3. **Mode invariance**. Verify-mode validator and produce-mode
+   proposer must run identical apply bytecode against identical
+   apply-visible inputs. If apply could observe "I have incoming
+   sigs" vs "I'm generating sigs", consensus would split. AA
+   guarantees apply only sees blob + key + chain context; the
+   sig-presence is kernel-only knowledge.
+
+## The userspace ABI
+
+AA is an **authority cap** in the generic pattern (see
+[generic-authority-pattern.md](../userspace/generic-authority-pattern.md)).
+Possession of `Cap::Instance[AA]` is the authority to request
+attestations. The endpoint follows request/response Instance shape:
+
+```
+AA.attest(key: PubKey, blob: Bytes) → AttestStatus
+  -- Builds an Attest request Instance with state {key, blob}.
+  --   image_hash_chain: ... → kernel → AA → Attest
+  -- Yields up with the Attest in slot[0]; cascade reaches kernel.
+  -- Kernel handles per-attest at the yield (mode-aware).
+  -- On resume, slot[0] holds an Attested response Instance.
+  -- CALLs Attested.get_status → returns status to caller.
+
+enum AttestStatus {
+  Recorded,           -- request processed (signed in produce mode,
+                      -- verified in verify mode); both modes return
+                      -- the same value for the same input.
+  InvalidKey,
+  MalformedBlob,
+  QuotaExceeded,
+  ...                 -- mode-invariant failure modes only
+}
+```
+
+Userspace does NOT see:
+- A signature. (The signature lives at the block layer, in
+  attestation_traces; never in apply-visible state.)
+- Trace data.
+- A mode indicator.
+- An origin tag (local vs remote).
+
+Userspace just declares the (key, blob) and receives a mode-
+invariant status. This guarantees consensus safety: produce and
+verify mode return the same status for the same apply-visible input.
+
+## Kernel-side processing
+
+When the apply yields with an Attest request in slot[0]:
+
+```
+Kernel.handle_attest_yield(attest_instance, context):
+  -- context = which endpoint is calling, which phase (verify/process),
+  --           which event in the cycle, etc. Kernel knows from call
+  --           stack (caller image_hash chain).
+
+  -- Per the generic-authority pattern, kernel calls Attest's
+  -- inspection endpoint, passing a kernel-handler witness as an
+  -- argument. The endpoint runs
+  --   host_same_type_as(kernel_handler_witness, HANDLER_EXEMPLAR, [])
+  -- to verify the witness is of the expected class. Intermediates
+  -- can't mint an Instance matching the exemplar (their chain doesn't
+  -- match), so they cannot read.
+  (key, blob) = attest_instance.get_request_for(kernel_handler_witness)
+
+  status: AttestStatus
+  if kernel.current_mode == VerifyMode (block has incoming traces):
+    -- The validator is processing a finalized block.
+    sig = lookup_in_traces(kernel.current_traces, key, blob)
+    if sig is None:
+      -- block claims fewer attestations than apply expects;
+      -- consensus failure. Fault the apply (early-discard).
+      fault apply
+    elif not hw_verify(key, blob, sig):
+      fault apply
+    else:
+      status = Recorded
+
+  elif kernel.current_mode == ProduceMode (this validator producing):
+    -- Apply seen-rule per cycle:
+    seen_keys = kernel.cycle_seen_keys[context.endpoint][context.cycle]
+    if context.phase == verify:
+      seen_keys.add(key)
+      status = Recorded
+    elif context.phase == process or apply:
+      if key not in seen_keys:
+        fault apply (seen-rule violation; proposer can't produce a
+                     valid block with this attest)
+      elif local_validator_has_authority(key):
+        sig = hw_sign(key, blob)
+        kernel.outgoing_traces.append({key, blob, sig})
+        status = Recorded
+      else:
+        -- non-local key; record acknowledged; another validator
+        -- with the key signs separately.
+        status = Recorded
+
+  -- Mode-invariant return: the same `status` value for the same
+  -- apply-visible inputs. Wrap in Attested via the attest_instance's
+  -- own fulfill endpoint (which only accepts a kernel-generated
+  -- witness).
+  answer_witness = host_derive_spawn(KernelAnswerImage,
+                                     init = { status })
+  attested = attest_instance.fulfill(answer_witness)
+  slot[0] := attested
+  CALL_RESUME
+```
+
+The kernel's mode-aware processing is entirely external to apply.
+Apply sees: yield → either resume with status (kernel approved) or
+fault (kernel discarded). Critically, the status enum is mode-
+invariant — apply cannot distinguish produce from verify mode by
+return value.
+
+Confidentiality from intermediates is preserved structurally: both
+`get_request_for(witness)` and `fulfill(answer_witness)` run
+`host_same_type_as` on the cap-passed witness against pinned
+exemplars of the kernel-handler and kernel-answer classes.
+Intermediates routing the Attest cascade cannot mint an Instance whose
+chain matches the exemplar, so they can neither inspect (key, blob)
+nor fabricate a valid fulfill.
+
+## Why this is consensus-safe
+
+**Apply visibility**: apply sees blob, chain context (read-only),
+and the (key, blob) it declared. No mode info. No traces. No sig.
+
+**Apply outcome determinism**: identical apply-visible inputs →
+identical apply outcome (HALT or fault at the same instruction).
+
+**Mode determines kernel reaction**:
+- Verify mode (validator processing block N): kernel has block's
+  attestation_traces. Verifies each attest against traces. Detects
+  bad/missing sigs deterministically. Faults apply identically
+  across all verifiers.
+- Produce mode (proposer building block N): kernel has no incoming
+  traces; generates them. Applies seen-rule + local-key signing.
+  Faults apply if seen-rule violated.
+
+**Cross-validator consistency**:
+- Verifiers of block N: same block, same traces → same kernel
+  reactions → same apply outcomes.
+- Proposer of block N: single role; either produces a valid block
+  (and verifiers will verify it) or aborts (and no block N is
+  proposed from this proposer).
+
+No two validators in the same role reach divergent apply outcomes
+given the same inputs.
+
+## The seen-rule
+
+The seen-rule restricts which keys produce mode can sign for: only
+keys observed during the current cycle's verify phase.
+
+**Purpose**: ensures subscription consistency. If endpoint k's process
+phase signs with key K, then key K must have been visible during
+endpoint k's per-event verify phase (i.e., someone sent an event
+containing key K's signature, which we verified). This means any
+node subscribed to endpoint k has seen key K; they're prepared to
+sign for it if they have local authority.
+
+Without the seen-rule, process could "invent" a key K from thin air,
+and subscribers might not know about K (no opportunity to subscribe
+for K's sigs).
+
+**Mechanism**: kernel maintains per-cycle seen_keys per endpoint.
+Per-event verify's attest calls add keys to the set. Per-cycle
+process's attest calls check against the set.
+
+**Enforcement timing**: at the attest yield call, kernel checks. If
+seen-rule violated in produce mode → kernel faults apply early.
+
+**Why fault is consensus-safe even though only produce mode hits it**:
+- Proposer that hits seen-rule violation: apply faults; proposer
+  abandons this block (or this event in the block).
+- Verifiers don't see this case: they receive whatever block the
+  proposer produced; if the proposer dropped the event, verifiers
+  see a block without that event; they verify the block as-is.
+- No verifier observes a "phantom event that proposer failed on"
+  — those events simply don't appear in the produced block.
+
+## Source distinction (without source-passing)
+
+The apply calls `AA.attest(key, blob)`. The same call. But records
+carry kernel-applied metadata that distinguishes:
+
+```
+Record metadata (kernel-only):
+  phase = verify   when the call was made during endpoint.verify
+  phase = process  when made during endpoint.process
+  phase = apply    when made during chain.apply
+```
+
+This is inferred from the kernel's call-stack tracking. At the moment
+of the attest yield, kernel knows which endpoint's apply made it.
+
+The phase metadata drives the kernel logic:
+- verify-phase records: contribute to seen_keys; never trigger
+  signing (verify is per-event acknowledgment).
+- process-phase or apply-phase records: subject to seen-rule;
+  trigger signing (in produce mode) or sig-checking (in verify mode).
+
+## AA lifecycle
+
+AA is a Cap::Instance minted by kernel and injected into the scratchpad
+at the start of each verify or process invocation. AA itself has no
+meaningful state — it's a thin façade whose single endpoint
+(`attest`) builds Attest request Instances. Since each attest call
+yields independently, AA accumulates nothing across calls.
+
+```
+For per-event verify (off-chain):
+  AA_event = kernel-derive Cap::Instance[AAImage]
+             -- image_hash_chain: kernel-bridge → AAImage,
+             --   structurally provable as kernel-minted.
+  pass AA_event in slot[0] alongside blob and chain_copy
+  CALL verify_endpoint
+  -- per-attest yields handled inline via the yield mechanism
+  -- (kernel sees each Attest, processes mode-aware, returns status).
+  drop AA_event
+
+For per-cycle process (off-chain, block boundary):
+  AA_cycle = kernel-derive Cap::Instance[AAImage]
+  pass AA_cycle in slot[0] alongside events and chain_copy
+  CALL process_endpoint
+  -- per-attest yields handled inline.
+  drop AA_cycle
+
+For on-chain apply_block:
+  AA_block = kernel-derive Cap::Instance[AAImage]
+  pass AA_block in slot[0] alongside body and chain
+  CALL chain.apply
+  -- per-attest yields handled inline.
+  drop AA_block
+```
+
+AA Instances don't persist across these boundaries. They're transient
+caps that grant per-invocation attestation authority and are
+discarded when their invocation returns.
+
+The image_hash chain for AA Instances:
+```
+AAImage.image_hash_chain = [kernel-bridge_hash, AAImage_hash]
+                         = canonical AA chain prefix
+```
+
+A receiver of `Cap::Instance[AA]` can verify canonicity via
+`host_same_type` against a chain-spec-known reference. Forgery
+prevention: an adversary cannot construct a Cap::Instance with a chain
+that begins with kernel-bridge — the chain extension is kernel-
+mediated and starts from the genesis kernel.
+
+## Why AA is an Instance at all (vs pure host call)
+
+A pure `host_attest(key, blob)` ABI without an AA Instance would work
+mechanically. Why wrap it in a Cap::Instance?
+
+**Cap-flow auditability**: the AA Instance is passed via scratchpad
+explicitly. Anyone reading the apply's input knows "this apply has
+attestation authority for this cycle". Without the Instance, that
+authority is implicit in being CALLed by the kernel.
+
+**Composition**: a chain author wanting to compose attestation
+(e.g., wrap with rate-limiting, audit logging, multi-validator
+aggregation) can place a wrapper Instance between the endpoint and the
+real AA. The wrapper CALLs the canonical AA after applying its
+logic. Pure host_attest doesn't compose this way.
+
+**Forgery resistance**: AA's image_hash chain proves canonicity.
+A wrapper that claims to be AA but isn't canonical: host_same_type
+detects.
+
+**Pinning**: AA Cap::Image can be pinned in chain's slots, ensuring
+chain endpoints always have access to the canonical AA reference.
+
+These are real but the cost is small. If we wanted to strip down, a
+pure `host_attest()` works too. The AA Instance is the canonical pattern.
+
+## Early-discard semantics
+
+When kernel decides "no point continuing" at an attest yield, apply
+is faulted:
+
+```
+Kernel.attest yield processing:
+  ... mode-aware logic ...
+  if decision is fault:
+    target Instance transitions to Faulted (cascade)
+    apply's CALL returns to its caller with status=Faulted
+    apply state is discarded (per fault semantics; sub-tree atomicity)
+```
+
+The fault is mode-aware-decided but apply-visible-uniform: apply
+just experienced a fault during a yield. Apply doesn't know why
+kernel decided to fault.
+
+**Implication for the calling layer**: when chain.apply or
+endpoint.process or endpoint.verify encounters a Faulted attest,
+it can:
+- Treat the entire event/transaction as invalid (drop it).
+- Move on to next event (per chain-spec policy).
+
+The fault propagates through cascade just like any other fault. The
+caller's apply gets Faulted signal in phi[8] and can decide how to
+proceed.
+
+For per-event verify (off-chain): fault means event dropped; not
+admitted to buffer.
+
+For per-cycle process (off-chain): fault means... what? The cycle's
+process is per-endpoint, processing all admitted events. If one
+attest yields and faults, the whole process invocation faults. The
+endpoint's process effectively didn't run this cycle. Probably the
+chain spec policy is: drop the dispatch's outputs for this cycle.
+
+For chain.apply (on-chain): fault means block invalid.
+
+## Block-level vs event-level attestation
+
+Two distinct concepts in legacy spec, both relevant in v3:
+
+**Block-level attestation_traces**: sigs proposer attached to the
+block as a whole. Used for things like the block's Schedule entries
+(per legacy 04-kernel-loop).
+
+**Event-level attestation_traces**: sigs included in each event's
+payload. Used for verifying incoming events have proper attestations.
+
+Both flow into kernel.current_traces during the relevant context:
+- For event verify: event's own traces.
+- For chain.apply with block-level traces: block.attestation_traces.
+- For chain.apply with Schedule slot: schedule_attestation_traces.
+
+The kernel manages which traces apply at which attest call (based
+on context). Apply sees nothing of this.
+
+## BLS aggregation
+
+For aggregation-pattern (sigscheme used by many validators that
+combine into one final sig):
+
+```
+AA.aggregate(group_key, partial_sig)
+  -- declares: "this validator contributes a partial sig to the
+  --  aggregate for group_key."
+  -- kernel-side processing:
+  --   if verify mode: kernel keeps partial sig for verification
+  --     against the block's aggregated sig.
+  --   if produce mode: kernel collects partials from each
+  --     contributing validator; aggregates at post-HALT; attaches
+  --     to outgoing block.
+```
+
+Same shape as AA.attest: userspace declares; kernel processes per
+mode.
+
+(Implementation note: cross-validator aggregation isn't possible
+during a single apply pass — it requires coordination across nodes.
+Likely the chain spec sets up an aggregation epoch where each node
+contributes during its turn, and the aggregate is produced over
+multiple blocks. Out of scope for this doc.)
+
+## Cross-chain attestations
+
+External chain's block headers (verified via known external pubkeys):
+
+```
+endpoint.apply, processing a cross-chain claim:
+  parse external_block_header from blob
+  for each (key, sig) in header's sig set:  -- userspace just declares;
+                                            -- doesn't see sig
+    AA.attest(key, header_hash)
+  -- kernel:
+  --   verify mode: looks up sig in incoming traces; hw_verify
+  --   produce mode: signs with local equivalent (if applicable)
+```
+
+External pubkeys live as ordinary chain state (Cap::Data in chain's
+cnode); known to chain spec; userspace bytecode references them.
+No special cap kind for "external attestation."
+
+## Summary
+
+- AA.attest(key, blob) → AttestStatus is the generic authority
+  pattern's request/response cycle: AA builds an Attest request
+  Instance, yields up, kernel handles, returns mode-invariant status.
+- Userspace sees no mode, no traces, no sig. Just declares a (key,
+  blob) and reads back a status enum.
+- The status enum is mode-invariant — produce mode and verify mode
+  return the same value for the same apply-visible inputs. Consensus
+  is structurally safe.
+- Kernel processes per-attest at the yield boundary:
+  - verify-mode: hw_verify against incoming traces; fault on failure.
+  - produce-mode: seen-rule + local-key signing; fault on rule
+    violation if local emit needs signing.
+- The Attest Instance's inspection endpoint
+  (`get_request_for(witness)`) and `fulfill(answer_witness)` both
+  use cap-passed witness checks via `host_same_type_as` against
+  pinned exemplars. Intermediates routing the cascade cannot mint a
+  Instance whose chain matches the exemplar, so they can neither read
+  (key, blob) nor fabricate a valid fulfill — V7 confidentiality
+  and V6 integrity preserved structurally.
+- Early-discard: kernel can fault apply if attest can't be
+  satisfied. Saves wasted computation in deterministic-failure cases.
+- AA Instance is kernel-derived per cycle/per event; transient;
+  image_hash-chain canonical.
+- The seen-rule ensures subscription consistency: keys signed for
+  must have been observed via incoming verifies in the same cycle.
+
+This is the canonical v3 attestation mechanism. It is one
+instantiation of the generic authority pattern documented in
+[../userspace/generic-authority-pattern.md](../userspace/generic-authority-pattern.md);
+see that doc for the broader request/response Instance structure,
+forgery-resistance argument via image_hash chain, and the V1–V9
+security analysis.

--- a/docs/spec/discussions/cap-scopes.md
+++ b/docs/spec/discussions/cap-scopes.md
@@ -1,0 +1,468 @@
+# Cap scopes — revocation without CDT
+
+This doc captures a design move that came out of a long thread on whether
+v3 needs Capability Derivation Trees (CDT). The short answer: **no — not
+in the seL4 sense.** Once you commit to two postulates we already
+implicitly hold (everything is addition-only at the protocol layer, and
+the system is by-value), revocation collapses into something much
+simpler: **caps carry a scope; scope is validated lazily on use;
+context boundaries are the natural revocation event.**
+
+This doc records why CDT was rejected, what replaces it, and the small
+extensions needed to make scope-bound caps work cleanly.
+
+## Background — what we were trying to solve
+
+We had a set of use cases that *looked like* they needed CDT-style
+atomic revocation:
+
+- **Gas meters.** A Gas cap points at a kernel-maintained meter. Many
+  copies exist during execution. At block (or invocation) end, the meter
+  is "gone." All outstanding copies should be invalid.
+- **UserEndpointCap.** ChainOrchestrator hands out caps to user-contract
+  endpoints. If a user contract is removed (or retired), all caps to it
+  should become invalid.
+- **StorageQuota.** Same shape: a quota meter, possibly many cap copies,
+  invalidation needed when the quota is decommissioned.
+
+The natural CDT instinct: kernel maintains back-references from each
+revocable entity to every slot holding a cap pointing at it. On revoke,
+walk the back-references and zero each slot atomically.
+
+This works in seL4 because seL4 caps are linear and live in known
+cnode slots that the kernel tracks. **It does not work in our system.**
+
+## Why CDT is structurally wrong here
+
+Two properties of our system rule out the CDT-with-sidecar approach:
+
+### 1. We are by-value
+
+Caps are self-contained data. Their meaning is determined by the cap's
+own content plus content-addressable σ lookups (image_hash →
+code_blobs, file_id → data_blobs, etc.). There is *no* kernel-tracked
+graph of "Instance A is the parent of Instance B" or "slots S1, S2 hold caps
+to entity X."
+
+This invariant matters because it's what makes cross-context
+operation work. State can be serialized, transferred to another
+kernel context (an L1↔L2 bridge, a re-execution, a light client),
+and rehydrated. There are no dangling references because there are
+no references — content travels in the cap, σ entries rehydrate by
+content hash, and the system runs identically.
+
+CDT with kernel-side back-references breaks this invariant. The moment
+you add `prev_instance`, `children`, or `cap_back_refs` as kernel-tracked
+fields, you've introduced a graph of mutual references that isn't
+self-contained in any single value. Moving an Instance cross-context
+would mean either dragging the entire reference graph (recursively
+unbounded), or producing an Instance whose back-references no longer
+point anywhere meaningful.
+
+### 2. We are addition-only at the protocol layer
+
+Blockchain state only grows. User contracts are not destroyed; once a
+piece of state is in σ, it stays in σ (subject to garbage collection
+under explicit gas/quota accounting, but never via "the owner
+destroyed it" semantics that the rest of the system has to react to).
+
+CDT's central operation is **destruction**. It exists to handle "I
+deleted X; propagate the invalidation to everything derived from X."
+In a system where you cannot delete X, there's no propagation to
+manage. There is no "the user contract was destroyed" event in pure
+addition-only — only "the user contract is no longer being called,"
+which doesn't need kernel mechanism.
+
+So we were trying to solve a problem the system doesn't actually
+have, and importing seL4 intuitions that depend on properties
+(linear caps + deletion) we don't share.
+
+## The reframing — dangling arises at context boundaries
+
+The use cases that *looked* like they needed revocation
+(Gas, scope-bound resources) are actually about **context lifetimes**,
+not about explicit destruction.
+
+A clean way to see this: **every invocation is conceptually its own
+kernel.** Call it Kernel_N. Kernel_N has:
+
+- Its own Gas budget, materialized as a meter in σ tagged with
+  Kernel_N's identity.
+- Its own ephemeral working state — Instances spawned mid-call, scratch
+  CNodes, etc.
+- Its own active invocation context: the call stack rooted at this
+  invocation.
+
+Kernel_N runs, terminates (HALT, Faulted, or Yield-up-into-caller).
+The next invocation conceptually starts Kernel_{N+1}: fresh budget,
+fresh ephemeral state, fresh call stack.
+
+In this framing, **a Gas cap minted by Kernel_N is scoped to Kernel_N's
+lifetime.** If someone preserved it past Kernel_N's end (e.g., stashed
+it in a long-lived Instance's cnode), it's now in a context (Kernel_{N+1})
+where its issuing kernel no longer exists. The cap is dangling.
+
+Same for the C-moved-from-B-to-D case. Inside a single invocation
+context, the call stack is `Kernel → A → B → C`. C's cnode might
+contain caps that referenced B-local state (a sub-Instance B spawned,
+a scratch CNode B passed in). If C is moved out of B's cnode and
+ends up in `Kernel → D → C`, those B-local references are now in
+D's context. They don't resolve. They dangle.
+
+**Dangling is the natural consequence of context boundaries plus
+ephemeral state.** It happens whether or not we have an explicit
+destroy operation. The system doesn't need to destroy anything
+explicitly — the boundary itself is the revocation event.
+
+## Cap scopes — the design
+
+The mechanism is small. Each cap that refers to scope-bound state
+**carries a scope tag**. On use, the kernel validates the tag against
+the current context. Mismatch → fault.
+
+### Scope vocabulary
+
+A handful of scope kinds covers what we need:
+
+| Scope | Lifetime | Examples |
+|---|---|---|
+| **Chain** (∞) | Forever; durable across all invocations | `Cap::Image` (content-addressed), persistent vault Instances, account state |
+| **Block** | One block apply | (rare; useful for block-scoped consensus state) |
+| **Invocation** (Kernel_N) | One invocation, from CALL to HALT/Fault/return-of-control | Gas meter, invocation-local ephemeral Instances |
+| **Instance** (Instance F's activation) | One Instance's running activation within an invocation | Working CNodes B passes to C, scratch slots, sub-Instances B spawned |
+
+Chain-scoped caps have no scope tag — they're "always valid"
+(content-addressable, durable). The other three scopes carry a tag
+that identifies the originating context.
+
+### Cap representation
+
+A scope-bound cap looks like:
+
+```
+Cap::Foo {
+    payload: ...,                  // the cap's actual content
+    scope: Scope,                  // tag identifying scope context
+}
+
+enum Scope {
+    Chain,                         // no tag — always valid
+    Block(BlockId),
+    Invocation(InvocationId),      // monotonic per invocation
+    Instance(InstanceActivationId),      // monotonic per activation
+}
+```
+
+`InvocationId` and `InstanceActivationId` are kernel-issued monotonic
+identifiers, assigned at invocation/activation start. They are
+**not** persistent identities of any object — they identify the
+*scope*, not the *thing*. Once that invocation or activation ends,
+the id is conceptually retired (never reused).
+
+### Validation on use
+
+Each operation that consumes a cap goes through scope validation
+against the current context:
+
+```
+fn validate_scope(cap_scope: Scope, current_context: Context) -> Result {
+    match cap_scope {
+        Scope::Chain => Ok,                              // always valid
+        Scope::Block(b) => if current_context.block == b { Ok } else { Err },
+        Scope::Invocation(i) => if current_context.invocation == i { Ok } else { Err },
+        Scope::Instance(f) => if current_context.instance_activation == f { Ok } else { Err },
+    }
+}
+```
+
+The kernel keeps the current `Context` (block, invocation, instance
+activation) on the active call stack. Validation is O(1) — a
+handful of integer comparisons. No back-refs, no graph walks.
+
+A scope-mismatch fault is **soft**: the consuming operation fails
+(returns an error to the caller instance), but the system continues.
+This is the same as any other capability-resolution failure (cap
+malformed, image hash unknown, etc.). The instance holding the bad
+cap can choose to ignore the error, clean its slot, or propagate.
+
+### Lazy slot cleanup
+
+Slots holding stale caps don't need to be eagerly zeroed. They
+contribute their 32-ish bytes to state-root, faulting on every
+attempted use, until something writes a fresh value to the slot
+(or the containing structure is itself dropped). For typical
+workloads — Gas caps that live in transient instances that are
+themselves discarded at invocation end — this is fine: the slot
+goes away with its instance.
+
+For the rare case of a stale cap stuck in a long-lived structure
+(an old Gas cap that someone stashed into a vault slot), it stays
+as garbage forever. State bloat is bounded by how many such
+accidents the design permits, which is small in practice — Gas
+caps don't *want* to be stashed cross-invocation; the discipline
+is enforced by the fact that doing so produces a useless cap.
+
+## Worked examples
+
+### Gas
+
+Setup at invocation start:
+
+```
+Kernel_N starts.
+  Mint gas meter entry into σ.gas_ledger at slot M with:
+    bytes_remaining: <budget>
+    scope_invocation: N
+  Mint Cap::Gas { meter: M, scope: Invocation(N) }, place in the
+    callee's BareInstance at a known slot.
+```
+
+During execution:
+
+```
+Anyone holding the Gas cap can MGMT_COPY it to other slots in their
+  cnode, or pass it as an argument to a sub-call. The cap content
+  is the same everywhere; scope tag is Invocation(N).
+
+To consume gas:
+  host_gas_consume(cap_slot, amount)
+  Kernel:
+    cap = read slot
+    validate_scope(cap.scope, current)   // Invocation(N) == N ? yes
+    meter = σ.gas_ledger[cap.meter]
+    meter.bytes_remaining -= amount      // (or fault on underflow)
+```
+
+At invocation end:
+
+```
+Kernel_N terminates.
+  σ.gas_ledger[M] may stay in σ (lazy cleanup) or be reclaimed
+    explicitly by the validator's apply logic. Either way:
+  Any leftover Cap::Gas { scope: Invocation(N) } in any slot is now
+    naturally invalid — current invocation is N+1, validation fails.
+
+Kernel_{N+1} starts.
+  Fresh meter M' minted, scope Invocation(N+1). New caps.
+```
+
+The "all Gas caps die at invocation end" property falls out of scope
+validation. No cascading destroy. No back-refs. No bookkeeping.
+
+### C moved B → D
+
+Inside one invocation (Kernel_N):
+
+```
+A → B → C is the call stack.
+B's cnode contains sub-Instance X, scope-tagged Instance(B_activation).
+B passes Cap::Instance { X, scope: Instance(B_activation) } as an arg to
+  C (placed in C's incoming scratchpad slot).
+
+C returns; B continues; eventually the chain returns to Kernel_N.
+```
+
+Later, in a separate invocation (Kernel_{N+5}):
+
+```
+D → C is the new call stack. C still has the cap to X in some slot.
+D calls into C; C tries to use the cap.
+  Kernel reads cap: scope = Instance(B_activation)
+  Current instance activation: some new id, ≠ B_activation
+  validate_scope → fail. Operation faults.
+```
+
+C's "stale" reference to X is detected on use. C can handle the
+failure (return error, clean the slot, fall back). No cascading
+cleanup needed; the bad slot just doesn't resolve until C is asked
+to use it.
+
+If C had instead been passed a chain-scoped cap (`Cap::Image` for some
+content-addressed image, say), validation would pass regardless of
+which invocation C is currently running in. Chain-scoped caps are
+the durable carry-across vehicle; everything else is context-bound.
+
+### UserEndpointCap (and the absence of revocation)
+
+In addition-only:
+
+```
+ChainOrchestrator creates a user contract for endpoint X.
+  user_contract X lives in σ forever.
+  Cap::Instance { X.instance_ref, scope: Chain } can be distributed widely.
+
+Some time later, X becomes "deprecated" — no one wants to use it.
+  X is still in σ. Caps to it still resolve successfully.
+  But: X's own code might check a flag and refuse calls, or its
+    CO-side dispatch entry might be unhooked. The caps remain
+    structurally valid; their utility is zero by convention.
+```
+
+No kernel revocation needed because no kernel destruction happens.
+Deprecation is a userspace concern (CO's policy, X's code), not a
+kernel one. Caps "going stale" in this sense is purely about who
+will honor them, which is downstream of the cap system entirely.
+
+### StorageQuota
+
+Same pattern as Gas. A quota meter in σ.storage_quotas with a scope
+tag (Invocation for per-call quotas, Chain for durable per-actor
+quotas). Caps carry the scope. Validation on use. Scope-end is the
+natural cleanup event.
+
+## Why this is sufficient
+
+CDT was attractive because it gave us *atomic* revocation: at the
+moment of destroy, every outstanding reference is dead. We were
+asking what we'd lose by giving that up.
+
+The answer turns out to be: nothing important, because:
+
+1. **The use cases that needed atomic revocation were all
+   scope-bound.** Gas, ephemeral Instances, scratch caps — they're
+   meant to live for one invocation or activation. Scope validation
+   gives atomic revocation at the boundary, for free.
+
+2. **The use cases that aren't scope-bound (durable caps) don't
+   need revocation in addition-only.** Caps to user contracts, Cap::Image
+   to durable code blobs, account-state references — these are
+   forever, and the user contracts they reference are also forever.
+   Deprecation is a policy concern, not a kernel one.
+
+3. **The dangling state in practice is tiny.** Real workloads don't
+   stash Gas caps cross-invocation (no useful purpose). The accidents
+   that produce truly dangling slots are rare; the slot bytes are a
+   negligible state-root contribution; lazy cleanup absorbs them.
+
+So we get atomic revocation where we need it (scope end), and the
+absence of revocation where we don't need it (durable state). The
+small price is the scope tag on each scope-bound cap — a handful of
+bytes per cap, an O(1) check per use.
+
+## Cross-context preservation
+
+Scope tags interact with bridging exactly the way we want:
+
+- **Chain-scoped caps** (Cap::Image, durable Cap::Instance) carry no
+  tag, are content-addressable, and resolve identically in any
+  context that has the referenced σ entries installed. Bridging
+  works.
+
+- **Block/Invocation/Instance-scoped caps** carry a tag specific to the
+  originating kernel's context. In a different kernel (an L1
+  importing an L2 Instance state), the tag doesn't match; the cap
+  faults on use. This is **correct behavior** — those caps were
+  never meant to leave their context.
+
+A bridge that imports L2 state into L1 will end up with chain-scoped
+caps still valid (they were durable; they remain durable) and
+scope-bound caps naturally invalid (they were context-local; the
+context isn't there). The L1 Instance[L2] can reproduce L2's
+InstanceHash from the imported state (chain-scoped content), and any
+ephemeral Gas-style caps in that state just won't resolve — which
+is what we'd want from the start, since L1 isn't a continuation of
+L2's invocation.
+
+## What's new in the spec
+
+This design needs:
+
+1. **`Scope` enum on every scope-bound cap kind.** Cap::Gas,
+   Cap::StorageQuota, and any future scope-bound caps carry a
+   `scope: Scope` field. Cap::Image stays untagged (implicitly
+   Chain).
+
+2. **Invocation and instance-activation ids in the kernel's call context.**
+   Monotonic counters, assigned at invocation start and at each Instance
+   activation. Accessible via the kernel's current-context state.
+
+3. **`validate_scope` in cap-resolution paths.** Every host call or
+   cap-consuming op runs the check before acting. Failure is a soft
+   fault (operation returns error; instance continues).
+
+4. **No new cap kind, no Instance field, no σ-side back-ref structure.**
+   This is the entire delta. `prev_instance`, `children`, `cap_back_refs`,
+   `Cap::Anchored` — all not needed and not added.
+
+## What's NOT needed (rejected paths)
+
+| Path | Reason for rejection |
+|---|---|
+| `Cap::Anchored { authority_id, instance_id }` new cap kind | Solves problem we don't have (revocation in addition-only is just scope-end). |
+| `prev_instance` chain as Instance identity | Imports cross-Instance references that break by-value cross-context portability. |
+| `children` index + `cap_back_refs` on Instance | Same — kernel-side reference graph that doesn't survive cross-context transfer. |
+| Authority + Instance sub-objects on Instance | Heavier than needed; the σ ledger pattern already handles every concrete case. |
+| Per-cap badging (seL4-style) | Adds cap-copy identity we don't need; scope tag is sufficient. |
+| Global CDT walker / destroy cascade | No destruction in addition-only; cascade has no event to react to. |
+
+## Open questions
+
+A few details that the implementation should pin down:
+
+1. **What exactly is "an invocation"?** The cleanest cut is "one call from
+   the outermost kernel entry point to its return" — i.e., one transact
+   dispatch, or one apply_block phase. This matches the Gas budget
+   shape. But block-level Gas (block-wide budget shared across many
+   tx invocations) would suggest Block scope as the natural cut.
+   Probably we want both: invocation-scoped Gas for per-tx accounting,
+   block-scoped for chain-level budgets. The vocabulary supports it;
+   the question is which apply where.
+
+2. **Instance-activation scope: needed in practice?** Instance scope is the
+   finest granularity (one activation of one Instance's call). Most
+   ephemeral caps probably want Invocation scope (one full invocation),
+   not the activation-level fineness. Instance scope might be unused in
+   practice. Worth seeing if the use cases (B passes scratch CNode to
+   C, etc.) really need it or if Invocation suffices.
+
+3. **Soft fault semantics.** When scope mismatch happens, what exactly
+   does the consuming op return? Probably the same shape as any
+   capability-resolution failure (a kernel-defined error variant).
+   Worth specifying so userspace can pattern-match on it cleanly.
+
+4. **State-root encoding of scope tags.** Caps with embedded `Scope`
+   need a canonical encoding. Easiest: discriminant byte + payload
+   (BlockId / InvocationId / InstanceActivationId as u64). Straightforward
+   extension to existing cap encoding.
+
+5. **Gas ledger lazy cleanup.** Old gas meter entries in σ.gas_ledger
+   contribute to state size. Validator can opt to reclaim them
+   explicitly at block end (since they're never useful after their
+   invocation ends), or leave them as lazy garbage. Probably we
+   want explicit cleanup at block apply end for tidiness — but it's
+   a state-management decision, not a correctness one. Reclamation
+   is safe: the only caps referencing the entry have a stale scope
+   tag and will fault regardless.
+
+## Relationship to other v3 design docs
+
+- Supersedes the (never-written) `discussions/instance-cdt.md` and
+  `discussions/authorities-and-revocation.md` ideas. CDT and authority
+  ledgers are not added; scope tags replace both.
+- Confirms and elaborates the kernel/invocation lifecycle described
+  in [[kernel-chain-interface]]. Each cycle's setup/teardown is
+  where invocation-scope state lives and dies.
+- Orthogonal to [[attestation-authority]]. AA records carry no scope
+  beyond the kernel's processing of the apply call; the seen-rule and
+  signing machinery are not affected by this doc.
+- Confirms what `discussions/sel4-mapping.md` already noted in its
+  deeper-linearity analysis: many seL4 patterns don't translate to
+  v3 because v3's by-value + addition-only properties replace them
+  with structural simpler mechanisms.
+
+## Summary
+
+The CDT excursion was solving the wrong problem. In a by-value,
+addition-only system, "revocation" is really "scope-end," and scope-end
+is structural — it's the boundary between one invocation and the next,
+or one instance activation and the next. Caps that should live across
+boundaries (chain-scoped, content-addressable) work unchanged; caps
+that shouldn't (Gas, ephemeral resources) carry a scope tag and fail
+gracefully when used out-of-scope. The kernel needs nothing more
+than O(1) scope validation on cap use, and the userspace pattern
+of "if a cap might be stale, just try it and handle the error" is
+adequate.
+
+This keeps the by-value invariant, keeps cross-context bridging
+working, and avoids importing a substantial chunk of seL4 machinery
+that doesn't fit our world.

--- a/docs/spec/discussions/data-flow-principle.md
+++ b/docs/spec/discussions/data-flow-principle.md
@@ -1,0 +1,864 @@
+# Data flow as the core — and the shared-state trap
+
+This doc captures the architectural insight underlying v3 and the
+detours we've considered (and rejected). It exists so we don't have
+to re-derive the same argument every time the question comes back.
+
+The central claim, stated as a structural invariant:
+
+> **At any moment, each piece of mutable state has at most one
+> in-flight mutator.** This is v3's foundational invariant. v3's
+> control-flow primitives (CALL, YIELD, HALT) and state-disciplines
+> (Instance isolation, hierarchical call stack, by-value content-
+> addressing) are chosen because together they make this invariant
+> structural — enforced by the kernel without needing programmer
+> discipline.
+
+Everything else — fault isolation, sub-fault recovery, the absence
+of rollback infrastructure, the absence of reentrancy bug classes —
+follows from this. When the model feels tortured, it's a sign we're
+trying to violate the invariant.
+
+## Principle vs mechanism
+
+A common source of confusion in our design discussions has been
+conflating the **principle** (the structural invariant we want) with
+the **mechanisms** (specific choices that implement it). Let's
+separate them explicitly.
+
+**The principle:**
+
+> Single-mutator-per-state-unit at any moment.
+
+This is mechanism-agnostic. It can be enforced in multiple ways.
+
+**v3's mechanisms (all of which together enforce the principle):**
+
+1. **Hierarchical call stack.** The kernel maintains a strict stack
+   of in-flight invocations. Exactly one entry is Running at a
+   time; all others are Waiting. The stack discipline enforces
+   single-activation and provides fault-boundary structure.
+
+2. **By-value content-addressing for caps.** Cap::Instance, Cap::Image,
+   Cap::Data, Cap::CNode are content-addressed. MGMT_COPY produces
+   sibling values; mutations diverge per §9 case (b). Two cap
+   copies don't share mutable state — they share initial content,
+   then evolve independently.
+
+3. **Instance isolation via cnode ownership.** Each Instance owns its
+   cnode; no other Instance can directly read or write it. Mutations
+   happen only via the Instance's own bytecode.
+
+4. **Slot-only-updates-at-termination.** An Instance's mutations to its
+   cnode are working state until HALT (commits) or fault
+   (discards). Sub-Instances in the cnode are part of the working
+   state; their mutations during this invocation are subject to the
+   parent's atomicity.
+
+These four mechanisms work together. Each contributes to the
+principle in a different way:
+
+- Hierarchy provides the invocation boundary (fault/linearity).
+- By-value provides the cross-context portability and snapshot
+  universality.
+- Instance isolation provides the structural ownership.
+- Slot-only-updates provides the atomic commit/discard.
+
+**It's important not to confuse any single mechanism for the
+principle.** "By-value caps" is not the principle — it's one
+mechanism. "Hierarchical call stack" is not the principle — it's
+another mechanism. The principle is single-mutator-per-state-unit;
+the mechanisms are how v3 chooses to enforce it.
+
+## The principle, stated precisely
+
+Single-mutator-per-state-unit, in v3 terms, means:
+
+1. **Each Instance is a closed unit of state.** Its cnode is its own;
+   no other Instance can directly read or write it. Mutations happen
+   only via the Instance's own bytecode running its own image's code.
+
+2. **CALL transfers a value (slot[0]); HALT/yield reflects a value
+   back.** Caller hands an input down; callee returns an output up.
+   No state is shared in either direction beyond what's explicitly
+   passed.
+
+3. **YIELD flows upward only; CALL flows downward only.** A child's
+   YIELD sends data up to a prior instance on the stack. A CALL pushes
+   a new instance on top. There is no primitive for a child to
+   initiate downward work in the parent (which would create
+   multi-activation).
+
+4. **In-flight invocations don't share working state.** When A
+   CALLs B, B's working mutations are in B's cnode (or in B's
+   working slot[0]); A's working state is paused but untouched.
+   Their states are isolated.
+
+5. **Termination commits or discards atomically.** An Instance's HALT
+   commits its working state to its persistent cnode atomically. A
+   Instance's fault discards its working state entirely. There is no
+   partial commit, no nested in-progress state across Instances.
+
+These five properties, taken together, are how the
+single-mutator-per-state-unit invariant manifests in v3's design.
+
+## The two pillars of complexity
+
+The architectural cost of *not* adopting this principle is determined
+by two structural properties that, when combined, force transactional
+infrastructure:
+
+### Pillar 1: Shared mutable state
+
+State that can be mutated by more than one in-flight context. The
+two contexts can be:
+
+- Multiple in-flight activations of the same Instance (multi-activation),
+- Multiple paths into the same shared store (global storage),
+- Multiple threads on shared memory (true concurrency).
+
+In each case, mutations by one context are visible (or potentially
+visible) to others.
+
+### Pillar 2: Per-context fault
+
+Faults can happen at any nesting depth, and each context's fault is
+independently observable. Specifically: a sub-CALL's fault doesn't
+necessarily fail the caller — the caller can catch it and recover.
+
+This is what enables `try { sub_call() } catch { recover() }`
+patterns. It's essential for nontrivial composition (try path A; if
+fails, try path B).
+
+### Together: the trap
+
+When **both** pillars are present, the system must implement:
+
+- **Rollback infrastructure** to selectively undo a faulted context's
+  mutations to shared state without disturbing other contexts' work.
+- **Visibility rules** to specify which mutations are observable to
+  which contexts at which times (commit chains, isolation levels).
+- **Fault propagation policy** to define what state survives each
+  fault scenario.
+- **Reentrancy reasoning** for programmers, since shared state plus
+  reentry breaks local-narrative reasoning about their code.
+
+Together this is the entire transactional-memory model. Databases
+need it. Multi-server OS architectures need it. Ethereum-style
+smart contract VMs need it (per-CALL journal of mutations to global
+storage).
+
+It's not impossible to build. It's just expensive — both in kernel
+machinery and in programmer mental load. And every system that has it
+struggles with its consequences (reentrancy bugs, isolation level
+ambiguities, complex fault recovery semantics).
+
+### Either pillar alone is harmless
+
+Disable **shared mutable state**:
+
+- Single-mutator-per-state-unit invariant holds.
+- Multiple contexts may exist, but they each operate on their own
+  state.
+- Faults discard the single context's working state; no other
+  context affected.
+- No rollback infrastructure needed.
+
+Disable **per-context fault** (whole-tx atomicity):
+
+- Faults always propagate to the outermost transaction.
+- Shared mutable state exists but is rolled back wholesale on any
+  fault.
+- Single transaction-scope working state (one overlay, not nested).
+- No per-context rollback; rollback is one bulk operation at tx end.
+
+In either case, the heavy transactional infrastructure is unneeded.
+Only the conjunction creates the trap.
+
+## v3's choice: disable shared mutable state
+
+v3 chose to **disable shared mutable state** by adopting Instance isolation:
+
+- Each Instance owns its cnode exclusively.
+- Sub-Instances have their own cnodes.
+- No state is shared across Instance boundaries during in-flight
+  invocations.
+- Single activation per Instance at a time.
+
+This gives v3:
+
+- **Sub-fault recovery for free, via structural isolation.** When B
+  faults, B's working state is discarded; A's state is untouched
+  (A and B don't share state). A's CALL to B returns Faulted; A
+  recovers or propagates.
+- **No rollback infrastructure.** Fault is simply "discard working
+  state of the faulted Instance." No transactional journaling, no
+  per-activation diffs, no commit chains.
+- **No reentrancy bugs.** Instances can't be reentered while in flight;
+  the structural single-activation invariant prevents the entire
+  class of "B called me back while I was paused" issues that
+  Ethereum-style systems have to mitigate via discipline.
+- **Snapshot universality.** Cap::Instance is content-addressed; copy
+  is structurally simple; no transactional state to consistently
+  capture mid-flight.
+
+The cost v3 pays for this:
+
+- **No intra-Instance reentry.** A single Instance can't have multiple
+  activations sharing its cnode. Patterns that would need this
+  (a handler that mutates state while main is paused) must be
+  rewritten.
+- **Upward calls require a structural mechanism.** A child can't
+  directly invoke an ancestor (that would create multi-activation
+  on the ancestor's state). Instead, the child yields a request up;
+  the ancestor handles in its own bytecode flow.
+
+## Hierarchy is the invocation boundary
+
+A central architectural fact about v3 that's worth stating directly:
+
+> **The hierarchical call stack is the invocation boundary that
+> simultaneously provides sub-tree atomicity (fault propagation) and
+> yield-resume linearity (single-resumer guarantee). These two
+> properties are dual aspects of the same structural discipline.
+> Reentry protection is a free side effect.**
+
+This is a stronger statement than "hierarchy enforces reentry
+protection." Hierarchy is doing three things, and the first two are
+the structural reasons we need it.
+
+### Fault atomicity (sub-tree atomicity)
+
+An Instance's HALT commits its working state — including any mutations
+made by sub-Instances it called during this invocation. An Instance's
+fault discards all of that. The fault propagates up the stack;
+each level can catch it (continue with Faulted status) or
+propagate.
+
+The cascade is structural: if A faults at any point, A's whole
+subtree (B, C, etc.) is unwound. There is no "preserve B and C as
+free-floating Paused" alternative — that would break the
+single-resumer guarantee for yield-resume (see next subsection).
+
+The cascade only works because hierarchy gives us a clear notion
+of "what's in A's subtree": everything pushed onto the stack after
+A by A's invocation.
+
+### Yield-resume linearity
+
+When B is in Waiting state (paused, awaiting a response), the
+single entity that can resume B is structurally determined: it's
+whatever stack entry is directly above B. When that entry HALTs
+(or CALL_RESUMEs, or DROP_RESUMEs), B is the next-top and resumes.
+
+There's no ambiguity. The kernel doesn't need to consult a registry
+or check a cap or look up a target — the stack position tells it
+exactly who resumes whom. **The linearity is structural; not a
+property we maintain via discipline.**
+
+This is what makes Authority caps (and the YIELD-via-cap pattern)
+secure. K's mint of a yieldref cap that targets K's stack position
+gives the cap-holder authority to wake K. Only K can produce the
+response. Because B's stack position is uniquely owned by K (and
+intermediates), only K's response can resume B. No party can fake
+a response from elsewhere.
+
+### Why these two are inseparable
+
+You might wonder: could we have fault atomicity without
+yield-linearity, or vice versa?
+
+**No.** They're dual aspects of the same structural property
+"stack position uniquely determines the relationship between
+entries."
+
+Suppose we tried to keep yield-linearity but allow fault to NOT
+cascade — preserve B and C as Paused-persistent when A faults.
+Then "who can resume B?" is no longer "the stack entry above B"
+(A is gone); it becomes "whoever holds a cap to Paused-B." We've
+broken yield-linearity. Authority caps become insecure.
+
+Suppose we tried to keep fault cascade but allow non-hierarchical
+yield routing — B could yield to any instance, not just the one
+above it on the stack. Then "what's in A's subtree?" becomes
+unclear; we'd need explicit ownership declarations beyond the
+stack structure. We'd be back to manually-maintained hierarchy.
+
+The stack structure provides both properties at once because both
+depend on the same fact: **stack position = nesting depth =
+ownership relation = resumer relation.**
+
+### Reentry protection: free side effect
+
+The single-activation invariant ("at most one Instance is Running
+at any moment, and an Instance can have at most one in-flight
+invocation") follows from the stack: only the top entry is Running;
+the same Instance can appear multiple times in the stack as references
+to its single in-flight invocation. There's never two concurrent
+activations.
+
+This is reentry protection. We get it for free as a side effect of
+the stack discipline.
+
+If we wanted reentry protection alone, we could enforce it via a
+per-Instance mutex without any stack discipline. But that wouldn't
+give us fault atomicity or yield-linearity — those would need
+separate mechanisms.
+
+**So hierarchy is the parsimonious choice: one mechanism, three
+properties.** Drop hierarchy and you'd need to design ownership,
+fault propagation, and continuation routing as separate concerns.
+
+### Why the orchestrator pattern is structurally required
+
+A consequential implication of hierarchy + single-activation: **two
+user contracts cannot directly call each other in v3 if they need
+independent fault isolation.** They must communicate through a
+common parent — the chain orchestrator. This is structural, not a
+design preference.
+
+Why? Trace the alternative.
+
+Suppose A and B hold caps to each other directly (in a hypothetical
+"flat" model). A calls B. Stack: `[..., A, B]`. B wants to call A.
+Single-activation says A can have only one in-flight invocation;
+A is already in-flight. So B's "call back to A" must be a YIELD —
+which pushes a reference to A on top of B. Stack: `[..., A, B, ref(A)]`.
+A's bytecode at its post-CALL point runs as the handler.
+
+But yield(A) and A_original are the same instance. They share fate.
+If yield(A) faults (e.g., during the callback handler logic), A's
+**whole invocation** faults — sub-tree atomicity discards
+everything A was doing, including B (which is in A's subtree).
+
+So **B cannot have a fault scope independent of A** in this
+arrangement. Whatever A's handler does — including reactions to
+B's callback — happens inside A's atomic scope. A bug in A's
+handler kills B's work too.
+
+This is unacceptable for inter-contract communication. Two user
+contracts deserve isolation: A's bugs shouldn't atomically destroy
+B's work, and vice versa.
+
+The resolution: A and B don't directly call each other. They both
+sit as siblings under a Chain orchestrator. Cross-contract requests
+flow through Chain. Chain's bytecode catches sub-faults explicitly:
+
+```
+Chain bytecode handling B's request to call A:
+  status = CALL(A_handler, args)
+  match status:
+    HALT(result) => continue handling B with result
+    Faulted     => either propagate or recover; B sees the
+                    failure as the result of its request
+```
+
+A_handler is invoked freshly from Chain (a separate invocation of
+A from Chain's perspective, sequentially after A's original work
+HALTed). If A_handler faults, Chain catches; B's invocation isn't
+disturbed.
+
+So: **A and B's isolation requires both to be sub-invocations of
+Chain.** Chain's bytecode is the explicit fault-catching boundary
+that gives A and B independent fault scopes.
+
+### Comparison with Ethereum's model
+
+Ethereum permits direct A→B→A calling chains with per-frame fault
+isolation because Ethereum maintains **per-CALL working state on
+shared storage**. Each CALL pushes a frame with its own journal of
+storage mutations. REVERT rolls back that frame's journal; the
+caller continues with the failure result.
+
+This is the per-CALL rollback infrastructure that v3 rejects.
+Ethereum pays:
+- Per-CALL journaling overhead.
+- Reentrancy bug class (DAO-style attacks) requiring discipline
+  (ReentrancyGuard, Checks-Effects-Interactions, etc.).
+- Complex isolation-level semantics for nested transactions.
+
+v3 doesn't pay these costs. The price v3 pays instead is the
+orchestrator-mediated communication pattern: contracts can't
+directly call each other for fault-isolated sub-invocations; they
+go through Chain.
+
+This isn't a workaround — it's the natural shape of v3's design.
+The orchestrator pattern is what v3 *is*, given the principle of
+single-mutator + per-context fault isolation without transactional
+infrastructure.
+
+### The deep architectural derivation
+
+We can now read v3's design as a chain of necessary consequences
+from one principle:
+
+```
+Principle: single-mutator-per-state-unit + per-context fault
+           isolation (sub-fault recovery available to caller).
+
+  ⇒ No shared mutable state across in-flight invocations.
+  
+  ⇒ Single-activation per Instance.
+  
+  ⇒ Hierarchical call stack as the invocation boundary
+    (fault atomicity + yield-linearity + reentry protection).
+  
+  ⇒ Direct A↔B between user contracts cannot provide
+    per-contract fault isolation (because yield-as-callback
+    shares fate with the original invocation).
+  
+  ⇒ Inter-contract communication must go through a common
+    parent (orchestrator) that catches faults explicitly.
+  
+  ⇒ Chain orchestrator is structurally required for any
+    chain with cross-contract calling.
+```
+
+Every step is forced by the previous one given the principle. There
+is no architectural slack here: changing any one step would either
+violate the principle or require additional mechanism (rollback
+infrastructure, multi-activation, etc.) that we've already rejected.
+
+This is why v3's orchestrator pattern feels "obvious" once you
+internalize it — and why competing models (direct cap-flow between
+user contracts, peer-to-peer contract communication, etc.) feel
+attractive but break either the principle or the architecture
+elsewhere.
+
+## The yield/resume direction insight
+
+A consequence of the invocation-boundary view: yield/resume is
+unavoidable but only in one direction.
+
+**Upward yield (data flowing up the call stack from child to caller)**
+is the safe direction. The child's instance is paused; the caller
+resumes and processes the data. No new activation is created in
+the caller; the caller's existing activation just continues from
+where it was paused (its CALL to the child). Single-activation
+invariant preserved.
+
+**Downward call (child invoking a method on the caller, while caller
+is paused)** is the dangerous direction. It would create a new
+activation in the caller while caller's existing activation is
+paused. Two activations on the caller's state → shared mutable
+state within the Instance → invariant violated.
+
+So:
+
+- A child's "I want something from upstream" must be expressed as
+  yield (upward data flow), not as call (downward into upstream).
+- The upstream Instance handles by reading the yielded data at its
+  own paused-CALL point, doing what's needed, and resuming the
+  child.
+- The upstream Instance does NOT get re-entered as a new activation.
+
+This is the structural constraint that prevents v3 from sliding
+into multi-activation. The "Chain handle" pattern that looks like
+a downward call must be implemented as an upward yield (or as a
+kernel-routed direct dispatch that doesn't touch Chain's bytecode
+flow at all). Either way, no multi-activation.
+
+## The stack model in detail
+
+v3's kernel maintains a call stack. Each entry is either:
+
+- **InstanceEntry(instance, pc, slot_state, status)** — pushed by CALL.
+  Introduces a fresh invocation of an Instance.
+
+- **ReferenceEntry(target_position, status)** — pushed by YIELD.
+  Refers to an InstanceEntry at an earlier stack position. Same
+  instance, same PC as the target; PC advances together when
+  active.
+
+Invariants:
+
+- **Exactly one entry is Running at any time** — the top of the
+  stack. All others are Waiting.
+- **Same-instance entries share PC.** If A appears multiple times
+  on the stack (once as InstanceEntry, once as ReferenceEntry from a
+  yield to A), they all reflect A's single PC.
+- **Instance state machine** (visible at the σ layer):
+  Idle ↔ Paused (multi-block persistent pause via DROP_RESUME).
+  All other states (Running, Waiting) are kernel-internal stack
+  accounting; not σ-visible.
+
+ABI primitives:
+
+- **CALL(cap, args)** — push InstanceEntry for target; caller's
+  current Running entry becomes Waiting.
+- **YIELD(yieldref_cap, args)** — push ReferenceEntry to the stack
+  position the cap names; that instance's bytecode resumes.
+- **CALL_RESUME(args)** — pop current Running entry (handler);
+  underlying Waiting entry becomes Running with args in slot[0].
+- **HALT(payload)** — pop current Running entry; commit Instance's
+  working state if this was the Instance's last entry. Underlying
+  entry becomes Running with payload in slot[0].
+- **DROP_RESUME** — bridge from in-flight Waiting to σ-resident
+  Paused. Materializes the topmost Waiting sub-Instance's continuation
+  as Paused-persistent; returns a cap to it; current instance continues.
+- **fault** — like HALT but with Faulted status; cascading discard.
+
+Snapshot semantics:
+
+- **An Instance is snapshottable iff it has zero stack entries.** Idle
+  Instances are snapshottable. Instances with active in-flight invocations
+  (any InstanceEntry or ReferenceEntry on the stack) are not. Paused-
+  persistent Instances are snapshottable (their continuation is
+  σ-resident, not on the stack).
+
+## Detours we've rejected (and why)
+
+Over the course of v3's design we've considered several alternatives.
+Each was a coherent architectural choice; each was ultimately rejected
+because it violated the principle.
+
+### Detour 1: Multi-activation with per-activation rollback
+
+The idea: allow Instances to have multiple in-flight activations sharing
+their cnode. Each activation has its own working diff over the cnode.
+HALT merges diffs upward; fault discards diffs.
+
+Rejected because: this is full transactional infrastructure inside
+the kernel. Per-activation diff overlays, merge-on-commit, discard-
+on-fault, visibility tracking. Heavy. And reintroduces the
+reentrancy bug class.
+
+The path leads to Ethereum-shape semantics — workable but expensive.
+v3 already has sub-fault recovery via Instance isolation; we don't need
+the rollback infrastructure to get it.
+
+### Detour 2: Multi-activation with whole-tx atomicity
+
+The idea: allow multi-activation reentry but eliminate per-context
+fault. Any fault propagates to the transaction root; the whole tx
+reverts. One transaction-scope working state.
+
+Rejected because: blockchains need sub-fault recovery for real
+patterns (try-catch, multi-path retries, conditional execution).
+Whole-tx-only-atomicity is too restrictive. The patterns that would
+use sub-fault recovery would have to be expressed across multiple
+transactions or via pre-validation.
+
+Plus: still has reentry complications (programmer must reason about
+handler interjections during their own code).
+
+### Detour 3: Immutable cnode (purely functional)
+
+The idea: replace mutable cnode with immutable versioned state.
+Each "mutation" produces a new version. Multiple versions coexist;
+faults discard the in-progress version.
+
+Rejected because: for single-activation, this is operationally
+equivalent to mutable cnode (just different implementation). For
+multi-activation, it imports MVCC-style conflict resolution
+(database-flavored). Doesn't simplify; just relocates complexity.
+
+### Detour 4: seL4-style fault handlers in same Instance
+
+The idea: a designated fault-handler endpoint runs when the Instance
+faults, gets access to fault context, can recover or finalize.
+
+Rejected because: the meaningful capability (recovery) requires
+per-context partial commits, which requires rollback infrastructure.
+The non-recovery variants (logging, cleanup) have nowhere useful to
+put their effects in a transactional system — they get discarded
+with the rest. No clean middle ground.
+
+### Detour 5: CDT-style revocation
+
+The idea: import seL4's capability derivation tree for authority
+revocation.
+
+Rejected because: CDT requires kernel-side back-references between
+caps and the contexts that hold them. This creates a graph of
+cross-references that doesn't survive cross-context portability
+(bridging, L2 import, etc.). Breaks the by-value invariant that
+makes v3 work cross-context.
+
+Replaced by structural mechanisms: image_hash chain for forgery
+resistance, scope-tagged caps for ephemeral authority, kernel-
+maintained ledgers for revocable budgets (Gas, etc.).
+
+### Detour 6: Per-cap-copy CDT identity
+
+The idea: each cap copy has its own identity; copies can be
+revoked independently.
+
+Rejected because: cap copies in v3 are content-addressed; making
+them per-copy distinguishable would require kernel-side
+identification of each copy, breaking the by-value model.
+
+Replaced by: caps are membership credentials; revocation is at the
+budget (ledger entry) level, not at the cap level.
+
+### Detour 7: Instance identity (instance_id)
+
+The idea: assign each Instance a stable unique identifier for use in
+revocation, references, etc.
+
+Rejected because: a stable instance_id implies multiple cap copies
+share that id; using one cap implies using all copies' equivalent
+authority (or requires linearity). Either re-introduces shared
+mutable state through the id-lookup channel, or requires linearity
+we already rejected.
+
+Replaced by: caps are by-value with image_hash_chain for type
+identity; no per-Instance identity at the cap level.
+
+### Common pattern in the rejections
+
+Each detour tried to add expressiveness that the data-flow model
+doesn't natively support — reentry, fine-grained revocation, fault
+handler recovery, etc. — and each required either:
+
+- Reintroducing shared mutable state somewhere (multi-activation,
+  CDT back-refs), or
+- Adding transactional infrastructure (rollback, per-context diffs),
+  or
+- Breaking by-value content-addressing (instance_id, per-cap identity).
+
+In each case, the cost wasn't worth the expressiveness gain. The
+patterns chain authors actually need can be expressed via:
+
+- **Cap-flow** (pre-supply caps for everything callee might need).
+- **Yield-cascade** (current v3 upward request pattern).
+- **Kernel-routed direct dispatch** (authority caps that route to a
+  handler without involving caller's bytecode).
+- **Emit/handle** (asynchronous; callee emits, caller processes
+  after callee HALTs).
+- **Saga / compensating actions** (explicit cleanup logic by chain
+  author, not kernel-mediated rollback).
+
+## The checkable invariant
+
+When designing or reviewing a v3 mechanism, the rule of thumb is:
+
+> **Does this introduce shared mutable state across in-flight
+> invocations?**
+
+If yes: the design is on the wrong side of the trap. Look for an
+alternative.
+
+Specific things to watch for:
+
+- **Multi-activation of an Instance.** Two activations sharing a cnode
+  is shared mutable state in flight.
+- **By-reference caps with mutable targets.** Two caps pointing at
+  the same mutable thing creates sharing.
+- **Cross-Instance state graphs maintained by the kernel.** Back-refs,
+  CDTs, sidecar tables tied to specific Instances — these are kernel-
+  tracked shared state.
+- **Yield/resume in the downward direction.** A child invoking the
+  caller is shared activation on caller's state.
+
+Things that are safe (and how v3 makes them safe):
+
+- **Cap::Image / Cap::Data / Cap::CNode copies.** These are content-
+  addressed values; "sharing" is at the value level (multiple slots
+  hold the same hash) but there's no shared mutator because the
+  content itself doesn't mutate — mutating "produces a new value."
+
+- **Cap::Instance copies of the same Instance value.** Same content-
+  addressing semantics. Two slots holding "the same Cap::Instance" both
+  reference the same hash. But the moment one is invoked and mutates,
+  the result is a new hash; the other slot still holds the old hash;
+  mutations diverge per §9 case (b).
+
+  So Cap::Instance copies don't share mutable state in the in-flight
+  sense — they each address a value that evolves independently.
+
+- **Yieldref caps as references to stack entries.** These are
+  by-reference (kernel-managed lifetime tied to a specific stack
+  position) but the referenced thing (a Waiting instance's continuation)
+  has only one resumer at any time by stack discipline. The
+  reference is the routing mechanism; the resumption authority is
+  structural.
+
+- **References on the call stack between InstanceEntry and ReferenceEntry
+  of the same Instance.** Same PC, same cnode, but they don't run
+  concurrently — exactly one entry is Running. The "sharing" is
+  notational across stack positions; it's not multi-mutator.
+
+The deep reason this works: **v3 separates "sharing of identity"
+from "sharing of mutator capacity."** Multiple things can address
+the same value or the same stack entry. But at any moment, only one
+mutator is active. The invariant holds.
+
+## Why this is a genuine architectural advantage
+
+Compared to Ethereum-style transactional state sharing, v3's
+combination of Instance isolation + hierarchical stack + by-value
+content-addressing:
+
+1. **Eliminates the reentrancy bug class structurally.** Bugs like
+   the DAO hack rely on a contract being reentered while its state
+   is mid-update. v3 single-activation prevents this. Chain authors
+   don't need ReentrancyGuard, Checks-Effects-Interactions
+   discipline, etc.
+
+2. **No journaling overhead.** Ethereum maintains per-CALL frame
+   journals of mutations for revert; v3 maintains nothing comparable.
+   Faults are trivial discards.
+
+3. **No isolation-level ambiguity.** Ethereum has to specify when
+   mutations become visible to sub-calls; v3 has no such question
+   because sub-calls have their own state.
+
+4. **Cross-context portability.** Instance state is self-contained;
+   moves cleanly between kernels (L1↔L2 bridging, light-client
+   replay). Ethereum-style transactional state has subtle issues
+   with concurrent / replay scenarios.
+
+5. **Simpler kernel.** Less code, easier to reason about, easier
+   to formally verify.
+
+The cost is real but bounded: no intra-Instance reentry. The patterns
+that would use it can be rewritten via cap-flow, emit/handle, or
+yield-cascade. Most real blockchain patterns don't actually need
+reentry on shared state.
+
+## Why this is robust
+
+We have walked this design space carefully over many discussions:
+
+- Considered CDT (rejected): broke by-value.
+- Considered linearity (rejected): no structural use case in by-value
+  world.
+- Considered multi-activation (rejected): introduces shared mutable
+  state, needs rollback.
+- Considered immutable functional (rejected): operationally
+  equivalent to v3 for single-activation; adds MVCC complexity for
+  multi-activation.
+- Considered seL4-style fault handlers (rejected): the meaningful
+  capability requires rollback.
+- Considered whole-tx atomicity (rejected): too restrictive for
+  blockchain.
+- Considered instance_id (rejected): breaks by-value cap identity.
+- Considered per-cap-copy CDT (rejected): breaks by-value
+  content-addressing.
+
+Every alternative either reintroduced shared mutable state, broke
+by-value semantics, or restricted expressiveness below what
+blockchains need. The data-flow + Instance-isolation model is the
+fixed point.
+
+When we doubt the model, it's worth re-walking these alternatives
+to see if anything has changed. Usually it hasn't, and the same
+arguments still rule them out. The model has earned trust through
+repeated stress-testing.
+
+## What remains to polish
+
+Most details have been resolved through extended discussion. What
+remains genuinely open:
+
+1. **Yieldref cap representation.** The cap carries a kernel-issued
+   stack-entry-id naming the target stack entry. Whether this is a
+   distinct cap kind (`Cap::YieldRef`) or an extension of `Cap::Instance`
+   is a spec-surface choice; behavior is the same either way.
+
+2. **Persistence behavior for yieldref caps.** Soft-scope (cap can
+   live in persistent slots but faults on use outside target's
+   stack lifetime) vs. hard-scope (cap structurally restricted to
+   transit/working slots; kernel rejects MGMT_COPY to persistent
+   slots). Both work; hard-scope is "cleaner" in that stale caps
+   don't exist; soft-scope is simpler kernel.
+
+3. **DROP_RESUME's cap delivery.** When DROP_RESUME promotes B to
+   Paused-persistent, where does the cap to Paused-B go? Returned
+   in caller's slot[0]? Left in a designated slot? Spec choice.
+
+4. **Multi-block pause as an explicit feature.** Whether v3 supports
+   Paused-persistent state at all (vs. OOG-as-fault and explicit
+   chain-author multi-block state machines). Practical/conceptual
+   question; not a structural one.
+
+Things that have been resolved through discussion:
+
+- **Yield is structurally a return** that pushes a reference to a
+  prior stack entry. Same primitive family as CALL/HALT; not a
+  separate concept.
+- **Authority caps work via YIELD on a yieldref cap.** No Request/
+  Response Instance triplet needed; structural linearity from the stack
+  gives us all the security properties (confidentiality from
+  intermediates, replay safety, single-resumer guarantee).
+- **Snapshot universality** is qualified: snapshot iff Instance has
+  zero stack entries (Idle or Paused-persistent at σ layer). This
+  is honest about what's actually true.
+- **Reentry protection is incidental.** The structural reason for
+  hierarchy is fault atomicity + yield-linearity. Reentry protection
+  is a free side effect.
+- **CALL_RESUME's role.** Pop top handler entry; underlying Waiting
+  entry becomes Running. Symmetric with HALT (which pops on
+  termination). Both are "transfer to whoever's below me."
+
+## Summary
+
+**The principle:**
+
+> Single-mutator-per-state-unit at any moment. At no point in v3
+> may two in-flight invocations operate on the same piece of
+> mutable state.
+
+**The trap:**
+
+> Shared mutable state + per-context fault. Together they force
+> transactional infrastructure (rollback, per-context working state,
+> commit chains, visibility rules). v3 avoids this by disabling
+> shared mutable state, not by avoiding per-context fault — sub-
+> fault recovery still works via Instance isolation.
+
+**The mechanisms (how v3 enforces the principle):**
+
+> - Hierarchical call stack — provides the invocation boundary
+>   (fault atomicity + yield-linearity); reentry protection is
+>   incidental.
+> - By-value content-addressing for caps — provides snapshot
+>   universality, cross-context portability, and the structural
+>   "mutations diverge per copy" semantics that prevents shared
+>   mutable state through cap-flow.
+> - Instance isolation via cnode ownership — ensures only an Instance's
+>   own bytecode can mutate its cnode.
+> - Slot-only-updates-at-termination — gives atomic commit/discard
+>   without any rollback infrastructure.
+
+**The checkable invariant when reviewing a design:**
+
+> Does this introduce two simultaneous mutators on the same state
+> unit? If yes, the design is on the wrong side of the trap. The
+> design space we've explored extensively says there's no clever
+> way to opt-in to "just a bit" of shared mutable state without
+> paying the full transactional infrastructure cost.
+
+**The reason this is robust:**
+
+> Every alternative we've considered (CDT, multi-activation,
+> linearity, fault handlers, instance_id, per-cap-copy identity,
+> multi-block yield, whole-tx atomicity, etc.) either violates a v3
+> invariant (single-mutator, by-value, by-value-content-addressing,
+> snapshot universality, cross-context portability) or requires
+> transactional infrastructure that the principle avoids. After
+> walking the design space repeatedly, the fixed point holds.
+
+**The takeaway for future design discussions:**
+
+> When something feels tortured, check whether we're trying to add
+> shared mutable state or per-context recovery on top of shared
+> state. We're not. Either find a way to express the goal without
+> shared mutable state, or accept that the goal isn't achievable
+> within v3's invariant.
+>
+> When something feels naturally to require "the same instance" of
+> an Instance across multiple positions: check whether the call stack's
+> reference-entry mechanism (same instance, different stack positions,
+> shared PC) captures it. Usually it does.
+>
+> When designing authority or routing: check whether the hierarchical
+> stack already gives you the structural property you want (single
+> resumer, fault atomicity, scope-bound caps). Usually it does, and
+> the right answer is "use the stack, don't reinvent it."
+
+If a future design discussion seems to be drifting into
+multi-activation, rollback, per-context working state, by-reference
+caps in persistent storage, or non-hierarchical fault routing —
+this is the doc to re-read. The arguments still rule those out.

--- a/docs/spec/discussions/kernel-assisted-instances.md
+++ b/docs/spec/discussions/kernel-assisted-instances.md
@@ -1,0 +1,584 @@
+# Kernel-assisted Instances
+
+This doc captures a unifying design pattern that emerged from
+considering how the kernel manages resources (yield routing, gas
+accounting, storage quotas, future kernel-mediated operations).
+The pattern is: **kernel resources are exposed via the Instance
+abstraction, with kernel short-circuit for performance.**
+
+Four supporting principles, three concrete instances, one minimal
+kernel-to-userspace interface.
+
+## The four design patterns
+
+These patterns, taken together, define how kernel resources fit
+into v3's uniform Instance-based model.
+
+### Pattern 1: Kernel uses normal Instances for storage-shaped state
+
+When the kernel needs to maintain state that userspace will interact
+with, that state lives in an Instance — not a special kernel-only data
+structure. The Instance might have a kernel-implemented Image (the
+"kernel-assisted Instance" concept below), but it's structurally a
+Instance: has a place in the system, has endpoints, can be cap-flowed.
+
+This means there's no parallel "kernel registry" / "kernel table"
+data type. Just Instances, consistently.
+
+### Pattern 2: Read access via raw DataCap
+
+When an Instance needs to give read access to its state to other parties,
+the standard pattern is to expose a `read() → Cap::Data` endpoint
+that serializes the relevant portion of state as a DataCap. Copy is
+free (content-addressed), so cheap; readers can iterate offline at
+no further kernel cost.
+
+This is the canonical read pattern. It's used by both:
+- Kernel-assisted Instances offering read access to their internal state.
+- Regular userspace Instances offering read access to their data.
+
+### Pattern 3: Kernel short-circuit for performance
+
+When the kernel itself needs to access the state of a kernel-assisted
+Instance (e.g., debit gas per instruction), it does so directly — not
+via the Instance's endpoints. The kernel knows the layout (since the
+Image is kernel-implemented) and reads/writes the struct directly.
+
+This keeps the Instance abstraction in place at the user-facing level
+without imposing endpoint-dispatch cost on the kernel's fast path.
+Userspace sees an Instance; kernel internally uses a struct. Same data;
+two views.
+
+### Pattern 4: Storage cost via dirty-page tracking
+
+Storage and memory are unified: the cost of state is the cost of
+its bytes. Specifically:
+- **Copy is free.** Content-addressed values can be referenced from
+  multiple places at zero cost.
+- **Write costs per page.** Mutating state dirties pages; each dirty
+  page is charged to a storage quota.
+- **Page size: 4 KiB**, matching the underlying JAVM page size.
+- **Dirty-page tracking clears when an Instance leaves the stack
+  entirely** (stack-leave reset, not per-CALL push/pop). This
+  matches "dirty until commit" intuition: while an Instance remains on
+  the stack across nested calls, its dirty set persists; once it
+  leaves the stack, the dirty set is finalized and charged.
+
+## The kernel-assisted Instance concept
+
+A **kernel-assisted Instance** is an Instance whose Image lives in a
+special `kernel:` namespace (e.g., `kernel:yieldcatcher`,
+`kernel:gasmeter`). Properties:
+
+- **Image is kernel-implemented in native code.** No userspace
+  bytecode runs; kernel implements the endpoints directly.
+- **State layout is a kernel-known struct.** Not a generic cnode of
+  arbitrary caps; the kernel reads/writes the struct directly.
+- **Kernel can short-circuit access** to the state during execution
+  (per Pattern 3).
+- **Userspace interacts via standard CALL on endpoints.** No
+  special ABI for talking to kernel-assisted Instances.
+- **Could in principle be reimplemented in pure JAVM bytecode.** The
+  kernel implementation is for performance and simplicity; the
+  abstraction is plain Instance.
+
+The kernel namespace prefix is documentation convention; mechanically
+kernel-assisted images are just well-known image_hashes baked into
+kernel code.
+
+### Creating kernel-assisted Instances
+
+Some kernel-assisted Instances require a kernel-issued capability to
+create (e.g., `CreateYieldCatcher`, `MintGas`). Holders of the
+factory cap can derive instances via the standard host call (kernel
+checks the factory cap is held before allowing the derive).
+
+This makes "having a kernel-managed resource" a capability — gated
+by cap-flow, like everything else.
+
+Other kernel-assisted Instances exist only at the kernel level
+(GasMeter, StorageQuota) and aren't user-derivable. They're
+internal kernel state, accessed only via specific kernel-issued
+caps (SetGasMeter, SetStorageQuota).
+
+## Where things live (hierarchical placement)
+
+The three concrete instances split into two categories by where
+they live:
+
+### Per-Instance (local) kernel-assisted Instances
+
+These live in user Instances' cnodes; one per user Instance as needed:
+
+- **YieldCatcher** — held in a user Instance's `yield_marker_slot`.
+  Each Instance has its own YieldCatcher (or none if it doesn't catch
+  yields).
+
+### Kernel-internal kernel-assisted Instances
+
+These live at the kernel level (not in any user Instance's cnode):
+
+- **GasMeter** — the global table of active meter values.
+- **StorageQuota** — the global table of active quota values.
+
+User chains never hold `Cap::Instance[GasMeter]` or
+`Cap::Instance[StorageQuota]`. These are kernel implementation detail.
+Userspace interacts with them only via kernel-issued caps (SetX).
+
+### Per-Instance unit handles (regular Cap::Instances)
+
+These are unit caps that name entries in the kernel-internal Instances:
+
+- **Gas{meter_id}** — names a meter in GasMeter. Held in Instance
+  cnodes; declared in `gas_slots`.
+- **Quota{quota_id}** — names a quota in StorageQuota. Held in
+  Instance cnodes; declared in `quota_slots`.
+
+Gas and Quota are kernel-assisted Instances (kernel-known images), but
+their state is just an opaque identifier; conservation lives in the
+kernel-internal GasMeter/StorageQuota, not in the unit cap itself.
+
+## The three instances, in detail
+
+### YieldCatcher (per-Instance, kernel-assisted)
+
+```
+Image: kernel:yieldcatcher
+State (kernel struct):
+  markers: Vec<Cap::Instance[YieldMarker]>  -- the set of markers
+                                            this Instance catches
+
+Endpoints:
+  add(marker: Cap::Instance[YieldMarker]) -> ()
+    Add marker to the catch list.
+  remove(marker: Cap::Instance[YieldMarker]) -> ()
+    Remove marker from the catch list.
+  read() -> Cap::Data
+    Serialize the marker list as a DataCap for reading.
+
+Creation: requires Cap::Instance[CreateYieldCatcher] (kernel-issued).
+Held in user Instance's yield_marker_slot (declared in Image).
+Kernel short-circuits access during YIELD routing.
+```
+
+A user Instance's Image declares `yield_marker_slot: Option<SlotIdx>`.
+That slot, if set, must hold a `Cap::Instance[YieldCatcher]`. When the
+kernel walks the call stack to route a yield, it consults each
+Instance's YieldCatcher's marker list directly (via short-circuit).
+
+For yield routing details, see §14 in README.
+
+### GasMeter (kernel-internal, kernel-assisted)
+
+```
+Image: kernel:gasmeter
+State (kernel struct):
+  meters: Map<MeterId, RemainingGas>  -- the active set
+
+Endpoints (only callable via SetGasMeter cap):
+  set(meter_id: u64, value: u64) -> u64
+    Atomically set GasMeter[meter_id] = value; return previous value.
+    (Returning previous enables read-while-write for harvest.)
+    If no entry exists for meter_id, "previous" is 0 and a fresh
+    entry is created at value.
+
+Lifecycle:
+  At block start: kernel initializes
+    meters = { root_meter_id: <chain-spec block budget> }
+  During block: chain populates lazily via SetGasMeter using
+    chain-chosen meter_ids (kernel is stateless across blocks, so
+    meter_id assignment is necessarily chain-managed).
+  At block end: kernel discards GasMeter entirely (kernel is
+    stateless across blocks).
+
+Access:
+  Read by kernel during execution (short-circuit, debit per instruction).
+  Modified by holder of SetGasMeter cap (chain-issued).
+  Userspace never reads directly — implicit via SetGasMeter's return
+    value or via OOG yield payload.
+```
+
+GasMeter is kernel-internal. Chain doesn't hold `Cap::Instance[GasMeter]`.
+The only path to GasMeter from userspace is via the `SetGasMeter`
+cap, which both writes and returns the previous value (atomic).
+
+### Gas{meter_id} (per-Instance unit handle)
+
+```
+Image: kernel:gas
+State (kernel struct):
+  meter_id: u64  -- the meter this cap names
+
+Endpoints: (none meaningful for users; kernel reads state directly)
+
+Creation: requires Cap::Instance[MintGas] (kernel-issued).
+  Caller supplies meter_id (chain-chosen — kernel cannot assign
+  uniquely without persistent state). Chain is responsible for
+  meter_id uniqueness; collisions silently alias to the same meter.
+
+Held in: user Instance's gas_slots (Image-declared).
+Used: when kernel debits gas during execution, it reads meter_id
+  from the active gas slot and decrements GasMeter[meter_id].
+```
+
+Gas caps are regular Cap::Instance; can be MGMT_COPY'd freely. Copies
+all name the same meter_id; debiting from any copy debits the same
+meter. **Conservation is preserved by the kernel-internal GasMeter,
+not by cap uniqueness.** Hence no narrow linearity is needed.
+
+### StorageQuota and Quota (analogous to GasMeter and Gas)
+
+```
+StorageQuota:
+  Image: kernel:storagequota
+  Kernel-internal; chain doesn't hold Cap::Instance[StorageQuota].
+  Endpoints (via SetStorageQuota cap):
+    set(quota_id: u64, value: u64) -> u64
+
+  Lifecycle:
+    At block start: kernel initializes
+      quotas = { root_quota_id: <chain-spec block storage budget> }
+    During block: chain populates lazily via SetStorageQuota with
+      chain-chosen quota_ids.
+    At block end: kernel discards StorageQuota entirely.
+
+Quota:
+  Image: kernel:quota
+  Per-Instance unit handle naming a chain-chosen quota_id.
+  Created via MintQuota cap (caller supplies quota_id).
+  Held in user Instance's quota_slots.
+```
+
+Same pattern as Gas. Kernel debits the relevant quota when pages are
+dirtied per Pattern 4. Userspace allocates via SetStorageQuota and
+the OOG-style pattern (with StorageExhaustedMarker) for lazy loading.
+
+## The minimal kernel-to-chain interface
+
+What kernel issues to the top-level chain Instance at chain init:
+
+```
+Caps in chain's cnode after init:
+  
+  Gas / Storage management:
+    Cap::Instance[Gas{root_meter_id}]      — initial root gas budget
+    Cap::Instance[Quota{root_quota_id}]    — initial root quota
+    Cap::Instance[SetGasMeter]             — modify GasMeter
+    Cap::Instance[SetStorageQuota]         — modify StorageQuota
+    Cap::Instance[MintGas]                 — factory for Gas caps
+    Cap::Instance[MintQuota]               — factory for Quota caps
+  
+  Yield routing:
+    Cap::Instance[CreateYieldCatcher]      — factory for per-Instance catchers
+  
+  (Possibly future: factories for other kernel-assisted Instance types.)
+
+Kernel-issued markers (pre-placed in chain's initial YieldCatcher):
+  OOG_marker            — caught when any meter hits 0
+  StorageExhausted_marker — caught when any quota hits 0
+  (others as needed)
+```
+
+That's the entire kernel ABI for chain orchestration. The kernel
+internals (GasMeter, StorageQuota) are opaque from userspace; only
+the cap-mediated operations are visible.
+
+## The lazy-load OOG-catch pattern
+
+Because the kernel is stateless across blocks, GasMeter starts each
+block with only `{ root_meter_id: <budget> }`. All other meter_ids
+have no entry (effectively zero).
+
+Rather than chain pre-loading every persistent user's meter value
+at block start (which scales linearly with active users), chain uses
+**lazy loading via OOG-catch**:
+
+```
+Setup at chain init (once):
+  chain.GasLedger = (chain's own custom Instance holding 
+                     persistent gas balances per user)
+  chain.YieldCatcher has OOG_marker
+  chain.holds SetGasMeter, MintGas caps
+
+Per-tx execution:
+  1. Chain receives a tx for User_X.
+  2. Chain reads User_X's persistent balance from GasLedger (chain's σ).
+  3. Chain picks meter_id for User_X (chain policy: may reuse the
+     same id across blocks, or freshen per block; both work).
+     If chain doesn't yet hold Cap::Instance[Gas{meter_id}] for it,
+     mint via MintGas(meter_id) and stash in GasLedger.
+  4. SetGasMeter(meter_id, balance)        — topup
+  5. CALL user_contract with gas_cap in gas_slots.
+  6. User runs; kernel debits GasMeter[meter_id].
+  7. If meter hits 0: OOG yield. Chain catches via YieldCatcher.
+       OOG payload: a single Cap::Instance[Gas{meter_id}] copy
+         identifying which meter ran out. No caller context
+         (intentional — see "OOG payload" below).
+       Chain decides: topup more, or fail tx.
+       If topup: SetGasMeter(meter_id, more_balance); CALL_RESUME.
+       If fail: DROP_RESUME (or whatever fault propagation).
+  8. User HALTs.
+  9. remaining = SetGasMeter(meter_id, 0)  — harvest, zero out
+  10. chain.GasLedger.update(User_X, remaining)
+  11. Tx complete.
+```
+
+Properties:
+
+- **No pre-loading.** Chain doesn't iterate over all users at block
+  start.
+- **Bounded by active set.** Only meter_ids of active users get
+  populated in kernel's GasMeter during a block.
+- **SetGasMeter is set-with-return-previous.** Chain doesn't need
+  separate read access; the atomic set+return is sufficient.
+- **OOG handler in chain bytecode controls all gas policy.** Topup,
+  rate limit, subsidize, refuse — all chain logic.
+- **Conservation enforced structurally.** Total spent ≤ sum of
+  SetGasMeter additions; chain bytecode is responsible for ensuring
+  additions match user balances.
+
+The same pattern applies to storage quotas via StorageExhausted_marker.
+
+### OOG payload: just the Gas cap, nothing else
+
+The OOG yield payload is **only** a `Cap::Instance[Gas{meter_id}]`
+copy. No "which call was running," no caller instance_hash, no stack
+context.
+
+This is deliberate. Encoding "which call ran out" would
+reintroduce CALLER information into a capability-only system —
+which is precisely the property v3 avoids (caps name capabilities,
+not call origins). There is also no clean way to encode it: a
+Instance is reentrant across copies, and "call context" is not a
+first-class cap.
+
+The meter_id alone is sufficient. Chain looks meter_id up in its
+GasLedger to find the owning user; that's all the context needed
+to decide topup vs fail. The same logic applies to
+StorageExhausted_marker: payload is a `Cap::Instance[Quota{quota_id}]`.
+
+## Why no narrow linearity is needed
+
+An earlier design exploration considered making balance-bearing
+Instances (Gas, Quota) non-copyable at the kernel level — "narrow
+linearity" for kernel resources. This turns out not to be needed.
+
+The reasoning:
+
+> **The balance is in the kernel-internal GasMeter / StorageQuota
+> table, not in the Gas/Quota unit cap.**
+
+If a user contract holds `Cap::Instance[Gas{meter_id_5}]` and
+MGMT_COPYs it to slot[7], both slots now hold caps to meter_id_5.
+Operations on either slot decrement the same `GasMeter[meter_id_5]`.
+Total spent is the sum of all operations across all copies, bounded
+by the meter's current value.
+
+Cap copies don't duplicate the balance because the balance isn't
+in the cap. The cap is just a handle naming a meter. The meter has
+one value, kernel-controlled, conservation-preserved.
+
+So Gas and Quota are **fully copyable Cap::Instances**. No special
+linearity rule. Conservation via the kernel-internal table.
+
+## Kernel statelessness implications
+
+The kernel maintains no persistent state across blocks. All
+persistence is via σ (chain's own Instances). What this means:
+
+1. **GasMeter restarts each block.** Only `root_meter_id` is
+   initialized; chain repopulates via SetGasMeter.
+
+2. **StorageQuota restarts each block.** Same pattern. (Wrinkle:
+   how does kernel know "how much storage" exists at block start?
+   See "Open questions.")
+
+3. **Chain holds all persistent state in its own custom Instances.**
+   GasLedger, StorageLedger, contract registry, account state,
+   etc. — all standard chain σ.
+
+4. **No kernel-side state-root contributions.** Only chain's σ
+   contributes to state-root computation. Kernel-internal Instances
+   (GasMeter, StorageQuota) are ephemeral; they don't appear in
+   state-root.
+
+5. **Cross-block portability** is preserved because all state lives
+   in chain's σ, which is content-addressed and serializable.
+
+## Conservation invariant
+
+Total gas spent in block ≤ initial root_meter_id budget +
+chain-issued topups.
+
+Because chain is the only entity holding SetGasMeter, and chain's
+bytecode is auditable, conservation is enforceable by inspection of
+chain code: chain must ensure SetGasMeter additions match balances
+debited from chain.GasLedger.
+
+If chain's code is incorrect (adds more gas than balances justify),
+conservation breaks. This is a chain-spec bug, not a kernel bug.
+For deterministic blockchain consensus, this is acceptable: the
+chain's bytecode is what defines the chain.
+
+## Comparison with earlier design attempts
+
+Several earlier approaches were considered and superseded:
+
+| Approach | Issue | Resolved by |
+|---|---|---|
+| Per-Instance Gas with value baked in | Conservation requires linearity (cap copies diverge values) | Kernel-internal GasMeter; Gas caps name meters, don't carry value |
+| Global GasMeter table accessed via Cap::Instance[GasMeter] | Chain holds kernel internals; conflates layers | Kernel-internal GasMeter; only SetGasMeter cap exposed |
+| Pre-load all persistent gas at block start | Scales with active user count; expensive | Lazy load via OOG-catch |
+| Image-level non-copyability for Gas (narrow linearity) | Adds linearity exception; complicates cap model | Conservation via kernel-internal table; cap copies share value |
+| Cap::Type for authority routing | Cap::Type is identification, not authority | Cap::Instance possession (via AuthorityCap holding marker); see §14 |
+
+The current design uses each kernel-assisted Instance for what it's
+naturally good at: yield routing (per-Instance YieldCatcher), gas
+accounting (kernel-internal GasMeter), storage accounting (kernel-
+internal StorageQuota). The unit handles (Gas, Quota) are regular
+Cap::Instances; conservation handled by the kernel-internal tables.
+
+## Naming summary
+
+| Concept | Per-Instance unit | Kernel-internal (if applicable) |
+|---|---|---|
+| Yield routing | `YieldMarker` (cap unit) | n/a — `YieldCatcher` lives per-Instance |
+| Gas accounting | `Gas{meter_id}` (handle) | `GasMeter` (kernel internal) |
+| Storage accounting | `Quota{quota_id}` (handle) | `StorageQuota` (kernel internal) |
+
+Kernel-assisted Instances in userspace use: `YieldCatcher`,
+`Gas{meter_id}`, `Quota{quota_id}`.
+
+Kernel-internal kernel-assisted Instances (never in chain hands):
+`GasMeter`, `StorageQuota`.
+
+## Cap-flow at chain init
+
+A concrete picture of what's in the top-level chain Instance's cnode
+right after kernel boot:
+
+```
+chain.cnode at chain init:
+  [PINNED slots: Image's pinned Cap::Image / Cap::Data]
+  
+  [Slot for YieldCatcher — Image-declared yield_marker_slot]
+  yield_catcher_slot = Cap::Instance[YieldCatcher]
+    with markers: { OOG_marker, StorageExhaustedMarker, ... }
+  
+  [Slots for gas]
+  Cap::Instance[Gas{root_meter_id}]
+  Cap::Instance[SetGasMeter]
+  Cap::Instance[MintGas]
+  
+  [Slots for storage]
+  Cap::Instance[Quota{root_quota_id}]
+  Cap::Instance[SetStorageQuota]
+  Cap::Instance[MintQuota]
+  
+  [Slot for YieldCatcher factory]
+  Cap::Instance[CreateYieldCatcher]
+  
+  [chain-specific genesis caps, etc.]
+```
+
+From here, chain bytecode does whatever chain spec defines.
+
+## Resolved design decisions
+
+The following points were initially flagged as open and have been
+resolved. Captured here so the rationale survives.
+
+1. **Dirty-page tracking lifetime — stack-leave reset.** An Instance's
+   dirty set persists while it remains on the kernel call stack
+   (across nested CALL/yield/resume), and is finalized + charged
+   when the Instance leaves the stack entirely. Matches "dirty until
+   commit" intuition; per-CALL reset would lose intra-call write
+   coalescing.
+
+2. **Page size — 4 KiB**, matching the underlying JAVM page size.
+   Consistent with the VM's native granularity; no separate kernel
+   page size to track.
+
+3. **Meter_id / quota_id assignment — chain-chosen.** The kernel
+   has no persistent state across blocks, so it cannot maintain a
+   monotonic counter or any other unique-id scheme on its own. Id
+   assignment is therefore chain's responsibility; MintGas /
+   MintQuota take the chain-supplied id as input. Collisions
+   silently alias to the same meter/quota — chain is responsible
+   for uniqueness within its own policy (this is fine: chain is the
+   only entity holding MintGas/MintQuota anyway).
+
+4. **OOG yield payload — only `Cap::Instance[Gas{meter_id}]`.** See
+   "OOG payload" section above. Deliberately minimal: no caller
+   context, no call-stack info. Encoding "which call ran out"
+   would reintroduce CALLER into a cap-only system, which v3
+   structurally avoids. The meter_id is sufficient — chain looks
+   it up in GasLedger. Same shape for StorageExhausted.
+
+5. **Storage quota at block start — chain-spec constant +
+   SetStorageQuota.** Kernel initializes
+   `quotas = { root_quota_id: <chain-spec block budget> }` at block
+   start; everything else is chain-populated lazily via
+   SetStorageQuota, analogous to gas. Same lazy-load + exhaustion-
+   catch pattern.
+
+6. **Reuse of meter_ids across blocks — chain's call.** Since
+   meter_ids are chain-chosen, this is purely chain policy. A
+   chain that wants persistent gas semantics will reuse meter_ids
+   across blocks (deterministic mapping from user → meter_id). A
+   chain that wants fresh-per-block can do that instead. Kernel
+   doesn't care; meter_ids are opaque numbers from kernel's view.
+
+7. **Read access to GasMeter for inspection — deferred.** The
+   current design exposes only write access via SetGasMeter
+   (which returns the previous value, enabling read-while-write
+   for the harvest pattern). Pure read access is not provided.
+   If a concrete need arises later (e.g., chain wants to inspect
+   without disturbing), add a `host_query_meter` read-only cap
+   then. Not adding speculatively.
+
+8. **`set_image` on kernel-assisted Instances — structurally
+   impossible.** Kernel-assisted Instances run native kernel code,
+   not bytecode. They never execute `set_image` (no bytecode to
+   issue the host call). The question is moot: there is no
+   execution context that could trigger an image change on a
+   kernel-assisted Instance.
+
+## Relationship to other docs
+
+- **README §1** (Image): yield_marker_slot field; Image declares
+  gas_slots and quota_slots for kernel debiting.
+- **README §3** (Instance state machine + kernel call stack): the
+  kernel-internal call stack underlies the yield routing.
+- **README §4** (Kernel ABI): the kernel-issued caps (SetGasMeter,
+  MintGas, CreateYieldCatcher, etc.) appear here.
+- **README §8** (Cap kinds): kernel-assisted Instances are regular
+  Cap::Instance; no new cap kind needed.
+- **README §14** (Authority via capability flow): yield-marker
+  authority pattern uses YieldCatcher.
+- **README §15, §16** (AA, MintInstance): instances of the authority
+  pattern.
+- **userspace/generic-authority-pattern.md**: pattern doc for
+  authority caps; uses YieldCatcher mechanism.
+- **discussions/data-flow-principle.md**: architectural derivation;
+  kernel-assisted Instances live within the data-flow / hierarchical
+  invocation discipline.
+
+## Summary
+
+> **Kernel resources are exposed via the Instance abstraction with
+> kernel short-circuit. Instance-level uniformity is preserved; kernel
+> implementation freedom is preserved. Per-Instance resources
+> (YieldCatcher) live in user Instances' cnodes; kernel-internal
+> resources (GasMeter, StorageQuota) live at the kernel level and
+> are accessed only via kernel-issued caps. Unit handles (Gas,
+> Quota) are regular Cap::Instances naming entries in the kernel-
+> internal tables. Conservation is structural via the kernel-
+> internal tables — no narrow linearity is needed. Persistence is
+> entirely in chain σ; kernel is stateless across blocks. Lazy load
+> via OOG-catch handles persistent state at scale.**
+
+This pattern unifies what would otherwise be ad-hoc kernel APIs
+(yield routing, gas, storage, future kernel resources) into a single
+shape. The kernel-to-chain interface stays small (a handful of caps
+and markers); chain controls all higher-level policy.

--- a/docs/spec/discussions/kernel-chain-interface.md
+++ b/docs/spec/discussions/kernel-chain-interface.md
@@ -1,0 +1,418 @@
+# Kernel / Chain interface design
+
+This doc proposes the canonical architecture for the kernel ↔ chain
+interface in v3, building on the four cap kinds, slot[0] scratchpad
+channel, and yield/resume cascade primitives.
+
+## Overview
+
+The architecture has three structural pieces:
+
+- **Kernel**: chain-spec-defined outermost runtime. Holds the canonical
+  Chain Instance plus per-cycle transient instances. Implemented as a
+  named-field struct in the validator binary; not generic Cap::Instance
+  storage.
+
+- **Chain**: a `Cap::Instance[ChainImage]` held by Kernel. Single source
+  of truth for chain state. Its image declares the protocol's apply
+  + verify + dispatch logic, and pins the Cap::Image references for
+  derived role instances.
+
+- **Derived role instances (Verify, Dispatch_k)**: per-block transient
+  Cap::Instances produced by MGMT_COPY of Chain + set_image to the
+  target role's image. They inherit Chain's state (via cnode
+  content-sharing) while running their own role-specific bytecode.
+
+## Kernel structure
+
+```
+Kernel (validator binary, not Cap::Instance):
+  
+  -- persistent across blocks:
+  chain               : Cap::Instance[ChainImage]
+  
+  -- per-cycle transient (initialized at cycle start; dropped at end):
+  verify_proto        : Cap::Instance[VerifyImage]
+                        (derived from chain via MGMT_COPY + set_image)
+  dispatch_protos     : Vec<Cap::Instance[Dispatch_k_Image]>
+                        (one per chain-declared dispatch endpoint)
+  aa                  : Cap::Instance[AAImage]
+                        (kernel-injected; semantics in
+                         attestation-authority.md)
+  
+  -- internal kernel state (off-σ):
+  per-event gas budgets
+  cycle_seen_keys     : Map<dispatch_endpoint_id, Set<PubKey>>
+  attestation_traces  : current cycle's traces (incoming or building)
+```
+
+Kernel respects Instance access boundaries conceptually (no privileged
+peek into Chain's cnode beyond what CALLs expose; standard cap-flow
+rules). But its representation is direct named fields, not a generic
+cnode — it's the runtime, not a userspace Instance.
+
+## Chain Instance structure
+
+```
+ChainImage:
+  code:             Bytes (canonical chain bytecode)
+  memory_mappings:  declared regions
+  endpoints:
+    apply                      : process body events; mutate state
+    transform_to_verify        : set_image to pinned VerifyImage
+    transform_to_dispatch_k    : set_image to pinned Dispatch_k_Image
+                                 (one such endpoint per dispatch type)
+  pinned_slots:
+    VERIFY_IMAGE_SLOT          : Cap::Image[VerifyImage]
+    DISPATCH_0_IMAGE_SLOT      : Cap::Image[Dispatch_0_Image]
+    DISPATCH_1_IMAGE_SLOT      : Cap::Image[Dispatch_1_Image]
+    ...
+    TRANSACT_IMAGE_SLOT        : Cap::Image[TransactImage]
+                                 (used by Verify to construct Cap::Instance[Transact])
+    DISPATCH_FRAME_IMAGE_SLOT  : Cap::Image[DispatchInstanceImage]
+                                 (used by Verify to construct Cap::Instance[Dispatch])
+    AA_IMAGE_SLOT              : Cap::Image[AAImage]
+                                 (used by kernel to inject AA instances)
+  gas_slots:        chain-spec policy
+  
+ChainImage.image_hash (derived):
+  hash(KernelImage_hash || hash(ChainImage))   -- canonical chain
+```
+
+Chain's cnode holds the actual chain state:
+- account balances, ledgers
+- per-user authorization tables
+- protocol-level state (epoch, slots, etc.)
+
+Layout is chain-spec-defined; outside this doc's scope.
+
+## Derivation: Verify and Dispatch_k
+
+At block-cycle start, kernel constructs the transient role instances.
+
+```
+Kernel.setup_cycle:
+  -- Derive Verify
+  MGMT_COPY(chain, verify_proto)
+    -- verify_proto.image       = ChainImage (inherited)
+    -- verify_proto.image_hash  = chain.image_hash (preserved)
+    -- verify_proto.cnode       = chain's cnode (content-shared)
+  CALL(verify_proto, transform_to_verify_endpoint, gas)
+    -- inside: set_image(self.pinned[VERIFY_IMAGE_SLOT]); HALT
+    -- after CALL:
+    --   verify_proto.image       = VerifyImage
+    --   verify_proto.image_hash  = hash(chain.image_hash || hash(VerifyImage))
+    --   verify_proto.cnode       = chain's cnode (still inherited),
+    --                              with VerifyImage's pinned slots overlaid
+  
+  -- Derive each Dispatch_k
+  for k in 0..N_dispatch_endpoints:
+    MGMT_COPY(chain, dispatch_protos[k])
+    CALL(dispatch_protos[k], transform_to_dispatch_k_endpoint, gas)
+      -- inside: set_image(self.pinned[DISPATCH_k_IMAGE_SLOT]); HALT
+      -- after: dispatch_protos[k] has Dispatch_k_Image, chain state,
+      --        canonical image_hash
+```
+
+After setup:
+
+```
+verify_proto:
+  image:       VerifyImage
+  image_hash:  hash(chain.image_hash || hash(VerifyImage))
+  cnode:       chain state + VerifyImage's pinned slots
+  status:      Idle (ready for verify CALLs)
+
+dispatch_protos[k]:
+  image:       Dispatch_k_Image
+  image_hash:  hash(chain.image_hash || hash(Dispatch_k_Image))
+  cnode:       chain state + Dispatch_k_Image's pinned slots
+  status:      Idle (ready for process CALLs at cycle end)
+```
+
+The image_hash chain proves canonical provenance: anyone holding a
+`Cap::Instance[Verify]` can verify it derives from canonical Chain via
+`host_same_type(verify_instance, chain_spec_canonical_verify_ref)`.
+
+## Pinned-slot layout
+
+Chain-spec author must ensure pinned slot indices don't collide with
+chain state slots:
+
+```
+slot[0]            : SCRATCHPAD (always; ABI convention)
+slot[1..20]        : RESERVED for pinned image references
+                     (VERIFY_IMAGE_SLOT, DISPATCH_*_IMAGE_SLOT, etc.)
+slot[20..256]      : Chain state slots (chain-spec-defined layout)
+```
+
+When Verify or Dispatch_k's set_image installs its own pinned slots,
+they go into the reserved range. State slots in [20..256) are
+untouched.
+
+VerifyImage and Dispatch_k_Image declare their pinned slots within
+the reserved range — possibly different sub-ranges to avoid colliding
+with each other, though that's overkill (they're derived separately
+from chain, not from each other).
+
+## Per-event verify flow (off-chain)
+
+For each incoming event for dispatch endpoint k from gossip:
+
+```
+Kernel.handle_incoming_event(event, dispatch_k):
+  -- Fresh per-event verify instance.
+  MGMT_COPY(verify_proto, event_verify)
+    -- content-shared from verify_proto; mutations diverge.
+  
+  AA_event = inject Cap::Instance[AAImage]
+    -- fresh AA per event.
+  
+  -- Kernel records event's attestation_traces internally
+  -- (kernel-private; not exposed to apply).
+  kernel.current_traces = event.attestation_traces
+  
+  build verify_scratchpad in Kernel.slot[0]:
+    blob:        Cap::Data (the event payload)
+    AA:          Cap::Instance[AA_event]
+    -- no traces; no mode info
+  
+  CALL(event_verify, verify_endpoint, gas_per_verify)
+  -- VerifyImage.verify runs:
+  --   reads blob from slot[0]
+  --   parses; validates against chain state (visible via cnode);
+  --   calls AA.attest(key, blob_hash) as needed
+  --     (each attest is a yield-based kernel call; kernel processes
+  --      per attestation-authority.md; may early-fault if invalid)
+  --   if reaches HALT: constructs Cap::Instance[Transact] or
+  --     Cap::Instance[Dispatch] via host_derive_spawn from Chain's
+  --     pinned TransactImage / DispatchInstanceImage.
+  --   places resulting Cap::Instance in slot[0]
+  --   HALTs
+  
+  if Faulted: drop event.
+  if HALT:
+    event_instance = Kernel.slot[0]  (reflected from event_verify)
+    -- For dispatch: admit event_instance to dispatch_protos[k]'s buffer
+    --   (via CALL dispatch_protos[k].admit_event(event_instance))
+    -- For transact: admit to proposer's transaction pool (off-σ)
+  
+  MGMT_DROP(event_verify)
+  -- AA_event also dropped; kernel post-processes attest records.
+  
+  -- Update kernel.cycle_seen_keys[k] with keys recorded during this
+  -- verify (per attestation-authority.md's seen-rule mechanics).
+```
+
+The `event_verify` instance is fresh per event: its state is
+verify_proto's state at the moment of MGMT_COPY (which inherits
+chain state). Any mutations the verify endpoint makes are local
+to event_verify; they don't pollute verify_proto or subsequent
+events.
+
+## Per-cycle process flow (off-chain → on-chain boundary)
+
+At block boundary, before chain.apply runs:
+
+```
+Kernel.run_cycle_process:
+  for k in 0..N_dispatch_endpoints:
+    AA_cycle = inject Cap::Instance[AAImage]
+      -- fresh AA per cycle per dispatch.
+    -- Pre-load seen_keys from per-event verifies (kernel bookkeeping).
+    
+    build process_scratchpad in Kernel.slot[0]:
+      events:    Cap::CNode containing the cycle's verified
+                 Cap::Instance[Dispatch] events
+      AA:        Cap::Instance[AA_cycle]
+    
+    CALL(dispatch_protos[k], process_endpoint, gas_per_process)
+    -- Dispatch_k_Image.process runs:
+    --   reads events from slot[0]
+    --   sequentially processes each
+    --   may call AA.attest(key, emit_blob_hash) — yield-based;
+    --     kernel applies seen-rule, may fault if violation.
+    --   may emit by writing to slot[0]: Cap::CNode of (target_path, blob)
+    --   HALTs
+    
+    if Faulted: handle per chain-spec policy.
+    if HALT:
+      emits = Kernel.slot[0]  (reflected emit list)
+      route emits: 
+        - For target = dispatch endpoint: queue for next cycle.
+        - For target = transact endpoint: add to proposer's pool.
+    
+    -- Kernel post-processes AA_cycle records (sign or verify per mode).
+    MGMT_DROP(AA_cycle)
+```
+
+After all dispatch_protos have processed, the proposer assembles the
+block body (its transaction pool + dispatch-emitted transacts +
+attestation_traces produced by kernel during AA processing).
+
+## On-chain apply
+
+```
+Kernel.apply_block(prior_state, body):
+  -- Kernel state: chain at state σ_{N-1}, ready for σ_N transition.
+  -- body contains: events + attestation_traces (kernel-private).
+  
+  AA_block = inject Cap::Instance[AAImage]
+  kernel.current_traces = body.attestation_traces
+  
+  build apply_scratchpad in Kernel.slot[0]:
+    body_data:  Cap::CNode of events (each event is Cap::Instance[Transact]
+                or a raw blob to be verify-inlined by chain.apply)
+    AA:         Cap::Instance[AA_block]
+  
+  CALL(chain, apply_endpoint, gas_block_budget)
+  -- ChainImage.apply runs on canonical chain (not a copy):
+  --   iterates events from slot[0]
+  --   for each event: dispatches to target sub-handler
+  --     (transact endpoint or Schedule slot)
+  --   may call AA.attest as needed
+  --   may emit additional events (next-block dispatches)
+  --   mutates chain state
+  --   HALTs with emits and new state hash via slot[0]
+  
+  if Faulted: block invalid; reject.
+  if HALT:
+    new_state_root = hash of chain.cnode_root
+    outgoing_emits = from slot[0]
+    
+  -- Kernel post-processes AA_block records.
+  attestation_traces = traces aggregated during apply (produce mode)
+                       or empty/verified (verify mode)
+  
+  -- Drop transient instances.
+  MGMT_DROP(verify_proto)
+  for k: MGMT_DROP(dispatch_protos[k])
+  MGMT_DROP(AA_block)
+  
+  return (new_state_root, attestation_traces, outgoing_emits)
+```
+
+After apply_block:
+
+- Chain's state has advanced from σ_{N-1} to σ_N.
+- verify_proto and dispatch_protos are dropped; transient state gone.
+- Next cycle: fresh setup_cycle starts from σ_N.
+
+## Per-block lifecycle visualized
+
+```
+σ_{N-1} (post-apply of block N-1)
+  │
+  ▼
+Cycle for block N begins
+  │
+  ├─ setup_cycle:
+  │    derive verify_proto from chain
+  │    derive dispatch_protos from chain
+  │
+  ├─ for each incoming event (gossip):
+  │    fresh event_verify = MGMT_COPY(verify_proto)
+  │    CALL event_verify.verify(blob)
+  │    admit to dispatch_protos[k] buffer
+  │
+  ├─ at block boundary:
+  │    for each k: CALL dispatch_protos[k].process(buffered_events)
+  │    route emits
+  │
+  ├─ apply_block:
+  │    CALL chain.apply(body)
+  │    chain state advances to σ_N
+  │
+  └─ teardown:
+       drop verify_proto, dispatch_protos
+  
+  ▼
+σ_N (committed)
+  │
+  ▼
+Cycle for block N+1 begins (fresh derivation from σ_N)
+  ...
+```
+
+The derived instances are explicitly transient per cycle. No
+cross-block state in Verify or Dispatch instances. All cross-block
+"memory" must live in chain state (committed in σ).
+
+## Why "transform from Chain" instead of separate canonical instances
+
+Alternative: each dispatch endpoint is a separate persistent
+`Cap::Instance[Dispatch_k]` held in chain's cnode, accumulating state
+across blocks.
+
+Problems with the alternative:
+- **Consensus risk**: state accumulation depends on gossip ordering;
+  validators with different network views accumulate differently.
+- **Implicit state hidden in dispatches**: anyone auditing chain
+  state must inspect dispatch instances separately; they're "outside"
+  chain's clean state representation.
+- **Lifecycle complexity**: when does a dispatch instance get
+  initialized? What if a validator joins late?
+
+The transform-from-Chain pattern:
+- **Per-block freshness**: derived at block start from canonical
+  chain. All validators derive the same starting point.
+- **Single source of truth**: chain state is the only persistent
+  state; dispatch role instances are typed views.
+- **Lifecycle is structural**: kernel-managed transient holdings;
+  drop at block end.
+
+## Comparison to legacy `~/docs/minimum` design
+
+| Legacy concept | v3 representation |
+|---|---|
+| `σ.transact_endpoints` flat list | Chain.apply dispatches by target_path internally; or held as Cap::Instances in chain's cnode |
+| `σ.dispatch_endpoints` flat list | Chain's pinned Cap::Image[Dispatch_k_Image]; dispatch_protos derived per block |
+| EventEndpointCap | Cap::Instance derived from chain via set_image; image_hash chain provides typed identity |
+| Vault.verify (fresh per event) | event_verify = MGMT_COPY(verify_proto); fresh per event |
+| Vault.process (per cycle) | dispatch_protos[k].process called per cycle |
+| AttestationAuthority (scoped per endpoint cycle) | Kernel-injected Cap::Instance[AA]; see [attestation-authority.md] |
+| caller() returns Kernel(Verify/Process) | userspace can't observe mode; kernel knows via call-stack context |
+| emit_event host call | Apply writes emits to slot[0]; kernel reads on HALT |
+| mint_attest_cap | AA.attest yield-based kernel call; see [attestation-authority.md] |
+| setScore for buffering | Kernel-managed buffer ordering (chain-spec policy) |
+
+The v3 vocabulary is more uniform: everything is Cap::Instance
+operations + the four cap kinds + cascade primitives. The "EventEndpointCap"
+and "Vault" abstractions of the legacy spec collapse into "Cap::Instance
+derived from Chain via set_image."
+
+## Open questions
+
+1. **`Instance[Transact]` storage in block body**: does the block carry
+   the original blob (with verify re-run on apply), or the verified
+   `Cap::Instance[Transact]` directly (saving re-verify cost but storing
+   more)? Probably blob + traces, with verify re-run; this is the
+   legacy pattern.
+
+2. **Where verified Cap::Instance[Dispatch] events accumulate**: inside
+   dispatch_protos[k]'s cnode (via an admit endpoint), or in kernel's
+   external buffer. The latter is simpler; the former gives the
+   dispatch image structural control over its own buffer.
+
+3. **Schedule slot semantics**: legacy treats Schedule specially.
+   Under single Chain Instance, fold into chain.apply, or treat as a
+   separate transform_to_schedule? Likely the former.
+
+4. **Cross-block dispatch continuation**: if a dispatch needs to
+   "remember" something across blocks (e.g., partial aggregation
+   across rounds), it must emit a transact that updates chain state.
+   Then next block's dispatch_proto is derived from updated chain,
+   inheriting the remembered state. No special mechanism needed.
+
+5. **Chain.apply yield**: if chain.apply yields (e.g., long
+   computation), chain is Paused at block end. Next block, kernel
+   CALL_RESUMEs chain. The transient role instances... still derived
+   fresh from chain (which is now Paused; can we MGMT_COPY a Paused
+   instance and then transform via set_image? set_image requires
+   running apply, which can't happen on a Paused instance). Need to
+   resolve. Probably: chain.apply doesn't yield; long-running
+   computations are decomposed into per-block apply runs (each block
+   processes a chunk).
+
+These are downstream design questions; the core architecture
+(transform-from-Chain) stands.

--- a/docs/spec/discussions/sel4-mapping.md
+++ b/docs/spec/discussions/sel4-mapping.md
@@ -1,0 +1,933 @@
+# seL4 security properties — side-by-side mapping with v3
+
+## Why this document exists
+
+The v3 design conversations have repeatedly hit the question: *is our
+model as secure as seL4?* That question has been re-litigated several
+times because we lack a precise referent. This document fixes the
+referent: it lists seL4's verified properties explicitly, then maps
+each onto v3's design, identifying which properties hold, which hold
+in a different form, which require kernel + ChainOrchestrator
+together, which we lose, and which don't apply.
+
+The goal is **not** mechanized verification (yet); just a precise
+decomposition that ends the doubt loop. Subsequent work — formal
+operational semantics, Lean theorems — would build on this list.
+
+This is **Option D** from the methodology discussion. Lighter than
+mechanized verification but precise enough to anchor design decisions.
+
+## Important framing: the TCB boundary
+
+In seL4, the trusted computing base is the kernel itself (~10K LoC,
+formally verified). Application processes are untrusted; the kernel
+prevents them from breaking system invariants regardless of their
+behavior.
+
+In v3, the TCB is **{kernel + chain orchestrator bytecode}**. The
+kernel handles mechanism (cap-flow, image_hash chain, VM, state-root
+hashing). The chain orchestrator's bytecode handles policy (auth
+tables, ledger arithmetic, dispatch). Both must be correct for system
+invariants to hold.
+
+This is a deliberate architectural choice; see
+[../README.md §0 principle 18](../README.md). The chain orchestrator
+is a small, chain-spec-defined, formally-verifiable artifact — but
+it IS in the TCB.
+
+When mapping seL4 properties below, we'll be explicit about whether
+each property is enforced by the kernel alone, or by the kernel
+together with chain orchestrator bytecode.
+
+## seL4's verified properties
+
+The seL4 verification literature (Klein et al. 2009, 2014; Murray
+et al. 2013) establishes a specific decomposition. We use it as
+our reference list.
+
+### P1. Functional correctness
+
+The seL4 implementation refines its abstract specification. Every
+behavior of the C kernel matches the specification's behavior. This
+property says nothing about *what* the spec does — only that the
+implementation matches.
+
+### P2. Integrity (authorized writes only)
+
+A subject S can only modify state that S's caps grant write access
+to. No write happens "through the back door"; every state mutation
+is traceable to a cap that authorized it.
+
+Formally: if subject S writes location L, then S holds (or held) a
+cap with write authority over L.
+
+### P3. Confidentiality (authorized reads only)
+
+A subject S can only observe state that S's caps grant read access
+to. No information leaks from regions S can't read into S's
+observations.
+
+Formally: a non-interference property. If two system states differ
+only in regions S can't read, S's observable behavior is the same in
+both.
+
+### P4. Cap-flow integrity
+
+Caps appear in a subject's CSpace only via legitimate kernel
+operations (Receive on an Endpoint, derived from a Retype, etc.).
+Adversary cannot synthesize caps from bytes.
+
+### P5. Authority confinement
+
+Operations only succeed if invoked with appropriate caps. The kernel
+enforces "you must hold this cap to do this" at every operation.
+
+### P6. Cap exclusivity (linearity / derivation tree)
+
+The kernel tracks cap derivation: every cap is either an original
+(from Retype) or a derivation of a parent cap. Revocation propagates
+through the derivation tree. At any moment, there's a definite
+ownership / sharing graph.
+
+### P7. Memory protection
+
+Each subject has its own VSpace; the MMU prevents access to memory
+not mapped in that VSpace. The kernel manages VSpace mappings via
+caps.
+
+### P8. Resource bounded operation
+
+Kernel does not allocate memory during operation. All memory is
+allocated explicitly via Retype on Untyped caps. Kernel itself runs
+in bounded space.
+
+### P9. Bounded latency
+
+Operations complete in bounded time; no unbounded loops in kernel.
+Real-time properties (interrupt response, scheduling latency).
+
+## Mapping to v3
+
+For each seL4 property, we ask:
+
+- Does v3 have an analog?
+- If yes, how is it enforced (kernel? kernel+orch?)?
+- If no, what do we have instead?
+- What are the residual gaps?
+
+### P1 → V1. Functional correctness
+
+**v3 status**: not-yet-verified.
+
+**v3 analog**: v3 spec is currently informal markdown. No formal
+abstract spec exists yet; no implementation exists yet against which
+refinement could be checked.
+
+**Path forward**: build a Lean operational semantics of v3 (Option
+A / B from the methodology discussion). Implementation refinement
+proofs are downstream work.
+
+**Gap**: the entire formalization. Functional correctness is a
+goal, not a current property.
+
+---
+
+### P2 → V2. Integrity (authorized writes only)
+
+**v3 status**: holds, with TCB extension to chain orchestrator.
+
+**v3 enforcement**:
+
+- **Kernel-enforced part**: an Instance's state is mutated only by
+  running its Image's bytecode (principle 13b: "trusted apply"). No
+  ABI op writes content into another Instance's state. This is direct
+  analog of seL4's integrity.
+
+- **Chain orchestrator part**: for resource conservation
+  (account_balances, storage_quotas, session_balances), the
+  authority is the orchestrator's bytecode. A buggy orchestrator
+  could write incorrectly to its own ledger. Userspace contracts
+  cannot bypass this — they don't hold the orchestrator's caps —
+  but the orchestrator's bytecode is in the TCB.
+
+**Difference from seL4**: in seL4, integrity is purely structural
+(caps + MMU). In v3, integrity is structural for *Instance state* (no
+backdoor writes; principle 13b) but bytecode-mediated for
+*ledger arithmetic* (orchestrator's bytecode must be correct).
+
+**TCB scope**:
+- Instance-state integrity: kernel only.
+- Ledger conservation: kernel + orchestrator.
+
+**Property statement (v3)**:
+> If subject S modifies state location L, then either (a) L is in
+> S's own cnode tree and S's apply ran (Instance-state integrity); or
+> (b) L is in some authority Instance O's cnode tree and O's apply ran
+> (bytecode-trusted ledger arithmetic).
+
+The gap from seL4: case (b) trusts O's bytecode. Case (a) is
+seL4-level structural.
+
+---
+
+### P3 → V3. Confidentiality (authorized reads only)
+
+**v3 status**: does not apply. σ is public.
+
+**v3 enforcement**: none. σ is content-addressed and replicated
+across all validators. There are no secrets in σ.
+
+**Why this differs**:
+- seL4 isolates processes that could potentially observe each
+  other's secrets via memory or covert channels.
+- v3's σ is public by definition (state-root committed; replicated;
+  reorg-able). There's nothing to confidentially-isolate.
+
+**What we have instead**: confidentiality is achieved off-σ via
+hardware-rooted attestation (§15). Validators sign attestations of
+state transitions; private keys live off-σ; signatures verify on-σ.
+This is a different security property from non-interference.
+
+**Gap**: v3 makes no confidentiality claims at the σ level. Chain-
+spec authors who want confidential state need off-σ mechanisms
+(zero-knowledge proofs, hardware enclaves, MPC). v3 supports
+these via the AttestationAuthority pattern but doesn't provide
+in-σ confidentiality.
+
+**Property statement (v3)**:
+> No confidentiality property is claimed for σ. σ is public; all
+> validators see all state.
+
+---
+
+### P4 → V4. Cap-flow integrity
+
+**v3 status**: holds, kernel-enforced.
+
+**v3 enforcement**:
+- Caps are typed values in slots. Type tagging at the slot level
+  prevents bytes-as-caps confusion.
+- Caps appear in an Instance's cnode only via:
+  - MGMT_MOVE/COPY from another slot the apply has access to.
+  - Scratchpad reflection on CALL (caller passes scratchpad; callee
+    receives at slot[0]).
+  - set_image installation of pinned slots.
+  - host_mint_cnode (mints a fresh empty Cap::CNode; no caps inside).
+  - host_derive_spawn (mints a fresh Cap::Instance with new image;
+    only callable from within self's apply).
+- Adversary's bytecode cannot synthesize Cap::Instance from raw bytes
+  via MGMT_MOVE from a Cap::Data slot — the runtime distinguishes
+  Cap::Data from Cap::Instance by type tagging.
+
+**Difference from seL4**: same property at the kernel-mechanism
+level. seL4 tracks caps in CSpace via kernel-managed table; v3
+tracks them in cnode slots via type-tagged slot encoding. Both
+prevent forgery.
+
+**TCB scope**: kernel only.
+
+**Property statement (v3)**:
+> A Cap::Instance, Cap::Image, Cap::Data, or Cap::CNode in any slot
+> was placed there via a kernel-mediated operation (MGMT_*,
+> scratchpad reflection, set_image, or spawn). Adversary cannot
+> create caps from bytes.
+
+---
+
+### P5 → V5. Authority confinement
+
+**v3 status**: holds *partially* at the kernel level; full coverage
+requires kernel + orchestrator.
+
+**v3 enforcement**:
+
+For **Instance invocation** (CALL on a Cap::Instance):
+- Kernel-enforced. To CALL Instance X, you must hold Cap::Instance[X] in
+  your cnode (via cap-flow). Same as seL4 cap-as-authority.
+
+For **resource consumption** (gas, quota, custom tokens):
+- Bytecode-mediated. To consume gas, the apply has a `gas_budget`
+  parameter on its CALL — kernel internal.
+- To consume quota, host_mint_data_cap takes a quota_slot arg; the
+  kernel reads quota_id from the cap and debits the orchestrator's
+  ledger. The kernel direct-accesses canonical ledgers (well-known
+  image pattern) for hot paths; otherwise CALL into authority.
+
+For **policy decisions** (which user contract can mint, which can
+transfer, which can write to certain ledgers):
+- Cap-mediated by chain orchestrator. The orchestrator mints
+  EndpointRefCap-style caps (§14) and grants them to authorized
+  contracts; possession of the cap is the authorization. Per-cap
+  policy (rate limits, arg filters) is either baked into cap
+  variants or held in a sidecar table keyed by cap identity — not
+  by user. Signature verification routes via AttestationAuthority
+  (§15) per the same yield-mediated authority pattern.
+
+**Difference from seL4**:
+
+| Concern | seL4 | v3 |
+|---|---|---|
+| Direct invocation authority | cap-as-authority | cap-as-authority (same) |
+| Per-user policy | revocable cap derivation | non-revocable cap grant + per-cap-identity policy sidecar |
+| Resource quotas | linear caps with kernel tracking | bytecode + ledger |
+
+**TCB scope**:
+- CALL-via-cap authority: kernel.
+- Resource and policy authority: kernel + orchestrator.
+
+**Property statement (v3)**:
+> An invocation on an Instance succeeds only if the invoker holds an
+> appropriate Cap::Instance (kernel-enforced). A resource-consuming
+> operation succeeds only if the relevant authority Instance's bytecode
+> approves and the corresponding ledger entry has sufficient balance.
+
+---
+
+### P6 → V6. Cap exclusivity (linearity / derivation tree)
+
+**v3 status**: explicitly dropped at the kernel level. Beyond the
+snapshot/revert trade-off, **linearity has no structural use case in
+v3 that other mechanisms don't already cover** — see analysis below.
+
+**v3 design choice**: all caps are uniformly copyable. There is no
+linear cap, no derivation tree, no revocation primitive at the
+kernel level.
+
+**What we have instead**: conservation invariants enforced by
+authority-Instance bytecode. The chain orchestrator's ledger arithmetic
+ensures total balances are preserved; the kernel verifies image_hash
+chain to gate access to canonical ledgers.
+
+**Why linearity isn't needed (deeper argument)**:
+
+Earlier discussion framed this as "we trade linearity for
+snapshot/revert". A deeper analysis shows linearity is *also* not
+load-bearing for any other property, so the trade isn't even
+necessary on its own merits. Walk through every plausible use case:
+
+1. **Delegate pattern (cap = resource)**. Linearity in seL4 enables
+   `Cap::Untyped{remaining}` to be the canonical resource holder.
+   But Delegate **requires** that the cap's invocation can mutate
+   the canonical resource directly. In v3, due to principle 13b
+   (trusted apply: "no ABI op writes content into another Instance's
+   state"), this is not possible regardless of linearity. A
+   `Cap::Instance[Counter]` invocation runs Counter's apply, mutates
+   Counter's state — but Counter's state is local to the Instance, not
+   the canonical resource counter held by ChainOrchestrator. For
+   actual conservation effect, Counter's apply must yield up to
+   ChainOrch.
+
+   So Delegate, even with kernel-level linearity, **cannot be
+   implemented in userspace**. It requires the cap-invocation
+   mechanism to be a kernel-mediated operation (a syscall), which is
+   exactly what our managed-cap-with-yield pattern provides
+   functionally. seL4's Delegate is syntactically a method call but
+   functionally a syscall; v3's managed cap is functionally a
+   syscall expressed as yield-to-kernel. Same shape, different
+   syntax.
+
+   Therefore: **linearity doesn't enable Delegate uniquely — Delegate
+   is already kernel-managed regardless. The "Delegate vs managed
+   cap" dichotomy was a false one.**
+
+2. **Singleton / identity enforcement**. Recovered in v3 via
+   image_hash chain canonical pattern + chain-author discipline.
+   Each canonical singleton has a unique image_hash chain;
+   `host_same_type` discrimination is structurally precise.
+
+3. **One-shot tickets**. Recovered in v3 via ledger entry marked
+   consumed. First call decrements and marks; subsequent calls
+   detect and reject.
+
+4. **Atomic transfer**. Recovered in v3 via MGMT_MOVE: source slot
+   empties; receiver gets cap; no double-give.
+
+5. **Linear protocol verification**. Recovered in v3 via bytecode
+   step state tracking; rejects out-of-order calls.
+
+6. **Capability secrecy / non-aliasing**. Doesn't apply: σ is
+   public regardless of cap kind. Linearity wouldn't help with
+   confidentiality.
+
+7. **Affine/relevant resource accounting**. Recovered in v3 via
+   bytecode discipline + tooling (linters/checkers can detect
+   forgotten cnode entries that should have been consumed).
+
+In every case, an existing v3 mechanism provides the property.
+**Linearity is not the unique enabler of any structural property in
+our setting.**
+
+**Why this is a genuine simplification, not a hidden cost**:
+
+The conservation we lose is structural (kernel-enforced). The
+conservation we recover via ledger arithmetic is bytecode-enforced.
+The TCB is therefore extended from "kernel" to "kernel + authority
+bytecode". This is a real cost.
+
+But: this cost would exist *even if we added linearity*, because
+authority bytecode is also responsible for the actual resource
+operation (Delegate doesn't change this, per the analysis above).
+Adding linearity to the kernel would add kernel surface (linear-
+count maintenance, derivation tree, MGMT_COPY gating, drop endpoint
+machinery for refunds) without removing the bytecode TCB extension.
+
+So adding linearity = strict cost increase. Not adding linearity =
+the design we have.
+
+**Difference from seL4**: significant in syntax/structure,
+functionally equivalent for the relevant properties. v3's
+conservation depends on bytecode correctness; seL4's depends on
+kernel correctness. But seL4's "kernel correctness" includes
+correctness of the cap derivation tree implementation, which is
+itself non-trivial.
+
+**TCB scope**: kernel + orchestrator (specifically, the ledger
+arithmetic in authority bytecodes).
+
+**Property statement (v3)**:
+> Conservation of resource X is enforced by authority-Instance F's
+> bytecode such that, across all sequences of operations on F's
+> ledger, the total X-balance is preserved (modulo legitimate
+> mints/burns per F's policy). The kernel structurally prevents
+> bypassing F's bytecode by gating access to F's ledger via cap-flow
+> + image_hash chain.
+
+> No cap kind in v3 stores a resource balance directly. All
+> resource balances live in authority ledgers. Cloning a cap clones
+> a reference to a ledger row, not the row's content; conservation
+> arithmetic on the row is preserved regardless of clone count.
+
+---
+
+### P7 → V7. Memory protection
+
+**v3 status**: holds via static memory model + deterministic VM.
+
+**v3 enforcement**:
+- Each Instance's address space is statically declared by its Image
+  (memory_mappings). Mappings reference cnode slots' DataCaps or
+  Ephemeral kernel-allocated regions.
+- The bytecode VM rejects access to undeclared addresses; access
+  Faults the Instance deterministically.
+- Page-faults are not exposed to bytecode; lazy paging is forbidden.
+- No MMU mediation needed because the VM is deterministic; access
+  control is at the bytecode-VM layer, not at hardware MMU.
+
+**Difference from seL4**: seL4 uses hardware MMU; v3 uses
+deterministic bytecode VM. Both achieve memory isolation. v3's is
+arguably *stronger* in some ways (no page-fault timing channels) but
+weaker in others (relies on VM correctness rather than hardware).
+
+**TCB scope**: kernel (specifically the VM correctness).
+
+**Property statement (v3)**:
+> An Instance's apply can only read/write addresses in its declared
+> memory_mappings. Access outside is a deterministic fault.
+
+---
+
+### P8 → V8. Resource bounded operation
+
+**v3 status**: holds, with subtleties.
+
+**v3 enforcement**:
+- Kernel maintains internal gas counter; per-instruction metering.
+- CALL specifies `gas_budget: u64`; kernel saves parent's counter,
+  sets to budget, runs callee, restores.
+- OOG → kernel-triggered yield.
+- Apply's working memory is bounded (declared by Image's
+  memory_mappings; Ephemeral allocation has explicit size).
+- State-root computation at outermost termination has bounded cost
+  (O(modified pages × log num pages)).
+
+**Subtlety**: divergence events (§9 case (b)) trigger hashing
+mid-block. The cost is bounded per event (proportional to the diverged
+value's size), but the count of events is bounded by the apply's
+gas (each MGMT_COPY costs gas).
+
+**Difference from seL4**: seL4 is more aggressive (no kernel
+allocation at all). v3 allocates Ephemeral regions per apply (heap,
+stack); these have declared sizes. Both are bounded; v3's bound is
+larger.
+
+**TCB scope**: kernel.
+
+**Property statement (v3)**:
+> Per-block kernel work is bounded by O(gas_budget × constant) for
+> per-instruction metering, plus O(modified pages × log(num pages))
+> for state-root hashing, plus O(divergence events) for mid-block
+> hashing. All terms are bounded by the block's gas budget.
+
+---
+
+### P9 → V9. Bounded latency
+
+**v3 status**: holds, with the same caveats as P8.
+
+**v3 enforcement**: per-block work is bounded; per-tx work is
+bounded by tx gas budget. Kernel internal operations (CALL setup,
+yield handling, etc.) are O(1).
+
+**Difference from seL4**: seL4 has formal real-time guarantees
+(MCS — Mixed Criticality Scheduling). v3 doesn't claim real-time
+properties; only "blocks complete in bounded time."
+
+**TCB scope**: kernel.
+
+**Property statement (v3)**:
+> Per-block latency is bounded by gas_limit × per-instruction-cost +
+> setup/teardown costs. No unbounded loops in kernel.
+
+---
+
+## Summary table
+
+| seL4 property | v3 status | TCB scope (v3) | Gap |
+|---|---|---|---|
+| P1: Functional correctness | Not verified yet | N/A | Entire formalization needed |
+| P2: Integrity (writes) | Holds | Kernel + orch | Ledger arithmetic in orch bytecode |
+| P3: Confidentiality | Does not apply | N/A | σ is public; off-σ mechanisms for confidential state |
+| P4: Cap-flow integrity | Holds | Kernel | None |
+| P5: Authority confinement | Holds (split) | Kernel + orch | Resource quotas via bytecode |
+| P6: Cap exclusivity / linearity | Dropped | Orch (replaced by ledger) | Structural conservation traded for snapshot/revert |
+| P7: Memory protection | Holds | Kernel (VM) | None at the VM layer |
+| P8: Resource bounded | Holds | Kernel | Slightly larger than seL4's bound |
+| P9: Bounded latency | Holds | Kernel | No real-time MCS-style guarantees |
+
+## Where v3 has more than seL4
+
+These are properties seL4 doesn't have (or doesn't care about):
+
+- **V10. Snapshot/revert as primitive.** MGMT_COPY of any Cap::Instance
+  produces a content-shared reference; mutations diverge per §9 case
+  (b). Universal across all caps. seL4 has no analog.
+
+- **V11. State-root determinism.** Every block has a canonical
+  state-root computed deterministically by the kernel. Validators
+  agree on the state-root. seL4 has no state-root concept.
+
+- **V12. Cross-block continuation.** Paused Instances carry
+  continuations across blocks. Long-running computation natively
+  supported. seL4's IPC is synchronous; no equivalent persistence.
+
+- **V13. Forgery resistance via image_hash chain.** Adversary cannot
+  construct a Cap::Instance with canonical image_hash without
+  legitimate descent. seL4's analog (cap derivation tree) is also
+  forgery-resistant but has different properties.
+
+- **V14. Content-addressed storage.** Instances, Images, Data are
+  content-addressed; storage dedups identical content. seL4 doesn't
+  do this.
+
+## Where v3 has less than seL4
+
+These are properties seL4 has that v3 lacks (or has weaker):
+
+- **L1. Linear cap exclusivity.** seL4 has it structurally; v3
+  doesn't. *However*, per the V6 analysis, linearity isn't actually
+  load-bearing for any structural property in v3 — every use case is
+  recoverable via other mechanisms (ledger arithmetic, image_hash,
+  MGMT_MOVE, bytecode discipline). So while v3 "lacks" this, the
+  practical loss is not a missing property but a redistribution of
+  enforcement (kernel → authority bytecode + structural mechanisms).
+
+- **L2. Cap revocation primitive.** seL4 has it (revoke propagates
+  through derivation tree); v3 doesn't structurally; recovered via
+  bytecode (orch invalidates ledger entries). Same pattern as L1:
+  the property exists in v3 but enforcement is in bytecode.
+
+- **L3. Pure-mechanism kernel TCB.** seL4's TCB is the kernel
+  alone; v3's TCB extends to orch bytecode for conservation. This
+  is the genuine architectural difference. Mitigated by orch
+  bytecode being chain-spec-defined, small, formally verifiable.
+
+- **L4. Hardware MMU isolation.** seL4 uses MMU; v3 uses VM.
+  Trade-off: VM is more deterministic; MMU is more battle-tested.
+
+- **L5. Real-time properties.** seL4 has MCS for real-time; v3 has
+  bounded latency but no MCS-style guarantees.
+
+- **L6. In-σ confidentiality.** seL4 has it (process isolation);
+  v3 doesn't (σ is public). Different threat model.
+
+The relationship between L1 and L3 is worth noting: **even if we
+added linearity (L1) to v3, the TCB extension (L3) would not
+shrink**. Authority bytecode is required for the actual resource
+operations regardless (per the V6 Delegate analysis), so adding
+linearity at the kernel would be strict cost increase, not a way
+to recover seL4's pure-kernel-TCB property.
+
+## Where the {kernel + ChainOrchestrator} composition matters
+
+The user observed: v3's security at the {kernel + ChainOrch} level
+is comparable to seL4. This is borne out by the analysis:
+
+- **At the kernel level alone**: v3 has P4 (cap-flow), P7 (memory),
+  P8 (bounded), and partial P2 (Instance-state integrity), partial P5
+  (CALL-via-cap authority).
+
+- **At the kernel + orch level**: v3 additionally has full P2 (with
+  ledger arithmetic), full P5 (resource and policy authority), and a
+  bytecode analog of P6 (conservation via ledger).
+
+- **Out of scope at any level**: P3 (confidentiality), P1 (functional
+  correctness — not yet verified).
+
+The orch's role in this composition is critical. If we think of seL4
+as "kernel = mechanism, processes = arbitrary policy," v3 splits
+this differently: "kernel = mechanism, orch = canonical policy
+(small, chain-spec-defined, in TCB), user contracts = arbitrary
+policy."
+
+This is a smaller TCB than "kernel + arbitrary userspace" but a
+larger TCB than seL4's kernel alone. It's the right boundary for
+blockchain because the chain spec defines a finite, well-known
+orchestrator policy.
+
+## Hierarchical orchestration is seL4-style cap-as-authority
+
+v3's authority model is uniformly capability-flow at every layer.
+The §14 EndpointRefCap pattern *is* cap-as-authority: orchestrators
+mint caps; user contracts hold them; possession = right to invoke.
+There is no parallel ACL anywhere — earlier drafts that proposed
+"orchestrator auth tables" have been retired.
+
+A hierarchical decomposition:
+
+```
+Kernel
+  └── ChainRoot
+       ├── DomainOrch_DeFi
+       │    ├── ProtocolOrch_AMM
+       │    └── ProtocolOrch_Lending
+       └── DomainOrch_NFT
+            └── ...
+```
+
+User contracts hold caps minted by the appropriate layer
+(ProtocolOrch_AMM mints AMM-endpoint caps; DomainOrch_DeFi mints
+cross-protocol caps; ChainRoot mints cross-domain caps). Each cap's
+image_hash chain proves which layer minted it, so dispatch
+structurally lands at the right authority. Same mechanism at every
+layer.
+
+Compared to seL4: the structural property is the same — invocation
+authority is gated by cap-holding, kernel-enforced (here, gated by
+the chain-check at the dispatching layer, which is structural via
+image_hash chain that the kernel produced). The TCB for direct
+invocation is the kernel; the TCB for policy-bearing caps (rate
+limits, etc., when baked into cap variants per §14) is the
+orchestrator that mints the variant.
+
+**Recommendation for chain-spec authors**: structure orchestrator
+hierarchies so each layer mints caps for the operations it controls,
+and grants them downward. Avoid sidecar policy tables unless a
+specific policy must change dynamically post-grant; even then,
+key by cap identity rather than by user.
+
+## Direct line vs intermediate-mediated authority: not a security loss
+
+A natural concern when comparing v3 to seL4: **in seL4, every
+process has a direct line to the kernel via syscall; in v3,
+invocations from user contracts to kernel cascade through
+intermediates (ChainOrchestrator, sub-orchestrators). Each
+intermediate could refuse to propagate. Isn't this a security
+regression?**
+
+The short answer: **no**. Direct line in seL4 is an architectural
+choice, not a verified security property. The properties seL4
+verifies (P2-P5) are about what happens *when* an invocation is
+honored, not about whether an invocation is structurally
+guaranteed to reach the authority.
+
+### What seL4 actually guarantees
+
+seL4's verified properties say:
+
+- **If holder has cap**, kernel honors invocation (P5).
+- **If holder doesn't have cap**, no invocation possible (P5).
+- **Caps cannot be forged or fabricated** (P4).
+- **Authority cannot be exercised without cap-holding** (P2-P3).
+
+None of these say "every process must have direct kernel access".
+They say what kernel does *when invoked*, not whether invocation
+arrives unobstructed.
+
+### Layering in seL4
+
+When seL4 systems need policy enforcement (rate limiting, audit,
+mediation), they add server processes between the user and kernel:
+
+```
+User → Cap::ServerEndpoint → server.apply → Cap::KernelOp → kernel
+```
+
+The user holds a cap to the server, not to the kernel. Server checks
+policy; if approved, server invokes kernel via *its own* cap.
+Server can:
+- Refuse to forward → user request fails (rate limit kicks in).
+- Mutate args before forwarding → user gets different behavior.
+- Log all activity → audit trail.
+
+This is standard seL4 design when policy enforcement is needed.
+Notice the implication: **users in such systems don't have direct
+kernel access either**. They go through the server. The server
+becomes a single point of failure for that pathway.
+
+seL4 is fine with this. Verified properties hold: server can't
+forge kernel responses (no cap forgery); kernel still mediates the
+final operation (authority confinement); no cap leaks through the
+server (cap-flow integrity).
+
+### v3's structure is the same shape
+
+v3's CO-in-path is essentially the seL4 server-pattern made
+structural. ChainOrchestrator IS the policy server; it sits
+between user contracts and kernel. User contracts hold caps that
+route through CO; CO can rate-limit, audit, gate.
+
+The only difference: in seL4, you *add* a server when you want
+policy. In v3, the orchestrator is *always there*, because chain
+specs always want policy enforcement (gas accounting, fairness, per-
+user budgets, governance restrictions).
+
+For chains that don't need much policy at a given pathway:
+hierarchical orchestration (sub-orchestrators) lets the user contract
+hold caps that route directly to a leaf orchestrator with minimal
+mediation. This is closer to seL4's direct-line model.
+
+### Practical example: rate limiting
+
+To enforce "user A can mint at most 100 DataCaps per block":
+
+```
+A's apply: host_yield(args, reason=NeedKernelMint)
+  Cascade up to CO. CO's bytecode receives Paused with
+    reason=NeedKernelMint.
+  CO's bytecode inspects reason; recognizes it as one CO wants to
+    intercept (rather than blindly forward).
+  CO checks O.users[A].mint_count_this_block.
+  If count > 100:
+    DROP_PAUSED(originating chain)
+    A's tx fails with rate-limit error.
+  If count ≤ 100:
+    CO increments count.
+    CO yields itself (host_yield + CALL_RESUME loop), propagating
+      to kernel.
+    Kernel handles. Resume cascades back. A receives DataCap.
+```
+
+(Intermediate layers that don't want to intercept run a simple
+passthrough loop: `host_yield(...) → CALL_RESUME(child, ...)` per
+iteration. See discussions/yield-passthrough-optimization.md for
+performance commentary.)
+
+In seL4, achieving the same property would require adding a
+rate-limit server between user processes and kernel. The user
+holds a cap to the server; the server holds a cap to the kernel;
+server enforces. Same shape; v3 just makes this structural.
+
+### What "single point of failure" really means
+
+When we earlier called CO a "single point of failure", we framed
+it as a security concern. The reframing:
+
+- **For correctness**: CO can't make wrong things happen. Forgery
+  resistance via image_hash ensures responses are authentic.
+- **For liveness**: CO can refuse service. This is the policy
+  enforcement mechanism in action.
+- **For fairness**: CO can prioritize. Same as a server in seL4.
+
+A "buggy or malicious CO" is in the same trust position as a
+"buggy or malicious seL4 kernel" or "buggy or malicious seL4
+rate-limit server". Trusted infrastructure, in TCB, expected to
+be correct. Replacement requires governance (chain upgrade in v3,
+firmware update in seL4).
+
+### Conditional authority is the right model for blockchain
+
+In seL4, the authority property is "you hold cap = you can invoke".
+Direct line is the mechanism that makes this absolute.
+
+In v3, the authority property is "you hold cap = you can invoke,
+subject to policy enforced by the orchestrator hierarchy". Cascade
+is the mechanism that makes policy enforceable.
+
+This conditional-authority model is what blockchains actually want:
+
+- **Gas accounting**: every operation must be metered; CO sees
+  every yield.
+- **Per-user fairness**: CO can dispatch to schedule fairly across
+  users in a block.
+- **Governance restrictions**: certain operations subject to chain
+  policy that may change; CO is the policy enforcement point.
+- **Audit logging**: all kernel-bound operations logged at CO for
+  off-chain analysis.
+- **Rate limits**: per-user, per-domain, per-resource limits
+  enforceable at CO.
+
+Trying to achieve these in seL4 would require multi-server layered
+designs. v3 makes the layered design native.
+
+### What we're not breaking
+
+- **P2 (integrity)**: holds. Forgery resistance (image_hash chain) +
+  cnode ownership prevent unauthorized writes and unauthorized cap
+  acquisition.
+- **P3 (confidentiality)**: σ is public, but Instance state is opaque
+  from outside; request Instances (Attest, MintRequest, etc.) gate
+  inspection endpoints on caller-witness image_hash, so intermediates
+  cannot read request payloads. Confidentiality from intermediates
+  preserved structurally.
+- **P4 (cap-flow)**: holds. Caps can't be synthesized.
+- **P5 (authority confinement)**: holds. Holder of cap can invoke
+  the operation the cap names; intermediates can rate-limit but
+  cannot make the operation succeed without cap-holding.
+- **All other Vn properties**: unaffected.
+
+### What we're trading
+
+- **seL4's "absolute authority via cap-holding"** → **v3's
+  "conditional authority subject to intermediate policy"**.
+
+This is a feature for blockchain (enables policy enforcement) and a
+restriction for general-purpose OS use (would require changing
+default behavior to use direct invocation paths).
+
+### Liveness as a separate concern
+
+The remaining "single point of failure" is liveness:
+intermediate-driven service degradation if CO is buggy or
+malicious. Mitigations:
+
+1. **Hierarchical orchestration**: smaller domains, smaller per-CO
+   blast radius.
+2. **Bytecode verification**: CO's policy bytecode is
+   chain-spec-defined, formally verifiable. Reduces "buggy CO"
+   risk.
+3. **Governance / chain upgrade**: chain governance can replace CO
+   if needed. seL4 analog: firmware update.
+4. **Multi-validator consensus**: a single validator running a
+   misbehaving CO doesn't break consensus; the chain follows the
+   honest majority.
+
+These are blockchain-native mitigations. For seL4 use cases (single
+machine, single trusted base), liveness depends entirely on the
+kernel + servers being correct. v3 has more layers but also
+governance + consensus to repair them.
+
+### Conclusion
+
+Direct line in seL4 is **not a verified security property**. It's
+an architectural choice that seL4 happens to make and that v3
+happens not to make. v3's intermediate-mediated authority is
+**equally secure** for the verified properties (P2-P5) and
+**better-suited for blockchain** because it enables policy
+enforcement natively.
+
+The "single point of failure" framing was misleading. Better
+framing: **CO is the policy enforcement point, by design**.
+Properties hold; trust is appropriately placed; layering is
+explicit.
+
+## Open questions for further analysis
+
+1. **Formal operational semantics of v3.** Build in Lean. Define
+   state, ABI ops, transition relation. Required for any formal
+   verification.
+
+2. **Theorem statements for V2-V14.** Translate each property
+   statement above into a Lean theorem. Identify which are provable
+   from the operational semantics, which require additional
+   assumptions (e.g., orch bytecode meets a specification).
+
+3. **Specification of orchestrator policy.** What does it mean for
+   "orch bytecode is correct"? Need a way to specify the orch's
+   intended ledger invariants and prove the orch maintains them.
+
+4. **Composability of theorems.** If kernel + orch are both
+   correct, is the composed system correct? The composition
+   theorem.
+
+5. **Confidentiality story.** Even though σ is public, can we
+   articulate confidentiality properties for off-σ inputs and
+   outputs? AttestationAuthority pattern, hardware enclaves, etc.
+
+6. **Information flow analysis.** Even on public σ, are there
+   timing channels or state-pattern channels we should worry about?
+
+7. **Empirical comparison with KeyKOS / EROS / Coyotos.** These
+   pre-seL4 capability OSes had explicit handling for snapshots
+   (KeyKOS's "checkpoint" mechanism). Do their properties carry
+   over?
+
+8. **Verified microkernel size.** seL4 is ~10K LoC. What's a
+   reasonable size estimate for a verified v3 kernel + orch?
+   Probably 30-50K LoC total (kernel ~20K, orch ~10-30K).
+
+## Conclusion
+
+v3 has **most of seL4's verified properties at the {kernel + chain
+orchestrator} level**, with notable exceptions:
+
+- **P3 (confidentiality)** doesn't apply — σ is public by design.
+- **P6 (cap exclusivity / linearity)** is explicitly dropped.
+  Conservation is recovered via bytecode-arithmetic in canonical
+  authority Instances. Per the V6 analysis, linearity has **no
+  structural use case in v3 that other mechanisms don't already
+  cover** — every plausible use (Delegate, singleton enforcement,
+  one-shot tickets, atomic transfer, linear protocol verification,
+  etc.) is recovered via existing v3 mechanisms (image_hash chain,
+  ledger arithmetic, MGMT_MOVE, bytecode discipline). Adding
+  linearity to the kernel would be strict cost increase, not
+  enabling any property we don't already have.
+- **P1 (functional correctness)** is a goal, not a current
+  property. Awaiting formal spec + verification.
+
+v3 has **additional properties not in seL4**:
+
+- Snapshot/revert as a primitive operation.
+- State-root determinism for replication.
+- Cross-block continuation.
+- Forgery resistance via image_hash chain (different from cap
+  derivation).
+- Content-addressed storage.
+
+The TCB extends from "kernel only" (seL4) to "kernel + orch
+bytecode" (v3). This is acceptable because:
+- The orch is small, chain-spec-defined, formally verifiable.
+- The orch's policy is finite and well-understood (ledger
+  arithmetic, auth tables, dispatch logic).
+- User contracts remain untrusted (their bugs don't affect chain
+  invariants because they don't hold orch caps).
+
+**Hierarchical orchestration** (vs monolithic ChainOrchestrator)
+recovers more seL4-style properties by delegating cap authority
+through the orchestrator hierarchy. Most operations end up gated by
+direct cap-holding (kernel-enforced); orch arbitration is reserved
+for cross-cutting concerns.
+
+**Direct line is not a security property.** seL4's direct kernel
+access is an architectural choice; its verified properties (P2-P5)
+hold equally for layered designs (server-in-path). v3's CO-in-path
+is the same shape as seL4 + a server layer, just made structural.
+The "single point of failure" of CO is the policy enforcement
+point, by design — enabling rate limiting, audit, fairness, and
+governance restrictions that blockchain chains need. Authority in
+v3 is **conditional on intermediate policy**, not absolute via
+cap-holding alone. This is a feature for blockchain, not a
+security regression.
+
+The path to seL4-equivalent verification is:
+
+1. Formalize v3's operational semantics in Lean.
+2. State each property above as a theorem.
+3. Prove or refute against the model.
+4. Specify orch policy correctness as an assumption; prove the
+   composition.
+5. (Eventually) implement and prove implementation refinement.
+
+This document anchors the design discussion. Future "is X
+secure?" questions can be checked against this property list.
+Properties can be added/refined here; if a question can't be
+answered by reference to this list, the list itself is incomplete.

--- a/docs/spec/discussions/yield-passthrough-optimization.md
+++ b/docs/spec/discussions/yield-passthrough-optimization.md
@@ -1,0 +1,152 @@
+# Yield passthrough — performance optimization options
+
+In v3, when an Instance in the middle of a CALL stack receives a yield
+from below that it doesn't want to handle, it must propagate the
+yield upward. The canonical pattern is a bytecode loop. This doc
+discusses the optimization options for that loop. **None of these
+are in the main spec; this is a forward-looking note.**
+
+## The canonical passthrough pattern
+
+An Instance layer that wants to propagate yields it doesn't handle
+writes the following loop after a CALL:
+
+```
+-- self.slot[0] holds the scratchpad for outbound CALL (the args
+-- the layer wants to send to child)
+
+ret = CALL(child_slot, endpoint, gas_budget)
+loop {
+  match ret.status:
+    HALT(value) =>
+      -- self.slot[0] now holds child's reflected output
+      return value
+    Paused(reason) =>
+      if reason ∈ MY_HANDLED_REASONS:
+        handle the reason ...
+      else:
+        -- self.slot[0] holds child's request (reflected from yield).
+        -- yield, propagating slot[0] up to our caller.
+        host_yield(reason)
+        -- on resume, self.slot[0] holds the response from our caller.
+        -- forward to child.
+        ret = CALL_RESUME(child_slot, gas_budget)
+    Faulted =>
+      -- self.slot[0] holds whatever child had at fault
+      handle fault
+}
+```
+
+This works using only the existing kernel ABI (CALL, host_yield,
+CALL_RESUME). No new primitives required. slot[0] threads the
+scratchpad through each cascade level automatically (yield reflects
+up; CALL_RESUME moves down). Per cascade layer cost: roughly 100ns
+(a few bytecode instructions per iteration). For K=5 cascade depth:
+~500ns total — well within block-apply budget.
+
+## When passthrough might become a bottleneck
+
+This loop runs at every layer between yield originator and handler.
+If chains routinely have deep call stacks with many yields per CALL,
+the cumulative cost could become measurable. Rough scaling:
+
+- Per yield: K × 100ns where K is cascade depth.
+- Per block: (yields per tx) × (txs per block) × K × 100ns.
+
+For typical chain workloads (hundreds of yields per block, K~3-5),
+this is well under 1ms — not a bottleneck.
+
+If we find a workload where it is (deeply-nested orchestration with
+high yield frequency), an optimization is available.
+
+## Optimization option: `call_passthrough` opcode
+
+A single new opcode that does the loop in kernel-internal code,
+skipping bytecode execution:
+
+```
+call_passthrough(child_slot, endpoint, gas_budget,
+                 handled_reasons_bitmap) → ret
+
+  Kernel internal:
+    let ret = CALL(child_slot, endpoint, gas_budget)
+    loop:
+      match ret.status:
+        HALT, Faulted => return ret
+        Paused(reason):
+          if reason ∈ handled_reasons_bitmap:
+            return ret  -- bytecode wants to handle this one
+          host_yield(reason)
+          ret = CALL_RESUME(child_slot, gas_budget)
+```
+
+Bytecode using it:
+
+```
+ret = call_passthrough(child, ep, gas, handled_reasons=MY_REASONS)
+match ret:
+  HALT(v) => use v
+  Paused(reason) => handle (must be in MY_REASONS)
+  Faulted => handle fault
+```
+
+The kernel runs the loop without invoking bytecode. Cost per layer:
+~10ns (state transition only).
+
+For K=5 cascade: ~50ns total. ~10× faster than bytecode loop.
+
+## Why not in the spec now
+
+This is a peephole optimization. The bytecode loop works correctly
+and is performant enough for any realistic workload. Adding the
+opcode is straightforward if/when profiling shows a need.
+
+- **No correctness benefit.** Same semantics either way.
+- **Negligible practical cost.** Bytecode loop adds ~500ns to typical
+  cascades. Block budgets are seconds; this rounds to zero.
+- **ABI minimalism.** One more opcode is small, but every opcode
+  added is one more thing to verify, document, and maintain.
+- **Adoption discipline.** If we add the opcode, chains must opt in
+  per CALL site. They might forget; performance varies based on
+  bytecode discipline. With bytecode loop, the cost is uniform and
+  predictable.
+
+## Alternative considered: Image-flag `auto_propagate`
+
+An earlier draft considered an Image-level declaration:
+
+```
+Image {
+  ...
+  auto_propagate: BitSet<reason_id>   // reasons this Image auto-propagates
+}
+```
+
+Kernel skips bytecode for these reasons; cascade is kernel-fast.
+
+Trade-offs:
+
+- **Declarative**: per-Image policy stated once.
+- **But static**: same Image can't intercept reason R for some sub-calls
+  while propagating it for others.
+- **Image author burden**: every Image needs to think about which
+  reasons it passes through.
+
+We chose against this in favor of per-CALL granularity (either via
+bytecode loop or via `call_passthrough` opcode). The bytecode pattern
+gives the Image author full runtime flexibility; the kernel doesn't
+need an Image-level field.
+
+## When to revisit
+
+Add `call_passthrough` opcode when:
+
+- Profiling shows cascade overhead is a measurable fraction of block
+  apply time.
+- Chain authors are routinely writing the same loop boilerplate and
+  errors arise from getting it wrong.
+- A common chain pattern (e.g., deep orchestrator hierarchies)
+  emerges and we want to make it fast by default.
+
+Until then: bytecode loop is the canonical pattern. Document it in
+the userspace coding guide when we write one.

--- a/docs/spec/implementation/architecture.md
+++ b/docs/spec/implementation/architecture.md
@@ -1,0 +1,812 @@
+# v3 implementation architecture
+
+A plan for how the v3 spec (this directory's README) maps onto a Rust
+workspace. Captures crate boundaries, layering, the few architectural
+choices that are load-bearing for the split, and a recommended path
+from the current `~/jar/rust` codebase to the target shape.
+
+This is a *living* design doc — it gets edited as implementation
+surfaces things the spec didn't anticipate. The spec is the source of
+truth for what the system *is*; this doc is the source of truth for
+how the code *is organized*.
+
+## Goals
+
+- **Cap system as the foundational layer.** The cap system (Cap kinds,
+  CNode, BMT, image_hash chain, MGMT_* semantics) sits at the bottom
+  of the dep graph. It has no knowledge of execution, hardware,
+  block apply, or chain orchestration.
+
+- **Execution engine separable from caps.** The pure execution part
+  of JAVM (interpreter, recompiler, memory pages, gas metering,
+  registers, ecall opcode dispatch) is a standalone crate. No cap
+  awareness.
+
+- **Full JAVM = caps + execution + call stack.** The call stack is
+  the natural place where execution meets caps (an InstanceEntry
+  holds both a Cap::Instance reference and PC/regs). It belongs
+  one layer up, in the integration crate that combines the two.
+
+- **Backend trait for storage.** CNodes can be large (up to 2^k slots
+  for any k); the storage backing must be abstracted via a trait so
+  we can swap in-memory for merkle-tree-backed implementations later
+  without touching upstream code.
+
+- **Incremental migration.** The current `javm`-and-`jar-kernel` split
+  has the right shape conceptually but not the right factoring. We
+  refactor in stages, each stage compile-clean.
+
+## Non-goals
+
+- No premature optimization. Initial implementation uses simple
+  hashing (flat blake2b-256) where the spec calls for BMT; the BMT
+  primitive lands when state-root computation cost actually matters.
+- No backwards compatibility with v1/v2 designs. The kernel branch
+  ahead of `master` is the migration target; old kernel shapes are
+  not preserved.
+- No new tooling crates this round. Bench / transpiler / build crates
+  stay as-is.
+
+## Crate dependency graph
+
+```
+                    jar (binary; testnet driver)
+                            ▲
+                    jar-harness (genesis, multi-node integration)
+                            ▲
+                    jar-kernel (σ, block apply, host calls,
+                                kernel-assisted Image defs,
+                                JAR-specific Images)
+                            ▲
+                          javm  (call stack, MainFrame/BareFrame,
+                                 MGMT ecall dispatch, host-call
+                                 coordination, InvocationKernel)
+                       ▲           ▲
+                       │           │
+              ┌────────┘           └────────┐
+              │                             │
+        javm-exec                       jar-cap
+        (interpreter,                   (Cap, CNode + backend trait,
+         recompiler, memory,             Image, BMT, image_hash chain,
+         gas, registers,                 MGMT_* pure semantics, hash)
+         ecall dispatch trait)
+```
+
+Five new/refactored crates:
+
+| Crate | Role | Depends on |
+|---|---|---|
+| `jar-cap` | Foundational cap system | (nothing in workspace; just `scale`, `blake2b`, etc.) |
+| `javm-exec` | Pure execution engine | (nothing in workspace) |
+| `javm` | Full JAVM (caps + execution + call stack) | `jar-cap`, `javm-exec` |
+| `jar-kernel` | Chain kernel | `javm` |
+| `jar-harness` | Genesis + integration | `jar-kernel` |
+
+Note: `javm` keeps its current name. The execution-only split is
+`javm-exec`; the cap layer is `jar-cap`. The integration crate `javm`
+is what callers (jar-kernel) reach for; its API is roughly today's
+`InvocationKernel`.
+
+## Layer 1: `jar-cap`
+
+The foundational cap system. No execution, no I/O, no kernel concepts.
+Just the structural primitives that the spec defines.
+
+### Responsibilities
+
+- **Cap kinds.** Exactly the five v3 cap kinds per spec README §8 —
+  a non-parameterized enum:
+  - `Cap::Instance(InstanceCap)` — Frame-bound stateful unit.
+  - `Cap::Image(ImageCap)`
+  - `Cap::Data(DataCap)`
+  - `Cap::CNode(CNodeCap)`
+  - `Cap::Type(TypeCap)`
+
+  No generic `<P>` parameter; no `Cap::Protocol` variant. The v2
+  ProtocolCap mechanism does not exist in v3. JAR-specific things
+  (vaults, files, quotas, kernel-assisted resources) are encoded
+  as `Cap::Instance` values with particular Images (in the
+  `kernel:` namespace for kernel-assisted), not as a separate
+  cap variant.
+
+- **CNode.** Variable-size cap table (2^k slots). Holds `Option<Cap>`
+  per slot. Pinned-slot machinery (per Image declaration). Slot path
+  addressing for nested cnodes.
+
+- **CNode backend trait.** Storage abstraction. See "CNode backend"
+  section below.
+
+- **Image content + image_hash chain.** Image structure
+  (code, endpoints, memory_mappings, gas_slots, quota_slots,
+  pinned_slots, yield_marker_slot). Hash chain math:
+  `genesis = hash(image)`, `set_image extends = hash(prev || hash(new))`,
+  `derive_spawn = hash(spawner_chain || hash(new))`.
+
+- **BMT (balanced merkle tree).** Generic merkle primitive used by:
+  - State-root computation (over σ — handled at jar-kernel level
+    but using this primitive)
+  - Page-merkleized DataCaps (large data values; modify-by-page)
+  - Large CNode merkleization (future; initial impl flat-hashes)
+  
+  Initial impl: a simple "compute root from leaves" function. No
+  persistent tree structure. Defer the lazy / incremental BMT to
+  when it's the bottleneck.
+
+- **MGMT_* semantics as pure functions.** `mgmt_copy(table, src, dst)`,
+  `mgmt_move`, `mgmt_drop`, `mgmt_cnode_swap`. Operate on cap tables;
+  no execution context required. javm-side ecall dispatch calls these.
+
+- **Hash trait.** `Hash<H>` with a default `Blake2b256` impl. Allows
+  swapping for testing (mock hash) or future hash agility.
+
+### Module layout
+
+```
+jar-cap/
+  src/
+    lib.rs
+    cap.rs          -- Cap enum, InstanceCap, ImageCap, DataCap,
+                       CNodeCap, TypeCap
+    cnode.rs        -- CNode + CNodeBackend trait + default in-mem impl
+    image.rs        -- Image struct, image_hash chain math
+    slot.rs         -- SlotPath, SlotIdx; pinned-slot whitelist
+    bmt.rs          -- balanced merkle tree primitive
+    hash.rs         -- Hash trait + blake2b default
+    ops.rs          -- mgmt_copy / mgmt_move / mgmt_drop / mgmt_cnode_swap
+                       as pure functions over &mut CNode
+    error.rs        -- CapError, OpError
+```
+
+### What jar-cap deliberately doesn't have
+
+- No knowledge of registers / PC / gas — those are execution concerns.
+- No "active VM" or "running instance" — those are call-stack concerns.
+- No host calls — those are integration concerns at the javm layer.
+- No σ / block / state-root — those are jar-kernel concerns.
+
+This means `jar-cap` can be tested as a pure value-typed system:
+build a CNode, do operations, verify hashes. Property tests over
+cnode operations belong here.
+
+## Layer 2: `javm-exec`
+
+The execution engine. PVM interpretation + native recompilation. No
+cap awareness.
+
+### Responsibilities
+
+- **Interpreter.** PVM instruction set; register state (13 GPRs +
+  internal); memory pages; gas counter; trap handling.
+
+- **Recompiler.** JIT to native (Linux x86-64 only initially).
+  Same execution semantics as interpreter; differs in throughput.
+
+- **Memory model.** Page-based (4 KiB pages); read / write / COW
+  semantics; explicit mapping table per "address space" (one per
+  active execution context). The current javm `MemoryMap` shape.
+
+- **Gas metering.** Per-instruction counter, decremented as code
+  runs. Out-of-gas is an exit reason; not a fault here (the layer
+  above translates OOG to a yield with the kernel-issued OOGMarker).
+
+- **ExitReason.** The terminal status from an execution batch:
+  `Halt`, `Trap`, `Panic`, `OutOfGas`, `PageFault`, `Ecall`, `HostCall`.
+
+- **Ecall dispatch as a trait.** `trait EcallHandler { fn dispatch(
+  &mut self, op: u32, regs: &mut Regs, mem: &mut Mem) -> EcallResult; }`
+  The execution engine knows there are ecalls; it doesn't know what
+  they mean. The caller (`javm` integration crate) supplies the
+  EcallHandler that interprets ecalli numbers as MGMT operations,
+  host-call selectors, etc.
+
+### Module layout
+
+```
+javm-exec/
+  src/
+    lib.rs
+    interp.rs       -- interpreter loop
+    recompiler/     -- existing recompiler subtree
+    mem.rs          -- pages, mapping table
+    regs.rs         -- register state
+    gas.rs          -- gas counter
+    exit.rs         -- ExitReason enum
+    ecall.rs        -- EcallHandler trait
+```
+
+### What javm-exec deliberately doesn't have
+
+- No `Cap`, `CNode`, `Image`. The execution engine knows it has 4 KiB
+  pages and registers; it doesn't know that some pages came from a
+  DataCap.
+
+- No call stack. A single `execute()` call runs until ExitReason.
+  The caller decides what to do next.
+
+- No InvocationKernel. That's the integration crate's job.
+
+This split means `javm-exec` can be benchmarked / fuzzed against
+PolkaVM independently of the cap system.
+
+## Layer 3: `javm` (integration)
+
+Combines `jar-cap` and `javm-exec`. Owns the call stack, the
+kernel-known cap-bearing Frame structures (MainFrame, BareFrame),
+the MGMT-ecall handler, and the host-call coordination boundary.
+
+### Responsibilities
+
+- **Call stack.** The kernel-internal stack of `InstanceEntry` and
+  `ReferenceEntry`. Exactly one entry Running at a time. Pushes on
+  CALL, pops on HALT/fault. ReferenceEntry pushed by yield routing.
+  See README §3 and discussions/data-flow-principle.md "The stack
+  model in detail."
+
+- **Frame structures.** `MainFrame` (the cnode of the currently-Running
+  Instance) and `BareFrame` (kernel-injected pinned slots — kernel-
+  issued caps like SetGasMeter, OOGMarker, etc.).
+
+- **MGMT ecall dispatch.** Translates ecalli numbers (MGMT_COPY,
+  MGMT_MOVE, MGMT_DROP, MGMT_CNODE_MINT, MGMT_CNODE_SWAP, etc.) into
+  calls on `jar-cap`'s pure ops. Updates registers per the ABI.
+
+- **Yield routing.** Walks the call stack matching markers against
+  each Instance's YieldCatcher. The YieldCatcher's state is read via
+  kernel short-circuit (not endpoint dispatch); javm has direct
+  access to the kernel-assisted Frame's struct.
+
+- **Per-instruction gas debit.** The execution engine reports gas
+  consumed; javm debits the meter named by the active Instance's
+  gas slot. On hit-zero: triggers OOG yield (with kernel-issued
+  OOGMarker payload).
+
+- **InvocationKernel-equivalent API.** A `Vm` surface (renamed from
+  v2's `InvocationKernel<P>` — non-generic in v3) implementing the
+  v3 spec (set_image, host_derive_spawn, host_yield-with-marker,
+  etc.). This is what `jar-kernel` calls into.
+
+### Module layout
+
+```
+javm/
+  src/
+    lib.rs
+    callstack.rs    -- InstanceEntry, ReferenceEntry, stack invariants
+    frame.rs        -- MainFrame, BareFrame
+    vm.rs           -- Vm (call-stack-aware VM driver; no <P> parameter)
+    ecall.rs        -- MGMT + host-call dispatch (impls EcallHandler
+                       from javm-exec)
+    yield_route.rs  -- yield-marker routing
+    gas_debit.rs    -- per-instruction gas debit, OOG yield trigger
+```
+
+No `ProtocolCap` / `ProtocolCapHost` traits — v2's generic
+protocol-payload mechanism is gone in v3. Kernel-assisted Images
+(YieldCatcher, GasMeter, etc.) are recognized by image_hash
+match against a fixed registry the kernel knows; no generic
+plug-in trait needed.
+
+### Key design decision: call stack lives here
+
+The call stack is the meeting point of execution + caps:
+- Each `InstanceEntry` references a `Cap::Instance` (from `jar-cap`)
+- Each entry carries execution state (PC, regs — from `javm-exec`)
+- The stack drives both ecall-dispatch (execution side) and
+  yield-routing (cap side)
+
+Therefore call stack belongs in the integration crate (`javm`), not
+in either underlying crate. Neither `jar-cap` nor `javm-exec` should
+need to know about it; they're each consumed by `javm` which weaves
+them together.
+
+## Layer 4: `jar-kernel`
+
+The chain kernel. Owns σ state; runs block apply; provides host
+calls; defines the well-known Images for kernel-assisted Instances.
+
+### Responsibilities
+
+- **Kernel-assisted Image definitions.** Native-code Images for
+  YieldCatcher, GasMeter, StorageQuota, Gas{meter_id},
+  Quota{quota_id}, and the factory caps (SetGasMeter,
+  SetStorageQuota, MintGas, MintQuota, CreateYieldCatcher) — all
+  recognized by their image_hash in the `kernel:` namespace. The
+  v3 spec encodes these as `Cap::Instance` values with kernel-known
+  Images; the kernel short-circuits their state access. There is
+  no separate "protocol cap" mechanism.
+
+- **JAR-specific Images.** Per-chain Images that the JAR chain uses
+  (vault, file, resource, ...) — also just regular Images. What
+  v2 called `RegCap::VaultRef` etc. become `Cap::Instance` values
+  with these Images.
+
+- **σ state.** Vaults, images, data_blobs, code_blobs, storage_quotas,
+  transact_endpoints, dispatch_endpoints, validators, IdCounters.
+
+- **State root.** Merkleization of σ. Uses jar-cap's BMT primitive
+  but composes over the σ shape (registries-of-entries). State-root
+  scheme described in README §3 and §12.
+
+- **Block apply.** The `apply_block` / transact / dispatch phases.
+  Drives javm per event. Catches yields per marker. Implements the
+  lazy-load OOG-catch pattern (catch OOG → SetGasMeter topup →
+  CALL_RESUME).
+
+- **Kernel-assisted Frames.** Native implementations of GasMeter,
+  StorageQuota, YieldCatcher. Kernel short-circuits these (no
+  bytecode dispatch).
+
+- **Host calls.** set_image, host_derive_spawn, host_open, host_save,
+  host_yield, host_mint_cnode, host_mint_data_cap, host_read_data_cap,
+  host_same_type, host_same_type_as, host_type_of, host_subtype,
+  host_type_eq, host_make_image (see "Cap::Image construction" below).
+
+- **PoA / consensus** (existing) — validator scheduling, block hash,
+  proposer rotation.
+
+### Module layout (refactor of current crate)
+
+Greenfield: jar-kernel-v3 is built from scratch using jar-cap + javm
+as building blocks; the v2 `jar-kernel` crate stays untouched until
+retirement. Major shape:
+- `cap/` module is gone — there are no JAR-specific cap kinds; just
+  Images that produce `Cap::Instance` values.
+- `vm/` module shrinks — call stack + ecall dispatch + invocation
+  kernel move to `javm`.
+- `state/` mostly unchanged.
+- New: `kernel_assisted/` module for native impls of YieldCatcher,
+  GasMeter, StorageQuota.
+
+## CNode backend (the trait)
+
+Cnodes vary widely in size:
+- **Root cnode (RootCNode)**: fixed 256 slots, ~8 KiB if naive
+  `[Option<Cap>; 256]`.
+- **Cap::CNode** (variable): 2^k slots for any k. Large k (e.g., 16
+  = 64K slots, 20 = 1M slots) is plausible for chain registries.
+
+A 1M-slot cnode held naively as `Vec<Option<Cap>>` is ~32 MB per
+instance. Many such cnodes in flight is untenable. Hence the trait.
+
+```rust
+pub trait CNodeBackend {
+    fn size_log(&self) -> u8;            // 2^k
+    fn get(&self, idx: u32) -> Option<&Cap>;
+    fn set(&mut self, idx: u32, cap: Option<Cap>);
+    fn hash(&self) -> Hash;              // content hash; cached/lazy ok
+    fn snapshot(&self) -> Self where Self: Sized;
+                                         // COW snapshot for working state
+}
+```
+
+Two initial implementations:
+
+1. **`MemoryCNode`** (default). Simple `Vec<Option<Cap>>`, allocated
+   to size. Hash computed from full content. Snapshot = clone. Fast
+   for small cnodes; uses too much memory for large.
+
+2. **`MerkleCNode`** (lazy, for large). A balanced merkle tree where
+   subtrees can be:
+   - **Hash-only** (not materialized — just the BMT hash)
+   - **Materialized** (a leaf array of slots, possibly with their
+     own substructure)
+   
+   `set()` materializes the path to the modified leaf; `hash()`
+   recomputes only the modified branches. `snapshot()` is O(1) —
+   shares all immutable subtrees.
+
+For v0, only `MemoryCNode` is implemented. The trait exists so we
+can drop in `MerkleCNode` later without touching anything upstream.
+
+## BMT (balanced merkle tree)
+
+The primitive: a balanced binary merkle tree over a sequence of
+leaves. Used at three places in the spec:
+
+1. **State-root.** σ is hashed canonically; chain header carries
+   `state_root = root_hash(σ)`. See README §12.
+
+2. **Page-merkleized DataCaps.** Large data values stored as a BMT
+   of 4 KiB pages so that modifying one page is O(log num_pages)
+   to recompute the hash. See README §2 "Page-merkleized DataCap."
+
+3. **MerkleCNode** (above; future).
+
+Initial implementation:
+
+```rust
+pub struct Bmt;
+
+impl Bmt {
+    /// Compute the merkle root over a slice of leaf hashes.
+    pub fn root<H: Hash>(leaves: &[H::Out]) -> H::Out;
+
+    /// Generate a proof for leaf at index i; verify via `verify_proof`.
+    pub fn proof<H: Hash>(leaves: &[H::Out], i: usize) -> MerkleProof<H>;
+
+    pub fn verify_proof<H: Hash>(
+        root: H::Out, leaf: H::Out, i: usize, proof: &MerkleProof<H>
+    ) -> bool;
+}
+```
+
+Domain separation: leaf hashes prepend `0x00`, internal nodes prepend
+`0x01` (standard practice).
+
+For v0, just `root()` is implemented; proofs are added if/when a
+host-call needs them.
+
+## Hash function
+
+`Blake2b256` is the default `Hash` impl. Matches existing JAR / spec
+conventions. The trait is generic so we can swap for testing or
+future agility, but the spec is currently written assuming
+blake2b-256.
+
+## Implementation path (greenfield)
+
+The v3 implementation is built from scratch as new crates alongside
+v2; v2 crates stay untouched as a reference/cherry-pick source until
+v3 is feature-complete. Each stage ends compile- and lint-clean.
+
+### Stage 1 — create `jar-cap`
+
+- New `rust/jar-cap/` crate.
+- Write (not "move") the v3 cap system:
+  - `Cap` enum (non-generic; five v3 kinds).
+  - `CNode` + `CNodeBackend` trait + `InMemoryCNode` default impl.
+  - `Image` + image_hash chain math.
+  - `Hash` trait + `Blake2b256` default.
+  - `Bmt::root()` primitive.
+  - Pure-function `mgmt_copy/move/drop/cnode_swap/cnode_mint` ops.
+- Cherry-pick the blake2b wrapper from v2; everything else is new.
+
+### Stage 2 — create `javm-exec`
+
+- New `rust/javm-exec/` crate.
+- Pure execution: interpreter, recompiler, memory pages, gas counter,
+  registers, ExitReason, `EcallHandler` trait.
+- Cherry-pick from v2's `javm/src/{interpreter,memory,recompiler/...}`
+  but strip all cap-awareness — execution engine knows nothing about
+  caps; ecalls go through `EcallHandler` trait.
+
+### Stage 3 — create `javm` (integration crate)
+
+- New `rust/javm/` crate (will collide with the v2 name; rename v2
+  to `javm-legacy` at that stage, or use a distinct name like
+  `jar-vm`).
+- Compose jar-cap + javm-exec via the call stack:
+  - `Vm` driver (renamed from v2's `InvocationKernel`; non-generic).
+  - InstanceEntry / ReferenceEntry call stack.
+  - MainFrame / BareFrame.
+  - MGMT ecall dispatch + host-call coordination.
+  - Yield-marker routing.
+  - Per-instruction gas debit against active Instance's gas slot.
+
+### Stage 4 — kernel-assisted Instances in jar-kernel-v3
+
+- Add `jar-kernel/src/kernel_assisted/`:
+  - `yield_catcher.rs` — kernel-implemented YieldCatcher image.
+  - `gas_meter.rs` — kernel-internal GasMeter table.
+  - `storage_quota.rs` — kernel-internal StorageQuota table.
+  - `gas.rs` — Gas{meter_id} unit-handle image.
+  - `quota.rs` — Quota{quota_id} unit-handle image.
+- Add factory caps: SetGasMeter, SetStorageQuota, MintGas, MintQuota,
+  CreateYieldCatcher.
+- Add kernel-issued markers: OOGMarker, StorageExhaustedMarker.
+- Inject all of these into chain Instance's cnode at genesis (per
+  README §12 "Chain init: kernel-issued caps").
+
+### Stage 5 — wire up the lazy-load OOG-catch pattern
+
+- jar-kernel's apply_block catches OOG yields, calls SetGasMeter to
+  top up, CALL_RESUMEs.
+- Reference: discussions/kernel-assisted-instances.md "The lazy-load
+  OOG-catch pattern."
+
+### Stage 6 — state-root via BMT
+
+- jar-kernel's state-root computation uses `jar-cap::Bmt`.
+- Per-registry: BMT over sorted (id → entry) pairs.
+- Composed: a fixed-shape parent BMT over the per-registry roots.
+- Hash chain header carries the composed root.
+
+### Stage 7 — page-merkleized DataCap
+
+- DataCap of size > one page stored as BMT of 4 KiB chunks.
+- HALT: recompute only modified chunk hashes + their paths.
+- Initial impl: just compute the root each time (O(N) on HALT). The
+  incremental version is a later optimization.
+
+After stage 7, we have the v3 spec end-to-end. Subsequent work is
+optimization (MerkleCNode, incremental BMT updates, JIT-recompiler
+support for new ops, etc.).
+
+## Big undecided spec issues (and recommended resolutions)
+
+These are spec-level questions still in the spec's §18 "Open
+questions" or implicit in the discussion docs. Each gets a
+recommended resolution that I'll use unless the user redirects —
+fill-in-the-gap defaults.
+
+### 1. Cap::Image construction
+
+**Question:** How are Cap::Image values constructed at runtime?
+
+**Recommendation:** A host call.
+
+```
+host_make_image(code, endpoints, mappings, gas_slots, quota_slots,
+                pinned_slots, yield_marker_slot, dst: SlotPath) → ()
+  Validates the input (bytecode parseable; slot indices in range;
+  no pinned-slot collisions with declared gas/quota/yield slots).
+  Constructs an Image; computes hash(image); places Cap::Image at dst.
+```
+
+Cost: bytecode validation work; debited from active gas meter.
+Storage cost: debited from active quota.
+
+Alternative considered: pre-image-construction at genesis only.
+Rejected because chains need to construct new Images during apply
+(e.g., when minting new subject types).
+
+### 2. Yieldref cap representation
+
+**Question:** Is the yield-marker cap a distinct kind (Cap::YieldRef)
+or just a Cap::Instance with a specific image_hash chain?
+
+**Recommendation:** Just a Cap::Instance. No new cap kind.
+
+The marker is a Frame derived via `host_derive_spawn(MarkerImage)`;
+its `instance_hash` is the routing key. The kernel does no special
+validation beyond `instance_hash` equality. There's no per-marker
+behavior — markers are pure routing keys. So no need for a distinct
+cap kind; Cap::Instance suffices.
+
+### 3. CNode size constraints on host_derive_spawn
+
+**Question:** Must the cnode argument to host_derive_spawn be exactly
+256 slots? Or auto-pad smaller? Or accept variable size?
+
+**Recommendation:** Exactly 256 slots (matching RootCNode). Caller is
+responsible. host_derive_spawn returns an error if size mismatches.
+
+Auto-padding is convenient but ambiguous (which slots are pinned?).
+Variable-size root cnodes complicate the address-space-mapping
+machinery. Exact size is simplest and not onerous (caller just
+host_mint_cnode's a 256-slot cnode).
+
+### 4. Recursion depth limit
+
+**Question:** Maximum kernel call-stack depth?
+
+**Recommendation:** Chain-spec constant. Default 256.
+
+Why 256: matches root cnode size (mnemonic), bounds memory per
+in-flight invocation (256 × ~few KB stack-entry-size ≈ ~MB worst
+case), well above any plausible legitimate depth. Going deeper is a
+fault.
+
+### 5. Pinned-slot collision policy on set_image
+
+**Question:** When set_image's new pinned slots collide with
+non-pinned content the caller has put in those slots, the current
+spec says FAIL. Should there be a "force" variant?
+
+**Recommendation:** No force variant. Caller MGMT_DROPs the colliding
+slot first if intentional. Spec semantics unchanged.
+
+A force variant would silently lose user data; a chain author who
+needs the slot can just drop it explicitly.
+
+### 6. MGMT_CNODE_SWAP cross-cnode semantics
+
+**Question:** Can MGMT_CNODE_SWAP swap a slot in the root cnode with
+a slot in a nested Cap::CNode? Across two different nested cnodes?
+
+**Recommendation:** Both ends of swap must be in the same cnode
+(either root or the same nested cnode). Cross-cnode swap is rejected.
+
+Rationale: cross-cnode swap means the two endpoints have different
+hash dependencies (modifying one updates the parent cnode hash; the
+other updates a different parent cnode hash). Atomic two-cnode swap
+requires updating two hashes; messier semantics. Same-cnode is the
+common case and is structurally simple.
+
+### 7. State-root scheme
+
+**Question:** Concrete merkle structure for σ?
+
+**Recommendation:** BMT over each registry's sorted key-value pairs;
+flat fixed-shape parent over the registry roots. Specifically:
+
+```
+state_root = bmt_root([
+  bmt_root(vaults, sorted by VaultId),
+  bmt_root(images, sorted by ImageId),
+  bmt_root(data_blobs, sorted by FileId),
+  bmt_root(code_blobs, sorted by CodeId),
+  bmt_root(storage_quotas, sorted by QuotaId),
+  bmt_root(transact_endpoints, indexed),
+  bmt_root(dispatch_endpoints, indexed),
+  bmt_root(validators, indexed),
+  hash(chain_index || ...miscellaneous fields...),
+])
+```
+
+Order is canonical; never reordered. Adding new registries appends
+to the parent shape — chain spec versioning.
+
+### 8. Paused-persistent vs Waiting
+
+**Question:** When does a yielded Instance stay Waiting on the call
+stack (in-flight only) vs become σ-resident Paused?
+
+**Recommendation:** All yields stay Waiting by default. Only an
+explicit `DROP_RESUME` host call promotes Waiting → Paused-persistent
+and detaches the continuation as a σ-resident cap.
+
+Block-end: any still-Waiting stack entries fault their corresponding
+Instances (block-end is a hard boundary). Chain that wants multi-
+block continuation explicitly DROP_RESUMEs.
+
+### 9. Cap::Type vs Cap::Image canonical form
+
+**Question:** Both reference image_hash chains. What's the difference?
+
+**Recommendation:** They stay distinct.
+
+- `Cap::Image` carries the full Image spec (code, endpoints,
+  mappings, pinned_slots, etc.) — content-addressed by its content
+  hash.
+- `Cap::Type` carries just an image_hash chain — opaque identifier
+  for "the type produced by deriving image X1 ∘ ... ∘ Xn from
+  genesis."
+
+You can compute Cap::Type from any Cap::Instance (via
+host_type_of) or from another Cap::Type extended by Images (via
+host_subtype). You can never go the other way — a Cap::Type doesn't
+let you recover the Images.
+
+Tests for type equality use `host_type_eq` (image_hash equality).
+Authority uses Cap::Instance possession + yield-marker pattern (per
+README §14), not Cap::Type.
+
+## Smaller fill-in-the-gap decisions
+
+These are sub-spec details where I'll just make a defensible call
+unless the user redirects.
+
+- **Page size: 4 KiB.** Matches the underlying JAVM page size; no
+  reason to introduce a different kernel-level page size.
+
+- **Hash: blake2b-256.** Matches existing JAR conventions.
+
+- **CodeId: blake2b-256 of code blob.** Content-addressed; auto-dedup.
+  (Already in the current implementation.)
+
+- **FileId / QuotaId / VaultId / ImageId: monotonic u64.**
+  Chain-state-resident counters in IdCounters. Already current.
+
+- **Meter_id / quota_id: chain-chosen u64.** Per resolved decisions
+  in [discussions/kernel-assisted-instances.md](../discussions/kernel-assisted-instances.md).
+
+- **Dirty-page tracking lifetime: stack-leave reset.** Per resolved
+  decisions in kernel-assisted-instances.md.
+
+- **OOG payload: just the Gas{meter_id} cap.** No caller context.
+  Per resolved decisions.
+
+- **Genesis chain Instance: derived from a `genesis_image` Cap::Image
+  the validator binary bakes in.** Spec calls it "Kernel" but the
+  name is just convention; what matters is that genesis is a single
+  fixed Image that the chain spec defines.
+
+- **Block apply gas budget: chain-spec constant.** Kernel initializes
+  `root_meter_id` to this value at block start.
+
+- **Block apply quota budget: chain-spec constant.** Same.
+
+- **Validator binary holds the genesis_image hash; the chain Instance
+  is materialized by deriving from genesis_image.**
+
+## Open implementation questions
+
+Smaller things I haven't decided but probably don't need to before
+starting Stage 1:
+
+1. **Async vs sync hardware trait.** Current `Hardware` trait in
+   jar-kernel is sync. Block store / persistence might want async
+   eventually. Defer.
+
+2. **Recompiler support for new ops.** MGMT_CNODE_SWAP, set_image,
+   host_derive_spawn, etc. are new ops the recompiler needs to
+   handle. Initially they can be interpreted (recompiler falls back
+   to interp for unrecognized opcodes). Recompile-all later.
+
+3. **Cap::CNode hashing.** Recursive — a cnode's hash depends on
+   slot caps' hashes (including nested cnodes' hashes). The
+   recursion bottoms out at content-addressed Cap::Image / Cap::Data
+   and at Cap::Instance whose hash is its content hash. Decision:
+   computed lazily, cached per-CNode.
+
+4. **Slot identity in cnode hashing.** Should empty slots be encoded
+   explicitly, or compressed via a bitmap? Current impl encodes
+   `Option<Cap>` per slot. Decision: encode explicitly for v0
+   (simple); optimize later if it matters.
+
+5. **Validator-binary version vs chain-spec version separation.**
+   Validator binary baked-in constants (genesis_image, block budgets,
+   etc.) vs chain-state-dependent constants. Probably both, but the
+   exact split should be drawn explicitly. Defer.
+
+## Sanity check: does this match the spec?
+
+Map the spec sections to crate placement:
+
+| Spec section | Implementation lives in |
+|---|---|
+| §0 Foundational principles | (philosophy; no code) |
+| §1 Instance and Image | `jar-cap` (Image, image_hash); `javm` (MainFrame) |
+| §2 Memory model | `javm-exec` (pages, mapping); `jar-cap` (DataCap structure); `jar-kernel` (Pattern 4 dirty-page tracking) |
+| §3 Status state machine + call stack | `javm` (call stack); `jar-kernel` (status as σ state) |
+| §4 Kernel ABI | `javm` (CALL/CALL_RESUME/host_yield/MGMT dispatch); `jar-kernel` (host_open/host_save/etc., kernel-issued cap endpoints) |
+| §5 Apply terminations | `javm` (HALT/yield/fault transitions); `jar-kernel` (status propagation) |
+| §6 Operation patterns | (usage patterns; no specific code) |
+| §7 Pure-function apply | (structural invariant; enforced by the layering) |
+| §8 Cap kinds | `jar-cap` (Cap enum, the five kinds) |
+| §9 By-value semantics | `jar-cap` (cnode hashing, hash divergence); `javm` (working-memory cap-table updates) |
+| §10 Sub-tree atomicity | `javm` (call-stack discipline; fault unwinds) |
+| §11 Sync CALL + emits + saga | `jar-kernel` (emit handling, saga compensation) |
+| §12 Per-block kernel + chain Instance | `jar-kernel` (apply_block, chain init kernel-issued caps) |
+| §13 Off-chain Dispatch | `jar-kernel` (off-chain dispatch path) |
+| §14 Authority via capability flow | (chain bytecode pattern; no kernel code) |
+| §15 Attestation | `jar-kernel` (AA kernel-assisted Instance; per-attest yield handler) |
+| §16 MintInstance | (chain bytecode pattern; same authority mechanism) |
+| §17 Footgun reduction | (structural; enforced by the layering) |
+| §22 Kernel-assisted Instances | `jar-kernel/kernel_assisted/` |
+
+Every spec mechanism has a home in exactly one crate. No spec
+section is split across more than two crates. Crate boundaries are
+informed by the spec, not arbitrary.
+
+## Summary
+
+```
+jar-cap     — foundational cap system (Cap, CNode + backend trait,
+              Image, BMT, image_hash chain, MGMT pure semantics)
+javm-exec   — pure execution (interpreter, recompiler, memory, gas)
+javm        — call stack + cap-aware Frame structures + MGMT dispatch
+              + yield routing + gas debit
+jar-kernel  — σ state, block apply, kernel-assisted Image
+              definitions, host calls, state-root, consensus
+jar-harness — genesis + multi-node integration (unchanged)
+jar         — testnet binary (unchanged)
+```
+
+Implementation path (greenfield, v2 stays as cherry-pick reference):
+create jar-cap → create javm-exec → create javm (integration) → add
+kernel-assisted Instances to jar-kernel-v3 → wire OOG-catch →
+state-root via BMT → page-merkleized DataCap. Each stage compile-
+clean.
+
+The architectural choices that are *load-bearing* for this split:
+
+1. **Call stack lives in `javm` integration crate.** It's the meeting
+   point of execution + caps; belongs at the integration layer.
+
+2. **CNode backend is a trait.** Allows in-memory default + future
+   merkle-backed impl for large cnodes without upstream churn.
+
+3. **BMT is a `jar-cap`-level primitive.** Shared by state-root,
+   page-merkleized DataCap, and (future) MerkleCNode.
+
+4. **Cap enum is non-generic.** No `<P>` parameter, no
+   `Cap::Protocol` variant. JAR-specific things are encoded as
+   `Cap::Instance` values with particular Images; kernel-assisted
+   things by image_hash match against the kernel's registry. The
+   v2 ProtocolCap mechanism is retired.
+
+For the spec-level questions still open in README §18, the
+recommended resolutions above are defensible defaults; the user
+can redirect any individual one.

--- a/docs/spec/implementation/kvm-microkernel.md
+++ b/docs/spec/implementation/kvm-microkernel.md
@@ -1,0 +1,927 @@
+# Nub: the KVM-microkernel architecture
+
+A design doc for moving javm into a long-running microkernel
+running under KVM (or any equivalent hardware-virtualization
+substrate) — with chain state σ resident entirely in the guest.
+The microkernel is named **`nub`**.
+
+The current v3 implementation track ([architecture.md](architecture.md))
+continues independently. This doc covers the alternative
+architecture that's been promoted past prototype.
+
+## Status (2026-05)
+
+- **Stage 0 (this doc).** Complete: design and decision gates
+  written down.
+- **Stage 1 (prototype).** Complete: a 5-commit Hyperlight + ring-0
+  spike validated every architectural gate (ring 0, long mode,
+  custom IDT, in-guest `#PF` handling, CR3 manipulation, CoW
+  round-trip) on the i9-13900K target hardware. Measured numbers
+  are recorded against the gate table below. The build-system
+  spike also passed: stable rustc + `x86_64-unknown-none` + a
+  one-shot `RUSTFLAGS` recipe drives the bare-metal guest build
+  without `cargo-hyperlight`, custom target JSONs, or picolibc.
+- **Crate skeleton.** Complete: `nub`, `nub-kernel`,
+  `nub-arch-local`, `nub-arch-hyperlight`, `nub-build` are
+  scaffolded with the `Arch` trait wired through both backends.
+  See [§Crate layout](#crate-layout-as-of-stage-1).
+- **Naming since Stage 0.** The doc was originally written around
+  a "HAL" trait (hardware abstraction layer) with concrete impls
+  named `HyperlightHal` / `PlainMemHal` / `PciSocHal`. The
+  implementation calls the trait `Arch` instead — matching
+  Linux's `arch/x86`, `arch/arm64` convention — and the impls
+  are named `nub-arch-hyperlight` / `nub-arch-local` /
+  `nub-arch-pci-soc` (the last still speculative). The body of
+  this doc has been updated in place; a couple of mentions of
+  the legacy "HAL" name remain where they refer specifically to
+  the original Stage 0 sketch.
+
+The rest of this doc retains the Stage 0 design analysis as
+written (it held up under prototyping), with [§Crate layout
+(as of Stage 1)](#crate-layout-as-of-stage-1) and [§Arch trait
+design](#arch-trait-design-after-stage-1) capturing decisions
+made during the prototype that the original design didn't have.
+
+## Why this is worth exploring
+
+Three threads converge on the same answer.
+
+**(a) Memory management.** The host-userspace track invents a lot
+of OS-shaped machinery for cheap cap copy and per-Instance memory
+management — per-DataCap memfds with `MAP_PRIVATE` CoW, an
+LSM-shard overlay model, userspace page-fault tricks (uffd / signal
+handlers), a per-thread pool of 4 GiB `FlatMemory` mmaps, a
+write-back protocol on unmount. Each piece is tractable. The
+aggregate is several KLoC reimplementing what a real OS gives us
+natively. In ring 0 with our own page tables, the whole stack
+collapses into "set a CoW bit, install a `#PF` handler."
+
+**(b) Security: no JIT in the host process.** The PolkaVM project
+explicitly identified untrusted JIT'd code running in the same
+process as the chain client as a hard problem — they ended up
+sandboxing the JIT in a separate child process. We rejected that
+for JAVM because the hostcall round-trip cost was unacceptable.
+A microkernel solves both: the JIT runs inside a hardware-isolated
+guest, and most "hostcalls" don't have to cross out to the host
+at all (the guest carries the cap manager, σ, the canonical
+encoder, the state-root computation).
+
+**(c) Portability.** Today's recompiler is gated
+`cfg(all(target_os = "linux", target_arch = "x86_64"))` —
+unavailable on macOS, Windows, BSD. Routing the recompiler through
+a hypervisor abstraction (KVM on Linux, Hypervisor.framework on
+macOS, WHP on Windows) *expands* coverage to all those platforms,
+not contracts. See *End-state architecture* below.
+
+The `mgmt_copy` O(1) property we want is provable in both the
+userspace and microkernel models (see below). The decision isn't
+"is it theoretically possible," it's "which model is the cleaner
+engineering bet over the next 5 years."
+
+## End-state architecture: Arch → nub → javm-exec
+
+Three layers, like a real OS:
+
+```
+┌──────────────────────────────────────────┐
+│  javm-exec  (interpreter + recompiler)   │  ← execution backends
+├──────────────────────────────────────────┤
+│  nub  (the microkernel)                  │  ← cap manager, σ-filesystem,
+│  (cap mgmt, state root, scheduler, the   │     IDT/page-table mgmt, JIT cache,
+│   interpreter, page-fault handler)       │     port. across all Arch impls
+├──────────────────────────────────────────┤
+│  Arch  (CPU/MMU substrate)               │  ← swap per deployment target
+└──────────────────────────────────────────┘
+```
+
+The kernel (`nub-kernel`) is **portable Rust, `no_std`**. It runs
+unchanged on whatever "hardware" the `Arch` implementation
+exposes. The `Arch` trait abstracts: physical memory, vCPU
+control, host-callback ABI, page-fault notification. Everything
+else is inside the kernel.
+
+This is the same factoring Linux's `arch/`, NetBSD's MI/MD split,
+Plan 9's portation discipline use. We get its benefits: one
+correctness story, one performance story, one set of tests.
+
+### Arch trait sketch (Stage 0 shape)
+
+```rust
+// crates/nub-kernel — pure no_std, no platform deps
+pub trait Arch {
+    // Memory management — Arch owns physical pages
+    fn alloc_pages(&mut self, n: usize) -> Result<GuestPhysPage>;
+    fn free_pages(&mut self, base: GuestPhysPage, n: usize);
+    fn map_region(&mut self, /* address, perms, flags */) -> Result<()>;
+
+    // vCPU control — what "running" means varies by Arch
+    fn run_until_yield(&mut self, /* entry, regs */) -> ExitReason;
+
+    // Host callbacks — what "asking the host" means varies by Arch
+    fn read_blob(&mut self, hash: [u8; 32]) -> Result<Bytes>;
+    fn write_blob(&mut self, bytes: &[u8]) -> Result<[u8; 32]>;
+    fn host_notify(&mut self, event: HostEvent);
+}
+```
+
+The post-prototype shape is more refined; see
+[§Arch trait design (after Stage 1)](#arch-trait-design-after-stage-1).
+
+### Three Arch implementations
+
+| Arch | Substrate | javm-exec backend | Deployment target |
+|---|---|---|---|
+| **`nub-arch-hyperlight`** | KVM / Hyper-V / WHP, guest ring 0 long mode | **Recompiler** (in-guest JIT) | Linux/macOS/Windows/BSD with hardware virt |
+| **`nub-arch-local`** | Plain Rust, runs in the host process | **Interpreter only** (no JIT — see below) | Any platform; portable fallback |
+| **`nub-arch-pci-soc`** (future) | ARM SoC or FPGA on PCIe; nub cross-compiled to device arch | Recompiler (device-resident JIT) | Validators with execution-accelerator hardware |
+
+**Why the Arch determines the javm-exec backend.** The recompiler
+emits and executes native code; it requires hardware isolation
+from the host process to avoid the JIT-injection security
+property we want. So an Arch with hardware isolation
+(`nub-arch-hyperlight`, `nub-arch-pci-soc`) can run the
+recompiler safely. The `nub-arch-local` doesn't have an isolation
+boundary — JIT'ing native code there means executing
+untrusted-derived code in the host process, the exact thing we're
+avoiding. So `nub-arch-local` exposes only the interpreter.
+
+### The cross-Arch determinism invariant
+
+The same `(prior_root, block)` input must produce byte-identical
+`new_state_root` regardless of which Arch/javm-exec combination
+ran the block. Validators on different deployment targets must
+not diverge in consensus. This is **the load-bearing correctness
+condition** for the multi-Arch deployment story; it's the same
+property as cross-backend equivalence (interpreter vs recompiler)
+but now also applies across hardware substrates.
+
+Verified via property test: corpus of blocks, run through each
+Arch × backend combination, state-roots compared. Already the
+shape of `pvm_bench`'s gas-match assertion; promote to a hard
+correctness gate.
+
+### `nub-arch-hyperlight`: portability matrix
+
+Hyperlight already abstracts the per-OS hypervisor:
+
+| Host OS | Hypervisor API | Recompiler available? |
+|---|---|---|
+| Linux | KVM | Yes (works today) |
+| macOS | Hypervisor.framework | **Yes** (on Hyperlight roadmap) |
+| Windows | WHP (Windows Hypervisor Platform) | **Yes** (Hyperlight ships this) |
+| FreeBSD | bhyve | **Yes** (we'd add this layer) |
+
+The remaining portability constraint is **host CPU arch**: the
+hypervisor only runs guests targeting the host's CPU, so per-arch
+JIT codegen (x86-64 today; ARM64 for Apple Silicon/Graviton
+later) is still our responsibility. This is the same cost we
+already accept for the userspace recompiler today.
+
+### `nub-arch-hyperlight`: nested-virt caveat in cloud
+
+Some cloud VMs don't expose hardware virt to tenants, or charge
+for it as a premium (AWS metal SKUs only without paid nested-virt;
+GCP preview; Azure SKU-restricted). Validators in such
+environments fall back to `nub-arch-local` (interpreter only) —
+slower but functional. The cross-Arch determinism invariant is
+what makes this safe.
+
+### `nub-arch-pci-soc`: the future-proofing story
+
+The Arch trait is the natural seam for execution-accelerator
+hardware: a dedicated ARM SoC or FPGA on PCIe running the
+microkernel as its firmware. The same microkernel source
+cross-compiles to the device's arch; the Arch impl talks to the
+device over PCIe instead of KVM.
+
+Sketch of the protocol:
+
+- Host writes commands to a PCIe BAR (command ring in MMIO).
+- SoC receives, runs the microkernel, returns results via a
+  result ring.
+- Bulk transfer (cap blob fetch/write) uses DMA between host
+  RAM and device memory.
+- Host-side API is unchanged: `kernel.apply_block(prior_root,
+  block)` returns `(new_root, deltas)`.
+
+This is the same architectural pattern Ethereum's prover-
+acceleration designs and Aptos's parallel-exec accelerators are
+exploring. The fact that we accommodate it as an Arch swap, not a
+rewrite, is a real win — but **purely future-proofing**. Not on
+the implementation roadmap today.
+
+### Custom compile target: a possibly-avoidable friction
+
+Hyperlight today defaults to a custom Rust target spec
+(`x86_64-hyperlight-none`) plus a `cargo-hyperlight` subcommand
+plus picolibc for C dependencies. That's significant build-system
+surface.
+
+Our microkernel is pure Rust (no C deps). For pure-Rust guests,
+most of what the custom target packages can be supplied via
+`RUSTFLAGS` on top of **`x86_64-unknown-none`** — stable since
+Rust 1.71 (August 2023). Linking against `hyperlight_guest` (the
+no-libc layer of Hyperlight's guest crates) directly, without
+`hyperlight_guest_bin` (the picolibc layer), should let us drop
+the custom-target/cargo-hyperlight/picolibc stack.
+
+A Stage 1 spike confirms: if `cargo build --target=x86_64-unknown-none`
+with the right `RUSTFLAGS` produces a Hyperlight-loadable ELF, we
+keep the friction at "supply a few linker flags." If it doesn't,
+we wear the custom-target cost; not the end of the world but
+worth knowing.
+
+## Crate layout (as of Stage 1)
+
+Today's workspace shape:
+
+```
+rust/
+├── nub/                      lib  — caller-facing `Nub` handle
+├── nub-kernel/               lib  — Kernel<A: Arch> + Arch trait + interp
+├── nub-arch-local/           lib  — in-process Arch (software-copy memory)
+├── nub-arch-hyperlight/      bin  — Hyperlight Arch (bare-metal guest, no_std + no_main)
+├── nub-build/                lib  — cross-compile helper for bare-metal arch guests
+│
+├── javm-interpreter/         lib  — PVM interpreter, no_std (lifted from javm-exec)
+├── javm-recompiler-x86/      lib  — x86_64 PVM recompiler (lifted from javm-exec)
+│
+└── jar-apply/                lib  — block-apply, gas, quota; built on Nub (future)
+```
+
+Dependency edges:
+
+- `nub-kernel` depends on `javm-interpreter` (the interp is
+  portable, lives with the kernel, runs against any
+  `Arch::Memory`).
+- `nub-arch-hyperlight` depends on `nub-kernel` +
+  `javm-recompiler-x86` (the recompiler is hardware-locked to
+  x86_64 + real pages, lives only with Arch impls that can run
+  it).
+- `nub-arch-local` depends only on `nub-kernel`.
+- `nub` depends on `nub-kernel`, `nub-arch-local`, and (via
+  `build.rs`) `nub-arch-hyperlight` as a guest blob.
+- `jar-apply` (future) depends on `nub`.
+
+Today's `javm-exec` crate is slated to split into
+`javm-interpreter` + `javm-recompiler-x86` to make the
+no_std-vs-x86-only boundary explicit. Until that split lands,
+`nub-kernel` and `nub-arch-hyperlight` consume `javm-exec`
+selectively via feature gates.
+
+`nub` (the entrypoint crate) exposes a single uniform handle:
+
+```rust
+pub struct Nub { /* enum over backends */ }
+
+impl Nub {
+    pub fn new_local() -> Self;
+    pub fn new_hyperlight() -> Result<Self>;
+    pub fn invoke(&mut self, target: InstanceRef, endpoint: u16,
+                  args: &[u8], opts: InvokeOptions) -> Result<InvokeOutcome>;
+    pub fn state_root(&self) -> CapHash;
+}
+```
+
+For the in-process backend, `Nub` owns a `Kernel<LocalArch>`
+directly. For Hyperlight, `Nub` holds a sandbox and ships the
+invocation as RPC; the *real* `Kernel<HyperlightArch>` lives
+guest-side. Both expose the same surface.
+
+## Arch trait design (after Stage 1)
+
+The original Stage 0 `Hal` sketch put memory and vCPU primitives
+on the trait. After working through how the interpreter and
+recompiler actually interact with memory, the design splits
+along two orthogonal axes:
+
+1. **Execution mode**: interpreter vs recompiler.
+2. **Memory mode**: hardware-paged (real CR3/PTE, CoW via `#PF`)
+   vs software-copy (page table simulated in Rust, CoW via
+   memcpy).
+
+The recompiler is *hardware-locked*: it emits native x86_64
+loads/stores, so it only works with hardware-paged memory. The
+interpreter is portable: it can go through either memory mode.
+This determines where each piece lives:
+
+- **Interpreter → `nub-kernel`.** Shared across all Arch impls,
+  parameterized over `A::Memory`. Same source compiled for both
+  the host process (over `LocalArch::Memory`) and the bare-metal
+  guest (over `HyperlightArch::Memory`).
+- **Recompiler → outside `nub-kernel`.** It's CPU-arch-specific
+  (today x86_64) and memory-mode-specific (hardware only). Lives
+  in `javm-recompiler-x86`, consumed only by
+  `nub-arch-hyperlight`. Future ARM Arch impls would consume a
+  hypothetical `javm-recompiler-aarch64`.
+
+The Arch trait grows accordingly:
+
+```rust
+pub trait Arch {
+    type Memory: Memory;
+    type Error;
+
+    /// Create a fresh address space (working memory for one
+    /// invocation). The returned `Memory` is hardware-paged or
+    /// software-copy depending on the Arch impl.
+    fn create_address_space(&mut self) -> Self::Memory;
+
+    /// Drive the kernel-supplied interpreter via `A::Memory`.
+    fn invoke(&mut self, target: InstanceRef, endpoint: u16,
+              args: &[u8], opts: InvokeOptions)
+              -> Result<InvokeOutcome, Self::Error>;
+
+    /// Recompiler dispatch — jumps into JIT'd code. Only
+    /// hardware-paged Arches implement this meaningfully;
+    /// software-paged Arches return Unsupported.
+    fn enter_native(&mut self, /* entry, regs, memory */)
+                    -> Result<ExitReason, Self::Error>;
+
+    fn state_root(&self) -> CapHash;
+}
+
+pub trait Memory {
+    fn read_u8(&self, vaddr: u64) -> Result<u8, MemFault>;
+    fn write_u8(&mut self, vaddr: u64, b: u8) -> Result<(), MemFault>;
+    // u16/u32/u64 width ops (or generic-over-width)
+    fn map(&mut self, vaddr: u64, size: u64, perms: Perms);
+    fn set_perms(&mut self, vaddr: u64, perms: Perms);
+    fn cow_fork(&self) -> Self;
+    // …
+}
+```
+
+Both `Memory` ops must inline cleanly to a hardware load/store
+on `HyperlightArch::Memory` (where the kernel runs in the same
+address space the program runs in) and to a sparse-vec/BTreeMap
+lookup on `LocalArch::Memory`. Width-specific methods + careful
+inlining keep the per-instruction interpreter cost competitive
+with a non-traited interpreter.
+
+The skeleton (as of Stage 1) only exposes `invoke` + `state_root`
+on `Arch`; `type Memory` and `enter_native` will land alongside
+the `javm-interpreter` port into `nub-kernel`.
+
+## Kernel runtime: collections + RNG
+
+`nub-kernel` is a real kernel — `no_std`, no host runtime to lean
+on. Two design decisions worth pinning:
+
+**Collections — `BTreeMap` everywhere by default.** Replay
+determinism is load-bearing for the chain. `HashMap`'s
+seed-dependent iteration order is a footgun: the moment any
+state-bearing decision touches iteration, two nodes with
+different seeds diverge. `alloc::collections::BTreeMap` is
+no_std-clean, deterministic by construction, and `log n` lookups
+are fine for the sizes the kernel touches. `HashMap` (via
+`hashbrown`) earns its keep only for **non-state caches** with
+adversarially-supplied keys; those use an explicit
+DoS-resistant `BuildHasher` seeded from the kernel's CSPRNG.
+Iteration over a `HashMap` anywhere on a state-affecting path is
+a bug.
+
+**RNG — host-seeded, in-kernel CSPRNG.** A 32-byte seed is pulled
+from the host at kernel boot and never replaced; the kernel runs
+a ChaCha20 CSPRNG (`rand_chacha`) downstream. The seed source
+per Arch:
+
+- `LocalArch`: from `getrandom` (host process entropy).
+- `HyperlightArch`: the host shoots 32 bytes into a known
+  shared-memory slot before the first guest call; the guest reads
+  it during kernel init. Not RDRAND/RDSEED — host-injection is
+  auditable and reproducible-when-replayed.
+
+A single `SecureRng` and a `KernelBuildHasher` (SipHash-13 seeded
+from one CSPRNG draw) are kernel globals. Per-node hasher seeds
+are fine — different validators can have different hasher seeds
+as long as iteration over hashmaps is never observable in state.
+
+Deps for `nub-kernel`:
+
+```toml
+hashbrown   = { version = "0.14", default-features = false, features = ["ahash", "inline-more"] }
+siphasher   = { version = "1", default-features = false }
+rand_core   = { version = "0.6", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }
+```
+
+(Not yet wired; lands with the `KernelSeed` plumbing through
+`Kernel::new`.)
+
+## The shape
+
+The descriptions below are written against `nub-arch-hyperlight` —
+the target we'd actually implement first. `nub-arch-local` is the
+degenerate case where most of these structures live in the host
+process directly; the API surface is identical.
+
+**Long-running microkernel.** One microvm per validator process,
+spawned at startup, kept alive until shutdown. Pay the boot cost
+**once** — even 100 ms is fine because it's amortised across
+millions of blocks. JIT-compiled code, hot caps, and σ working set
+all persist across blocks.
+
+**Host (thin):**
+
+- Spawns the microvm at process startup.
+- Exposes a **virtio-blk** device backed by host storage — the
+  guest formats and owns it. The host treats σ as opaque bytes;
+  it does not parse or interpret the chain state.
+- Exposes a network/IPC channel (virtio-net or a callback-style
+  host function ABI) for block ingress, peer egress, and
+  external-API routing.
+- Forwards messages: "here's a block, apply it" → guest;
+  "external client wants Y" → "call endpoint Y on Cap::Instance Z"
+  → guest.
+- Supervises the VM: restart on crash, replay from disk.
+
+**Guest (heavy):**
+
+- Single ring-0 function: `apply_block(prior_root, block) →
+  (new_root, deltas)`. Stateful (retains JIT cache, cap working
+  set, page tables) but pure externally (same inputs → same
+  outputs).
+- In-guest cap manager: refcounts cap objects, manages
+  page-table-level CoW on `mgmt_copy`, LSM-shard storage for
+  DataCaps.
+- In-guest σ filesystem: content-addressed store on the
+  virtio-blk device. LSM-tree shape (matches DataCap shard
+  semantics). All cap encode/decode is guest-only.
+- Recompiler + interpreter, both guest-resident.
+- A minimal IDT entry for `#PF`, handling CoW write-faults
+  in-guest at ring 0.
+
+**Per-call flow:**
+
+1. Host forwards `apply_block(prior_root, block)` into the guest
+   (Hyperlight-style host-callable function).
+2. Guest's cap manager locates `Instance[Chain]` (already in
+   memory from previous block, or reloaded from virtio-blk on
+   startup).
+3. Guest runs each event: spawns a sub-Instance call, executes
+   via JIT or interpreter, harvests mutations.
+4. After all events: walk the mutated subtree, recompute hashes
+   bottom-up (Merkle re-root), produce `new_state_root`.
+5. Write new blobs to the in-guest filesystem (which writes
+   through to virtio-blk → host disk).
+6. Return `(new_root, summary)` to host.
+
+Sub-Instance isolation is at the **PVM level** (bounds-checked
+memory, gas-metered execution), not the hardware level. Hardware
+isolation between sub-Instances would be overkill — the PVM is
+already the sandboxing boundary. So sub-Instance "calls" are
+function calls inside the recompiler's dispatch, no process
+switch, no CPL transition.
+
+## Provability: O(1) `mgmt_copy`
+
+The original motivating question. The answer is **yes, provable**,
+and the proof doesn't actually require KVM — the userspace
+LSM-shard model already proves it constructively. KVM doesn't add
+new theoretical capability for O(1) copy; it strengthens the
+constants and the architecture.
+
+**Userspace proof.** Every mutable cap kind is `Arc<Inner>`.
+`Clone` is one atomic refcount bump. Mutations route through
+`Arc::make_mut`. All amortised cost moves to *first observation
+after copy*; none lands on the copy itself.
+
+**Microkernel proof.** Cap structures live in microkernel-managed
+objects with refcounts. `mgmt_copy` is a microkernel primitive
+that bumps the refcount and marks DataCap page-table entries CoW.
+Hardware does the rest: subsequent writes fault, handler allocates
+fresh physical page, remaps writable. Constant-time work per
+`mgmt_copy`, regardless of cap size.
+
+The proof is one paragraph in either model. We can ship it as a
+design-doc paragraph today; implementation choice is independent.
+
+## Performance gains from ring-0 execution
+
+Estimates for what the microkernel-resident recompiler buys *over
+and above* the security and architecture wins:
+
+| Gain | Mechanism | Estimated impact |
+|------|-----------|------------------|
+| **Eliminate JIT bounds checks** | Rely on hardware `#PF` for OOB instead of emitted `cmp/jmp` per memory op | ~30% on memory-bound workloads |
+| **In-guest CoW page fault** | `#PF` → in-guest IDT handler → fix → `iretq`; no SIGSEGV | ~10× per CoW fault (10 µs → 500 ns) |
+| **Huge pages for code + data** | Ring 0 controls page tables; 2 MiB/1 GiB pages easy | 10–30% TLB savings on memory-heavy code |
+| **No scheduler preemption** | vCPU runs until VM-exit; no Linux preempting mid-loop | Tail-latency improvement, throughput similar |
+| **W^X dance elimination** | RWX pages allowed in ring 0; no `mprotect` after emit | Tens of µs per JIT compile |
+
+Combined: **10–30% steady-state speedup on existing `pvm_bench`
+workloads**, dominated by bounds-check elimination and TLB
+improvements. The CoW fault speedup is huge per-fault but only
+matters in proportion to how often we fault.
+
+**The flip side — VM-exits to the host:**
+
+When the guest needs to call out (e.g., write a block to disk via
+virtio-blk completion), it's a VM-exit + handler + VM-resume,
+~1 µs round-trip. Today's equivalent inside the host process is a
+function call (~5–10 ns).
+
+But: with σ entirely in-guest and the cap manager guest-resident,
+most "would-be hostcalls" don't need to cross out at all.
+Cap manipulation, `mgmt_copy`, sub-Instance call, JIT compile —
+all in-guest, no exit. The crossings that remain are:
+
+- virtio-blk completion (disk I/O) — already async; one exit per
+  block batch, not per byte
+- virtio-net traffic — bulk; not in the hot path of execution
+- External-API endpoint dispatch — one exit per external query
+
+Net: the VM-exit cost is bounded by the *real I/O frequency*, not
+by the *cap-operation frequency*. This is exactly the property
+PolkaVM was looking for and didn't get with separate-process
+sandboxing.
+
+## The hard parts to validate
+
+If we do pursue this, the design questions Stage 0 needs to
+answer. Failure on any one is a reason to stop.
+
+### 1. In-guest σ filesystem
+
+σ is content-addressed: keys are 32-byte hashes, values are
+canonical-encoded cap bytes. The guest stores σ on its virtio-blk
+device. The natural shape: an LSM-style content-addressed store —
+incoming writes append to a fresh shard, background compaction
+merges old shards. This matches the DataCap-shard semantics
+exactly; same compaction discipline applies.
+
+Reference designs are everywhere (RocksDB, Pebble, LMDB-style
+B-trees). Pick the smallest one that works. Estimated size: ~1–2
+KLoC of guest code, including a tiny journal for crash
+consistency.
+
+**Risk:** crash consistency. If the guest dies between writing a
+block's deltas and writing the new state-root, we need to recover
+cleanly. Standard journal+commit pattern; well-understood.
+
+### 2. Working-set cache + eviction
+
+Long-running guest accumulates state. When memory pressure rises,
+cold caps must spill back to virtio-blk and free their guest
+physical pages. Reload on next access via the filesystem layer.
+Same shape as a database buffer pool.
+
+**Risk:** unbounded growth if eviction policy lags. Need an
+LRU-style policy with explicit memory budget. Probably tunable
+via configuration: how much guest RAM dedicated to cap cache.
+
+### 3. In-guest cap representation
+
+The userspace-track cap structures (`Arc<InstanceInner>`,
+`Arc<DataCapInner>` with shards) translate to in-guest objects
+with microkernel-managed refcounts:
+
+- `Arc<T>` ⇒ microkernel-refcounted handle.
+- `Arc::make_mut` ⇒ microkernel CoW primitive: bump-and-clone the
+  object metadata, mark page-table entries CoW.
+- `im::OrdMap` ⇒ persistent map against the microkernel allocator
+  (the `im` crate works `no_std`).
+- DataCap shards ⇒ refcounted sets of guest physical pages;
+  "mount" inserts page-table entries into the recompiler's
+  address space.
+
+### 4. State-root computation
+
+Standard Merkle re-root. Each cap object has a cached hash;
+mutation invalidates; root request walks the cap graph
+bottom-up, recomputing for invalidated nodes only. Deterministic
+iteration order (sorted by key) is required throughout.
+
+For a block that mutates K caps, re-root walks `O(K · depth)`
+nodes. Typical: <100 hash computations per block, sub-millisecond.
+
+### 5. Microkernel determinism
+
+Validators on different hosts (and on the same host with different
+backends, interpreter vs recompiler) must produce byte-identical
+`new_state_root` for the same `(prior_root, block)`. Requirements:
+
+- **Deterministic allocator.** Cap encoded form depends only on
+  protocol-defined content, not on allocation order.
+- **No host-time observable.** Guest never branches on wall-clock
+  or anything else the host can vary.
+- **Deterministic iteration.** All collection traversal during
+  state-root computation is sorted by protocol-defined key.
+- **Identical JIT codegen.** Recompiler is deterministic today;
+  property preserved in the guest.
+
+None of these are novel. They are the standard discipline every
+blockchain validator already follows. The microkernel doesn't add
+new constraints; it just requires the discipline to apply to the
+entire microkernel binary, not just the cap layer.
+
+**Cross-Arch × cross-backend invariant.** Every Arch × backend
+combination (`nub-arch-hyperlight` + recompiler, `nub-arch-local` +
+interpreter, future `nub-arch-pci-soc` + recompiler) must produce
+identical `new_state_root` for the same `(prior_root, block)`.
+Verify via property test: corpus of blocks, run through each
+combination, state-roots compared. Same shape as `pvm_bench`'s
+gas-match assertion; the multi-Arch model promotes it from
+benchmark sanity to a hard correctness gate.
+
+### 6. Commit/rollback semantics
+
+When a block is applied but not yet committed by network consensus,
+the guest needs the ability to roll back. Two natural options:
+
+(a) **`mgmt_copy` the chain Instance before applying.** The
+existing CoW machinery handles the snapshot. On commit, drop the
+old copy; on rollback, drop the new one.
+
+(b) **Host buffers blocks until consensus accepts.** Only commit
+once accepted. Simpler if the chain client already does this.
+
+Both work. Probably (a) — the cap manager already has the
+machinery, and it lets the guest pipeline speculation.
+
+## Exploration plan
+
+If the design doc clears review, the prototype proceeds in stages.
+Each stage has a decision gate; we stop if the gate fails.
+
+| Stage | Goal | Output | Time |
+|-------|------|--------|------|
+| 0 | This design doc | Written spec; open questions identified | **done** |
+| 1 | Arch trait + boot prototype | Sketch the `Arch` trait. Build a minimal `nub-arch-hyperlight` impl: boots a guest, exposes one host-callable function, calls back to host. Also: confirm `x86_64-unknown-none` works as the compile target. Measure per-call latency, host-callback round-trip, in-guest `#PF` round-trip. | **done** (5 commits, ~1 week; all gates passed) |
+| 1.5 | Crate skeleton | Lift the prototype into proper crates: `nub-kernel`, `nub-arch-local`, `nub-arch-hyperlight`, `nub`, `nub-build`. Define the `Arch` trait and `Nub` handle. Stub `invoke` / `state_root` on both backends to prove the boundary end-to-end. | **done** (5 commits) |
+| 2 | σ filesystem + interpreter through `nub-kernel` | Split `javm-exec` into `javm-interpreter` (no_std, depended on by `nub-kernel`) and `javm-recompiler-x86` (x86-only, depended on by `nub-arch-hyperlight`). Wire `javm-interpreter` through `Kernel<A>::invoke` over `A::Memory` for both Arches. Implement LSM-style content-addressed σ store inside the kernel; port cap encode/decode. Assert post-state root matches host-replay across both Arches. | 1 month |
+| 3 | Recompiler in-guest, delete standalone host JIT | Wire `javm-recompiler-x86` through `nub-arch-hyperlight` (via `Arch::enter_native`); **delete the userspace recompiler from the legacy `javm-exec`**; assert pvm_bench numbers hold; measure new performance (bounds-check elimination, CoW fault speedup). | 1 month |
+| 4 | Production shape | Cross-Arch × backend determinism audit; commit/rollback wiring; per-OS hypervisor shim (Linux/KVM, macOS/Hypervisor.framework, Windows/WHP); observability; performance tuning. | 1 month |
+
+Total: ~3 months from Stage 1 to a working prototype.
+
+### Decision gates
+
+**After Stage 0 (this doc):**
+- Does the determinism story hold up under skeptical review? (We
+  already handle these constraints at the blockchain level, so
+  the bar is "no new categories of risk," not "novel correctness
+  story.")
+- Does the in-guest filesystem story look workable? (1–2 KLoC of
+  guest code is plausible.)
+
+**After Stage 1 (Arch trait + boot prototype) — all passed:**
+- **Per-call latency** (host → guest function dispatch → return,
+  with both sides warm). **Target: <100 µs**, ideally <10 µs.
+  **Measured: ~5.9 µs** per round trip across 10,000 noop calls
+  on i9-13900K. ✓
+- **Host-callback round-trip** (guest → host function → guest).
+  **Target: <5 µs.** **Measured: ~5.8 µs** (12.5 − 6.7); just
+  over target but in the right zone. ✓
+- **In-guest `#PF` round-trip** (write to CoW page → handler →
+  resume). **Target: <500 ns.** **Measured: ~860 ns** for the
+  pure-CoW path (D2 test) and ~7.5 µs for the full demand-paging
+  path with mapping setup (C1 test). The 860 ns CoW number is
+  the load-bearing one for `mgmt_copy` performance; the 7.5 µs
+  full-setup number is one-shot per first-touch, not per-fault.
+  ✓
+- **Custom-target shed:** does `x86_64-unknown-none` work as the
+  build target? **Yes.** Drop-in stable Rust + a 5-flag RUSTFLAGS
+  recipe + `nub-build`'s 100-line `build.rs` helper — no
+  `cargo-hyperlight`, no picolibc, no Nix shell. ✓
+- Cold-boot time is *not* a hard gate — paid once, amortised
+  over millions of blocks.
+
+**After Stage 2 (`nub-arch-local` + `nub-arch-hyperlight` interpreter, σ filesystem):**
+- Per-block overhead vs current userspace track on a realistic
+  workload. **Target: within 2× of userspace.** (If much worse,
+  redesign.)
+- Cross-host AND cross-Arch determinism test: same
+  `(prior_root, block)`, run on (a) two different machines and
+  (b) `nub-arch-local` vs `nub-arch-hyperlight` (both running the
+  interpreter at this stage). Identical `new_state_root` in
+  every combination. **Target: passes.** (Load-bearing for the
+  multi-Arch model.)
+- Crash-and-restart test: kill the guest mid-block; verify σ on
+  disk is consistent; verify reload produces identical state.
+
+**After Stage 3 (recompiler in-guest):**
+- `pvm_bench` numbers ideally **improved** by 10–30% vs the
+  userspace recompiler (per the gain estimates above). At
+  minimum, no worse than the userspace path.
+- Cross-Arch × cross-backend invariant test: `nub-arch-hyperlight` +
+  recompiler vs `nub-arch-hyperlight` + interpreter vs `nub-arch-local` +
+  interpreter — all three produce identical state roots for a
+  property-test corpus.
+
+## Stage 0 deliverables (this doc)
+
+### σ encoding and storage
+
+σ is a content-addressed key-value store **inside the guest**.
+Keys: 32-byte content hashes (blake2b). Values: canonical-encoded
+cap bytes (existing `jar-cap` Image/Instance/CNode/DataCap
+encoding).
+
+Storage layout (in guest, on virtio-blk):
+
+- LSM-style content-addressed shards.
+- Hot working set in guest RAM, evicted by LRU to disk.
+- Background compaction merges old shards.
+- A small commit journal at the head of the device records the
+  current consensus state root after each accepted block.
+
+The host never decodes any of this. The host sees the virtio-blk
+device as an opaque blob of bytes.
+
+### Host ↔ Guest interface
+
+The host exposes these guest-callable functions (host-callbacks):
+
+- Logging / telemetry (debug only)
+
+The guest exposes these host-callable functions:
+
+- `apply_block(prior_root: H256, block: Bytes) → (H256, Summary)`
+- `query_endpoint(instance: H256, endpoint: u8, args: Bytes) →
+  Bytes` (for external-API dispatch)
+- `commit(root: H256)` and `rollback()` (consensus signalling)
+- `health_check() → Status`
+
+The transport is Hyperlight-style function-call ABI plus
+virtio-blk for σ persistence. virtio-net or a host-callback
+channel for the external-API surface — choice deferred to Stage 1
+based on latency measurements.
+
+### In-guest cap layout
+
+```text
+// Microkernel objects, refcounted by the kernel.
+
+Image       (immutable, refcounted)
+TypeDef     (immutable, refcounted)
+
+Instance    {
+  image:       ImageHandle,
+  cnode:       CNodeHandle,
+  state:       InstanceState (small),
+  cached_hash: Option<H256>,
+}
+
+CNode       {
+  slots:       OrdMap<SlotIdx, SlotHandle>,
+  cached_hash: Option<H256>,
+}
+
+DataCap     {
+  shards:      Vec<ShardHandle>,
+  page_table:  OrdMap<u32, (shard_idx, page_offset)>,
+  size:        u64,
+  cached_hash: Option<H256>,
+}
+
+DataCapShard {
+  base_page:   GuestPhysPageNum,
+  n_pages:     u32,
+  content_hash:H256,
+}
+```
+
+`mgmt_copy` of any cap kind = microkernel `dup_handle`: bump
+refcount, mark all child page-table entries CoW (for DataCap
+shards). Constant time.
+
+Write-fault on a CoW page = in-guest `#PF` handler allocates a
+fresh guest physical page, copies content, updates the offending
+mapping's PTE writable, `iretq`. Sub-µs.
+
+### State-root algorithm
+
+```text
+fn state_root(cap: &Cap) -> H256:
+    if let Some(h) = cap.cached_hash:
+        return h
+    h = match cap:
+        Image | TypeDef | DataCapShard:
+            blake2b(canonical_encode(cap))
+        Instance { image, cnode, state }:
+            blake2b(SCALE.encode {
+                image_hash: state_root(image),
+                cnode_hash: state_root(cnode),
+                state: canonical_encode(state),
+            })
+        CNode { slots }:
+            blake2b(SCALE.encode(
+                slots.iter_sorted().map(|(slot, cap)|
+                    (slot, state_root(cap)))))
+        DataCap { shards, page_table, size }:
+            blake2b(SCALE.encode {
+                shard_hashes: shards.iter().map(state_root).collect(),
+                page_table: page_table.clone(),
+                size,
+            })
+    cap.cached_hash = Some(h)
+    h
+```
+
+Mutation invalidates `cached_hash` on the mutated cap and all
+ancestors up to the root. Walk dirty subtree on each `state_root`
+call; reuse cached hashes elsewhere.
+
+### Determinism analysis
+
+Output (`new_state_root`, blob writes) must be byte-identical
+across validators **and** across Arch × backend combinations
+(`nub-arch-hyperlight` + recompiler vs `nub-arch-local` + interpreter vs
+the future `nub-arch-pci-soc` + device-resident recompiler).
+Requirements:
+
+1. **Allocator** doesn't leak into encoded bytes. Cap encoded
+   form contains only protocol-defined content.
+2. **All hashing-path iteration** is sorted by protocol-defined
+   key. No HashMap iteration.
+3. **No host clock observable** to the guest. Block inputs +
+   prior state root are the only host-supplied data.
+4. **JIT codegen** deterministic. Regression test: compile the
+   same blob N times, assert byte-identical output. (Per-arch:
+   x86-64 codegen on `nub-arch-hyperlight`, ARM64 on `nub-arch-pci-soc`.)
+5. **Read-protocol return** content-addressed (free).
+6. **Microvm/device boot** deterministic. Same initial state
+   every time, regardless of Arch.
+
+None novel. Same discipline every blockchain validator follows.
+The multi-Arch story sharpens it slightly: codegen determinism is
+now per-arch, and cross-Arch property tests are a hard correctness
+gate.
+
+## Open questions for review
+
+1. **Which microvm runtime under `nub-arch-hyperlight`?** Hyperlight is
+   the strongest fit — ring-0 long mode, fast `OUT`-port +
+   shared-memory function-call ABI (single VM-exit per call),
+   KVM+WHP+MSHV abstraction. macOS not yet supported (no
+   Hypervisor.framework backend); on the roadmap. Alternatives:
+   raw `kvm-ioctls` plus per-OS shims (more work, more control);
+   Firecracker (slower boot, but irrelevant for long-running
+   model). Probably Hyperlight; reconsider after Stage 1 numbers.
+
+2. **Can we drop the custom Rust target?** Hyperlight today uses
+   `x86_64-hyperlight-none` plus `cargo-hyperlight` plus picolibc.
+   For our pure-Rust microkernel we should be able to use stable
+   `x86_64-unknown-none` plus `RUSTFLAGS`. Stage 1 spike: confirm
+   that `cargo build --target=x86_64-unknown-none -p
+   microkernel-hyperlight` produces a Hyperlight-loadable ELF. If
+   yes, build-system surface shrinks dramatically. If no, we wear
+   the custom-target cost.
+
+3. **Which guest framework, if any?** Hyperlight's Guest Library
+   gives us the host-callback ABI for free. We're not using it as
+   an OS; we're using it as a function-execution shell with our
+   own paging and IDT. Compatible.
+
+4. **σ filesystem format.** Roll our own LSM, port RocksDB, or
+   something between. ~1–2 KLoC if we roll our own; "free" but
+   heavyweight if we port. Probably roll our own.
+
+5. **virtio-blk vs Hyperlight's host-callback ABI for σ I/O.**
+   virtio-blk wins on throughput (hundreds of thousands of IOPS
+   via io_uring). Host-callback wins on simplicity. Stage 1 to
+   measure.
+
+6. **Commit/rollback policy.** `mgmt_copy` snapshot before apply,
+   or host-buffered blocks. Cross-cutting with chain consensus
+   design. Defer to chain orchestrator decisions.
+
+7. **Validator deployment story.** Validators with hardware virt
+   → `nub-arch-hyperlight` + recompiler. Without (cloud no-nested-virt)
+   → `nub-arch-local` + interpreter. State-root equivalence across
+   Arch × backend combinations is what makes this safe. Already in
+   the doc; flag here as a deployment-guidance task.
+
+8. **`nub-arch-pci-soc` realism.** Not for v1, but worth keeping the Arch
+   trait shape compatible with: a PCIe accelerator card running
+   the microkernel as firmware, accessed via MMIO command rings +
+   DMA bulk transfer. Cross-CPU-arch codegen (ARM64) becomes
+   necessary; the rest is an Arch impl swap. Don't design *for*
+   this, but don't design *against* it either.
+
+## Decision history
+
+**2026-05: Commit to Stage 2.** Stages 0, 1, and 1.5 are
+complete. Every Stage 1 gate passed: ring 0 + long mode + custom
+IDT + in-guest `#PF` handling + CR3 manipulation + CoW round-trip
+all work on the i9-13900K target hardware, and the build-system
+spike passed (stable `x86_64-unknown-none` + `nub-build`
+replaces `cargo-hyperlight` and picolibc). Stage 1.5 lifted the
+prototype into proper crates and proved the `Arch` boundary
+through both backends.
+
+Stage 2 (~1 month) splits `javm-exec` into
+`javm-interpreter` + `javm-recompiler-x86`, wires the interp
+through `nub-kernel` over `Arch::Memory`, and stands up the
+in-guest σ filesystem. The decision point for Stage 3 (delete
+the userspace JIT, run only in-guest) is the cross-Arch
+determinism audit at the end of Stage 2.
+
+**Original Stage 0 decision text (preserved for archaeology):**
+The original framing of this section asked whether to commit to a
+Stage 1 prototype as a small bet (~1 engineering-week of
+throwaway prototyping) for high information value about whether
+the architecture was worth pursuing. The bet was made; the
+information arrived; the answer was yes.

--- a/docs/spec/userspace/generic-authority-pattern.md
+++ b/docs/spec/userspace/generic-authority-pattern.md
@@ -1,0 +1,370 @@
+# Generic authority capability pattern
+
+This doc specifies the canonical userspace pattern for **authority
+capabilities** in v3: caps that represent the right to invoke a
+privileged operation mediated by an authoritative handler (the chain
+orchestrator, the kernel, or any layer holding the marker in its
+`yield_marker_slot`).
+
+The pattern uses only existing v3 primitives:
+
+- `host_derive_spawn` to mint marker Instances and AuthorityCap Instances.
+- Standard Cap::Instance copyable semantics.
+- `host_yield` with the kernel's yield-marker routing mechanism (§4).
+- `yield_marker_slot` declaration in Image (§1).
+- instance_hash equality for routing — no new primitives.
+
+**No new cap kinds needed.** Earlier drafts of this doc explored
+Request/Response Instance triplets, `host_same_type_as` chain checks,
+exemplar Instances, Cap::Type-based routing, etc. — all superseded by
+this simpler mechanism.
+
+## The shape
+
+```
+                                      ┌─────────────────────┐
+        Chain (handler)               │ yield_marker_slot   │
+        ─────────────────────         │ slots:              │
+        Image:                        │  [0] marker_invoke  │
+          yield_marker_slot = 5       │  [1] marker_attest  │
+        cnode:                        │  [2] ...            │
+          [5] CNode containing ───────┴─────────────────────┘
+              the markers Chain catches
+        
+        Chain mints AuthorityCap Instances:
+        ─────────────────────
+        AuthorityCap (e.g. EndpointRefCap):
+          state:
+            marker: Cap::Instance[marker_invoke]   <-- embedded in cnode
+            target, endpoint_idx, etc.
+          bytecode:
+            invoke(args) → status
+              -- compose payload from state + args
+              -- place marker in yield scratchpad
+              -- host_yield
+              -- on resume, slot[0] has handler response
+              -- return to caller
+        
+        User contract holds Cap::Instance[AuthorityCap].
+        User contract CALLs AuthorityCap.invoke(args).
+        AuthorityCap's bytecode is what yields.
+        Kernel walks call stack; matches instance_hash; routes to Chain.
+```
+
+## The three roles
+
+| Role | Image | Constructed by | Constructed into | Purpose |
+|---|---|---|---|---|
+| **Marker** | `XMarkerImage` (well-known per authority type) | Chain via `host_derive_spawn`, init typically empty | Chain's `yield_marker_slot` CNode (for catching) and inside each AuthorityCap's state (for yielding) | The routing key for yield matching |
+| **AuthorityCap** | `XAuthorityCapImage` (well-known per authority pattern) | Chain via `host_derive_spawn`, init with marker + parameters | Distributed via cap-flow to user contracts | The bytecode-mediated entry point for invoking the authority |
+| **Chain (handler)** | The chain orchestrator's own Image | Genesis / chain spec | Top of the chain's call hierarchy | The yield handler that processes requests |
+
+## The mechanism, step by step
+
+### Setup (Chain init)
+
+```
+1. Chain derives a marker for each authority type:
+     marker_M = host_derive_spawn(MarkerImage, init={})
+   
+   marker_M's image_hash_chain = Chain.image_hash_chain || hash(MarkerImage).
+   This chain is unforgeable (kernel-mediated extension).
+
+2. Chain places Cap::Instance[marker_M] in its yield_marker_slot CNode:
+     Chain.cnode[yield_marker_slot_idx].slot[k] = Cap::Instance[marker_M]
+   
+   This declares: "I catch yields whose marker matches marker_M."
+
+3. (Optional, can be deferred per-grant.) Chain mints AuthorityCaps:
+     auth_cap = host_derive_spawn(AuthorityCapImage,
+                                  init={ marker: Cap::Instance[marker_M],
+                                         ...other state... })
+   
+   The AuthorityCap holds the marker in its state. Crucially, the
+   marker is in AuthorityCap's CNODE — accessible only to
+   AuthorityCap's bytecode, not to outside observers.
+
+4. Chain distributes Cap::Instance[auth_cap] via cap-flow to user
+   contracts that should hold the authority.
+```
+
+### Invocation (user contract calling the authority)
+
+```
+1. User contract A holds Cap::Instance[auth_cap] in its cnode.
+
+2. A's bytecode prepares args in slot[0]:
+     A.slot[0] := { ...args... }
+
+3. A invokes the AuthorityCap:
+     CALL(slot containing auth_cap, "invoke", gas_budget)
+
+4. AuthorityCap's bytecode runs (per AuthorityCapImage's spec):
+   a. Read args from slot[0].
+   b. Compose payload from self.state + args.
+   c. Place payload in arg slot (a known slot for handler to read).
+   d. Place self.cnode[marker_slot] (Cap::Instance[marker_M]) in the
+      yield-scratchpad slot.
+   e. host_yield(yield-scratchpad).
+
+5. Kernel processes the yield:
+   - Read marker instance_hash from yield-scratchpad.
+   - Walk call stack from top down.
+   - For each InstanceEntry F:
+       If F.image.yield_marker_slot is set, examine F.cnode at that
+       slot. For each cap there: if instance_hash equality, match.
+   - First match wins. Push ReferenceEntry pointing to F.
+   - F's bytecode resumes at its post-CALL continuation point with
+     the payload in F's slot[0].
+
+6. F (Chain) handles the request:
+   a. Read payload from slot[0].
+   b. Validate and process (route to target contract, etc.).
+   c. Compose response.
+   d. CALL_RESUME with response in slot[0].
+
+7. AuthorityCap's bytecode resumes (popping the ReferenceEntry):
+   a. Read response from slot[0].
+   b. Place response in caller-visible slot[0].
+   c. HALT.
+
+8. A's bytecode receives the response in its slot[0] and continues.
+```
+
+### Revocation (marker rotation)
+
+```
+Chain wants to revoke all outstanding AuthorityCaps of a type:
+
+1. Remove Cap::Instance[marker_M] from yield_marker_slot CNode.
+   (Or replace with a different marker.)
+
+2. From this moment, yields with marker_M no longer match. All
+   outstanding AuthorityCaps holding marker_M will fault on yield.
+
+3. Mint a new marker marker_M_new for the type. Place in slot.
+4. Mint new AuthorityCaps with the new marker. Distribute.
+
+Outstanding old AuthorityCaps are structurally dead. No per-cap
+tracking needed.
+```
+
+## Why this is forgery-resistant
+
+The forgery argument has one structural pillar: **marker
+derivation is kernel-mediated and produces a chain-extended
+image_hash that an adversary cannot replicate.**
+
+To match Chain's marker, an adversary would need:
+- An Instance with image_hash equal to `hash(Chain's chain || hash(MarkerImage))`.
+- Plus byte-identical state (per instance_hash equality on full state).
+
+For the chain: the adversary's derivation history would need to be
+prefixed by Chain's derivation history. host_derive_spawn extends
+the *deriver's* chain; the deriver is the adversary, not Chain. So
+the adversary's chain doesn't start with Chain's chain prefix. Hash
+mismatch. Forgery prevented.
+
+For the state: the marker is typically derived with empty state, so
+state matching is trivial. But state can be non-empty; the
+forgery-resistance argument holds at the chain level regardless.
+
+## Cap::Instance vs Cap::Type — for authority routing, use Cap::Instance
+
+A core principle (also documented in README §8):
+
+> **Cap::Type identifies an Instance's type. Cap::Instance authorizes
+> invocation of a specific Instance. These are NOT
+> interchangeable for authority purposes.**
+
+A pattern like "if I hold Cap::Type{X}, I have authority X" would be
+WRONG. Anyone with a Cap::Instance to any Instance in Chain's chain can
+compute Cap::Type{Chain.chain + derive_steps} via host_subtype.
+Cap::Type is just a type identifier, not an authority credential.
+
+The yield-marker pattern uses **Cap::Instance** (specifically, a real
+marker Instance derived via host_derive_spawn). Routing is by
+instance_hash equality of Cap::Instance values, not Cap::Type values.
+
+Cap::Type is useful for:
+- Runtime type-checking ("is this Instance of type X?").
+- Type-based dispatch.
+- Composing types abstractly.
+
+Cap::Type is NOT useful for:
+- Authority routing.
+- Authorization checks.
+- Anywhere "possession proves something" matters.
+
+If your design has a Cap::Type stored somewhere that's being treated
+as an authority credential, that's a bug. Use Cap::Instance.
+
+## Security properties preserved (V1–V9 mapping)
+
+See [discussions/sel4-mapping.md](../discussions/sel4-mapping.md)
+for the full V1–V9 analysis. Under the yield-marker pattern:
+
+| Property | Status |
+|---|---|
+| V1 Authority confinement | ✓ AuthorityCap conveys one operation per cap |
+| V2 Authority unforgeability | ✓ image_hash chain prevents marker forgery |
+| V3 Revocation | ✓ Marker rotation revokes all caps holding the old marker |
+| V4 Endpoint mediation | ✓ AuthorityCap bytecode is the only path to yielding the marker |
+| V5 Cap rights | ✓ Cap-level differentiation via state baked into AuthorityCap |
+| V6 Integrity | ✓ Marker forgery prevented; intermediates can't synthesize state changes |
+| V7 Confidentiality from intermediates | ✓ Kernel routes directly to handler; intermediates not on call path don't see payload |
+| V8 Availability | Lost from intermediates (intrinsic to layered system); mitigated by chain-level discipline |
+| V9 Determinism | ✓ All operations are deterministic |
+
+## Where policy attaches
+
+Different AuthorityCaps can have different policies baked into their
+state:
+
+```
+Mint a per-rate-limit cap:
+  rate_limited_cap = host_derive_spawn(EndpointRefCapImage,
+                                       init = { marker, target, endpoint_idx,
+                                                rate_limit: 100/sec })
+
+The cap's bytecode reads its own state and includes rate_limit in
+payload. Chain's handler enforces the rate limit by reading the
+payload.
+
+Or: per-cap-identity sidecar tracked at Chain. AuthorityCap state
+includes a cap_id (monotonic, baked in at mint time). Chain
+maintains a small map: cap_id → policy. Useful when policy must be
+adjustable post-grant.
+```
+
+Both patterns are capability-pure. Neither reintroduces ACL anti-
+patterns.
+
+## Comparison with earlier drafts (history)
+
+Earlier drafts of this doc explored several mechanisms that have
+been superseded:
+
+| Earlier mechanism | Issue | Resolution |
+|---|---|---|
+| Request/Response Instance triplet | Required new endpoint discipline; cascade through intermediates exposed payloads | Single yield with marker; direct routing skips intermediates |
+| `host_same_type_as` chain checks | Caller witness mechanism was over-engineered | Instance_hash equality on real markers (the marker is the proof) |
+| Exemplar Instances for caller cert checks | Required deriving Instances just for type identification | Marker Instances serve both as exemplars and as routing keys |
+| Cap::TypeWitness / Cap::Type for authority | Cap::Type is derivable from any descendant Cap::Instance; doesn't prove authority | Use Cap::Instance; Cap::Type is identification-only (§8) |
+| Image_hash matching for routing | Required "fake template Instances" or Cap::Image variant; complex | Instance_hash matching with single shared marker; payload carries variations |
+| Linear caps for Request/Response | Replay-during-cascade concerns | No cascade; no Request/Response wrappers; replay handled by structural routing |
+| Chain-prefix check at yield | Defense in depth that became unnecessary | Instance_hash check at the marker level is sufficient |
+
+The simpler mechanism (instance_hash + yield-marker routing) replaces
+all of the above. The principle: **the marker Instance itself is the
+routing key and the unforgeable proof of origin.** No separate Request,
+Response, exemplar, or witness needed.
+
+## Worked examples
+
+### AttestationAuthority (AA)
+
+See [discussions/attestation-authority.md](../discussions/attestation-authority.md)
+for the full design with mode-invariance and seen-rule. In yield-
+marker terms:
+
+| Role | Image | Notes |
+|---|---|---|
+| Marker | AttestMarkerImage | Empty state; image_hash_chain rooted in kernel |
+| AuthorityCap | AAImage | Bytecode for `attest(key, blob) → status`; embeds marker; handler is kernel itself |
+| Handler | kernel | Has AttestMarkerImage marker in its yield_marker_slot; processes mode-aware |
+
+User contract: `CALL(aa_cap, "attest", ...)`. AA's bytecode yields with
+marker; kernel catches; runs hw_verify or hw_sign per mode; returns
+AttestStatus (mode-invariant). Userspace never sees the signature.
+
+### EndpointRefCap (chain orchestrator's user contract dispatch)
+
+See README §14. In yield-marker terms:
+
+| Role | Image | Notes |
+|---|---|---|
+| Marker | InvokeMarkerImage | Empty state; image_hash_chain rooted in Chain |
+| AuthorityCap | EndpointRefCapImage | Bytecode for `invoke(args)`; embeds marker + target_address + endpoint_idx |
+| Handler | Chain orchestrator | Has InvokeMarkerImage marker in its yield_marker_slot; routes to target contract |
+
+User contract A holds Cap::Instance[EndpointRefCap(B, 5)]. CALLs invoke.
+AuthorityCap's bytecode yields with marker; Chain catches; Chain
+calls B.endpoint_5; returns result.
+
+### MintInstance
+
+See README §16. In yield-marker terms:
+
+| Role | Image | Notes |
+|---|---|---|
+| Marker | MintMarkerImage | Empty state; image_hash_chain rooted in Chain |
+| AuthorityCap | MintRefCapImage | Bytecode for `mint(content) → status`; embeds marker + domain |
+| Handler | Chain orchestrator (with MintInstance inside it) | Catches mint yields; routes to MintInstance.mint |
+
+User contract A holds Cap::Instance[MintRefCap(domain_X)]. CALLs mint.
+AuthorityCap yields; Chain handler invokes MintInstance.mint(domain_X, content).
+
+## Glossary
+
+- **Marker / Marker Instance**: an Instance derived by Chain that serves as
+  the routing key for a class of yields. Its instance_hash is what's
+  compared during yield routing.
+- **AuthorityCap**: an Instance whose state holds a marker and whose
+  bytecode is the entry point for invoking the authority. Distributed
+  via cap-flow to grant invocation rights.
+- **Handler**: the Instance that catches the yield (has the marker in
+  its yield_marker_slot). Typically the chain orchestrator or the
+  kernel itself.
+- **yield_marker_slot**: the Image-declared slot in an Instance's cnode
+  that holds the CNode of marker Instances this Instance catches.
+- **Marker rotation**: replacing markers in the yield_marker_slot to
+  revoke outstanding AuthorityCaps.
+
+## Relationship to other docs
+
+- [README.md §1](../README.md): `yield_marker_slot` field in Image.
+- [README.md §3](../README.md): kernel call stack model.
+- [README.md §4](../README.md): `host_yield` ABI with marker routing;
+  `host_type_of` / `host_subtype` / `host_type_eq` for Cap::Type.
+- [README.md §8](../README.md): Cap::Type vs Cap::Instance distinction;
+  authority is Cap::Instance.
+- [README.md §14](../README.md): authority via capability flow,
+  using the yield-marker mechanism.
+- [README.md §15](../README.md): AttestationAuthority as an instance.
+- [README.md §16](../README.md): MintInstance as an instance.
+- [discussions/attestation-authority.md](../discussions/attestation-authority.md):
+  AA design including mode-invariance.
+- [discussions/data-flow-principle.md](../discussions/data-flow-principle.md):
+  architectural derivation of why authority must go through Chain
+  orchestrator under v3's single-mutator + per-context fault model.
+- [discussions/sel4-mapping.md](../discussions/sel4-mapping.md):
+  V1–V9 security analysis.
+
+## Summary
+
+The v3 authority pattern is:
+
+> **A handler declares the marker types it catches in its
+> `yield_marker_slot` CNode. Marker Instances are derived by the
+> handler via `host_derive_spawn`; their image_hash chain is
+> kernel-mediated and forgery-resistant. The handler mints
+> AuthorityCap Instances that embed the marker in their state and
+> whose bytecode is the entry point for invoking the authority.
+> AuthorityCaps are distributed via cap-flow. User contracts
+> invoke AuthorityCaps; AuthorityCap bytecode yields with the
+> marker; kernel walks the call stack matching by instance_hash;
+> handler catches and processes; result returns.**
+
+No new cap kinds. No new kernel primitives beyond `host_yield`'s
+marker routing. No Request/Response wrappers. No witness caps. No
+Cap::Type-as-authority. Just Cap::Instance, instance_hash equality, and
+yield_marker_slot.
+
+The architectural justification (why this is structurally required,
+not just a design choice) is in
+[discussions/data-flow-principle.md](../discussions/data-flow-principle.md):
+single-mutator + per-context fault → single-activation → hierarchical
+call stack → cross-contract calls must go through a common parent →
+Chain orchestrator is structurally the only place fault-isolated
+cross-contract communication can be implemented.


### PR DESCRIPTION
## Summary

Imports the minimum-kernel v3 spec (currently lived outside the repo in \`~/docs/minimum-v3\`) into \`docs/spec/\` so it ships alongside the code that implements it.

Eleven files:
- \`README.md\` — top-level spec overview
- \`implementation/{architecture,kvm-microkernel}.md\` — implementation notes
- \`discussions/*.md\` — seven design discussions (cap scopes, data-flow principle, sel4 mapping, kernel-chain interface, attestation authority, kernel-assisted instances, yield passthrough)
- \`userspace/generic-authority-pattern.md\` — userspace authority pattern

## Test plan
- [x] No code changes; CI's lint / SBOM / test / audit jobs aren't affected.
- [ ] Spot-check on the rendered diff that nothing in the imported tree references private paths (a couple of cross-links to \`../minimum/discussions/…\` remain — they were external in the source tree too; we can rewrite or import the linked files as a follow-up).