### PR TITLE
feat(nub-arch-x86): in-sandbox sub-VM CALL/HALT loop + recurse bench (~30-36k VMs/sec)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bench-sub-vm-recurse"
+version = "0.1.0"
+dependencies = [
+ "subsoil",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "components/benches/poly-eval",
     "components/benches/poseidon2-perm",
     "components/benches/prime-sieve",
+    "components/benches/sub-vm-recurse",
     "components/examples/simple-chain",
     "components/tests/spawn-child-s",
     "components/tests/spawn-parent-m",

--- a/components/benches/sub-vm-recurse/Cargo.toml
+++ b/components/benches/sub-vm-recurse/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bench-sub-vm-recurse"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+subsoil = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_env, values("javm"))', 'cfg(target_os, values("none"))'] }

--- a/components/benches/sub-vm-recurse/src/kernel_abi.rs
+++ b/components/benches/sub-vm-recurse/src/kernel_abi.rs
@@ -1,0 +1,44 @@
+//! Inline-asm wrappers around the kernel's `ecall` interface for
+//! the recursive-spawn bench guest. Mirrors `spawn-parent-m`'s ABI
+//! module but trimmed to just the two operations the bench uses:
+//! `host_derive_spawn` (op 18) and a depth-passing form of
+//! `host_call` (op 26) that lands the caller's `arg` in `a2` so the
+//! kernel can forward it as the child's φ[7].
+
+#![allow(dead_code, unsafe_op_in_unsafe_fn)]
+
+const OP_DERIVE_SPAWN: u64 = 18;
+const OP_HOST_CALL: u64 = 26;
+
+#[inline]
+pub unsafe fn host_derive_spawn(image: u8, cnode: u8, dst: u8) {
+    core::arch::asm!(
+        "csrw 0x800, zero",
+        "ecall",
+        inlateout("a0") image as u64 => _,
+        inlateout("a1") cnode as u64 => _,
+        inlateout("a2") dst as u64 => _,
+        inlateout("a4") OP_DERIVE_SPAWN => _,
+        lateout("a3") _,
+        lateout("a5") _,
+        options(nostack, preserves_flags),
+    );
+}
+
+/// `host_call(instance, endpoint)` with a single u64 arg threaded
+/// via `a2` (= φ[9]). The kernel's HOST_CALL handler maps φ[9..=10]
+/// → child's φ[7..=8] and zeros higher arg slots; we only use one.
+#[inline]
+pub unsafe fn host_call_with_arg(instance: u8, endpoint: u8, arg: u64) {
+    core::arch::asm!(
+        "csrw 0x800, zero",
+        "ecall",
+        inlateout("a0") instance as u64 => _,
+        inlateout("a1") endpoint as u64 => _,
+        inlateout("a2") arg => _,
+        inlateout("a4") OP_HOST_CALL => _,
+        lateout("a3") _,
+        lateout("a5") _,
+        options(nostack, preserves_flags),
+    );
+}

--- a/components/benches/sub-vm-recurse/src/lib.rs
+++ b/components/benches/sub-vm-recurse/src/lib.rs
@@ -1,0 +1,11 @@
+//! Recursive sub-VM spawn bench guest.
+//!
+//! Endpoint 0 reads `depth` from φ[7] (a0). If zero, returns 0. Else
+//! derive_spawns a child Cap::Instance from the Image at
+//! `SLOT_IMAGE_RECURSE` (recursive — same image as the parent),
+//! threads `depth - 1` to the child via φ[9] (host_call's
+//! arg-passing convention), and CALLs the child at endpoint 0.
+
+#![cfg_attr(target_os = "none", no_std)]
+
+use subsoil as _;

--- a/components/benches/sub-vm-recurse/src/lib.rs
+++ b/components/benches/sub-vm-recurse/src/lib.rs
@@ -1,9 +1,9 @@
 //! Recursive sub-VM spawn bench guest.
 //!
-//! Endpoint 0 reads `depth` from φ[7] (a0). If zero, returns 0. Else
-//! derive_spawns a child Cap::Instance from the Image at
+//! Endpoint 0 reads `depth` from `φ[7]` (a0). If zero, returns 0;
+//! otherwise derive_spawns a child Cap::Instance from the Image at
 //! `SLOT_IMAGE_RECURSE` (recursive — same image as the parent),
-//! threads `depth - 1` to the child via φ[9] (host_call's
+//! threads `depth - 1` to the child via `φ[9]` (host_call's
 //! arg-passing convention), and CALLs the child at endpoint 0.
 
 #![cfg_attr(target_os = "none", no_std)]

--- a/components/benches/sub-vm-recurse/src/main.rs
+++ b/components/benches/sub-vm-recurse/src/main.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(target_env = "javm", no_std)]
+#![cfg_attr(target_env = "javm", no_main)]
+
+use bench_sub_vm_recurse as _;
+use subsoil as _;
+
+#[cfg(target_env = "javm")]
+mod kernel_abi;
+
+/// Slot holding `Hash(Cap::Image)` for this guest itself — the bench
+/// harness pre-populates the top Instance's cnode with the recursive
+/// image's hash here, and the in-kernel HOST_CALL handler inherits
+/// it into every spawned child's cnode, so each recursion level
+/// finds the same image to spawn again.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const SLOT_IMAGE_RECURSE: u8 = 3;
+
+/// Slot the in-kernel `derive_spawn` writes the child's chain hash
+/// to; the next `host_call` reads from here.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const SLOT_CHILD: u8 = 6;
+
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const CHILD_ENDPOINT: u8 = 0;
+
+#[cfg(all(target_env = "javm", target_os = "none"))]
+#[subsoil::endpoint(0)]
+fn javm_main(depth: u64) -> u64 {
+    use kernel_abi::*;
+
+    if depth == 0 {
+        return 0;
+    }
+
+    // Derive a fresh Cap::Instance from the recursive image. The
+    // kernel's transient-instances table records this; the next
+    // host_call resolves SLOT_CHILD against that table.
+    unsafe { host_derive_spawn(SLOT_IMAGE_RECURSE, 0, SLOT_CHILD) };
+
+    // CALL the child with `depth - 1`. The kernel maps the parent's
+    // φ[9] (a2) onto the child's φ[7] (a0), so the child sees the
+    // decremented depth as its `_args_len` argument.
+    unsafe { host_call_with_arg(SLOT_CHILD, CHILD_ENDPOINT, depth - 1) };
+
+    // Return depth — bench's host driver mostly ignores the value
+    // (it measures wall time), but keep it non-zero so an accidental
+    // halt-without-recurse falls out as zero on the harness side.
+    depth
+}
+
+#[cfg(not(target_env = "javm"))]
+fn main() {}

--- a/rust/javm-bench/Cargo.toml
+++ b/rust/javm-bench/Cargo.toml
@@ -38,6 +38,10 @@ harness = false
 name = "stark_bench"
 harness = false
 
+[[bench]]
+name = "sub_vm_recurse"
+harness = false
+
 [[example]]
 name = "publish_profile"
 path = "examples/publish_profile.rs"

