### PR TITLE
Publish workspace rustdoc at /rustdoc/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+          targets: x86_64-unknown-none
 
       - name: Cache Lake packages
         uses: actions/cache@v4
@@ -72,9 +75,81 @@ jobs:
         working-directory: spec
         run: make book
 
-      # -- Combine: JarBook served at /lean/ (the /spec/ path now hosts the minimum-v3 spec docs) --
+      # -- Rustdoc (workspace, served at /rustdoc/) --
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: docs-rustdoc
+
+      - name: Build rustdoc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+          SKIP_GUEST_BUILD: "1"
+        run: |
+          # Start clean: ci-rust.yml's cache layer can ship a target/ with
+          # leftover crate dirs we don't want to publish.
+          rm -rf target/doc
+          cargo doc --locked --workspace --no-deps
+
+      - name: Generate rustdoc landing page
+        run: |
+          DOC_DIR=target/doc
+          {
+            cat <<'HEADER'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>JAR Rust Docs</title>
+            <style>
+              body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; max-width: 48rem; margin: 4rem auto; padding: 0 1rem; color: #1f2937; line-height: 1.5; }
+              h1 { font-size: 2rem; margin: 0 0 0.5rem; letter-spacing: -0.02em; }
+              p.lead { color: #6b7280; margin: 0 0 2rem; }
+              ul { list-style: none; padding: 0; columns: 2; column-gap: 2rem; }
+              @media (max-width: 40rem) { ul { columns: 1; } }
+              li { padding: 0.25rem 0; break-inside: avoid; }
+              a { color: #2563eb; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+              .footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; color: #9ca3af; font-size: 0.85rem; }
+              @media (prefers-color-scheme: dark) {
+                body { background: #0a0a0a; color: #e5e7eb; }
+                p.lead { color: #9ca3af; }
+                a { color: #60a5fa; }
+                .footer { border-color: #262626; color: #6b7280; }
+              }
+            </style>
+          </head>
+          <body>
+            <h1>JAR Rust Docs</h1>
+            <p class="lead">API documentation for the JAR Rust workspace. Pick a crate below.</p>
+            <ul>
+          HEADER
+            # Use cargo metadata so we list workspace members only (rustdoc
+            # turns hyphens into underscores in directory names).
+            cargo metadata --no-deps --format-version 1 \
+              | jq -r '.packages[].name' \
+              | sort \
+              | while read -r name; do
+                  dir=$(echo "$name" | tr - _)
+                  if [ -f "$DOC_DIR/$dir/index.html" ]; then
+                    echo "      <li><a href=\"${dir}/index.html\">${name}</a></li>"
+                  fi
+                done
+            cat <<'FOOTER'
+            </ul>
+            <p class="footer">← <a href="/">jarchain.org</a></p>
+          </body>
+          </html>
+          FOOTER
+          } > "$DOC_DIR/index.html"
+
+      # -- Combine: JarBook served at /lean/ (the /spec/ path now hosts the
+      #    minimum-v3 spec docs); rustdoc served at /rustdoc/. --
       - name: Copy JarBook into site
         run: cp -r spec/_out/html-multi site/lean
+
+      - name: Copy rustdoc into site
+        run: cp -r target/doc site/rustdoc
 
       - uses: actions/upload-pages-artifact@v4
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -61,18 +61,22 @@ menu:
       name: Lean Book
       url: /lean/
       weight: 3
+    - identifier: rustdoc
+      name: Rustdoc
+      url: /rustdoc/
+      weight: 4
     - identifier: blog
       name: Blog
       pageRef: /blog
-      weight: 4
+      weight: 5
     - identifier: matrix
       name: Matrix
       url: https://matrix.to/#/#jar:matrix.org
-      weight: 5
+      weight: 6
     - identifier: github
       name: GitHub
       url: https://github.com/jarchain/jar
-      weight: 6
+      weight: 7
       params:
         icon: github
 


### PR DESCRIPTION
## Summary

- Build the workspace rustdoc in CI and publish it at `/rustdoc/` on jarchain.org.
- Generate a landing page that lists workspace crates (the workspace has no root crate, so the bare `/rustdoc/` URL would otherwise 404).
- Add a **Rustdoc** entry to the Hugo navbar.

## Why

The Rust workspace is unreviewable from a browser today: readers have to clone the repo or paste paths into github.com. Mirroring rustdoc on jarchain.org makes types, host calls, and cap definitions linkable from prose docs, the Lean spec, and PR reviews. AI agents reviewing PRs benefit from this too — they can follow links instead of fetching raw source.

`cargo doc --workspace --no-deps` already runs on every PR via [ci-rust.yml](.github/workflows/ci-rust.yml#L87) (Lint job), so the wire is half-built; this PR just adds the publish + index step.

## Implementation notes

- Reuse the existing `dtolnay/rust-toolchain@stable` install in docs.yml + `Swatinem/rust-cache@v2` and `SKIP_GUEST_BUILD=1` to match the pattern in ci-rust.yml.
- `RUSTDOCFLAGS=-D warnings` so broken intra-doc links fail the build (catches stale references early — same flag ci-rust.yml uses).
- `rm -rf target/doc` before each `cargo doc` so a restored cache can't sneak stale crate dirs into the published output.
- Landing page filters strictly by `cargo metadata --no-deps` rather than listing subdirectories of `target/doc/`, so any stale dep dirs in a restored cache wouldn't pollute the index. Rustdoc renames hyphens to underscores in directory names, so the script maps each name accordingly.
- Landing page has light/dark CSS via `prefers-color-scheme` so it doesn't clash with rustdoc's own theme.
- Navbar uses a hardcoded `url: /rustdoc/` (not `pageRef`) because rustdoc isn't Hugo content — it's a static drop-in.

## Test plan

- [ ] CI: `cargo doc --workspace --no-deps` succeeds with `-D warnings` (no broken intra-doc links).
- [ ] `site/rustdoc/index.html` lists all ~37 workspace crates and each link resolves.
- [ ] Pages deploy: clicking **Rustdoc** on jarchain.org lands on the workspace index; clicking through reaches an actual rustdoc page (e.g. `jar_kernel/`).
- [ ] No accidental publication of dependency docs (the index should not include `tokio`, `serde`, `libp2p`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)