### PR TITLE
fix(javm): thread cache through ecall dispatch

### DIFF
--- a/rust/jar-kernel/src/kernel_assist.rs
+++ b/rust/jar-kernel/src/kernel_assist.rs
@@ -7,12 +7,9 @@
 //! looked up through there; this trait surface no longer reaches
 //! into σ.
 //!
-//! NB: at this stage the host_open / host_save ecalls don't actually
-//! get exercised from inside `Vm::invoke_cached` — those ecalls trap
-//! because the cache borrow isn't threaded through to the kernel
-//! assist (a follow-up commit will wire it). The implementation is
-//! present so the trait surface compiles and stays exercisable from
-//! unit tests.
+//! `Vm::invoke_cached` resolves DataCap sizes before calling into
+//! this trait, so `host_save` debits the actual logical byte size
+//! while this type remains free of direct cache ownership.
 
 use std::collections::HashMap;
 
@@ -121,16 +118,12 @@ impl KernelAssist for SigmaKernelAssist {
         self.files.get(&file_id).copied()
     }
 
-    fn host_save(&mut self, data: CapHashOrRef, quota_id: u64) -> Option<u64> {
-        // Without a cache borrow we can't read the data's size; debit
-        // a placeholder 1-byte charge so the mechanics are observable.
-        // A follow-up commit threads `&mut Cache<Global>` through to
-        // resolve the actual data size.
+    fn host_save(&mut self, data: CapHashOrRef, quota_id: u64, size: u64) -> Option<u64> {
         let current = self.storage_quotas.get(&quota_id).copied().unwrap_or(0);
-        if current < 1 {
+        if current < size {
             return None;
         }
-        self.storage_quotas.insert(quota_id, current - 1);
+        self.storage_quotas.insert(quota_id, current - size);
         let file_id = self.next_file_id;
         self.next_file_id += 1;
         self.files.insert(file_id, data);
@@ -146,9 +139,9 @@ mod tests {
     fn host_save_debits_quota_and_allocates_file_id() {
         let mut ka = SigmaKernelAssist::new();
         ka.seed_root_quota(1000);
-        let file_id = ka.host_save(CapHashOrRef::Hash([0u8; 32]), 0).unwrap();
+        let file_id = ka.host_save(CapHashOrRef::Hash([0u8; 32]), 0, 32).unwrap();
         assert_eq!(file_id, 1); // first allocation
-        assert_eq!(ka.storage_quota_get(0), 999);
+        assert_eq!(ka.storage_quota_get(0), 968);
         assert_eq!(ka.host_open(file_id), Some(CapHashOrRef::Hash([0u8; 32])));
     }
 
@@ -156,7 +149,7 @@ mod tests {
     fn host_save_exhausted_quota_returns_none() {
         let mut ka = SigmaKernelAssist::new();
         // Quota 0 starts empty; any save should fail.
-        assert!(ka.host_save(CapHashOrRef::Hash([0u8; 32]), 0).is_none());
+        assert!(ka.host_save(CapHashOrRef::Hash([0u8; 32]), 0, 1).is_none());
     }
 
     #[test]

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -147,10 +147,23 @@ impl<A: Allocator + Clone> Cache<A> {
         Some(entry as *const CacheEntry<A> as u64)
     }
 
-    /// Insert a cap as a blob keyed by `hash`. If the hash is already
-    /// present, increment its refcount instead of allocating a fresh
-    /// entry. Returns the post-insertion refcount.
-    pub fn put_blob(&mut self, hash: CapHash, cap: Cap<A>) -> Result<u32, CacheError> {
+    /// Test-only blob insert: takes `Cap<A>` already in this cache's
+    /// allocator and stores it under `hash`. Idempotent (bumps refcount
+    /// on a hit). Returns the post-insertion refcount.
+    ///
+    /// Not exposed in production builds because the `Cap<A>` argument
+    /// leaks the cache's allocator onto the API surface — an outside
+    /// caller could construct a `Cap<A>` against a *different* `A`
+    /// instance (e.g., a foreign `TalcAlloc` over an unrelated arena)
+    /// and hand it in. The cache would then hold cap content whose
+    /// backing memory lives outside the cache's own arena, breaking
+    /// invariants like "all Hyperlight shared-cache content lives in
+    /// the MAP_SHARED region at `STATE_CACHE_VA`". Public publish goes
+    /// through [`Self::put_cap`] / [`Self::put_cap_with_hash`], which
+    /// take `&Cap<Global>` and deep-clone into `A` so the cache owns
+    /// every allocation.
+    #[cfg(test)]
+    pub(crate) fn put_blob(&mut self, hash: CapHash, cap: Cap<A>) -> Result<u32, CacheError> {
         if let Some(existing) = self.blobs.get(&hash) {
             let prev = existing.refcount.fetch_add(1, Ordering::Relaxed);
             return Ok(prev + 1);
@@ -399,8 +412,8 @@ impl<A: Allocator + Clone> Cache<A> {
     ///   a `Ref`, replace with the resulting `Hash`, then hash the
     ///   InstanceCap. The instance entry **stays in `instances`** as
     ///   the live mutable state; the returned hash is a snapshot
-    ///   identifier (callers can `put_blob`-snapshot externally if
-    ///   they want to keep an immutable copy).
+    ///   identifier (callers can re-`put_cap` the snapshot to retain an
+    ///   independent immutable copy).
     /// - For a CNode ref: recursively settle each Ref slot target,
     ///   replace with Hashes, hash the CNodeCap, then move the entry
     ///   from `instances` to `blobs` under the new hash.

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -41,11 +41,12 @@
 //! operate on `CapHashOrRef` targets in the running root cnode and
 //! cross-reference into the caller-supplied `Cache<Global>` for kind
 //! dispatch. `Vm::drive_and_translate` installs a short-lived
-//! [`CachedEcallHandler`] for interpreter runs, so cache-touching host
+//! `CachedEcallHandler` for interpreter runs, so cache-touching host
 //! calls can read/write cap content without storing the cache borrow
 //! in the long-lived `Vm`.
 
 use allocator_api2::alloc::Global;
+use allocator_api2::vec::Vec as AVec;
 use javm_cap::{
     Blake2b256, Cache, Cap, CapHashOrRef, DataCap, DataContent, Hash, SlotIdx, TypeCap,
 };
@@ -533,7 +534,14 @@ impl<K: KernelAssist> Vm<K> {
         }
         self.kernel_assist
             .storage_quota_set(quota_id, quota - debit);
-        let h = cache.publish_data_inline(&bytes[..canonical_len])?;
+        let mut inline = AVec::new_in(Global);
+        inline.extend_from_slice(&bytes[..canonical_len]);
+        let cap = Cap::Data(DataCap {
+            size: canonical_len as u64,
+            content: DataContent::Inline(inline),
+        });
+        let h = javm_cap::cap_hash(&cap);
+        cache.put_blob(h, cap)?;
 
         let running = self
             .stack
@@ -756,12 +764,14 @@ impl<K: KernelAssist> Vm<K> {
         size_log: u8,
         cache: Option<&mut Cache<Global>>,
     ) -> Result<(), VmError> {
+        let cap = Cap::CNode(javm_cap::CNodeCap::<Global>::new(size_log)?);
+        let cap_hash = javm_cap::cap_hash(&cap);
         let h = match cache {
-            Some(cache) => cache.publish_cnode(size_log, &[])?,
-            None => {
-                let cn = javm_cap::CNodeCap::<Global>::new(size_log)?;
-                javm_cap::cap_hash(&Cap::CNode(cn))
+            Some(cache) => {
+                cache.put_blob(cap_hash, cap)?;
+                cap_hash
             }
+            None => cap_hash,
         };
         let running = self
             .stack
@@ -820,6 +830,18 @@ mod tests {
     ) -> EcallResult {
         let mut handler = CachedEcallHandler { vm, cache };
         handler.handle(EcallKind::Ecalli(op), regs, mem)
+    }
+
+    fn publish_data_inline(cache: &mut Cache<Global>, bytes: &[u8]) -> javm_cap::CapHash {
+        let mut inline = AVec::new_in(Global);
+        inline.extend_from_slice(bytes);
+        let cap = Cap::Data(DataCap {
+            size: bytes.len() as u64,
+            content: DataContent::Inline(inline),
+        });
+        let h = javm_cap::cap_hash(&cap);
+        cache.put_blob(h, cap).unwrap();
+        h
     }
 
     #[test]
@@ -984,7 +1006,9 @@ mod tests {
         let mut img = Image::empty();
         img.code = vec![10u8, 0];
         img.packed_bitmask = vec![0b01u8];
-        let image_hash = cache.publish_image(&img).unwrap();
+        let image_hash = cache
+            .put_cap(&Cap::image_with_slots(&img, &[], &[]).unwrap())
+            .unwrap();
         vm.stack
             .running_instance_mut()
             .unwrap()
@@ -1120,7 +1144,7 @@ mod tests {
     fn host_read_data_cap_copies_bytes_from_cache() {
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
-        let data_hash = cache.publish_data_inline(b"hello").unwrap();
+        let data_hash = publish_data_inline(&mut cache, b"hello");
         vm.stack
             .running_instance_mut()
             .unwrap()
@@ -1191,7 +1215,7 @@ mod tests {
     fn host_open_places_registered_file_data_in_slot() {
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
-        let data_hash = cache.publish_data_inline(b"file").unwrap();
+        let data_hash = publish_data_inline(&mut cache, b"file");
         vm.kernel_assist
             .register_file(9, CapHashOrRef::Hash(data_hash));
         let mut regs = Regs::new();
@@ -1214,7 +1238,7 @@ mod tests {
     fn host_save_debits_actual_data_size_and_returns_file_id() {
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
-        let data_hash = cache.publish_data_inline(b"stored").unwrap();
+        let data_hash = publish_data_inline(&mut cache, b"stored");
         vm.kernel_assist.storage_quota_set(0, 10);
         vm.stack
             .running_instance_mut()

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -39,14 +39,16 @@
 //!
 //! After the move to the `javm_cap::Cap<A>` cache model, ecalls
 //! operate on `CapHashOrRef` targets in the running root cnode and
-//! cross-reference into the caller-supplied `Cache<Global>` for
-//! kind dispatch. The `Cache<Global>` is NOT borrowed for the
-//! duration of `Interpreter::run` — the ecall handler keeps the
-//! call-stack mutation local; host calls that need cache writes
-//! (host_open / host_save / host_mint_data_cap) are deferred to
-//! Stage 4 once the borrow model crystallizes.
+//! cross-reference into the caller-supplied `Cache<Global>` for kind
+//! dispatch. `Vm::drive_and_translate` installs a short-lived
+//! [`CachedEcallHandler`] for interpreter runs, so cache-touching host
+//! calls can read/write cap content without storing the cache borrow
+//! in the long-lived `Vm`.
 
-use javm_cap::{Blake2b256, CapHashOrRef, Hash, SlotIdx};
+use allocator_api2::alloc::Global;
+use javm_cap::{
+    Blake2b256, Cache, Cap, CapHashOrRef, DataCap, DataContent, Hash, SlotIdx, TypeCap,
+};
 use javm_exec::{EcallHandler, EcallKind, EcallResult, ExitReason, Memory, Regs};
 
 use crate::callstack::Entry;
@@ -97,24 +99,46 @@ pub mod host_op {
 impl<K: KernelAssist> EcallHandler for Vm<K> {
     fn handle(&mut self, kind: EcallKind, regs: &mut Regs, mem: &mut dyn Memory) -> EcallResult {
         match kind {
-            EcallKind::Ecalli(op) => self.dispatch_ecalli(op, regs, mem),
-            EcallKind::Ecall => self.dispatch_ecall(regs, mem),
+            EcallKind::Ecalli(op) => self.dispatch_ecalli(op, regs, mem, None),
+            EcallKind::Ecall => self.dispatch_ecall(regs, mem, None),
+        }
+    }
+}
+
+pub(crate) struct CachedEcallHandler<'a, K: KernelAssist> {
+    pub(crate) vm: &'a mut Vm<K>,
+    pub(crate) cache: &'a mut Cache<Global>,
+}
+
+impl<K: KernelAssist> EcallHandler for CachedEcallHandler<'_, K> {
+    fn handle(&mut self, kind: EcallKind, regs: &mut Regs, mem: &mut dyn Memory) -> EcallResult {
+        match kind {
+            EcallKind::Ecalli(op) => self
+                .vm
+                .dispatch_ecalli(op, regs, mem, Some(&mut *self.cache)),
+            EcallKind::Ecall => self.vm.dispatch_ecall(regs, mem, Some(&mut *self.cache)),
         }
     }
 }
 
 impl<K: KernelAssist> Vm<K> {
-    fn dispatch_ecalli(&mut self, op: u32, _regs: &mut Regs, _mem: &mut dyn Memory) -> EcallResult {
+    fn dispatch_ecalli(
+        &mut self,
+        op: u32,
+        regs: &mut Regs,
+        mem: &mut dyn Memory,
+        cache: Option<&mut Cache<Global>>,
+    ) -> EcallResult {
         match op {
             0 => {
                 // REPLY is handled by the CALL/HALT driver.
                 EcallResult::Exit(ExitReason::Halt)
             }
-            o if o <= mgmt_op::MAX => match self.dispatch_mgmt(o, _regs) {
+            o if o <= mgmt_op::MAX => match self.dispatch_mgmt(o, regs, cache) {
                 Ok(()) => EcallResult::Continue,
                 Err(_) => EcallResult::Exit(ExitReason::Trap),
             },
-            o if o <= host_op::MAX => self.dispatch_host_call(o, _regs, _mem),
+            o if o <= host_op::MAX => self.dispatch_host_call(o, regs, mem, cache),
             _ => {
                 // Chain-user host calls (64+) land later. Continue
                 // silently for now so prologue-like ecalls (used by
@@ -129,7 +153,8 @@ impl<K: KernelAssist> Vm<K> {
         &mut self,
         op: u32,
         regs: &mut Regs,
-        _mem: &mut dyn Memory,
+        mem: &mut dyn Memory,
+        cache: Option<&mut Cache<Global>>,
     ) -> EcallResult {
         fn trap_on_err<T>(r: Result<T, VmError>, ok: impl FnOnce(T) -> EcallResult) -> EcallResult {
             match r {
@@ -139,9 +164,12 @@ impl<K: KernelAssist> Vm<K> {
         }
         match op {
             host_op::HOST_YIELD => trap_on_err(self.dispatch_host_yield(regs), |r| r),
-            host_op::SET_IMAGE => {
-                trap_on_err(self.dispatch_set_image(regs), |()| EcallResult::Continue)
-            }
+            host_op::SET_IMAGE => match cache {
+                Some(cache) => trap_on_err(self.dispatch_set_image_cached(regs, cache), |()| {
+                    EcallResult::Exit(ExitReason::HostCall(host_op::SET_IMAGE))
+                }),
+                None => trap_on_err(self.dispatch_set_image(regs), |()| EcallResult::Continue),
+            },
             host_op::DERIVE_SPAWN => {
                 trap_on_err(self.dispatch_derive_spawn(regs), |()| EcallResult::Continue)
             }
@@ -152,16 +180,40 @@ impl<K: KernelAssist> Vm<K> {
             host_op::HOST_SAME_TYPE => trap_on_err(self.dispatch_host_same_type(regs), |()| {
                 EcallResult::Continue
             }),
-            host_op::HOST_TYPE_OF
-            | host_op::HOST_READ_DATA_CAP
-            | host_op::HOST_MINT_DATA_CAP
-            | host_op::HOST_OPEN
-            | host_op::HOST_SAVE => {
-                // These host calls all require cache writes, which the
-                // interpreter-borrow shape doesn't allow until Stage 4
-                // wires a deferred-effect channel. For now, trap.
-                EcallResult::Exit(ExitReason::Trap)
-            }
+            host_op::HOST_TYPE_OF => match cache {
+                Some(cache) => trap_on_err(self.dispatch_host_type_of(regs, cache), |()| {
+                    EcallResult::Continue
+                }),
+                None => EcallResult::Exit(ExitReason::Trap),
+            },
+            host_op::HOST_READ_DATA_CAP => match cache {
+                Some(cache) => {
+                    trap_on_err(self.dispatch_host_read_data_cap(regs, mem, cache), |()| {
+                        EcallResult::Continue
+                    })
+                }
+                None => EcallResult::Exit(ExitReason::Trap),
+            },
+            host_op::HOST_MINT_DATA_CAP => match cache {
+                Some(cache) => {
+                    trap_on_err(self.dispatch_host_mint_data_cap(regs, mem, cache), |()| {
+                        EcallResult::Continue
+                    })
+                }
+                None => EcallResult::Exit(ExitReason::Trap),
+            },
+            host_op::HOST_OPEN => match cache {
+                Some(cache) => trap_on_err(self.dispatch_host_open(regs, cache), |()| {
+                    EcallResult::Continue
+                }),
+                None => EcallResult::Exit(ExitReason::Trap),
+            },
+            host_op::HOST_SAVE => match cache {
+                Some(cache) => trap_on_err(self.dispatch_host_save(regs, cache), |()| {
+                    EcallResult::Continue
+                }),
+                None => EcallResult::Exit(ExitReason::Trap),
+            },
             _ => {
                 // Chain-user host calls (64+) land later. Continue
                 // silently for now.
@@ -272,6 +324,58 @@ impl<K: KernelAssist> Vm<K> {
         Ok(())
     }
 
+    fn dispatch_set_image_cached(
+        &mut self,
+        regs: &mut Regs,
+        cache: &Cache<Global>,
+    ) -> Result<(), VmError> {
+        let image_slot = SlotIdx((regs.gpr[7] & 0xFF) as u32);
+        let (new_image_hash, extended_chain) = {
+            let running = self
+                .stack
+                .running_instance()
+                .ok_or(VmError::CallStackEmpty)?;
+            let new_image_hash = match running.root_cnode.get(image_slot) {
+                Some(CapHashOrRef::Hash(h)) => h,
+                Some(CapHashOrRef::Ref(_)) => {
+                    return Err(VmError::SlotKindMismatch(image_slot.get()));
+                }
+                None => return Err(VmError::SlotEmpty(image_slot.get())),
+            };
+            (
+                new_image_hash,
+                Blake2b256::hash_pair(&running.image_hash_chain, &new_image_hash),
+            )
+        };
+
+        let img = match cache
+            .get(CapHashOrRef::Hash(new_image_hash))
+            .ok_or(VmError::ImageNotFound)?
+        {
+            Cap::Image(i) => i.clone(),
+            _ => return Err(VmError::ImageNotFound),
+        };
+        let unpacked_bitmask = javm_exec::unpack_bitmask(img.bitmask.as_slice(), img.code.len());
+        let program = self.image_cache.get_or_decode(
+            new_image_hash,
+            img.code.as_slice().to_vec(),
+            unpacked_bitmask,
+            img.jump_table.as_slice().to_vec(),
+        )?;
+        let pinned_slots: Vec<SlotIdx> = img.pinned.iter().map(|e| e.slot).collect();
+
+        let running = self
+            .stack
+            .running_instance_mut()
+            .ok_or(VmError::CallStackEmpty)?;
+        running.image_hash_chain = extended_chain;
+        running.image_hash = new_image_hash;
+        running.program = program;
+        running.pinned_slots = pinned_slots;
+        running.yield_marker_slot = img.yield_marker_slot;
+        Ok(())
+    }
+
     /// `host_derive_spawn(image_slot=φ[7], dst_slot=φ[8])`.
     ///
     /// Mint a fresh `CapHashOrRef::Hash` carrying
@@ -344,6 +448,163 @@ impl<K: KernelAssist> Vm<K> {
         regs.gpr[7] = if ha == hb { 1 } else { 0 };
         Ok(())
     }
+
+    fn dispatch_host_type_of(
+        &mut self,
+        regs: &mut Regs,
+        cache: &mut Cache<Global>,
+    ) -> Result<(), VmError> {
+        let src = SlotIdx((regs.gpr[7] & 0xFF) as u32);
+        let dst = SlotIdx((regs.gpr[8] & 0xFF) as u32);
+        let target = self
+            .stack
+            .running_instance()
+            .ok_or(VmError::CallStackEmpty)?
+            .root_cnode
+            .get(src)
+            .ok_or(VmError::SlotEmpty(src.get()))?;
+        let image_hash_chain = match cache.get(target).ok_or(VmError::InstanceNotFound)? {
+            Cap::Instance(i) => i.image_hash_chain,
+            _ => return Err(VmError::InstanceNotFound),
+        };
+        let cap = Cap::Type(TypeCap { image_hash_chain });
+        let h = javm_cap::cap_hash(&cap);
+        cache.put_blob(h, cap)?;
+
+        let running = self
+            .stack
+            .running_instance_mut()
+            .ok_or(VmError::CallStackEmpty)?;
+        if running.pinned_slots.binary_search(&dst).is_ok() {
+            return Err(javm_cap::OpError::SlotPinned(dst.get()).into());
+        }
+        running.root_cnode.set(dst, Some(CapHashOrRef::Hash(h)))?;
+        Ok(())
+    }
+
+    fn dispatch_host_read_data_cap(
+        &mut self,
+        regs: &mut Regs,
+        mem: &mut dyn Memory,
+        cache: &Cache<Global>,
+    ) -> Result<(), VmError> {
+        let src = SlotIdx((regs.gpr[7] & 0xFF) as u32);
+        let dst_offset = regs.gpr[8] as u32;
+        let len = regs.gpr[9] as usize;
+        let target = self
+            .stack
+            .running_instance()
+            .ok_or(VmError::CallStackEmpty)?
+            .root_cnode
+            .get(src)
+            .ok_or(VmError::SlotEmpty(src.get()))?;
+        let data = match cache
+            .get(target)
+            .ok_or(VmError::Invariant("data cap missing"))?
+        {
+            Cap::Data(d) => d,
+            _ => return Err(VmError::Invariant("slot does not hold Cap::Data")),
+        };
+        let bytes = data_cap_prefix(data, len);
+        mem.write(dst_offset, &bytes)
+            .map_err(|_| VmError::Invariant("host_read_data_cap memory write failed"))?;
+        regs.gpr[7] = bytes.len() as u64;
+        Ok(())
+    }
+
+    fn dispatch_host_mint_data_cap(
+        &mut self,
+        regs: &mut Regs,
+        mem: &mut dyn Memory,
+        cache: &mut Cache<Global>,
+    ) -> Result<(), VmError> {
+        let src_offset = regs.gpr[7] as u32;
+        let len = regs.gpr[8] as usize;
+        let quota_id = regs.gpr[9];
+        let dst = SlotIdx((regs.gpr[10] & 0xFF) as u32);
+        let bytes = mem
+            .read(src_offset, len)
+            .map_err(|_| VmError::Invariant("host_mint_data_cap memory read failed"))?;
+        let canonical_len = strip_trailing_zeros_len(&bytes);
+        let debit = canonical_len as u64;
+        let quota = self.kernel_assist.storage_quota_get(quota_id);
+        if quota < debit {
+            return Err(VmError::Invariant("storage quota exhausted"));
+        }
+        self.kernel_assist
+            .storage_quota_set(quota_id, quota - debit);
+        let h = cache.publish_data_inline(&bytes[..canonical_len])?;
+
+        let running = self
+            .stack
+            .running_instance_mut()
+            .ok_or(VmError::CallStackEmpty)?;
+        if running.pinned_slots.binary_search(&dst).is_ok() {
+            return Err(javm_cap::OpError::SlotPinned(dst.get()).into());
+        }
+        running.root_cnode.set(dst, Some(CapHashOrRef::Hash(h)))?;
+        Ok(())
+    }
+
+    fn dispatch_host_open(
+        &mut self,
+        regs: &mut Regs,
+        cache: &mut Cache<Global>,
+    ) -> Result<(), VmError> {
+        let file_id = regs.gpr[7];
+        let dst = SlotIdx((regs.gpr[8] & 0xFF) as u32);
+        let data_ref = self
+            .kernel_assist
+            .host_open(file_id)
+            .ok_or(VmError::Invariant("unknown file id"))?;
+        match cache
+            .get(data_ref)
+            .ok_or(VmError::Invariant("file data missing"))?
+        {
+            Cap::Data(_) => {}
+            _ => return Err(VmError::Invariant("file target is not Cap::Data")),
+        }
+        let h = cache.settle(data_ref)?;
+
+        let running = self
+            .stack
+            .running_instance_mut()
+            .ok_or(VmError::CallStackEmpty)?;
+        if running.pinned_slots.binary_search(&dst).is_ok() {
+            return Err(javm_cap::OpError::SlotPinned(dst.get()).into());
+        }
+        running.root_cnode.set(dst, Some(CapHashOrRef::Hash(h)))?;
+        Ok(())
+    }
+
+    fn dispatch_host_save(
+        &mut self,
+        regs: &mut Regs,
+        cache: &Cache<Global>,
+    ) -> Result<(), VmError> {
+        let src = SlotIdx((regs.gpr[7] & 0xFF) as u32);
+        let quota_id = regs.gpr[8];
+        let target = self
+            .stack
+            .running_instance()
+            .ok_or(VmError::CallStackEmpty)?
+            .root_cnode
+            .get(src)
+            .ok_or(VmError::SlotEmpty(src.get()))?;
+        let size = match cache
+            .get(target)
+            .ok_or(VmError::Invariant("host_save data missing"))?
+        {
+            Cap::Data(d) => d.size,
+            _ => return Err(VmError::Invariant("host_save source is not Cap::Data")),
+        };
+        let file_id = self
+            .kernel_assist
+            .host_save(target, quota_id, size)
+            .ok_or(VmError::Invariant("host_save failed"))?;
+        regs.gpr[7] = file_id;
+        Ok(())
+    }
 }
 
 /// Canonical-form length: number of leading bytes before trailing
@@ -358,17 +619,53 @@ pub(crate) fn strip_trailing_zeros_len(bytes: &[u8]) -> usize {
     n
 }
 
+fn data_cap_prefix(data: &DataCap<Global>, len: usize) -> Vec<u8> {
+    let actual_len = len.min(data.size as usize);
+    let mut out = vec![0u8; actual_len];
+    match &data.content {
+        DataContent::Inline(bytes) => {
+            let copy_len = actual_len.min(bytes.len());
+            out[..copy_len].copy_from_slice(&bytes[..copy_len]);
+        }
+        DataContent::Paged { page_size, pages } => {
+            let page_size = *page_size as usize;
+            for (page_idx, page) in pages.iter().enumerate() {
+                let start = page_idx * page_size;
+                if start >= actual_len {
+                    break;
+                }
+                let end = (start + page_size).min(actual_len);
+                if let javm_cap::page::PageSlot::Loaded(page_ref) = page {
+                    let page_bytes = &page_ref.get().bytes;
+                    out[start..end].copy_from_slice(&page_bytes[..end - start]);
+                }
+            }
+        }
+    }
+    out
+}
+
 impl<K: KernelAssist> Vm<K> {
     /// Plain `ecall` (opcode 3, no immediate). Spec §4 reads φ[11]
     /// (mgmt_op) and φ[12] (subject|object) for the management
     /// dispatch. Stage 3 routes the same way as `ecalli imm`, treating
     /// φ[11] as the op.
-    fn dispatch_ecall(&mut self, regs: &mut Regs, mem: &mut dyn Memory) -> EcallResult {
+    fn dispatch_ecall(
+        &mut self,
+        regs: &mut Regs,
+        mem: &mut dyn Memory,
+        cache: Option<&mut Cache<Global>>,
+    ) -> EcallResult {
         let op = regs.gpr[11] as u32;
-        self.dispatch_ecalli(op, regs, mem)
+        self.dispatch_ecalli(op, regs, mem, cache)
     }
 
-    fn dispatch_mgmt(&mut self, op: u32, regs: &mut Regs) -> Result<(), VmError> {
+    fn dispatch_mgmt(
+        &mut self,
+        op: u32,
+        regs: &mut Regs,
+        cache: Option<&mut Cache<Global>>,
+    ) -> Result<(), VmError> {
         let a = SlotIdx((regs.gpr[7] & 0xFF) as u32);
         let b = SlotIdx((regs.gpr[8] & 0xFF) as u32);
         match op {
@@ -378,7 +675,7 @@ impl<K: KernelAssist> Vm<K> {
             mgmt_op::CNODE_SWAP => self.mgmt_cnode_swap(a, b),
             mgmt_op::CNODE_MINT => {
                 let size_log = (regs.gpr[8] & 0xFF) as u8;
-                self.mgmt_cnode_mint(a, size_log)
+                self.mgmt_cnode_mint(a, size_log, cache)
             }
             _ => Err(VmError::Invariant("unknown MGMT op")),
         }
@@ -453,16 +750,19 @@ impl<K: KernelAssist> Vm<K> {
         Ok(())
     }
 
-    fn mgmt_cnode_mint(&mut self, dst: SlotIdx, size_log: u8) -> Result<(), VmError> {
-        // Create a fresh empty CNodeCap, hash it via `cap_hash`, and
-        // store the hash at `dst`. The cnode content itself isn't
-        // published to the cache here (V1: deferred-effect channel
-        // not yet wired). The hash is stable for an empty cnode of
-        // the given size so callers can address the slot
-        // consistently across invocations.
-        use javm_cap::Cap;
-        let cn = javm_cap::CNodeCap::<allocator_api2::alloc::Global>::new(size_log)?;
-        let h = javm_cap::cap_hash(&Cap::CNode(cn));
+    fn mgmt_cnode_mint(
+        &mut self,
+        dst: SlotIdx,
+        size_log: u8,
+        cache: Option<&mut Cache<Global>>,
+    ) -> Result<(), VmError> {
+        let h = match cache {
+            Some(cache) => cache.publish_cnode(size_log, &[])?,
+            None => {
+                let cn = javm_cap::CNodeCap::<Global>::new(size_log)?;
+                javm_cap::cap_hash(&Cap::CNode(cn))
+            }
+        };
         let running = self
             .stack
             .running_instance_mut()
@@ -481,8 +781,9 @@ mod tests {
     use crate::callstack::{EntryStatus, InstanceEntry};
     use crate::kernel_assist::InProcessKernelAssist;
     use allocator_api2::alloc::Global;
-    use javm_cap::CNodeCap;
-    use javm_exec::{GasCounter, Mem, PvmProgram, Regs};
+    use javm_cap::image::Image;
+    use javm_cap::{CNodeCap, InstanceCap, NUM_REGS, RwOverlay};
+    use javm_exec::{Access, GasCounter, Mem, PAGE_SIZE, PvmProgram, Regs};
     use std::sync::Arc;
 
     fn fixture_vm() -> Vm<InProcessKernelAssist> {
@@ -508,6 +809,17 @@ mod tests {
         };
         vm.stack.push_instance(entry).unwrap();
         vm
+    }
+
+    fn handle_cached(
+        vm: &mut Vm<InProcessKernelAssist>,
+        cache: &mut Cache<Global>,
+        op: u32,
+        regs: &mut Regs,
+        mem: &mut Mem,
+    ) -> EcallResult {
+        let mut handler = CachedEcallHandler { vm, cache };
+        handler.handle(EcallKind::Ecalli(op), regs, mem)
     }
 
     #[test]
@@ -561,6 +873,27 @@ mod tests {
         assert!(matches!(r, EcallResult::Continue));
         let cnode = &vm.stack.running_instance().unwrap().root_cnode;
         assert!(matches!(cnode.get(SlotIdx(5)), Some(CapHashOrRef::Hash(_))));
+    }
+
+    #[test]
+    fn mgmt_cnode_mint_publishes_cnode_when_cache_threaded() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let mut regs = Regs::new();
+        regs.gpr[7] = 5;
+        regs.gpr[8] = 3;
+        let mut mem = Mem::new();
+        let r = handle_cached(
+            &mut vm,
+            &mut cache,
+            mgmt_op::CNODE_MINT,
+            &mut regs,
+            &mut mem,
+        );
+        assert!(matches!(r, EcallResult::Continue));
+        let cnode = &vm.stack.running_instance().unwrap().root_cnode;
+        let target = cnode.get(SlotIdx(5)).unwrap();
+        assert!(matches!(cache.get(target), Some(Cap::CNode(_))));
     }
 
     #[test]
@@ -645,6 +978,33 @@ mod tests {
     }
 
     #[test]
+    fn set_image_reloads_program_from_cache() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let mut img = Image::empty();
+        img.code = vec![10u8, 0];
+        img.packed_bitmask = vec![0b01u8];
+        let image_hash = cache.publish_image(&img).unwrap();
+        vm.stack
+            .running_instance_mut()
+            .unwrap()
+            .root_cnode
+            .set(SlotIdx(3), Some(CapHashOrRef::Hash(image_hash)))
+            .unwrap();
+
+        let mut regs = Regs::new();
+        regs.gpr[7] = 3;
+        let mut mem = Mem::new();
+        let r = handle_cached(&mut vm, &mut cache, host_op::SET_IMAGE, &mut regs, &mut mem);
+        assert!(
+            matches!(r, EcallResult::Exit(ExitReason::HostCall(op)) if op == host_op::SET_IMAGE)
+        );
+        let running = vm.stack.running_instance().unwrap();
+        assert_eq!(running.image_hash, image_hash);
+        assert_eq!(running.program.code, vec![10u8, 0]);
+    }
+
+    #[test]
     fn derive_spawn_mints_extended_chain_target() {
         let mut vm = fixture_vm();
         let parent_chain = vm.stack.running_instance().unwrap().image_hash_chain;
@@ -706,6 +1066,177 @@ mod tests {
     }
 
     #[test]
+    fn host_type_of_publishes_type_cap() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let inst = InstanceCap {
+            image_hash_chain: [0x42; 32],
+            image_hash: [0x24; 32],
+            root_cnode: CapHashOrRef::Hash([0x11; 32]),
+            rw_overlays: allocator_api2::vec::Vec::<RwOverlay<Global>, Global>::new_in(Global),
+            mem_size: 0,
+            regs: [0u64; NUM_REGS],
+            pc: 0,
+            gas_remaining: 0,
+        };
+        let cap = Cap::Instance(inst);
+        let inst_hash = javm_cap::cap_hash(&cap);
+        cache.put_blob(inst_hash, cap).unwrap();
+        vm.stack
+            .running_instance_mut()
+            .unwrap()
+            .root_cnode
+            .set(SlotIdx(3), Some(CapHashOrRef::Hash(inst_hash)))
+            .unwrap();
+
+        let mut regs = Regs::new();
+        regs.gpr[7] = 3;
+        regs.gpr[8] = 6;
+        let mut mem = Mem::new();
+        let r = handle_cached(
+            &mut vm,
+            &mut cache,
+            host_op::HOST_TYPE_OF,
+            &mut regs,
+            &mut mem,
+        );
+        assert!(matches!(r, EcallResult::Continue));
+        let target = vm
+            .stack
+            .running_instance()
+            .unwrap()
+            .root_cnode
+            .get(SlotIdx(6))
+            .unwrap();
+        assert!(matches!(
+            cache.get(target),
+            Some(Cap::Type(TypeCap {
+                image_hash_chain
+            })) if *image_hash_chain == [0x42; 32]
+        ));
+    }
+
+    #[test]
+    fn host_read_data_cap_copies_bytes_from_cache() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let data_hash = cache.publish_data_inline(b"hello").unwrap();
+        vm.stack
+            .running_instance_mut()
+            .unwrap()
+            .root_cnode
+            .set(SlotIdx(3), Some(CapHashOrRef::Hash(data_hash)))
+            .unwrap();
+        let mut mem = Mem::new();
+        mem.map_region(0, PAGE_SIZE as u64, Access::ReadWrite, None)
+            .unwrap();
+        let mut regs = Regs::new();
+        regs.gpr[7] = 3;
+        regs.gpr[8] = 16;
+        regs.gpr[9] = 8;
+
+        let r = handle_cached(
+            &mut vm,
+            &mut cache,
+            host_op::HOST_READ_DATA_CAP,
+            &mut regs,
+            &mut mem,
+        );
+        assert!(matches!(r, EcallResult::Continue));
+        assert_eq!(regs.gpr[7], 5);
+        assert_eq!(mem.read(16, 5).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn host_mint_data_cap_publishes_canonical_bytes() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        vm.kernel_assist.storage_quota_set(0, 10);
+        let mut mem = Mem::new();
+        mem.map_region(0, PAGE_SIZE as u64, Access::ReadWrite, None)
+            .unwrap();
+        mem.write(32, b"abc\0\0").unwrap();
+        let mut regs = Regs::new();
+        regs.gpr[7] = 32;
+        regs.gpr[8] = 5;
+        regs.gpr[9] = 0;
+        regs.gpr[10] = 6;
+
+        let r = handle_cached(
+            &mut vm,
+            &mut cache,
+            host_op::HOST_MINT_DATA_CAP,
+            &mut regs,
+            &mut mem,
+        );
+        assert!(matches!(r, EcallResult::Continue));
+        assert_eq!(vm.kernel_assist.storage_quota_get(0), 7);
+        let target = vm
+            .stack
+            .running_instance()
+            .unwrap()
+            .root_cnode
+            .get(SlotIdx(6))
+            .unwrap();
+        match cache.get(target).unwrap() {
+            Cap::Data(d) => {
+                assert_eq!(d.size, 3);
+                assert_eq!(data_cap_prefix(d, 10), b"abc");
+            }
+            _ => panic!("expected Data cap"),
+        }
+    }
+
+    #[test]
+    fn host_open_places_registered_file_data_in_slot() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let data_hash = cache.publish_data_inline(b"file").unwrap();
+        vm.kernel_assist
+            .register_file(9, CapHashOrRef::Hash(data_hash));
+        let mut regs = Regs::new();
+        regs.gpr[7] = 9;
+        regs.gpr[8] = 6;
+        let mut mem = Mem::new();
+        let r = handle_cached(&mut vm, &mut cache, host_op::HOST_OPEN, &mut regs, &mut mem);
+        assert!(matches!(r, EcallResult::Continue));
+        let target = vm
+            .stack
+            .running_instance()
+            .unwrap()
+            .root_cnode
+            .get(SlotIdx(6))
+            .unwrap();
+        assert!(matches!(cache.get(target), Some(Cap::Data(_))));
+    }
+
+    #[test]
+    fn host_save_debits_actual_data_size_and_returns_file_id() {
+        let mut vm = fixture_vm();
+        let mut cache = Cache::new_in(Global);
+        let data_hash = cache.publish_data_inline(b"stored").unwrap();
+        vm.kernel_assist.storage_quota_set(0, 10);
+        vm.stack
+            .running_instance_mut()
+            .unwrap()
+            .root_cnode
+            .set(SlotIdx(3), Some(CapHashOrRef::Hash(data_hash)))
+            .unwrap();
+        let mut regs = Regs::new();
+        regs.gpr[7] = 3;
+        regs.gpr[8] = 0;
+        let mut mem = Mem::new();
+        let r = handle_cached(&mut vm, &mut cache, host_op::HOST_SAVE, &mut regs, &mut mem);
+        assert!(matches!(r, EcallResult::Continue));
+        assert_eq!(regs.gpr[7], 1);
+        assert_eq!(vm.kernel_assist.storage_quota_get(0), 4);
+        assert_eq!(
+            vm.kernel_assist.host_open(1),
+            Some(CapHashOrRef::Hash(data_hash))
+        );
+    }
+
+    #[test]
     fn make_image_stubbed_traps() {
         let mut vm = fixture_vm();
         let mut regs = Regs::new();
@@ -715,10 +1246,9 @@ mod tests {
     }
 
     #[test]
-    fn cache_dependent_host_calls_trap() {
-        // host_read_data_cap / host_mint_data_cap / host_open /
-        // host_save / host_type_of all need cache access during
-        // interpreter run — deferred to Stage 4. They trap in V1.
+    fn cache_dependent_host_calls_without_cache_still_trap() {
+        // Direct `Vm` handler calls don't carry a cache borrow, so
+        // cache-dependent host calls still trap outside invoke_cached.
         for op in [
             host_op::HOST_TYPE_OF,
             host_op::HOST_READ_DATA_CAP,

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -470,7 +470,7 @@ impl<K: KernelAssist> Vm<K> {
         };
         let cap = Cap::Type(TypeCap { image_hash_chain });
         let h = javm_cap::cap_hash(&cap);
-        cache.put_blob(h, cap)?;
+        cache.put_cap_with_hash(h, &cap)?;
 
         let running = self
             .stack
@@ -541,7 +541,7 @@ impl<K: KernelAssist> Vm<K> {
             content: DataContent::Inline(inline),
         });
         let h = javm_cap::cap_hash(&cap);
-        cache.put_blob(h, cap)?;
+        cache.put_cap_with_hash(h, &cap)?;
 
         let running = self
             .stack
@@ -768,7 +768,7 @@ impl<K: KernelAssist> Vm<K> {
         let cap_hash = javm_cap::cap_hash(&cap);
         let h = match cache {
             Some(cache) => {
-                cache.put_blob(cap_hash, cap)?;
+                cache.put_cap_with_hash(cap_hash, &cap)?;
                 cap_hash
             }
             None => cap_hash,
@@ -792,7 +792,7 @@ mod tests {
     use crate::kernel_assist::InProcessKernelAssist;
     use allocator_api2::alloc::Global;
     use javm_cap::image::Image;
-    use javm_cap::{CNodeCap, InstanceCap, NUM_REGS, RwOverlay};
+    use javm_cap::{CNodeCap, NUM_REGS};
     use javm_exec::{Access, GasCounter, Mem, PAGE_SIZE, PvmProgram, Regs};
     use std::sync::Arc;
 
@@ -833,15 +833,7 @@ mod tests {
     }
 
     fn publish_data_inline(cache: &mut Cache<Global>, bytes: &[u8]) -> javm_cap::CapHash {
-        let mut inline = AVec::new_in(Global);
-        inline.extend_from_slice(bytes);
-        let cap = Cap::Data(DataCap {
-            size: bytes.len() as u64,
-            content: DataContent::Inline(inline),
-        });
-        let h = javm_cap::cap_hash(&cap);
-        cache.put_blob(h, cap).unwrap();
-        h
+        cache.put_cap(&Cap::data_inline(bytes)).unwrap()
     }
 
     #[test]
@@ -1093,19 +1085,24 @@ mod tests {
     fn host_type_of_publishes_type_cap() {
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
-        let inst = InstanceCap {
-            image_hash_chain: [0x42; 32],
-            image_hash: [0x24; 32],
-            root_cnode: CapHashOrRef::Hash([0x11; 32]),
-            rw_overlays: allocator_api2::vec::Vec::<RwOverlay<Global>, Global>::new_in(Global),
-            mem_size: 0,
-            regs: [0u64; NUM_REGS],
-            pc: 0,
-            gas_remaining: 0,
-        };
-        let cap = Cap::Instance(inst);
-        let inst_hash = javm_cap::cap_hash(&cap);
-        cache.put_blob(inst_hash, cap).unwrap();
+        // Instance references image + cnode by hash; both must be in
+        // the cache for `put_cap` to accept the Instance.
+        let image_hash = cache
+            .put_cap(&Cap::image_with_slots(&Image::empty(), &[], &[]).unwrap())
+            .unwrap();
+        let cnode_hash = cache.put_cap(&Cap::empty_cnode(0).unwrap()).unwrap();
+        let inst_hash = cache
+            .put_cap(&Cap::instance_with_overlays(
+                [0x42; 32],
+                image_hash,
+                cnode_hash,
+                &[],
+                0,
+                [0u64; NUM_REGS],
+                0,
+                0,
+            ))
+            .unwrap();
         vm.stack
             .running_instance_mut()
             .unwrap()

--- a/rust/javm/src/kernel_assist.rs
+++ b/rust/javm/src/kernel_assist.rs
@@ -86,9 +86,9 @@ pub trait KernelAssist {
     }
 
     /// Mint a new file from the cache reference `data` after debiting
-    /// `quota_id`. Returns the new `file_id`. Default returns None
-    /// (no file registry).
-    fn host_save(&mut self, _data: CapHashOrRef, _quota_id: u64) -> Option<u64> {
+    /// `quota_id` by the resolved DataCap size. Returns the new
+    /// `file_id`. Default returns None (no file registry).
+    fn host_save(&mut self, _data: CapHashOrRef, _quota_id: u64, _size: u64) -> Option<u64> {
         None
     }
 }
@@ -217,17 +217,12 @@ impl KernelAssist for InProcessKernelAssist {
         self.files.get(&file_id).copied()
     }
 
-    fn host_save(&mut self, data: CapHashOrRef, quota_id: u64) -> Option<u64> {
-        // Default impl ignores the size (it's stored on the cache side)
-        // and just allocates a fresh file_id. Real impl would debit
-        // quota by the data's logical size; this stub debits a
-        // placeholder 1 byte per save so tests can observe the
-        // mechanics.
+    fn host_save(&mut self, data: CapHashOrRef, quota_id: u64, size: u64) -> Option<u64> {
         let q = self.storage_quotas.get(&quota_id).copied().unwrap_or(0);
-        if q < 1 {
+        if q < size {
             return None;
         }
-        self.storage_quotas.insert(quota_id, q - 1);
+        self.storage_quotas.insert(quota_id, q - size);
         let id = self.next_file_id;
         self.next_file_id += 1;
         self.files.insert(id, data);

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -24,6 +24,7 @@ use javm_cap::{Cache, Cap, CapHash, CapHashOrRef, SlotIdx};
 use javm_exec::{Access, CopyingMemory, ExitReason, GasCounter, Interpreter, Mem, Regs};
 
 use crate::callstack::{CallStack, DEFAULT_MAX_DEPTH, Entry, EntryStatus, InstanceEntry};
+use crate::ecall::{CachedEcallHandler, host_op};
 use crate::error::VmError;
 use crate::image_cache::ImageCache;
 use crate::kernel_assist::{KernelAssist, KernelImage, kernel_image_hash};
@@ -315,12 +316,24 @@ impl<K: KernelAssist> Vm<K> {
         gas_initial: u64,
         pushed_pos: usize,
     ) -> Result<CallResult, VmError> {
-        let program = match &self.stack.entries()[pushed_pos] {
-            Entry::Instance(e) => e.program.clone(),
-            _ => return Err(VmError::Invariant("pushed_pos points at non-Instance")),
+        let exit = loop {
+            let program = match &self.stack.entries()[pushed_pos] {
+                Entry::Instance(e) => e.program.clone(),
+                _ => return Err(VmError::Invariant("pushed_pos points at non-Instance")),
+            };
+            let mut handler = CachedEcallHandler { vm: self, cache };
+            let exit = Interpreter::run(
+                program.as_ref(),
+                &mut regs,
+                &mut mem,
+                &mut gas,
+                &mut handler,
+            );
+            if matches!(exit, ExitReason::HostCall(op) if op == host_op::SET_IMAGE) {
+                continue;
+            }
+            break exit;
         };
-
-        let exit = Interpreter::run(program.as_ref(), &mut regs, &mut mem, &mut gas, self);
 
         let gas_used = gas_initial.saturating_sub(gas.remaining());
 

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -602,7 +602,7 @@ mod tests {
     use super::*;
     use crate::kernel_assist::InProcessKernelAssist;
     use javm_cap::image::Image;
-    use javm_cap::{Cache, NUM_REGS};
+    use javm_cap::{Cache, Cap, NUM_REGS};
     use std::collections::BTreeMap;
 
     fn empty_image_with_code(code: Vec<u8>) -> Image {


### PR DESCRIPTION
## Summary

- Add a scoped cached ecall handler so `invoke_cached` can service cache-touching host calls during interpreter execution.
- Implement cache-backed `host_type_of`, `host_read_data_cap`, `host_mint_data_cap`, `host_open`, `host_save`, and `MGMT_CNODE_MINT` publication paths.
- Reload cached image bytecode on `set_image` and debit `host_save` quota by the resolved DataCap size.

Addresses #847.

## Test plan

- `cargo fmt --all --check`
- `cargo test -p javm`
- `cargo test -p jar-kernel`
- `cargo clippy -p javm -p jar-kernel --all-targets -- -D warnings`
- `cargo doc --locked --workspace --no-deps`
- GitHub CI: passing