--- a/rust/javm-bench/benches/sub_vm_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_recurse.rs
@@ -1,0 +1,236 @@
+//! Sub-VM recursive-spawn bench for the in-kernel JIT path.
+//!
+//! Measures how many `Cap::Instance`s the KVM microkernel can
+//! derive-and-CALL inside one second. The guest at
+//! `components/benches/sub-vm-recurse` reads `depth` from φ[7]; if
+//! zero, returns; otherwise `derive_spawn`s a child Instance from the
+//! same Image and `host_call`s it with `depth - 1`. The in-kernel
+//! CALL/HALT loop ([`nub_arch_x86::call_loop`]) keeps each level in a
+//! kernel-private call stack; the JIT code cache
+//! ([`nub_arch_x86::jit_cache`]) amortises the compile across all
+//! levels.
+//!
+//! ## What this measures
+//!
+//! Per recursion level the kernel pays:
+//!   1. ~3 µs `derive_spawn` (Blake2b chain extend + transient-table
+//!      insert).
+//!   2. ~10–15 µs PT setup + ring-3 entry + JIT entry.
+//!   3. ~10–15 µs HALT exit + PT teardown + parent restore.
+//!
+//! On bench warmup the first CALL pays the one-time JIT compile
+//! (~500 µs); every subsequent CALL hits the cache. The reported
+//! VMs/sec at depth ≥ 100 is the steady-state rate.
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use allocator_api2::alloc::Global;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use javm_cap::image::{Image, PinnedCap};
+use javm_cap::slot::SlotIdx;
+use javm_cap::{CNodeCap, Cap, CapHash, CapHashOrRef, NUM_REGS};
+use nub::Nub;
+use ssz::Decode;
+use std::sync::{Mutex, OnceLock};
+
+const BLOB: &[u8] = include_bytes!(env!("SUB_VM_RECURSE_BLOB"));
+const SLOT_IMAGE_RECURSE: u8 = 3;
+const ENDPOINT_IDX: u8 = 0;
+const INITIAL_GAS: u64 = 100_000_000_000;
+const EXIT_HOSTCALL: u32 = 4;
+
+/// Result of one `Nub::invoke_cached` against the top recurse
+/// instance: just a per-bench sanity check that the invocation
+/// completed cleanly.
+struct Built {
+    top_instance: CapHash,
+    image_hash: CapHash,
+}
+
+/// Build + publish (once) the recurse Image, its cnode, and the top
+/// Instance into the given `Nub`. Returns the top instance hash so
+/// the iter loop can invoke it directly.
+fn build_and_publish(nub: &mut Nub, depth_seed: u64) -> Built {
+    let image = Image::from_ssz_bytes(BLOB).expect("decode recurse image");
+
+    // The bench guest is a real Rust program (subsoil trampoline +
+    // tiny ecall sequence) and ships .rodata + a small stack via its
+    // image mappings. Publish a Cap::Data per pinned/initial slot
+    // and reference them from the Cap::Image — the in-kernel
+    // call_loop will read those Cap::Data bytes from the shared
+    // cache when building a child frame's mem image.
+    let mut data_caps: Vec<(CapHash, Cap<Global>)> = Vec::new();
+    let mut pinned_hashes: Vec<(SlotIdx, CapHash)> = Vec::new();
+    let mut initial_hashes: Vec<(SlotIdx, CapHash)> = Vec::new();
+    for (slot, pinned) in &image.pinned_slots {
+        let (h, maybe_cap) = match pinned {
+            PinnedCap::Data { content, size } => {
+                let cap = Cap::data_inline_with_size(content, *size);
+                let h = ssz::hash_tree_root(&cap);
+                (h, Some(cap))
+            }
+            PinnedCap::Image { content_hash } => (*content_hash, None),
+        };
+        pinned_hashes.push((*slot, h));
+        if let Some(cap) = maybe_cap {
+            data_caps.push((h, cap));
+        }
+    }
+    for (slot, init) in &image.initial_slots {
+        let cap = Cap::data_inline_with_size(&init.content, init.size);
+        let h = ssz::hash_tree_root(&cap);
+        initial_hashes.push((*slot, h));
+        data_caps.push((h, cap));
+    }
+    for (h, cap) in &data_caps {
+        nub.put_cap_with_hash(*h, cap).expect("put data");
+    }
+    let image_cap =
+        Cap::image_with_slots(&image, &pinned_hashes, &initial_hashes).expect("image_with_slots");
+    let image_hash = ssz::hash_tree_root(&image_cap);
+    nub.put_cap_with_hash(image_hash, &image_cap)
+        .expect("put image");
+
+    // Recurse cnode: slot 3 → image_hash. Each level's frame inherits
+    // this entry from its parent (see `dispatch_host_call` in
+    // `nub-arch-x86::call_loop`).
+    let mut cn = CNodeCap::<Global>::new(8).expect("cnode");
+    cn.set(
+        SlotIdx(SLOT_IMAGE_RECURSE as u32),
+        Some(CapHashOrRef::Hash(image_hash)),
+    )
+    .expect("set image slot");
+    let cnode_cap = Cap::CNode(cn);
+    let cnode_hash = ssz::hash_tree_root(&cnode_cap);
+    nub.put_cap_with_hash(cnode_hash, &cnode_cap)
+        .expect("put cnode");
+
+    // Top instance: image_hash, root_cnode, fresh state, depth_seed
+    // is overridden each iter by the caller's `args[0]`.
+    let _ = depth_seed; // depth is supplied via invoke_cached args
+    let endpoint = image.endpoints.get(&ENDPOINT_IDX).expect("endpoint 0");
+    let mut regs = [0u64; NUM_REGS];
+    for (&i, &v) in &endpoint.initial_regs {
+        if let Some(slot) = regs.get_mut(i as usize) {
+            *slot = v;
+        }
+    }
+    // Materialise rw_overlays so the top frame sees the actual
+    // .rodata / .data bytes. Same layout used by `javm-bench`'s
+    // existing pvm_bench harness — pinned `Data` content and
+    // non-empty initial-slot content map onto `(start, bytes)`
+    // overlays at the mapping's start.
+    let mut mem_size: u32 = 0;
+    let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
+    for mapping in &image.memory_mappings {
+        let end = (mapping.start + mapping.size) as u32;
+        if end > mem_size {
+            mem_size = end;
+        }
+        let target = mapping.source.target();
+        if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
+            if !content.is_empty() {
+                overlays.push((mapping.start as u32, content.clone()));
+            }
+        } else if let Some(init) = image.initial_slots.get(&target)
+            && !init.content.is_empty()
+        {
+            overlays.push((mapping.start as u32, init.content.clone()));
+        }
+    }
+    let overlay_slices: Vec<(u32, &[u8])> =
+        overlays.iter().map(|(s, b)| (*s, b.as_slice())).collect();
+    let inst_cap = Cap::instance_with_overlays(
+        [0u8; 32],
+        image_hash,
+        cnode_hash,
+        &overlay_slices,
+        mem_size,
+        regs,
+        0,
+        0,
+    );
+    let inst_hash = ssz::hash_tree_root(&inst_cap);
+    nub.put_cap_with_hash(inst_hash, &inst_cap)
+        .expect("put instance");
+
+    Built {
+        top_instance: inst_hash,
+        image_hash,
+    }
+}
+
+/// One bench iteration: invoke the top instance with `depth` and
+/// validate it halted cleanly.
+fn invoke(nub: &mut Nub, top: &Built, depth: u64) {
+    let result = nub
+        .invoke_cached(
+            top.top_instance,
+            ENDPOINT_IDX,
+            [depth, 0, 0, 0],
+            INITIAL_GAS,
+        )
+        .expect("invoke_cached");
+    if !(result.exit_reason == EXIT_HOSTCALL && result.exit_arg == 0) {
+        panic!(
+            "sub-VM recurse exited non-cleanly: reason={} arg={} ret={} gas={}",
+            result.exit_reason, result.exit_arg, result.return_value, result.gas_remaining,
+        );
+    }
+}
+
+/// Long-lived Hyperlight sandbox shared across bench iterations.
+fn nub_hyperlight() -> &'static Mutex<Nub> {
+    static NUB: OnceLock<Mutex<Nub>> = OnceLock::new();
+    NUB.get_or_init(|| Mutex::new(Nub::new_hyperlight().expect("Hyperlight sandbox")))
+}
+
+fn sub_vm_recurse(c: &mut Criterion) {
+    // Publish once, outside the bench loop. The kernel side stays
+    // warm across iters: the JIT cache holds the compiled image; the
+    // shared cap cache holds the Image + Top-Instance + CNode at
+    // their content hashes.
+    let top = {
+        let mut nub = nub_hyperlight().lock().expect("nub mutex");
+        build_and_publish(&mut nub, 0)
+    };
+    eprintln!(
+        "[sub_vm_recurse] image_hash={} top_instance={}",
+        hex_short(&top.image_hash),
+        hex_short(&top.top_instance),
+    );
+
+    // Sanity: depth=0 (no recursion, single CALL/HALT) must
+    // round-trip cleanly. Catches top-frame setup bugs early.
+    {
+        let mut nub = nub_hyperlight().lock().expect("nub mutex");
+        invoke(&mut nub, &top, 0);
+        eprintln!("[sub_vm_recurse] depth=0 ok");
+        invoke(&mut nub, &top, 1);
+        eprintln!("[sub_vm_recurse] depth=1 ok");
+    }
+
+    let mut g = c.benchmark_group("sub_vm_recurse");
+    g.sample_size(20);
+    for &depth in &[10u64, 100, 1_000] {
+        g.throughput(Throughput::Elements(depth));
+        g.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, &d| {
+            b.iter(|| {
+                let mut nub = nub_hyperlight().lock().expect("nub mutex");
+                invoke(&mut nub, &top, d);
+            })
+        });
+    }
+    g.finish();
+}
+
+fn hex_short(h: &CapHash) -> String {
+    let mut s = String::with_capacity(16);
+    for b in &h[..8] {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+criterion_group!(benches, sub_vm_recurse);
+criterion_main!(benches);

--- a/rust/javm-bench/build.rs
+++ b/rust/javm-bench/build.rs
@@ -62,6 +62,11 @@ fn main() {
             "bench-fri-fold-tree",
             "FRI_FOLD_TREE_BLOB",
         ),
+        (
+            "../../components/benches/sub-vm-recurse",
+            "bench-sub-vm-recurse",
+            "SUB_VM_RECURSE_BLOB",
+        ),
     ] {
         let blob = build_javm::build(path, crate_name);
         println!("cargo:rustc-env={env}={}", blob.display());

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1,0 +1,560 @@
+//! In-kernel CALL/HALT loop driving the in-sandbox sub-VM lifecycle.
+//!
+//! `nub_invoke_cached` calls [`run_top`] with a top-level
+//! `Cap::Instance` hash + endpoint. We build a [`KernelFrame`] from
+//! the published cap state, push it on an in-memory `Vec` stack, then
+//! iterate:
+//!
+//!   1. Run one ring-3 cycle via [`crate::jit_run::run_pvm_with_mem`].
+//!   2. On `EXIT_HALT` (or `EXIT_HOST_CALL` with `exit_arg == 0` —
+//!      `subsoil`'s endpoint trampoline issues `li t0, 0; ecall`,
+//!      which the transpiler emits as PVM `ecalli 0`): pop. If the
+//!      stack is empty, return; otherwise reflect the child's φ[7]
+//!      into the parent's φ[7].
+//!   3. On `EXIT_HOST_CALL` / `EXIT_ECALL` with a recognised host op
+//!      (`DERIVE_SPAWN` = 18, `HOST_CALL` = 26): dispatch in-place.
+//!      MGMT ops (`COPY` etc.) are accepted as no-ops in V1 — the
+//!      bench guest doesn't need them.
+//!   4. Anything else terminates the loop and returns the exit code
+//!      to the host.
+//!
+//! ## V1 simplifications
+//!
+//! - **No mem snapshotting across CALL/HALT.** Each frame entry
+//!   allocates fresh per-invocation memory from the image's overlays;
+//!   on resume after a child HALT, the parent's mem is rebuilt the
+//!   same way it was on first entry. Bench guests that don't write
+//!   memory (the recursive-spawn bench) see no observable change.
+//!
+//! - **Kernel-private transient instances.** `derive_spawn` does NOT
+//!   publish a fresh `Cap::Instance` to the shared talc cache —
+//!   `CacheDirectory` has only `MAX_BLOB_SLOTS = 256` blob slots, so
+//!   a deep recursion (depth ≥ 256) would exhaust it. Instead, we
+//!   keep a kernel-private `BTreeMap<CapHash, TransientInstance>`
+//!   keyed by the child's extended `image_hash_chain`. `host_call`
+//!   looks up here first, falling back to the shared cache for
+//!   `Cap::Instance`s published by the host driver.
+//!
+//! - **Per-frame cnode is a flat `[Option<CapHash>; 256]`.** Top
+//!   frame's cnode is seeded from the running `Cap::Instance`'s
+//!   `root_cnode` (looked up in the shared cache); child frames
+//!   inherit the parent's cnode entries. The published cnode is
+//!   read-only — slot writes (`derive_spawn` → dst) mutate the
+//!   per-frame copy.
+
+#![cfg(target_os = "none")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+use javm_cap::cap::Cap;
+use javm_cap::hash::{Blake2b256, Hash};
+use javm_cap::{CapHash, NUM_REGS};
+
+use crate::jit_run::{self, ExitInfo, MemRegion};
+use crate::state_cache;
+
+const EXIT_HALT: u32 = 0;
+const EXIT_HOST_CALL: u32 = 4;
+const EXIT_ECALL: u32 = 6;
+
+const OP_REPLY: u32 = 0;
+const OP_DERIVE_SPAWN: u32 = 18;
+const OP_HOST_CALL: u32 = 26;
+
+const CNODE_SLOTS: usize = 256;
+const MAX_DEPTH: usize = 32_768;
+
+// Error codes returned to the host as InvocationResult.exit_arg when
+// the call loop bails out. The byte stays small so a hex dump in the
+// host bench output is easy to read.
+const ERR_CACHE_MAP: u32 = 20;
+const ERR_INSTANCE_NOT_FOUND: u32 = 21;
+const ERR_INSTANCE_KIND: u32 = 22;
+const ERR_IMAGE_NOT_FOUND: u32 = 23;
+const ERR_IMAGE_KIND: u32 = 24;
+const ERR_ENDPOINT_OOB: u32 = 25;
+const ERR_ENDPOINT_UNDEFINED: u32 = 26;
+const ERR_DERIVE_SLOT_OOB: u32 = 31;
+const ERR_HOST_CALL_SLOT_EMPTY: u32 = 40;
+const ERR_JIT_FAILED: u32 = 50;
+const ERR_DEPTH_LIMIT: u32 = 51;
+
+/// One stack frame on the in-kernel call stack. Owns the per-frame
+/// PVM state (regs, pc, cnode) plus copies of the image's code /
+/// bitmask / jump-table arrays (those copies are small — the JIT
+/// code cache holds the heavy compiled bytes, not us). Top frame is
+/// built from a published `Cap::Instance` lookup; child frames are
+/// built by [`dispatch_host_call`].
+pub struct KernelFrame {
+    image_hash: CapHash,
+    image_hash_chain: CapHash,
+    code: Vec<u8>,
+    bitmask: Vec<u8>,
+    jump_table: Vec<u32>,
+    regs: [u64; NUM_REGS],
+    pc: u32,
+    mem_size: u32,
+    overlays: Vec<(u32, Vec<u8>)>,
+    cnode: Vec<Option<CapHash>>,
+}
+
+/// One transient `Cap::Instance` created by an in-kernel
+/// `derive_spawn`. Lives until the corresponding child frame HALTs,
+/// then is dropped from the table by [`forget_transient`].
+struct TransientInstance {
+    image_hash: CapHash,
+    image_hash_chain: CapHash,
+}
+
+struct TransientTable {
+    inner: UnsafeCell<BTreeMap<CapHash, TransientInstance>>,
+}
+
+/// SAFETY: single-threaded guest (Hyperlight serialises calls).
+unsafe impl Sync for TransientTable {}
+
+static TRANSIENT: TransientTable = TransientTable {
+    inner: UnsafeCell::new(BTreeMap::new()),
+};
+
+fn transient_get(hash: &CapHash) -> Option<TransientInstance> {
+    // SAFETY: single-threaded guest.
+    let map = unsafe { &*TRANSIENT.inner.get() };
+    map.get(hash).map(|t| TransientInstance {
+        image_hash: t.image_hash,
+        image_hash_chain: t.image_hash_chain,
+    })
+}
+
+fn transient_insert(hash: CapHash, t: TransientInstance) {
+    // SAFETY: single-threaded guest.
+    let map = unsafe { &mut *TRANSIENT.inner.get() };
+    map.insert(hash, t);
+}
+
+fn forget_transient(hash: &CapHash) {
+    // SAFETY: single-threaded guest.
+    let map = unsafe { &mut *TRANSIENT.inner.get() };
+    map.remove(hash);
+}
+
+/// Successful loop result — what the host RPC returns to the bench
+/// driver. On guest-side panic the loop returns `Err(code)` instead
+/// and `nub_invoke_cached` packs the code into `exit_arg`.
+pub struct LoopOutcome {
+    pub exit_reason: u32,
+    pub exit_arg: u32,
+    pub return_value: u64,
+    pub gas_remaining: i64,
+}
+
+/// Drive the CALL/HALT loop until either the top frame HALTs (clean
+/// exit) or the JIT signals an unrecoverable condition (page fault,
+/// gas exhaustion, …). See module docs for the loop body.
+pub fn run_top(
+    instance_hash: &CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+    initial_gas: i64,
+) -> Result<LoopOutcome, u32> {
+    state_cache::ensure_mapped().map_err(|_| ERR_CACHE_MAP)?;
+
+    let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
+    let mut stack: Vec<KernelFrame> = Vec::with_capacity(8);
+    let mut transient_owned: Vec<Option<CapHash>> = Vec::with_capacity(8);
+    stack.push(top);
+    transient_owned.push(None);
+    let mut gas = initial_gas;
+
+    loop {
+        // Phase 1: run one ring-3 entry on the top frame.
+        let info = {
+            let frame = stack.last().expect("stack non-empty");
+            run_one_entry(frame, gas)?
+        };
+        gas = info.gas_remaining;
+        // Mirror the JIT's post-exit state back into the top frame.
+        {
+            let frame = stack.last_mut().expect("stack non-empty");
+            frame.regs = info.regs;
+            frame.pc = info.pc;
+        }
+
+        // Phase 2: classify the exit. Borrow scopes are kept tight so
+        // we can mutate `stack` (push/pop) inside each arm.
+        match info.exit_reason {
+            EXIT_HALT => {
+                if pop_and_reflect(&mut stack, &mut transient_owned, info.regs[7])? {
+                    // Top frame halted — pass the JIT's own exit
+                    // reason through so callers that distinguish
+                    // EXIT_HALT (explicit) from EXIT_HOST_CALL(0)
+                    // (REPLY trampoline) see the right code.
+                    return Ok(LoopOutcome {
+                        exit_reason: info.exit_reason,
+                        exit_arg: info.exit_arg,
+                        return_value: info.regs[7],
+                        gas_remaining: gas,
+                    });
+                }
+            }
+            EXIT_HOST_CALL | EXIT_ECALL => {
+                let op = if info.exit_reason == EXIT_HOST_CALL {
+                    info.exit_arg
+                } else {
+                    info.regs[11] as u32
+                };
+                match op {
+                    OP_REPLY
+                        if pop_and_reflect(&mut stack, &mut transient_owned, info.regs[7])? =>
+                    {
+                        // Preserve the JIT exit shape so the host bench
+                        // harness, which asserts `(reason=4, arg=0)` for
+                        // the subsoil trampoline halt, doesn't trip.
+                        return Ok(LoopOutcome {
+                            exit_reason: info.exit_reason,
+                            exit_arg: info.exit_arg,
+                            return_value: info.regs[7],
+                            gas_remaining: gas,
+                        });
+                    }
+                    OP_REPLY => {
+                        // Stack still has frames; the parent picks up at
+                        // the next iter with the child's φ[7] reflected.
+                    }
+                    OP_DERIVE_SPAWN => {
+                        let frame = stack.last_mut().expect("non-empty");
+                        dispatch_derive_spawn(frame)?;
+                    }
+                    OP_HOST_CALL => {
+                        if stack.len() >= MAX_DEPTH {
+                            return Err(ERR_DEPTH_LIMIT);
+                        }
+                        let (child, owns) = {
+                            let parent = stack.last().expect("non-empty");
+                            dispatch_host_call(parent)?
+                        };
+                        stack.push(child);
+                        transient_owned.push(owns);
+                    }
+                    // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
+                    // arbitrary `ecalli imm`, …) is not in-kernel-
+                    // handled in V1: bubble it up to the host with
+                    // the JIT's reported exit reason/arg verbatim.
+                    // Mirrors pre-call-loop behaviour so unit tests
+                    // that fire `ecalli imm` and check `(reason=4,
+                    // arg=imm)` keep passing.
+                    _ => {
+                        return Ok(LoopOutcome {
+                            exit_reason: info.exit_reason,
+                            exit_arg: info.exit_arg,
+                            return_value: info.regs[7],
+                            gas_remaining: gas,
+                        });
+                    }
+                }
+            }
+            _ => {
+                // PageFault (3), Panic (1), OOG (2), Trap (7), …
+                return Ok(LoopOutcome {
+                    exit_reason: info.exit_reason,
+                    exit_arg: info.exit_arg,
+                    return_value: info.regs[7],
+                    gas_remaining: gas,
+                });
+            }
+        }
+    }
+}
+
+/// Run exactly one ring-3 cycle for `frame`. Builds the per-call mem
+/// overlays from the frame's stashed copies (so each entry starts
+/// from a known image-initial state — V1 mem-snapshotting decision).
+fn run_one_entry(frame: &KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
+    let mut regions: [(u32, &[u8]); 3] = [(0, &[]), (0, &[]), (0, &[])];
+    for (slot, ov) in regions.iter_mut().zip(frame.overlays.iter()).take(3) {
+        *slot = (ov.0, ov.1.as_slice());
+    }
+    let [arg, ro, rw] = regions;
+
+    let info = unsafe {
+        jit_run::run_pvm_with_mem(
+            &frame.image_hash,
+            &frame.code,
+            &frame.bitmask,
+            &frame.jump_table,
+            gas,
+            frame.pc,
+            frame.regs,
+            frame.mem_size,
+            MemRegion {
+                start: arg.0,
+                data: arg.1,
+            },
+            MemRegion {
+                start: ro.0,
+                data: ro.1,
+            },
+            MemRegion {
+                start: rw.0,
+                data: rw.1,
+            },
+        )
+    };
+    info.ok_or(ERR_JIT_FAILED)
+}
+
+/// Pop the top frame; if a parent exists, reflect the popped child's
+/// `return_value` into the parent's φ[7]. Returns `true` when the
+/// stack has been drained — the RPC caller uses this to know it's
+/// time to hand a result back to the host.
+fn pop_and_reflect(
+    stack: &mut Vec<KernelFrame>,
+    transient_owned: &mut Vec<Option<CapHash>>,
+    return_value: u64,
+) -> Result<bool, u32> {
+    let _popped = stack.pop().expect("non-empty");
+    let owned = transient_owned.pop().expect("paired with stack");
+    if let Some(h) = owned {
+        forget_transient(&h);
+    }
+    if stack.is_empty() {
+        return Ok(true);
+    }
+    let parent = stack.last_mut().unwrap();
+    parent.regs[7] = return_value;
+    Ok(false)
+}
+
+/// `host_derive_spawn(image_slot=φ[7], cnode_slot=φ[8],
+/// dst_slot=φ[9])`. V1: ignores `cnode_slot` (no prepared cnode
+/// support — the child inherits the parent's cnode at CALL time).
+/// Computes `child_chain = blake2b(running.chain, image_hash)`,
+/// inserts a transient-instances entry, writes the chain hash to
+/// the parent's `dst_slot`.
+fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<(), u32> {
+    let image_slot = (frame.regs[7] & 0xFF) as usize;
+    let _cnode_slot = (frame.regs[8] & 0xFF) as usize;
+    let dst_slot = (frame.regs[9] & 0xFF) as usize;
+
+    if image_slot >= CNODE_SLOTS || dst_slot >= CNODE_SLOTS {
+        return Err(ERR_DERIVE_SLOT_OOB);
+    }
+    // V1: cnode lookup is best-effort. We can't walk the published
+    // `Cap::CNode` from the guest (SparseList's inner BTreeMap lives
+    // in the host's Global allocator, so the pointers don't map),
+    // so empty slots fall back to the running frame's own image_hash.
+    // That matches the recursive-spawn bench's usage exactly — it
+    // wants to spawn its own image — and is a reasonable default for
+    // any caller that just wants to re-enter its own program with
+    // fresh state.
+    let image_hash = frame.cnode[image_slot].unwrap_or(frame.image_hash);
+    let child_chain = Blake2b256::hash_pair(&frame.image_hash_chain, &image_hash);
+    transient_insert(
+        child_chain,
+        TransientInstance {
+            image_hash,
+            image_hash_chain: child_chain,
+        },
+    );
+    frame.cnode[dst_slot] = Some(child_chain);
+    Ok(())
+}
+
+/// `host_call(instance_slot=φ[7], endpoint_idx=φ[8])`. Reads the
+/// target hash from the parent's cnode, builds a fresh
+/// [`KernelFrame`] for the child. Parent's φ[9..=12] become child's
+/// φ[7..=10] (arg-passing convention — used by the recursive-spawn
+/// bench to thread the remaining depth count).
+fn dispatch_host_call(parent: &KernelFrame) -> Result<(KernelFrame, Option<CapHash>), u32> {
+    let instance_slot = (parent.regs[7] & 0xFF) as usize;
+    let endpoint_idx = (parent.regs[8] & 0xFF) as u32;
+    if instance_slot >= CNODE_SLOTS {
+        return Err(ERR_HOST_CALL_SLOT_EMPTY);
+    }
+    let instance_hash = parent.cnode[instance_slot].ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
+
+    // Arg-passing convention: parent's φ[9..=10] → child's φ[7..=8].
+    // φ[11] holds the ecall op-code on a kernel-mode ecall exit (not
+    // a usable arg), and φ[12] is reserved; both default to 0 for
+    // the child. The bench guest threads `depth` through φ[9] alone.
+    let args = [parent.regs[9], parent.regs[10], 0, 0];
+
+    // Look up the child instance: transient table first (in-kernel
+    // derives don't hit the shared cache), then fall back to shared
+    // cache for host-pre-published `Cap::Instance`s.
+    let (mut child, owns) = if let Some(t) = transient_get(&instance_hash) {
+        let frame =
+            build_frame_from_image(&t.image_hash, t.image_hash_chain, endpoint_idx, args, None)?;
+        (frame, Some(instance_hash))
+    } else {
+        (
+            build_frame_from_published(&instance_hash, endpoint_idx, args)?,
+            None,
+        )
+    };
+    // Child inherits the parent's cnode entries that the child's
+    // image didn't pre-populate. Lets the bench guest reach
+    // `SLOT_IMAGE` without the harness re-installing it per level.
+    for (i, slot) in parent.cnode.iter().enumerate() {
+        if child.cnode[i].is_none() {
+            child.cnode[i] = *slot;
+        }
+    }
+    Ok((child, owns))
+}
+
+/// Build a frame from a `Cap::Instance` published in the shared talc
+/// cache (the top-level invocation path, plus host_call to host-
+/// pre-published Instances).
+fn build_frame_from_published(
+    instance_hash: &CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+) -> Result<KernelFrame, u32> {
+    let inst_cap = state_cache::lookup_cap(instance_hash).ok_or(ERR_INSTANCE_NOT_FOUND)?;
+    let inst = match inst_cap {
+        Cap::Instance(i) => i,
+        _ => return Err(ERR_INSTANCE_KIND),
+    };
+    let mut frame = build_frame_from_image(
+        &inst.image_hash,
+        inst.image_hash_chain,
+        endpoint_idx,
+        args,
+        Some(&inst.regs),
+    )?;
+
+    // V1 limitation: we deliberately do NOT walk the published
+    // `Cap::CNode` from inside the guest sandbox. `CNodeCap.slots`
+    // is a `SparseList<…>` whose inner `entries` field is a `Global`-
+    // allocated `BTreeMap` — even for `Cap<TalcAlloc>`. The deep-
+    // clone path leaves those BTreeMap nodes in host memory, so a
+    // guest-side walk would deref host VAs and page-fault. Top-frame
+    // cnode seeding still picks up the image's pinned + initial
+    // overlay slots (handled in `build_frame_from_image`), and
+    // [`dispatch_derive_spawn`] falls back to the parent's
+    // image_hash for the recursive-spawn case where no explicit
+    // image slot lookup is needed.
+
+    // Override the frame's overlay set with the published Instance's
+    // `rw_overlays` so the host driver's `instance_with_overlays`
+    // call (which bakes mem-region content directly into the
+    // InstanceCap, bypassing image.mappings + cnode resolution) keeps
+    // working. The image-mappings path
+    // ([`build_frame_from_image`]) only kicks in when the Instance
+    // has no overlays of its own — the case for transient sub-VM
+    // children created by `derive_spawn`.
+    if !inst.rw_overlays.is_empty() {
+        frame.overlays.clear();
+        for ov in inst.rw_overlays.iter() {
+            if !ov.bytes.is_empty() {
+                frame
+                    .overlays
+                    .push((ov.start, ov.bytes.as_slice().to_vec()));
+            }
+        }
+    }
+    if inst.mem_size > frame.mem_size {
+        frame.mem_size = inst.mem_size;
+    }
+
+    Ok(frame)
+}
+
+/// Core frame builder shared by published + transient instance
+/// paths. Looks up the image (in the shared cache, unconditionally —
+/// images are always content-addressed and never transient), copies
+/// code/bitmask/jt, seeds regs + cnode from image pinned/initial.
+fn build_frame_from_image(
+    image_hash: &CapHash,
+    image_hash_chain: CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+    inst_regs: Option<&[u64; NUM_REGS]>,
+) -> Result<KernelFrame, u32> {
+    let img_cap = state_cache::lookup_cap(image_hash).ok_or(ERR_IMAGE_NOT_FOUND)?;
+    let img = match img_cap {
+        Cap::Image(i) => i,
+        _ => return Err(ERR_IMAGE_KIND),
+    };
+
+    let endpoint = endpoint_idx as usize;
+    if endpoint >= img.endpoints.len() {
+        return Err(ERR_ENDPOINT_OOB);
+    }
+    let ep = &img.endpoints[endpoint];
+    if ep.entry_pc == 0 {
+        return Err(ERR_ENDPOINT_UNDEFINED);
+    }
+
+    let code: Vec<u8> = img.code.as_slice().to_vec();
+    let bitmask: Vec<u8> = javm_exec::unpack_bitmask(img.bitmask.as_slice(), code.len());
+    let jump_table: Vec<u32> = img.jump_table.as_slice().to_vec();
+
+    let mut regs = ep.initial_regs;
+    if let Some(inst_regs) = inst_regs {
+        for (i, v) in inst_regs.iter().enumerate() {
+            if *v != 0 {
+                regs[i] = *v;
+            }
+        }
+    }
+    for (i, v) in args.iter().enumerate() {
+        regs[7 + i] = *v;
+    }
+
+    let mut cnode: Vec<Option<CapHash>> = vec![None; CNODE_SLOTS];
+    for e in img.pinned.iter() {
+        let s = e.slot.get() as usize;
+        if s < CNODE_SLOTS {
+            cnode[s] = Some(e.cap_hash);
+        }
+    }
+    for e in img.initial.iter() {
+        let s = e.slot.get() as usize;
+        if s < CNODE_SLOTS && cnode[s].is_none() {
+            cnode[s] = Some(e.cap_hash);
+        }
+    }
+
+    let mut mem_size: u32 = 0;
+    let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
+    for m in img.mappings.iter() {
+        let end = (m.start + m.size) as u32;
+        if end > mem_size {
+            mem_size = end;
+        }
+        if m.source_path_len == 0 {
+            continue;
+        }
+        let src_slot = m.source_path[0];
+        let target_hash = match cnode.get(src_slot.get() as usize).and_then(|s| s.as_ref()) {
+            Some(h) => *h,
+            None => continue,
+        };
+        if let Some(Cap::Data(d)) = state_cache::lookup_cap(&target_hash)
+            && let javm_cap::DataContent::Inline(bytes) = &d.content
+            && !bytes.is_empty()
+        {
+            overlays.push((m.start as u32, bytes.as_slice().to_vec()));
+        }
+    }
+
+    Ok(KernelFrame {
+        image_hash: *image_hash,
+        image_hash_chain,
+        code,
+        bitmask,
+        jump_table,
+        regs,
+        pc: ep.entry_pc as u32,
+        mem_size,
+        overlays,
+        cnode,
+    })
+}

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -84,7 +84,14 @@ pub fn get_or_compile(
     // call back into this module.
     let map = unsafe { &mut *CACHE.inner.get() };
     if !map.contains_key(image_hash) {
-        let compiler = Compiler::new(bitmask, jump_table, helpers, code.len(), jit_va_m, mem_cycles);
+        let compiler = Compiler::new(
+            bitmask,
+            jump_table,
+            helpers,
+            code.len(),
+            jit_va_m,
+            mem_cycles,
+        );
         let CompileResult {
             native_code,
             dispatch_table,

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -1,0 +1,117 @@
+//! Per-image JIT code cache.
+//!
+//! `Compiler::compile` emits native x86-64 bytes whose RIP-relative
+//! references hard-code the per-invocation VA layout: `CTX_VA` (4 GiB),
+//! `JIT_VA_M` (META_BASE + 64 MiB), `BB_VA_M`, `JT_VA_M`,
+//! `DISPATCH_VA_M`. Those VAs are *constants* in this crate, so the
+//! compiled bytes are reusable across every ring-3 entry — the JIT
+//! page-table sets up the same layout each time. Only the per-frame
+//! memory (CTX page, mem region, stack, PT skeleton) changes.
+//!
+//! Caching the compile result keyed by `image_hash` (the `Cap::Image`
+//! content hash) lets the recursive-spawn bench reuse one compile pass
+//! across thousands of CALLs of the same Image. Without the cache,
+//! `Compiler::compile` runs once per invocation (~100–500 µs per
+//! call) and dwarfs the ~10 µs ring-3 context switch we're trying to
+//! measure.
+
+#![cfg(target_os = "none")]
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
+
+use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
+
+use javm_cap::CapHash;
+
+/// One cached compile result, retained by `image_hash`.
+///
+/// The fields mirror [`CompileResult`] but live in long-term storage.
+/// Each ring-3 entry copies `native` into the per-invocation user-RX
+/// page and `dispatch_table` into the user-RO dispatch page. The
+/// `trap_table` is consulted by `jit_pf_handler` to translate native
+/// offsets back to PVM PCs on page faults; we hand a borrowed slice
+/// to the handler via static atomics.
+pub struct CompiledImage {
+    pub native: Vec<u8>,
+    pub dispatch_table: Vec<i32>,
+    pub trap_table: Vec<(u32, u32)>,
+    pub exit_label_offset: u32,
+}
+
+/// Process-wide compile cache.
+///
+/// Hyperlight serialises host calls, so the guest is single-threaded
+/// and a plain `UnsafeCell` is sound. We wrap it in a newtype so the
+/// `unsafe` is local and the public API can stay safe.
+struct CompileCache {
+    inner: UnsafeCell<BTreeMap<CapHash, CompiledImage>>,
+}
+
+/// SAFETY: single-threaded guest (Hyperlight serialisation).
+unsafe impl Sync for CompileCache {}
+
+static CACHE: CompileCache = CompileCache {
+    inner: UnsafeCell::new(BTreeMap::new()),
+};
+
+/// Look up the compile cache by `image_hash`. On miss, run
+/// `Compiler::compile` and insert the result. Returns a `'static`
+/// borrow into the cache entry — caller may freely read `native`,
+/// `dispatch_table`, `trap_table`, `exit_label_offset` for the
+/// duration of the invocation.
+///
+/// # Safety
+///
+/// Hyperlight serialises host calls, so concurrent access is not
+/// possible. The returned reference is valid until the cache entry is
+/// evicted; in V1 we never evict, so the borrow lifetime is
+/// effectively `'static`.
+pub fn get_or_compile(
+    image_hash: &CapHash,
+    code: &[u8],
+    bitmask: &[u8],
+    jump_table: &[u32],
+    jit_va_m: u64,
+    mem_cycles: u8,
+    helpers: HelperFns,
+) -> &'static CompiledImage {
+    // SAFETY: single-threaded guest. Reentrant access from inside the
+    // closure below is impossible because `Compiler::compile` doesn't
+    // call back into this module.
+    let map = unsafe { &mut *CACHE.inner.get() };
+    if !map.contains_key(image_hash) {
+        let compiler = Compiler::new(bitmask, jump_table, helpers, code.len(), jit_va_m, mem_cycles);
+        let CompileResult {
+            native_code,
+            dispatch_table,
+            trap_table,
+            exit_label_offset,
+        } = compiler.compile(code, bitmask);
+        map.insert(
+            *image_hash,
+            CompiledImage {
+                native: native_code,
+                dispatch_table,
+                trap_table,
+                exit_label_offset,
+            },
+        );
+    }
+    // SAFETY: just inserted (or already present); BTreeMap never
+    // moves entries by value once allocated through the global
+    // allocator, so the reference is stable for the cache's lifetime.
+    map.get(image_hash).expect("inserted above")
+}
+
+/// Diagnostic: number of cached images. Useful for tests that assert
+/// the cache is being hit.
+#[allow(dead_code)]
+pub fn cached_count() -> usize {
+    // SAFETY: single-threaded guest.
+    let map = unsafe { &*CACHE.inner.get() };
+    map.len()
+}

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -140,8 +140,13 @@ pub struct ExitInfo {
     pub exit_arg: u32,
     /// Gas remaining at exit.
     pub gas_remaining: i64,
-    /// PVM register 7 (PVM ABI: the program's u32 return value).
-    pub reg_a0: u64,
+    /// PVM register file at exit. φ[7] is the program's return value
+    /// (PVM ABI); the call loop also reads φ[7..=12] for HOST_CALL
+    /// args + φ[11] as the op code on plain `ecall` exits.
+    pub regs: [u64; 13],
+    /// PVM PC at exit (the instruction *after* the ecall on a clean
+    /// HOST_CALL / ECALL exit, the faulting PC on a PageFault).
+    pub pc: u32,
 }
 
 // === Per-invocation memory layout =======================================
@@ -464,7 +469,8 @@ pub unsafe fn run_pvm_with_mem(
             exit_reason: (*ctx).exit_reason,
             exit_arg: (*ctx).exit_arg,
             gas_remaining: (*ctx).gas,
-            reg_a0: (*ctx).regs[7],
+            regs: (*ctx).regs,
+            pc: (*ctx).pc,
         }
     };
 

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -44,6 +44,7 @@
 
 extern crate alloc;
 
+use crate::jit_cache;
 use crate::paging::{PAGE_SIZE, PageTable, Perm};
 use crate::ring3;
 use alloc::alloc::{alloc_zeroed, dealloc};
@@ -52,7 +53,7 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
 use javm_recompiler_x86::JitContext;
-use javm_recompiler_x86::codegen::{Compiler, HelperFns};
+use javm_recompiler_x86::codegen::HelperFns;
 
 // === Per-invocation context for the #PF handler ===========================
 //
@@ -232,6 +233,7 @@ impl Drop for PageBuf {
 /// Hyperlight construction.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn run_pvm_with_mem(
+    image_hash: &javm_cap::CapHash,
     code: &[u8],
     bitmask: &[u8],
     jump_table: &[u32],
@@ -245,7 +247,7 @@ pub unsafe fn run_pvm_with_mem(
 ) -> Option<ExitInfo> {
     assert_eq!(code.len(), bitmask.len());
 
-    // ---- compile -----------------------------------------------------------
+    // ---- compile (cached by image_hash) -----------------------------------
     //
     // The codegen reads the helper-fn addresses to look up the access
     // width (`if fn_addr == helpers.mem_write_u8 { width = 1 }`).
@@ -266,19 +268,19 @@ pub unsafe fn run_pvm_with_mem(
         mem_write_u64: 0x1008,
         sbrk_helper: 0x1009,
     };
-    let compiler = Compiler::new(
+    let cached = jit_cache::get_or_compile(
+        image_hash,
+        code,
         bitmask,
         jump_table,
-        helpers,
-        code.len(),
         JIT_VA_M,
         javm_exec::gas_cost::DEFAULT_MEM_CYCLES,
+        helpers,
     );
-    let result = compiler.compile(code, bitmask);
-    let native = result.native_code;
-    let dispatch_table = result.dispatch_table;
-    let trap_table = result.trap_table;
-    let exit_label_offset = result.exit_label_offset;
+    let native: &[u8] = cached.native.as_slice();
+    let dispatch_table: &[i32] = cached.dispatch_table.as_slice();
+    let trap_table: &[(u32, u32)] = cached.trap_table.as_slice();
+    let exit_label_offset = cached.exit_label_offset;
     if native.is_empty() {
         return None;
     }
@@ -455,8 +457,6 @@ pub unsafe fn run_pvm_with_mem(
     TRAP_TABLE_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);
     TRAP_TABLE_LEN.store(0, Ordering::SeqCst);
     JIT_CODE_LEN.store(0, Ordering::SeqCst);
-
-    drop(trap_table);
 
     // SAFETY: ctx_kva still points to the same page (ctx_buf alive until end of fn).
     let info = unsafe {

--- a/rust/nub-arch-x86/src/main.rs
+++ b/rust/nub-arch-x86/src/main.rs
@@ -30,6 +30,8 @@ extern crate alloc;
 extern crate hyperlight_guest_bin;
 
 #[cfg(target_os = "none")]
+mod jit_cache;
+#[cfg(target_os = "none")]
 mod jit_run;
 #[cfg(target_os = "none")]
 mod paging;
@@ -150,6 +152,7 @@ mod guest {
 
         let info = unsafe {
             crate::jit_run::run_pvm_with_mem(
+                &inst.image_hash,
                 &code,
                 &bitmask,
                 &jump_table,

--- a/rust/nub-arch-x86/src/main.rs
+++ b/rust/nub-arch-x86/src/main.rs
@@ -30,6 +30,8 @@ extern crate alloc;
 extern crate hyperlight_guest_bin;
 
 #[cfg(target_os = "none")]
+mod call_loop;
+#[cfg(target_os = "none")]
 mod jit_cache;
 #[cfg(target_os = "none")]
 mod jit_run;
@@ -76,115 +78,38 @@ mod guest {
             .into_vec()
     }
 
-    /// Cache-based RPC: read an `InvokePacket`, look up the referenced
-    /// `Cap::Instance` in the host-published state cache, walk to its
-    /// `Cap::Image`, run the bytecode, return an `InvocationResult`.
+    /// Cache-based RPC: read an `InvokePacket`, drive the in-kernel
+    /// CALL/HALT loop ([`crate::call_loop`]) — which spins up frames,
+    /// dispatches `derive_spawn` + `host_call` in-sandbox, and tears
+    /// each frame down on HALT.
     ///
-    /// V1 path: copies cache slabs into per-call `Vec<u8>`s and calls
-    /// the existing `run_pvm_with_mem`. A follow-up can flip the cache
-    /// mapping to USER and let the JIT reference talc VAs directly
-    /// (zero-copy).
+    /// Memory regions live behind the per-invocation page-table for the
+    /// duration of one JIT entry; the call loop builds them fresh on
+    /// every push.
     #[guest_function(fn_id = FN_ID_NUB_INVOKE_CACHED)]
     pub fn nub_invoke_cached(packet_bytes: &[u8]) -> Vec<u8> {
-        use javm_cap::cap::Cap;
-
         let packet = match InvokePacket::from_bytes(packet_bytes) {
             Some(p) => p,
             None => return encode_result_error(10),
         };
-        let inst_cap = match crate::state_cache::lookup_cap(&packet.instance_hash) {
-            Some(c) => c,
-            None => return encode_result_error(11),
-        };
-        let inst = match inst_cap {
-            Cap::Instance(i) => i,
-            _ => return encode_result_error(12), // cap at hash isn't an Instance
-        };
-        let img_cap = match crate::state_cache::lookup_cap(&inst.image_hash) {
-            Some(c) => c,
-            None => return encode_result_error(13),
-        };
-        let img = match img_cap {
-            Cap::Image(i) => i,
-            _ => return encode_result_error(14), // cap at image_hash isn't an Image
-        };
 
-        let endpoint = packet.endpoint_idx as usize;
-        if endpoint >= img.endpoints.len() {
-            return encode_result_error(15);
-        }
-        let ep = &img.endpoints[endpoint];
-        if ep.entry_pc == 0 {
-            return encode_result_error(16); // endpoint not defined
-        }
+        let outcome = crate::call_loop::run_top(
+            &packet.instance_hash,
+            packet.endpoint_idx,
+            packet.args,
+            packet.initial_gas as i64,
+        );
 
-        // Code/bitmask/jt: copy from cache into per-call Vec<u8>s.
-        // ImageCap stores the packed bitmask (1 bit per code byte);
-        // the JIT path wants the unpacked form (1 byte per code byte).
-        // SAFETY: cache mapping is installed (state_cache::lookup_cap
-        // succeeded); pointers live inside the cache region.
-        let code: Vec<u8> = img.code.as_slice().to_vec();
-        let bitmask: Vec<u8> = javm_exec::unpack_bitmask(img.bitmask.as_slice(), code.len());
-        let jump_table: Vec<u32> = img.jump_table.as_slice().to_vec();
-
-        // Endpoint baseline first, then layer the InstanceCap's
-        // persisted regs on top (non-zero entries override). Caller-
-        // supplied args overlay φ[7..=10] last.
-        let mut initial_regs = ep.initial_regs;
-        for (i, v) in inst.regs.iter().enumerate() {
-            if *v != 0 {
-                initial_regs[i] = *v;
-            }
-        }
-        for (i, v) in packet.args.iter().enumerate() {
-            initial_regs[7 + i] = *v;
-        }
-
-        // Build memory regions from InstanceCap.rw_overlays. V1 puts
-        // ro/rw/arg data all in rw_overlays (the spec-level
-        // distinction is materialised by the caller). For backwards
-        // compat with run_pvm_with_mem, we pack the first three
-        // overlays into the (arg, ro, rw) slots; the JIT path treats
-        // them uniformly as initial-state byte regions.
-        let mut overlays = img.code.as_slice().iter(); // dummy iterator for type
-        let _ = &mut overlays;
-        let (arg, ro, rw) = pack_overlays(&inst.rw_overlays);
-
-        let info = unsafe {
-            crate::jit_run::run_pvm_with_mem(
-                &inst.image_hash,
-                &code,
-                &bitmask,
-                &jump_table,
-                packet.initial_gas as i64,
-                ep.entry_pc as u32,
-                initial_regs,
-                inst.mem_size,
-                crate::jit_run::MemRegion {
-                    start: arg.0,
-                    data: &arg.1,
-                },
-                crate::jit_run::MemRegion {
-                    start: ro.0,
-                    data: &ro.1,
-                },
-                crate::jit_run::MemRegion {
-                    start: rw.0,
-                    data: &rw.1,
-                },
-            )
-        };
-
-        let result = match info {
-            Some(i) => InvocationResult {
-                exit_reason: i.exit_reason,
-                exit_arg: i.exit_arg,
-                return_value: i.reg_a0,
-                gas_remaining: i.gas_remaining.max(0) as u64,
+        let result = match outcome {
+            Ok(o) => InvocationResult {
+                exit_reason: o.exit_reason,
+                exit_arg: o.exit_arg,
+                return_value: o.return_value,
+                gas_remaining: o.gas_remaining.max(0) as u64,
             },
-            None => InvocationResult {
+            Err(code) => InvocationResult {
                 exit_reason: u32::MAX,
-                exit_arg: 17,
+                exit_arg: code,
                 return_value: 0,
                 gas_remaining: 0,
             },
@@ -193,24 +118,6 @@ mod guest {
         rkyv::to_bytes::<rkyv::rancor::Error>(&result)
             .expect("rkyv-encode InvocationResult")
             .into_vec()
-    }
-
-    /// Materialised mem overlay: `(start, bytes)` pair, ready for
-    /// `run_pvm_with_mem` to lay flat into the per-call memory image.
-    type Overlay = (u32, Vec<u8>);
-
-    /// Pack up to three `RwOverlay` entries into the (arg, ro, rw)
-    /// triple expected by `run_pvm_with_mem`. Missing entries become
-    /// `(0, empty)` which `run_pvm_with_mem` treats as "no overlay".
-    fn pack_overlays<A: allocator_api2::alloc::Allocator + Clone>(
-        overlays: &allocator_api2::vec::Vec<javm_cap::instance::RwOverlay<A>, A>,
-    ) -> (Overlay, Overlay, Overlay) {
-        let mut packed = [(0u32, Vec::<u8>::new()), (0, Vec::new()), (0, Vec::new())];
-        for (i, o) in overlays.iter().take(3).enumerate() {
-            packed[i] = (o.start, o.bytes.as_slice().to_vec());
-        }
-        let [arg, ro, rw] = packed;
-        (arg, ro, rw)
     }
 
     /// Diagnostic: report talc's current allocation state as 32 LE

--- a/rust/nub-arch-x86/src/state_cache.rs
+++ b/rust/nub-arch-x86/src/state_cache.rs
@@ -17,19 +17,51 @@
 
 #![cfg(target_os = "none")]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use allocator_api2::alloc::Allocator;
+use allocator_api2::boxed::Box as ABox;
+use core::cell::UnsafeCell;
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use javm_cap::cap::Cap;
 use javm_cap::entry::CacheEntry;
 use nub_host_common::cache::{
-    CACHE_DIRECTORY_OFFSET, CacheDirectory, STATE_CACHE_GPA, STATE_CACHE_SIZE, STATE_CACHE_VA,
-    TalcAlloc,
+    CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheTalcLock, STATE_CACHE_GPA, STATE_CACHE_SIZE,
+    STATE_CACHE_VA, TalcAlloc,
 };
 
 use crate::paging::{Perm, install_persistent_kernel_mapping};
 
 static CACHE_MAPPED: AtomicBool = AtomicBool::new(false);
+
+/// Per-RPC tracker of guest-published cap entries so we can clear
+/// them at end of dispatch. The guest writes new caps into the
+/// host-visible `CacheDirectory` for the duration of one
+/// `nub_invoke_cached` call (e.g., children minted by in-kernel
+/// `derive_spawn`); they're cleared before the RPC returns so the
+/// host doesn't see stale "scratch" entries.
+struct ScratchTracker {
+    entries: Vec<(usize, NonNull<CacheEntry<TalcAlloc>>)>,
+}
+
+/// SAFETY: single-threaded guest (Hyperlight serialises calls).
+unsafe impl Sync for ScratchTracker {}
+
+struct ScratchCell {
+    inner: UnsafeCell<ScratchTracker>,
+}
+
+/// SAFETY: single-threaded guest.
+unsafe impl Sync for ScratchCell {}
+
+static SCRATCH: ScratchCell = ScratchCell {
+    inner: UnsafeCell::new(ScratchTracker {
+        entries: Vec::new(),
+    }),
+};
 
 /// Idempotent: install the cache mapping in the active PML4 if not
 /// already done. Called lazily from the first `nub_invoke_cached`
@@ -97,4 +129,87 @@ pub fn lookup_instance<A: Allocator + Clone>(ref_id: u64) -> Option<&'static Cac
 /// Convenience: resolve a blob hash directly to its inner `Cap`.
 pub fn lookup_cap(hash: &[u8; 32]) -> Option<&'static Cap<TalcAlloc>> {
     lookup_blob::<TalcAlloc>(hash).map(|e| &e.cap)
+}
+
+/// `TalcAlloc` handle pointing at the shared cache region's lock at
+/// `STATE_CACHE_VA + 0`. Cheap to obtain (just wraps a pointer).
+#[allow(dead_code)]
+pub fn talc_alloc() -> TalcAlloc {
+    ensure_mapped().expect("cache mapping");
+    let lock_ptr =
+        NonNull::new(STATE_CACHE_VA as *mut CacheTalcLock).expect("STATE_CACHE_VA is non-null");
+    // SAFETY: the host's `Cache<TalcAlloc>` lives at the same VA and
+    // already `claim`ed the lock; we share the same lock instance.
+    unsafe { TalcAlloc::from_raw(lock_ptr) }
+}
+
+/// Publish a `Cap<TalcAlloc>` to the shared cache region by writing
+/// a fresh `CacheEntry<TalcAlloc>` to the talc heap and recording
+/// `(hash, entry_va)` in the host-visible `CacheDirectory`.
+///
+/// Tracks the published entry in [`SCRATCH`] so [`clear_scratch`]
+/// can free + zero the directory slot at end of RPC.
+///
+/// V1: the host's `Cache<TalcAlloc>` BTreeMap is NOT updated — the
+/// guest's view is via the directory only. The host doesn't query
+/// guest-published caps mid-RPC (Hyperlight serialises calls), and
+/// the cleanup at end-of-RPC ensures no stale entries leak across
+/// invocations.
+#[allow(dead_code)]
+pub fn publish_blob(hash: [u8; 32], cap: Cap<TalcAlloc>) -> Result<(), &'static str> {
+    let alloc = talc_alloc();
+    let entry = CacheEntry::new(cap);
+    let boxed = ABox::try_new_in(entry, alloc).map_err(|_| "publish_blob: alloc failed")?;
+    // Leak the Box so the cache owns the entry; the pointer is
+    // recorded in `SCRATCH` and freed in `clear_scratch`.
+    let entry_ptr: *mut CacheEntry<TalcAlloc> = ABox::into_raw(boxed);
+    let entry_nn = NonNull::new(entry_ptr).expect("just allocated");
+    let entry_va = entry_ptr as u64;
+
+    let dir_ptr = (STATE_CACHE_VA + CACHE_DIRECTORY_OFFSET as u64) as *mut CacheDirectory;
+    // SAFETY: directory ptr is in the persistent kernel mapping.
+    let idx = unsafe { CacheDirectory::first_empty_blob(dir_ptr) }
+        .ok_or("publish_blob: directory full")?;
+    // SAFETY: idx < MAX_BLOB_SLOTS; directory ptr is valid.
+    unsafe {
+        let slot = CacheDirectory::blob_slot_ptr(dir_ptr, idx);
+        (*slot).hash = hash;
+        (*slot).entry_va = entry_va;
+        (*dir_ptr).blob_count_incr();
+    }
+
+    // Record for cleanup at end of RPC.
+    // SAFETY: single-threaded guest.
+    let tracker = unsafe { &mut *SCRATCH.inner.get() };
+    tracker.entries.push((idx, entry_nn));
+    Ok(())
+}
+
+/// Clear all entries this RPC published via [`publish_blob`]. Walks
+/// the scratch tracker, zeroes each directory slot, and frees the
+/// `CacheEntry` storage on the shared talc heap. Idempotent.
+#[allow(dead_code)]
+pub fn clear_scratch() {
+    let alloc = talc_alloc();
+    let dir_ptr = (STATE_CACHE_VA + CACHE_DIRECTORY_OFFSET as u64) as *mut CacheDirectory;
+
+    // SAFETY: single-threaded guest.
+    let tracker = unsafe { &mut *SCRATCH.inner.get() };
+    for (idx, entry_ptr) in tracker.entries.drain(..) {
+        // SAFETY: idx is < MAX_BLOB_SLOTS; we wrote (hash, entry_va)
+        // when publishing.
+        unsafe {
+            let slot = CacheDirectory::blob_slot_ptr(dir_ptr, idx);
+            (*slot).hash = [0u8; 32];
+            (*slot).entry_va = 0;
+            (*dir_ptr).blob_count_decr();
+        }
+        // SAFETY: we allocated this CacheEntry via `ABox::try_new_in`
+        // in `publish_blob` and leaked it; reconstruct + drop frees
+        // it through the same TalcAlloc.
+        unsafe {
+            let boxed = ABox::from_raw_in(entry_ptr.as_ptr(), alloc);
+            drop(boxed);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Threads the sub-VM lifecycle through the KVM microkernel. The JIT's
`nub_invoke_cached` now drives an iterative `Vec<KernelFrame>` stack,
dispatches `derive_spawn` (op 18) and `host_call` (op 26) inside the
sandbox, and tears each frame down on HALT — only the top-level HALT
returns to the host.

Builds on PR #853's host-side sub-VM lifecycle (byte-PVM interpreter).

## Results

```
sub_vm_recurse/10      time:   [275.67 µs 275.83 µs 275.98 µs]
                       thrpt:  [36.235 Kelem/s 36.254 Kelem/s 36.275 Kelem/s]
sub_vm_recurse/100     time:   [2.7703 ms  2.7730 ms  2.7760 ms]
                       thrpt:  [36.023 Kelem/s 36.063 Kelem/s 36.097 Kelem/s]
sub_vm_recurse/1000    time:   [32.958 ms  33.016 ms  33.108 ms]
                       thrpt:  [30.204 Kelem/s 30.289 Kelem/s 30.342 Kelem/s]
```

**~30–36k sub-VMs/sec** at steady state. Per-VM cost ≈ 28–33 µs,
dominated by the per-frame ring-3 transition (PT setup + iretq +
JIT entry + `int 0x81` exit + teardown).

## What's in the PR

- **`rust/nub-arch-x86/src/jit_cache.rs`** (Stage A): process-wide
  `BTreeMap<CapHash, CompiledImage>` keyed by `image_hash`. First
  CALL pays the compile (~500 µs); every subsequent CALL hits the
  cache. Without this, codegen drowns out the ring-3 transition cost
  we're trying to measure.

- **`rust/nub-arch-x86/src/state_cache.rs`** (Stage B): adds
  `publish_blob`/`clear_scratch` + a per-RPC `SCRATCH` tracker for
  cap-publish from inside the sandbox. Unused in V1 (transient
  instances avoid the directory limit) but kept for follow-ups.

- **`rust/nub-arch-x86/src/call_loop.rs`** (Stages C+D, new): the
  iterative `Vec<KernelFrame>` stack + `dispatch_derive_spawn` +
  `dispatch_host_call` + HALT pop/reflect.

- **`components/benches/sub-vm-recurse/`** (Stage E, new): the bench
  guest. Reads depth from φ[7]; if zero, returns; otherwise
  derive_spawns its own image and host_calls it with depth-1.

- **`rust/javm-bench/benches/sub_vm_recurse.rs`** (Stage E, new):
  criterion harness driving the bench guest at depths 10/100/1000.

## V1 simplifications

Documented in `call_loop.rs`:

- **Kernel-private transient instances.** `derive_spawn` does NOT
  publish a fresh `Cap::Instance` to the shared talc cache —
  `CacheDirectory.MAX_BLOB_SLOTS = 256` would cap recursion depth
  too low. Instead, an in-kernel `BTreeMap<CapHash,
  TransientInstance>` holds the `(image_hash, image_hash_chain)`
  tuple keyed by the extended chain; `host_call` falls back to the
  shared cache for host-pre-published instances.

- **No mem snapshotting across CALL/HALT.** Bench guests that don't
  write memory (the recurse guest is one) see no observable change;
  parent mem is rebuilt from image overlays on resume. Sub-VMs that
  need cross-call mem state are deferred to V2.

- **`CNode` walk skipped on the guest side.** `SparseList`'s inner
  `entries` field is a `Global`-allocated `BTreeMap`, even on
  `Cap<TalcAlloc>`. The deep-clone leaves those nodes in host VAs
  that the guest's page table can't reach. `derive_spawn` falls
  back to the running frame's own `image_hash` when the cnode slot
  is empty — exactly the recursive-spawn case.

## Test plan

- [x] `cargo test --workspace --tests` (incl. existing
  `recompile_ecalli`, `conformance`, host-side `sub_vm`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all --check`.
- [x] `cargo bench -p javm-bench --bench sub_vm_recurse` reports
  VMs/sec curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)