### PR TITLE
perf(nub-arch-x86): in-kernel sub-VM lifecycle — 5-phase cache + KernelFrame refactor (~10x throughput)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,11 +97,3 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 async-trait = "0.1"
 jsonrpsee = { version = "0.24", features = ["server", "macros"] }
-
-
-[profile.release]
-lto = "thin"
-codegen-units = 1
-
-[profile.release.package.polkavm-linux-raw]
-opt-level = 0

--- a/rust/javm-bench/examples/publish_profile.rs
+++ b/rust/javm-bench/examples/publish_profile.rs
@@ -28,7 +28,6 @@ use javm_cap::cap::Cap;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use javm_cap::cap_hash::cap_hash;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-use javm_cap::data::{DataCap, DataContent};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use javm_cap::image::Image;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -136,28 +135,16 @@ fn main() {
 
     // (c) cap_hash(Cap::Data) — SSZ merkleize over the bytes, with Cap
     //     already built. Isolates the hash work from the alloc/copy.
-    let cap_data: Cap<Global> = {
-        let mut v: AVec<u8, Global> = AVec::with_capacity_in(bytes.len(), Global);
-        v.extend_from_slice(bytes);
-        Cap::Data(DataCap {
-            size: size_u64,
-            content: DataContent::Inline(v),
-        })
-    };
+    let cap_data: Cap<Global> = Cap::data_inline_with_size(bytes, size_u64);
     measure("(c) cap_hash(Cap::Data) on pre-built Cap", n, || {
         let h = cap_hash(&cap_data);
         std::hint::black_box(h);
     });
 
-    // (d) Full publish_data_inline_with_size hit-path on Global: build
+    // (d) Full data_inline_with_size hit-path on Global: build
     //     Cap::Data + cap_hash + drop. Compare against the talc-backed (e).
     measure("(d) build Cap::Data(Global) + cap_hash + drop", n, || {
-        let mut v: AVec<u8, Global> = AVec::with_capacity_in(bytes.len(), Global);
-        v.extend_from_slice(bytes);
-        let cap: Cap<Global> = Cap::Data(DataCap {
-            size: size_u64,
-            content: DataContent::Inline(v),
-        });
+        let cap: Cap<Global> = Cap::data_inline_with_size(bytes, size_u64);
         let h = cap_hash(&cap);
         std::hint::black_box(h);
         drop(cap);

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -794,7 +794,16 @@ pub(crate) fn deep_clone_into<A: Allocator + Clone>(src: &Cap<Global>, alloc: A)
 /// Shallow-clone a cap: duplicate the slot/page table allocations
 /// only, sharing all targets. Targets' refcounts must be bumped by
 /// the caller after this returns.
-fn shallow_clone_cap<A: Allocator + Clone>(cap: &Cap<A>, alloc: A) -> Result<Cap<A>, CacheError> {
+/// Shallow-clone a `Cap<A>` into a fresh allocation. Only the
+/// directly-owned slot/page tables are duplicated; cross-references
+/// (CapHashOrRef in cnode slots, page hashes in DataCap) carry over
+/// by value. The caller is responsible for bumping the refcounts of
+/// any cross-referenced targets (host-side: [`Cache::bump_targets`];
+/// guest-side: state-cache's `cap_make_mut`).
+pub fn shallow_clone_cap<A: Allocator + Clone>(
+    cap: &Cap<A>,
+    alloc: A,
+) -> Result<Cap<A>, CacheError> {
     match cap {
         Cap::CNode(cn) => {
             // SparseList clones into a new allocator handle: the BTreeMap

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -798,7 +798,7 @@ pub(crate) fn deep_clone_into<A: Allocator + Clone>(src: &Cap<Global>, alloc: A)
 /// directly-owned slot/page tables are duplicated; cross-references
 /// (CapHashOrRef in cnode slots, page hashes in DataCap) carry over
 /// by value. The caller is responsible for bumping the refcounts of
-/// any cross-referenced targets (host-side: [`Cache::bump_targets`];
+/// any cross-referenced targets (host-side: `Cache::bump_targets`;
 /// guest-side: state-cache's `cap_make_mut`).
 pub fn shallow_clone_cap<A: Allocator + Clone>(
     cap: &Cap<A>,

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -656,9 +656,19 @@ pub(crate) fn deep_clone_into<A: Allocator + Clone>(src: &Cap<Global>, alloc: A)
         Cap::Data(d) => {
             let content = match &d.content {
                 DataContent::Inline(bytes) => {
+                    // Page-aligned re-allocation through `alloc`: the
+                    // resulting buffer can be mapped directly into a
+                    // ring-3 PT without an intermediate copy. Source
+                    // length is already a page-multiple (DataCap
+                    // invariant); we mirror the same length on the
+                    // target side.
+                    debug_assert!(
+                        bytes.len().is_multiple_of(crate::data::PAGE_SIZE),
+                        "DataCap inline content must be page-multiple"
+                    );
                     let mut new_bytes: AVec<u8, A> =
-                        AVec::with_capacity_in(bytes.len(), alloc.clone());
-                    new_bytes.extend_from_slice(bytes.as_slice());
+                        crate::data::alloc_page_aligned_zeroed::<A>(bytes.len(), alloc.clone());
+                    new_bytes[..bytes.len()].copy_from_slice(bytes.as_slice());
                     DataContent::Inline(new_bytes)
                 }
                 DataContent::Paged { page_size, pages } => {
@@ -670,9 +680,15 @@ pub(crate) fn deep_clone_into<A: Allocator + Clone>(src: &Cap<Global>, alloc: A)
                             PageSlot::Missing(h) => PageSlot::Missing(*h),
                             PageSlot::Loaded(pr) => {
                                 let src_pb = pr.get();
-                                let mut bytes: AVec<u8, A> =
-                                    AVec::with_capacity_in(src_pb.bytes.len(), alloc.clone());
-                                bytes.extend_from_slice(src_pb.bytes.as_slice());
+                                // Page bytes are also page-aligned so
+                                // they can be mapped directly.
+                                let mut bytes: AVec<u8, A> = crate::data::alloc_page_aligned_zeroed::<
+                                    A,
+                                >(
+                                    src_pb.bytes.len(), alloc.clone()
+                                );
+                                bytes[..src_pb.bytes.len()]
+                                    .copy_from_slice(src_pb.bytes.as_slice());
                                 let pb = PageBytes {
                                     refcount: core::sync::atomic::AtomicU32::new(1),
                                     hash: src_pb.hash,
@@ -691,10 +707,7 @@ pub(crate) fn deep_clone_into<A: Allocator + Clone>(src: &Cap<Global>, alloc: A)
                     }
                 }
             };
-            Cap::Data(DataCap {
-                size: d.size,
-                content,
-            })
+            Cap::Data(DataCap { content })
         }
         Cap::Image(img) => {
             let mut code = AVec::with_capacity_in(img.code.len(), alloc.clone());
@@ -804,9 +817,13 @@ fn shallow_clone_cap<A: Allocator + Clone>(cap: &Cap<A>, alloc: A) -> Result<Cap
         Cap::Data(d) => {
             let content = match &d.content {
                 DataContent::Inline(bytes) => {
+                    debug_assert!(
+                        bytes.len().is_multiple_of(crate::data::PAGE_SIZE),
+                        "DataCap inline content must be page-multiple"
+                    );
                     let mut new_bytes: AVec<u8, A> =
-                        AVec::with_capacity_in(bytes.len(), alloc.clone());
-                    new_bytes.extend_from_slice(bytes.as_slice());
+                        crate::data::alloc_page_aligned_zeroed::<A>(bytes.len(), alloc.clone());
+                    new_bytes[..bytes.len()].copy_from_slice(bytes.as_slice());
                     DataContent::Inline(new_bytes)
                 }
                 DataContent::Paged { page_size, pages } => {
@@ -825,10 +842,7 @@ fn shallow_clone_cap<A: Allocator + Clone>(cap: &Cap<A>, alloc: A) -> Result<Cap
                     }
                 }
             };
-            Ok(Cap::Data(DataCap {
-                size: d.size,
-                content,
-            }))
+            Ok(Cap::Data(DataCap { content }))
         }
         Cap::Instance(inst) => {
             let mut new_overlays: AVec<RwOverlay<A>, A> =

--- a/rust/javm-cap/src/cache_tests.rs
+++ b/rust/javm-cap/src/cache_tests.rs
@@ -111,7 +111,7 @@ fn t_publish_data_paged(
     cache: &mut Cache,
     page_size: u32,
     pages: &[Option<&[u8]>],
-    size: u64,
+    _size: u64,
 ) -> Result<CapHash, super::cache::CacheError> {
     let page_size_usize = page_size as usize;
     let mut slots: AVec<PageSlot<Global>, Global> = AVec::with_capacity_in(pages.len(), Global);
@@ -145,7 +145,6 @@ fn t_publish_data_paged(
         }
     }
     let cap = Cap::Data(DataCap {
-        size,
         content: DataContent::Paged {
             page_size,
             pages: slots,
@@ -179,12 +178,9 @@ fn t_publish_instance_blob(
 }
 
 fn make_data_inline(bytes: &[u8]) -> Cap<Global> {
-    let mut v = AVec::new_in(Global);
-    v.extend_from_slice(bytes);
-    Cap::Data(DataCap {
-        size: bytes.len() as u64,
-        content: DataContent::Inline(v),
-    })
+    // DataCap content is always page-multiple; the bytes get padded
+    // to the next 4 KiB boundary inside `data_inline`.
+    Cap::data_inline(bytes)
 }
 
 fn make_cnode_with(entries: &[(SlotIdx, CapHashOrRef)]) -> Cap<Global> {
@@ -247,12 +243,15 @@ fn sole_owner_get_mut_move_promotes() {
     // New instance entry's refcount starts at 1.
     assert_eq!(cache.refcount(CapHashOrRef::Ref(r)), Some(1));
 
-    // Content preserved.
+    // Content preserved (page-padded to 4 KiB).
     match cache.get(CapHashOrRef::Ref(r)).unwrap() {
         Cap::Data(d) => {
-            assert_eq!(d.size, 4);
+            assert_eq!(d.content_len(), crate::data::PAGE_SIZE as u64);
             match &d.content {
-                DataContent::Inline(bs) => assert_eq!(bs.as_slice(), b"sole"),
+                DataContent::Inline(bs) => {
+                    assert_eq!(bs.len(), crate::data::PAGE_SIZE);
+                    assert_eq!(&bs[..4], b"sole");
+                }
                 _ => panic!("expected Inline"),
             }
         }
@@ -288,7 +287,8 @@ fn shared_blob_get_mut_clones() {
     if let Cap::Data(d) = cache.get(CapHashOrRef::Hash(h)).unwrap()
         && let DataContent::Inline(bs) = &d.content
     {
-        assert_eq!(bs.as_slice(), b"shared");
+        // Page-padded: only the first len bytes are meaningful.
+        assert_eq!(&bs[..b"shared".len()], b"shared");
     }
 }
 
@@ -841,7 +841,7 @@ fn publish_data_paged_round_trips() {
     let cap = cache.get(CapHashOrRef::Hash(h)).expect("present");
     match cap {
         Cap::Data(d) => {
-            assert_eq!(d.size, 4096 * 3);
+            assert_eq!(d.content_len(), 4096 * 3);
             match &d.content {
                 DataContent::Paged { page_size, pages } => {
                     assert_eq!(*page_size, 4096);
@@ -951,7 +951,10 @@ fn put_cap_deep_clones_content_into_cache_allocator() {
     // After put, the in-cache cap must roundtrip identical content.
     match cache.get(CapHashOrRef::Hash(h)).unwrap() {
         Cap::Data(d) => match &d.content {
-            DataContent::Inline(bs) => assert_eq!(bs.as_slice(), b"gamma"),
+            DataContent::Inline(bs) => {
+                // Page-padded; only the meaningful prefix is checked.
+                assert_eq!(&bs[..b"gamma".len()], b"gamma");
+            }
             _ => panic!("expected Inline"),
         },
         _ => panic!("expected Data"),

--- a/rust/javm-cap/src/cap.rs
+++ b/rust/javm-cap/src/cap.rs
@@ -208,24 +208,38 @@ impl<A: Allocator + Clone> Cap<A> {
 // values without going through a `Cache`, suitable for callers (jar-
 // kernel, javm) that build caps locally before publishing.
 impl Cap<Global> {
-    /// Build a heap `Cap::Data` whose content is `bytes` inline.
-    /// `DataCap.size` is set to `bytes.len()`. Use a direct
-    /// `DataCap { size, content: DataContent::Inline(...) }` build
-    /// if the logical size differs from the inline byte count
-    /// (e.g. zero-padded paged data).
+    /// Build a heap `Cap::Data` whose content is `bytes` padded up to
+    /// the next [`PAGE_SIZE`](super::data::PAGE_SIZE) boundary with
+    /// zeros. The backing allocation is page-aligned so the kernel
+    /// can later map the cap's pages directly into a ring-3 PT.
+    ///
+    /// `DataCap.content_len()` returns the padded length (always a
+    /// 4 KiB-multiple). There is no separate logical-size field;
+    /// callers needing a shorter logical payload (e.g. variable-length
+    /// args) interpret the meaningful prefix themselves.
     pub fn data_inline(bytes: &[u8]) -> Self {
-        Self::data_inline_with_size(bytes, bytes.len() as u64)
+        let mut buf = super::data::alloc_page_aligned_zeroed::<Global>(bytes.len(), Global);
+        buf[..bytes.len()].copy_from_slice(bytes);
+        Cap::Data(DataCap {
+            content: super::data::DataContent::Inline(buf),
+        })
     }
 
-    /// Build a heap `Cap::Data` with an explicit logical `size` that
-    /// may exceed `bytes.len()` (e.g. zero-padded paged data, or a
-    /// pinned `.bss`-style region with non-empty initial content but a
-    /// larger declared size).
-    pub fn data_inline_with_size(bytes: &[u8], size: u64) -> Self {
-        let mut buf = allocator_api2::vec::Vec::with_capacity_in(bytes.len(), Global);
-        buf.extend_from_slice(bytes);
+    /// Build a heap `Cap::Data` whose backing buffer is at least
+    /// `target_size` bytes (rounded up to the next page boundary).
+    /// `bytes` is copied to the start of the buffer; the remainder is
+    /// zero-padded. Used by callers that need a cap matching a specific
+    /// `MemoryMapping.size` from an image manifest (e.g. genesis +
+    /// transpiler-emitted initial data).
+    ///
+    /// If `target_size < bytes.len()`, the buffer is sized to fit
+    /// `bytes` (still page-multiple) — i.e. `target_size` is a floor,
+    /// not a ceiling.
+    pub fn data_inline_with_size(bytes: &[u8], target_size: u64) -> Self {
+        let target = (target_size as usize).max(bytes.len());
+        let mut buf = super::data::alloc_page_aligned_zeroed::<Global>(target, Global);
+        buf[..bytes.len()].copy_from_slice(bytes);
         Cap::Data(DataCap {
-            size,
             content: super::data::DataContent::Inline(buf),
         })
     }

--- a/rust/javm-cap/src/cap_hash.rs
+++ b/rust/javm-cap/src/cap_hash.rs
@@ -101,13 +101,20 @@ mod tests {
             v.extend_from_slice(b"abc");
             v
         };
+        // Two caps with different inline byte lengths (same prefix)
+        // hash differently because content storage IS the identifier.
+        // Pad to distinct page-multiple sizes.
+        let mut bytes_a_padded: AVec<u8, Global> = AVec::new_in(Global);
+        bytes_a_padded.resize(crate::data::PAGE_SIZE, 0);
+        bytes_a_padded[..bytes_a.len()].copy_from_slice(bytes_a.as_slice());
+        let mut bytes_b_padded: AVec<u8, Global> = AVec::new_in(Global);
+        bytes_b_padded.resize(crate::data::PAGE_SIZE * 2, 0);
+        bytes_b_padded[..bytes_b.len()].copy_from_slice(bytes_b.as_slice());
         let a: Cap<Global> = Cap::Data(DataCap {
-            size: 3,
-            content: DataContent::Inline(bytes_a),
+            content: DataContent::Inline(bytes_a_padded),
         });
         let b: Cap<Global> = Cap::Data(DataCap {
-            size: 4, // different size, same inline bytes → different cap hash
-            content: DataContent::Inline(bytes_b),
+            content: DataContent::Inline(bytes_b_padded),
         });
         assert_ne!(cap_hash(&a), cap_hash(&b));
     }
@@ -195,7 +202,6 @@ mod tests {
         let mut pages: AVec<PageSlot<Global>, Global> = AVec::new_in(Global);
         pages.push(PageSlot::Loaded(pr));
         let cap: Cap<Global> = Cap::Data(DataCap {
-            size: 3,
             content: DataContent::Paged {
                 page_size: 4096,
                 pages,
@@ -214,7 +220,6 @@ mod tests {
         let mut pages2: AVec<PageSlot<Global>, Global> = AVec::new_in(Global);
         pages2.push(PageSlot::Loaded(pr2));
         let cap2: Cap<Global> = Cap::Data(DataCap {
-            size: 3,
             content: DataContent::Paged {
                 page_size: 4096,
                 pages: pages2,
@@ -240,7 +245,6 @@ mod tests {
         let mut pages_loaded: AVec<PageSlot<Global>, Global> = AVec::new_in(Global);
         pages_loaded.push(PageSlot::Loaded(pr));
         let cap_loaded: Cap<Global> = Cap::Data(DataCap {
-            size: 16,
             content: DataContent::Paged {
                 page_size: 16,
                 pages: pages_loaded,
@@ -250,7 +254,6 @@ mod tests {
         let mut pages_missing: AVec<PageSlot<Global>, Global> = AVec::new_in(Global);
         pages_missing.push(PageSlot::Missing(page_hash));
         let cap_missing: Cap<Global> = Cap::Data(DataCap {
-            size: 16,
             content: DataContent::Paged {
                 page_size: 16,
                 pages: pages_missing,

--- a/rust/javm-cap/src/cap_tests.rs
+++ b/rust/javm-cap/src/cap_tests.rs
@@ -80,9 +80,14 @@ fn data_inline_constructor() {
     let cap = Cap::data_inline(b"hello");
     match cap {
         Cap::Data(d) => {
-            assert_eq!(d.size, 5);
+            // DataCap content is page-padded to next 4 KiB boundary.
+            assert_eq!(d.content_len(), crate::data::PAGE_SIZE as u64);
             match d.content {
-                DataContent::Inline(bytes) => assert_eq!(bytes.as_slice(), b"hello"),
+                DataContent::Inline(bytes) => {
+                    assert_eq!(bytes.len(), crate::data::PAGE_SIZE);
+                    assert_eq!(&bytes[..5], b"hello");
+                    assert!(bytes[5..].iter().all(|b| *b == 0));
+                }
                 _ => panic!("expected Inline content"),
             }
         }
@@ -180,13 +185,16 @@ fn cnode_lookup_after_set() {
 #[test]
 fn data_inline_round_trip() {
     let mut bytes = AVec::new_in(Global);
-    bytes.extend_from_slice(b"hello");
+    bytes.resize(crate::data::PAGE_SIZE, 0);
+    bytes[..5].copy_from_slice(b"hello");
     let data: DataCap<Global> = DataCap {
-        size: 5,
         content: DataContent::Inline(bytes),
     };
     match data.content {
-        DataContent::Inline(b) => assert_eq!(b.as_slice(), b"hello"),
+        DataContent::Inline(b) => {
+            assert_eq!(b.len(), crate::data::PAGE_SIZE);
+            assert_eq!(&b[..5], b"hello");
+        }
         _ => panic!("expected Inline"),
     }
 }

--- a/rust/javm-cap/src/data.rs
+++ b/rust/javm-cap/src/data.rs
@@ -2,26 +2,46 @@
 //!
 //! Two storage forms:
 //! - `Inline` — bytes in one `Vec<u8, A>`. Used for "small" Data
-//!   (typically ≤ 1 page; the exact threshold is a callers' choice).
+//!   (typically a single page).
 //! - `Paged` — page-merkleized; each page is owned by the DataCap
 //!   via a reference-counted [`PageRef`](crate::page::PageRef) so
 //!   multiple DataCap clones can share page bytes between CoW
 //!   operations.
+//!
+//! ## Page-aligned invariant
+//!
+//! `DataCap` content storage is always a multiple of [`PAGE_SIZE`]
+//! bytes. There is no separate logical-size field — `content.len()`
+//! is the size, always 4 KiB-multiple. This lets the kernel map the
+//! cap's pages directly into a ring-3 page table without an
+//! intermediate per-call copy (see the v3 spec, §2 "Memory model").
+//!
+//! Callers that want to pass shorter payloads (variable-length args)
+//! pad up to the next page boundary at mint time; the meaningful
+//! bytes are interpreted by the receiver (length-prefix encoding or
+//! zero-terminator scanning).
+
+use core::alloc::Layout;
 
 use allocator_api2::alloc::{Allocator, Global};
 use allocator_api2::vec::Vec;
 
 use super::page::PageSlot;
 
+/// Cap-level page size. Mirrors the architecture's 4 KiB page (must
+/// match `nub_arch_x86::paging::PAGE_SIZE` for direct PT mapping to
+/// work).
+pub const PAGE_SIZE: usize = 4096;
+
 #[derive(Clone, Debug, ssz_derive::HashTreeRoot)]
 pub struct DataCap<A: Allocator + Clone = Global> {
-    pub size: u64,
     pub content: DataContent<A>,
 }
 
 #[derive(Clone, Debug, ssz_derive::HashTreeRoot)]
 pub enum DataContent<A: Allocator + Clone = Global> {
-    /// Bytes in a single slab.
+    /// Bytes in a single slab. `bytes.len()` must be a multiple of
+    /// [`PAGE_SIZE`] (zero-padded by the constructor).
     #[ssz(selector = 0)]
     Inline(Vec<u8, A>),
     /// Page-merkleized form. Each page is owned (via refcounted
@@ -34,4 +54,40 @@ pub enum DataContent<A: Allocator + Clone = Global> {
         /// Dense slot table indexed by page index.
         pages: Vec<PageSlot<A>, A>,
     },
+}
+
+impl<A: Allocator + Clone> DataCap<A> {
+    /// Total content size in bytes. Always a multiple of
+    /// [`PAGE_SIZE`].
+    pub fn content_len(&self) -> u64 {
+        match &self.content {
+            DataContent::Inline(bytes) => bytes.len() as u64,
+            DataContent::Paged { page_size, pages } => {
+                (*page_size as u64).saturating_mul(pages.len() as u64)
+            }
+        }
+    }
+}
+
+/// Allocate a zero-filled `Vec<u8, A>` of `len` bytes (rounded up to
+/// the next page boundary) with `PAGE_SIZE`-aligned backing storage.
+///
+/// The resulting `Vec` has `len == capacity == padded_len`; all bytes
+/// are zero. Page alignment of the underlying allocation is what lets
+/// the kernel later map the buffer directly into a ring-3 PT.
+///
+/// Panics if the allocator returns null (out-of-memory) or if
+/// constructing the `Layout` overflows.
+pub fn alloc_page_aligned_zeroed<A: Allocator + Clone>(len: usize, alloc: A) -> Vec<u8, A> {
+    let padded = len.next_multiple_of(PAGE_SIZE).max(PAGE_SIZE);
+    let layout =
+        Layout::from_size_align(padded, PAGE_SIZE).expect("DataCap page-aligned layout overflow");
+    let nn = alloc
+        .allocate_zeroed(layout)
+        .expect("DataCap page-aligned allocation failed");
+    // SAFETY: `allocate_zeroed` returned a non-null pointer to
+    // `padded` zeroed bytes aligned to PAGE_SIZE. The capacity we
+    // pass to `from_raw_parts_in` matches the allocation; the length
+    // (== capacity) reflects that all bytes are initialised (to zero).
+    unsafe { Vec::from_raw_parts_in(nn.as_ptr() as *mut u8, padded, padded, alloc) }
 }

--- a/rust/javm-cap/src/entry.rs
+++ b/rust/javm-cap/src/entry.rs
@@ -10,6 +10,8 @@
 use allocator_api2::alloc::{Allocator, Global};
 use core::sync::atomic::AtomicU32;
 
+use nub_host_common::cache::AarcRefCounted;
+
 use super::cap::Cap;
 
 pub struct CacheEntry<A: Allocator + Clone = Global> {
@@ -24,5 +26,11 @@ impl<A: Allocator + Clone> CacheEntry<A> {
             refcount: AtomicU32::new(1),
             cap,
         }
+    }
+}
+
+impl<A: Allocator + Clone> AarcRefCounted for CacheEntry<A> {
+    fn refcount(&self) -> &AtomicU32 {
+        &self.refcount
     }
 }

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -44,7 +44,7 @@ pub use cap::{
 };
 pub use cap_hash::cap_hash;
 pub use cnode::{CNodeCap, CNodeSlotEntry};
-pub use data::{DataCap, DataContent};
+pub use data::{DataCap, DataContent, PAGE_SIZE};
 pub use entry::CacheEntry;
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash};

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -80,9 +80,15 @@ const CALLER_SAVED: [Reg; 8] = [
 /// JitContext lives above the PVM u32 address space (no bounds check
 /// on guest mem — the full low 4 GiB of native VA belongs to the
 /// program). CTX is reached via RIP-relative `[rip+disp32]`, which
-/// gives ±2 GiB range from the JIT code, so CTX just needs to be
-/// adjacent to the JIT region.
-pub const CTX_VA: u64 = 1u64 << 32;
+/// gives ±2 GiB range from the JIT code, so CTX must be **adjacent**
+/// to the JIT region.
+///
+/// In the nub-x86 microkernel, CTX and the per-Image JIT arena both
+/// live in PML4 slot 1 (base 512 GiB). Sharing one PML4 slot lets
+/// the Image's PDPT subtree be cached as a template across all
+/// Instances (per-call PT just shallow-clones the slot's entry). MEM
+/// stays in PML4[0] at VA 0 so PVM addr == native VA still holds.
+pub const CTX_VA: u64 = 1u64 << 39;
 
 use super::JitContext;
 use memoffset::offset_of;

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -87,7 +87,7 @@ const CALLER_SAVED: [Reg; 8] = [
 /// live in PML4 slot 1 (base 512 GiB). Sharing one PML4 slot lets
 /// the Image's PDPT subtree be cached as a template across all
 /// Instances (per-call PT just shallow-clones the slot's entry). MEM
-/// stays in PML4[0] at VA 0 so PVM addr == native VA still holds.
+/// stays in `PML4[0]` at VA 0 so PVM addr == native VA still holds.
 pub const CTX_VA: u64 = 1u64 << 39;
 
 use super::JitContext;

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -46,7 +46,6 @@
 //! in the long-lived `Vm`.
 
 use allocator_api2::alloc::Global;
-use allocator_api2::vec::Vec as AVec;
 use javm_cap::{
     Blake2b256, Cache, Cap, CapHashOrRef, DataCap, DataContent, Hash, SlotIdx, TypeCap,
 };
@@ -702,18 +701,21 @@ impl<K: KernelAssist> Vm<K> {
         let bytes = mem
             .read(src_offset, len)
             .map_err(|_| VmError::Invariant("host_mint_data_cap memory read failed"))?;
-        let canonical_len = strip_trailing_zeros_len(&bytes);
-        let debit = canonical_len as u64;
+        // DataCap content is page-multiple by construction: pad the
+        // caller's bytes up to the next 4 KiB boundary with zeros.
+        // Quota is debited by the padded length — the kernel owns
+        // a full page-aligned allocation regardless of caller's slice
+        // length, so callers pay for what they store.
+        let mut inline = javm_cap::data::alloc_page_aligned_zeroed::<Global>(bytes.len(), Global);
+        inline[..bytes.len()].copy_from_slice(&bytes);
+        let debit = inline.len() as u64;
         let quota = self.kernel_assist.storage_quota_get(quota_id);
         if quota < debit {
             return Err(VmError::Invariant("storage quota exhausted"));
         }
         self.kernel_assist
             .storage_quota_set(quota_id, quota - debit);
-        let mut inline = AVec::new_in(Global);
-        inline.extend_from_slice(&bytes[..canonical_len]);
         let cap = Cap::Data(DataCap {
-            size: canonical_len as u64,
             content: DataContent::Inline(inline),
         });
         let h = javm_cap::cap_hash(&cap);
@@ -779,7 +781,7 @@ impl<K: KernelAssist> Vm<K> {
             .get(target)
             .ok_or(VmError::Invariant("host_save data missing"))?
         {
-            Cap::Data(d) => d.size,
+            Cap::Data(d) => d.content_len(),
             _ => return Err(VmError::Invariant("host_save source is not Cap::Data")),
         };
         let file_id = self
@@ -859,20 +861,8 @@ impl<K: KernelAssist> Vm<K> {
     }
 }
 
-/// Canonical-form length: number of leading bytes before trailing
-/// zeros. Used by host_mint_data_cap once that host call lands
-/// (Stage 4 wires the cache borrow).
-#[allow(dead_code)]
-pub(crate) fn strip_trailing_zeros_len(bytes: &[u8]) -> usize {
-    let mut n = bytes.len();
-    while n > 0 && bytes[n - 1] == 0 {
-        n -= 1;
-    }
-    n
-}
-
 fn data_cap_prefix(data: &DataCap<Global>, len: usize) -> Vec<u8> {
-    let actual_len = len.min(data.size as usize);
+    let actual_len = len.min(data.content_len() as usize);
     let mut out = vec![0u8; actual_len];
     match &data.content {
         DataContent::Inline(bytes) => {
@@ -1383,6 +1373,11 @@ mod tests {
 
     #[test]
     fn host_read_data_cap_copies_bytes_from_cache() {
+        // After the page-aligned DataCap refactor, the cap'\''s content
+        // is always page-multiple. `host_read_data_cap` copies up to
+        // `len` bytes (capped at `content_len()`), so callers asking
+        // for fewer bytes than a page get exactly that many — with
+        // the meaningful prefix at the start and trailing zero-pad.
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
         let data_hash = publish_data_inline(&mut cache, b"hello");
@@ -1408,15 +1403,20 @@ mod tests {
             &mut mem,
         );
         assert!(matches!(r, EcallResult::Continue));
-        assert_eq!(regs.gpr[7], 5);
-        assert_eq!(mem.read(16, 5).unwrap(), b"hello");
+        // Asked for 8 bytes; the cap has 4096 bytes available so we
+        // get all 8: 5 meaningful "hello" plus 3 trailing zeros.
+        assert_eq!(regs.gpr[7], 8);
+        assert_eq!(mem.read(16, 8).unwrap(), b"hello\0\0\0");
     }
 
     #[test]
-    fn host_mint_data_cap_publishes_canonical_bytes() {
+    fn host_mint_data_cap_publishes_page_padded_bytes() {
+        // After the page-aligned DataCap refactor, mint pads the
+        // caller's bytes up to the next 4 KiB boundary and debits
+        // quota by the padded length (1 page = 4096 bytes).
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
-        vm.kernel_assist.storage_quota_set(0, 10);
+        vm.kernel_assist.storage_quota_set(0, 8192);
         let mut mem = Mem::new();
         mem.map_region(0, PAGE_SIZE as u64, Access::ReadWrite, None)
             .unwrap();
@@ -1435,7 +1435,8 @@ mod tests {
             &mut mem,
         );
         assert!(matches!(r, EcallResult::Continue));
-        assert_eq!(vm.kernel_assist.storage_quota_get(0), 7);
+        // Debit = one page (4096), starting from 8192 leaves 4096.
+        assert_eq!(vm.kernel_assist.storage_quota_get(0), 4096);
         let target = vm
             .stack
             .running_instance()
@@ -1445,8 +1446,10 @@ mod tests {
             .unwrap();
         match cache.get(target).unwrap() {
             Cap::Data(d) => {
-                assert_eq!(d.size, 3);
-                assert_eq!(data_cap_prefix(d, 10), b"abc");
+                assert_eq!(d.content_len(), javm_cap::PAGE_SIZE as u64);
+                // First 5 bytes echo what we wrote, including the
+                // two trailing zeros — no stripping.
+                assert_eq!(data_cap_prefix(d, 5), b"abc\0\0");
             }
             _ => panic!("expected Data cap"),
         }
@@ -1477,10 +1480,13 @@ mod tests {
 
     #[test]
     fn host_save_debits_actual_data_size_and_returns_file_id() {
+        // Page-aligned DataCap: `host_save` debits by the full
+        // page-multiple content length (4 KiB for the padded "stored"
+        // cap). Quota seeded with enough headroom for one save.
         let mut vm = fixture_vm();
         let mut cache = Cache::new_in(Global);
         let data_hash = publish_data_inline(&mut cache, b"stored");
-        vm.kernel_assist.storage_quota_set(0, 10);
+        vm.kernel_assist.storage_quota_set(0, 8192);
         vm.stack
             .running_instance_mut()
             .unwrap()
@@ -1494,7 +1500,8 @@ mod tests {
         let r = handle_cached(&mut vm, &mut cache, host_op::HOST_SAVE, &mut regs, &mut mem);
         assert!(matches!(r, EcallResult::Continue));
         assert_eq!(regs.gpr[7], 1);
-        assert_eq!(vm.kernel_assist.storage_quota_get(0), 4);
+        // Debit one page (4096) from initial 8192 → 4096 remaining.
+        assert_eq!(vm.kernel_assist.storage_quota_get(0), 4096);
         assert_eq!(
             vm.kernel_assist.host_open(1),
             Some(CapHashOrRef::Hash(data_hash))
@@ -1703,13 +1710,5 @@ mod tests {
             _ => panic!("entry 0 not Instance"),
         };
         assert!(parent.root_cnode.get(SlotIdx(0)).is_none());
-    }
-
-    #[test]
-    fn strip_trailing_zeros_basic() {
-        assert_eq!(strip_trailing_zeros_len(&[1, 2, 3]), 3);
-        assert_eq!(strip_trailing_zeros_len(&[1, 2, 3, 0, 0]), 3);
-        assert_eq!(strip_trailing_zeros_len(&[0, 0, 0]), 0);
-        assert_eq!(strip_trailing_zeros_len(&[]), 0);
     }
 }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -55,7 +55,7 @@ use javm_cap::cap::Cap;
 use javm_cap::hash::{Blake2b256, Hash};
 use javm_cap::{CapHash, NUM_REGS};
 
-use crate::jit_run::{self, ExitInfo, MemRegion};
+use crate::jit_run::{self, ExitInfo, FrameRuntime, MemRegion};
 use crate::state_cache;
 
 const EXIT_HALT: u32 = 0;
@@ -68,6 +68,17 @@ const OP_HOST_CALL: u32 = 26;
 
 const CNODE_SLOTS: usize = 256;
 const MAX_DEPTH: usize = 32_768;
+/// Maximum number of concurrently-resident [`FrameRuntime`]s. Each
+/// runtime keeps ~48 KiB of pages alive (page table + mem/ctx/stack
+/// buffers); bounding this at 256 caps the in-kernel footprint at
+/// ~12 MiB even for pathologically deep recursion.
+///
+/// On each push, the frame at depth `stack.len() - RUNTIME_CACHE_CAP`
+/// is evicted: that frame is about to fall outside the cached window
+/// and will rebuild its runtime on resume. For depth ≤ cap, no
+/// eviction — every frame keeps its cached PT + bufs across the
+/// inevitable child-HALT → parent-resume cycle.
+const RUNTIME_CACHE_CAP: usize = 256;
 
 // Error codes returned to the host as InvocationResult.exit_arg when
 // the call loop bails out. The byte stays small so a hex dump in the
@@ -101,6 +112,12 @@ pub struct KernelFrame {
     mem_size: u32,
     overlays: Vec<(u32, Vec<u8>)>,
     cnode: Vec<Option<CapHash>>,
+    /// Per-frame ring-3 resources (PT + mem/ctx/stack buffers). Lazily
+    /// built on the first [`run_one_entry`] for this frame and reused
+    /// across every subsequent re-entry (after a child HALTs and the
+    /// parent resumes). Cuts N PageTable + 3 PageBuf allocations for
+    /// a depth-N recursion. Dropped when the frame is popped.
+    runtime: Option<FrameRuntime>,
 }
 
 /// One transient `Cap::Instance` created by an in-kernel
@@ -174,7 +191,7 @@ pub fn run_top(
     loop {
         // Phase 1: run one ring-3 entry on the top frame.
         let info = {
-            let frame = stack.last().expect("stack non-empty");
+            let frame = stack.last_mut().expect("stack non-empty");
             run_one_entry(frame, gas)?
         };
         gas = info.gas_remaining;
@@ -238,6 +255,18 @@ pub fn run_top(
                             let parent = stack.last().expect("non-empty");
                             dispatch_host_call(parent)?
                         };
+                        // Bound the resident-runtime set to the top
+                        // RUNTIME_CACHE_CAP frames. After the new child
+                        // is pushed, the frame at depth (len -
+                        // RUNTIME_CACHE_CAP) is the one just falling
+                        // outside the window — evict its runtime so
+                        // talc reclaims the ~48 KiB of pages it held.
+                        // That frame will rebuild its runtime when it
+                        // eventually resumes.
+                        if stack.len() >= RUNTIME_CACHE_CAP {
+                            let evict_idx = stack.len() - RUNTIME_CACHE_CAP;
+                            stack[evict_idx].runtime = None;
+                        }
                         stack.push(child);
                         transient_owned.push(owns);
                     }
@@ -271,41 +300,48 @@ pub fn run_top(
     }
 }
 
-/// Run exactly one ring-3 cycle for `frame`. Builds the per-call mem
-/// overlays from the frame's stashed copies (so each entry starts
-/// from a known image-initial state — V1 mem-snapshotting decision).
-fn run_one_entry(frame: &KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
-    let mut regions: [(u32, &[u8]); 3] = [(0, &[]), (0, &[]), (0, &[])];
-    for (slot, ov) in regions.iter_mut().zip(frame.overlays.iter()).take(3) {
-        *slot = (ov.0, ov.1.as_slice());
-    }
-    let [arg, ro, rw] = regions;
+/// Run exactly one ring-3 cycle for `frame`. The first call on a
+/// frame builds [`FrameRuntime`] (PT + mem/ctx/stack pages, mem
+/// populated from overlays); subsequent calls (parent resumes after
+/// a child HALT) reuse the cached runtime. Frame mem persists across
+/// re-entries — the parent's writes survive the child's execution.
+fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
+    if frame.runtime.is_none() {
+        let mut regions: [(u32, &[u8]); 3] = [(0, &[]), (0, &[]), (0, &[])];
+        for (slot, ov) in regions.iter_mut().zip(frame.overlays.iter()).take(3) {
+            *slot = (ov.0, ov.1.as_slice());
+        }
+        let [arg, ro, rw] = regions;
 
-    let info = unsafe {
-        jit_run::run_pvm_with_mem(
-            &frame.image_hash,
-            &frame.code,
-            &frame.bitmask,
-            &frame.jump_table,
-            gas,
-            frame.pc,
-            frame.regs,
-            frame.mem_size,
-            MemRegion {
-                start: arg.0,
-                data: arg.1,
-            },
-            MemRegion {
-                start: ro.0,
-                data: ro.1,
-            },
-            MemRegion {
-                start: rw.0,
-                data: rw.1,
-            },
-        )
-    };
-    info.ok_or(ERR_JIT_FAILED)
+        let rt = unsafe {
+            jit_run::build_frame_runtime(
+                &frame.image_hash,
+                &frame.code,
+                &frame.bitmask,
+                &frame.jump_table,
+                frame.pc,
+                frame.mem_size,
+                MemRegion {
+                    start: arg.0,
+                    data: arg.1,
+                },
+                MemRegion {
+                    start: ro.0,
+                    data: ro.1,
+                },
+                MemRegion {
+                    start: rw.0,
+                    data: rw.1,
+                },
+            )
+        }
+        .ok_or(ERR_JIT_FAILED)?;
+        frame.runtime = Some(rt);
+    }
+
+    let rt = frame.runtime.as_mut().expect("just built");
+    let info = unsafe { jit_run::enter_frame(rt, gas, frame.pc, frame.regs) };
+    Ok(info)
 }
 
 /// Pop the top frame; if a parent exists, reflect the popped child's
@@ -556,5 +592,6 @@ fn build_frame_from_image(
         mem_size,
         overlays,
         cnode,
+        runtime: None,
     })
 }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -160,6 +160,21 @@ fn forget_transient(hash: &CapHash) {
     map.remove(hash);
 }
 
+/// Drop-guard that triggers the per-RPC scratch sweep on the way
+/// out of [`run_top`], regardless of how the loop returns (clean
+/// HALT, propagated `Err`, or any path that unwinds locals). Lives
+/// at the top of the function so it drops AFTER the per-RPC
+/// `Vec<KernelFrame>` stack — any `CapHandle` held inside a frame
+/// decrements its refcount before [`state_cache::clear_scratch`]
+/// observes the entries.
+struct ScratchGuard;
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        state_cache::clear_scratch();
+    }
+}
+
 /// Successful loop result — what the host RPC returns to the bench
 /// driver. On guest-side panic the loop returns `Err(code)` instead
 /// and `nub_invoke_cached` packs the code into `exit_arg`.
@@ -180,6 +195,14 @@ pub fn run_top(
     initial_gas: i64,
 ) -> Result<LoopOutcome, u32> {
     state_cache::ensure_mapped().map_err(|_| ERR_CACHE_MAP)?;
+
+    // `_scratch_guard` is declared BEFORE `stack` so its `Drop` runs
+    // AFTER the stack is dropped — frame-held `CapHandle`s release
+    // their refcounts first, then the per-RPC scratch sweep frees
+    // any guest-published cache entries whose refcounts have fallen
+    // to 1 (the scratch tracker's own reference). See
+    // [`state_cache::clear_scratch`] for the refcount safety net.
+    let _scratch_guard = ScratchGuard;
 
     let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
     let mut stack: Vec<KernelFrame> = Vec::with_capacity(8);

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -26,37 +26,39 @@
 //!   same way it was on first entry. Bench guests that don't write
 //!   memory (the recursive-spawn bench) see no observable change.
 //!
-//! - **Kernel-private transient instances.** `derive_spawn` does NOT
-//!   publish a fresh `Cap::Instance` to the shared talc cache —
-//!   `CacheDirectory` has only `MAX_BLOB_SLOTS = 256` blob slots, so
-//!   a deep recursion (depth ≥ 256) would exhaust it. Instead, we
-//!   keep a kernel-private `BTreeMap<CapHash, TransientInstance>`
-//!   keyed by the child's extended `image_hash_chain`. `host_call`
-//!   looks up here first, falling back to the shared cache for
-//!   `Cap::Instance`s published by the host driver.
+//! - **Sub-VM instances live in `cache.instances`.** `derive_spawn`
+//!   publishes a fresh `Cap::Instance` via
+//!   [`state_cache::publish_instance`]; the returned `CapRef` goes
+//!   into the parent's cnode slot. `host_call` then resolves
+//!   `cnode[slot]: CapHashOrRef` via [`state_cache::lookup_handle`],
+//!   yielding either a host-pre-published blob or a kernel-derived
+//!   instance. Refcount on each entry is bumped by the lookup and
+//!   decremented when the [`KernelFrame`] drops, so the cache slot
+//!   stays pinned for the frame's lifetime.
 //!
-//! - **Per-frame cnode is a flat `[Option<CapHash>; 256]`.** Top
-//!   frame's cnode is seeded from the running `Cap::Instance`'s
-//!   `root_cnode` (looked up in the shared cache); child frames
-//!   inherit the parent's cnode entries. The published cnode is
-//!   read-only — slot writes (`derive_spawn` → dst) mutate the
-//!   per-frame copy.
+//! - **Per-frame cnode snapshot.** Top frame's cnode is seeded from
+//!   the running `Cap::Instance`'s `root_cnode` (now walkable from
+//!   the guest after the SSZ `SparseList` allocator-genericity
+//!   change); child frames inherit the parent's cnode entries. The
+//!   in-frame cnode is mutable (slot writes via `derive_spawn`); the
+//!   underlying `Cap::CNode` in the cache is read-only. A follow-up
+//!   commit will migrate writes into the cache via `cap_make_mut` so
+//!   the cnode lives entirely in cache.instances.
 
 #![cfg(target_os = "none")]
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::cell::UnsafeCell;
 
-use javm_cap::cap::Cap;
+use javm_cap::cap::{Cap, CapHashOrRef};
 use javm_cap::hash::{Blake2b256, Hash};
-use javm_cap::{CapHash, NUM_REGS};
+use javm_cap::{CapHash, CapRef, NUM_REGS};
+use nub_host_common::cache::TalcAlloc;
 
 use crate::jit_run::{self, ExitInfo, FrameRuntime, MemRegion};
-use crate::state_cache;
+use crate::state_cache::{self, CapHandle};
 
 const EXIT_HALT: u32 = 0;
 const EXIT_HOST_CALL: u32 = 4;
@@ -91,73 +93,51 @@ const ERR_IMAGE_KIND: u32 = 24;
 const ERR_ENDPOINT_OOB: u32 = 25;
 const ERR_ENDPOINT_UNDEFINED: u32 = 26;
 const ERR_DERIVE_SLOT_OOB: u32 = 31;
+const ERR_DERIVE_PUBLISH: u32 = 32;
 const ERR_HOST_CALL_SLOT_EMPTY: u32 = 40;
 const ERR_JIT_FAILED: u32 = 50;
 const ERR_DEPTH_LIMIT: u32 = 51;
 
-/// One stack frame on the in-kernel call stack. Owns the per-frame
-/// PVM state (regs, pc, cnode) plus copies of the image's code /
-/// bitmask / jump-table arrays (those copies are small — the JIT
-/// code cache holds the heavy compiled bytes, not us). Top frame is
-/// built from a published `Cap::Instance` lookup; child frames are
-/// built by [`dispatch_host_call`].
+/// One stack frame on the in-kernel call stack. Carries refcount-
+/// pinning handles to the Image blob and the Instance entry (blob
+/// or ref), plus per-frame mutable PVM state and the ring-3
+/// resources cache.
+///
+/// All immutable image data (code/bitmask/jump_table/endpoints/
+/// mappings/pinned/initial) is read on demand through `image.cap`
+/// — no per-frame copies.
 pub struct KernelFrame {
+    /// Refcount-pinned handle on the `Cap::Image` blob this frame
+    /// runs against. Dropped automatically on frame teardown.
+    image: CapHandle<TalcAlloc>,
+    /// Cached content-hash of the image. Used as the cnode-slot
+    /// fallback in `derive_spawn` and as the JIT-cache key in
+    /// `build_frame_runtime`.
     image_hash: CapHash,
+    /// Image's chain hash. Read by `derive_spawn` to compute the
+    /// child's chain. Cached locally to avoid an instance deref per
+    /// derive.
     image_hash_chain: CapHash,
-    code: Vec<u8>,
-    bitmask: Vec<u8>,
-    jump_table: Vec<u32>,
+    /// Refcount-pinned handle on the `Cap::Instance` entry — blob
+    /// for host-pre-published top-level instances, instance-slot
+    /// for kernel-derived sub-VMs. Drop releases the slot back to
+    /// the cache for reuse.
+    #[allow(dead_code)]
+    instance: CapHandle<TalcAlloc>,
+    /// Live PVM register file. Written by the JIT on every entry/
+    /// exit; settled back to the instance at HALT in Phase 4.
     regs: [u64; NUM_REGS],
+    /// Current PVM PC. Same lifecycle as `regs`.
     pc: u32,
-    mem_size: u32,
-    overlays: Vec<(u32, Vec<u8>)>,
-    cnode: Vec<Option<CapHash>>,
-    /// Per-frame ring-3 resources (PT + mem/ctx/stack buffers). Lazily
-    /// built on the first [`run_one_entry`] for this frame and reused
-    /// across every subsequent re-entry (after a child HALTs and the
-    /// parent resumes). Cuts N PageTable + 3 PageBuf allocations for
-    /// a depth-N recursion. Dropped when the frame is popped.
+    /// Per-frame cnode snapshot. Each slot holds a `CapHashOrRef`
+    /// (blob hash for image pinned/initial entries; instance ref
+    /// for kernel-derived transient instances) or `None`.
+    cnode: Vec<Option<CapHashOrRef>>,
+    /// Per-frame ring-3 resources (PT + mem/ctx/stack buffers).
+    /// Lazily built on the first [`run_one_entry`] for this frame
+    /// and reused across every subsequent re-entry. Cuts N
+    /// PageTable + 3 PageBuf allocations for a depth-N recursion.
     runtime: Option<FrameRuntime>,
-}
-
-/// One transient `Cap::Instance` created by an in-kernel
-/// `derive_spawn`. Lives until the corresponding child frame HALTs,
-/// then is dropped from the table by [`forget_transient`].
-struct TransientInstance {
-    image_hash: CapHash,
-    image_hash_chain: CapHash,
-}
-
-struct TransientTable {
-    inner: UnsafeCell<BTreeMap<CapHash, TransientInstance>>,
-}
-
-/// SAFETY: single-threaded guest (Hyperlight serialises calls).
-unsafe impl Sync for TransientTable {}
-
-static TRANSIENT: TransientTable = TransientTable {
-    inner: UnsafeCell::new(BTreeMap::new()),
-};
-
-fn transient_get(hash: &CapHash) -> Option<TransientInstance> {
-    // SAFETY: single-threaded guest.
-    let map = unsafe { &*TRANSIENT.inner.get() };
-    map.get(hash).map(|t| TransientInstance {
-        image_hash: t.image_hash,
-        image_hash_chain: t.image_hash_chain,
-    })
-}
-
-fn transient_insert(hash: CapHash, t: TransientInstance) {
-    // SAFETY: single-threaded guest.
-    let map = unsafe { &mut *TRANSIENT.inner.get() };
-    map.insert(hash, t);
-}
-
-fn forget_transient(hash: &CapHash) {
-    // SAFETY: single-threaded guest.
-    let map = unsafe { &mut *TRANSIENT.inner.get() };
-    map.remove(hash);
 }
 
 /// Drop-guard that triggers the per-RPC scratch sweep on the way
@@ -206,9 +186,7 @@ pub fn run_top(
 
     let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
     let mut stack: Vec<KernelFrame> = Vec::with_capacity(8);
-    let mut transient_owned: Vec<Option<CapHash>> = Vec::with_capacity(8);
     stack.push(top);
-    transient_owned.push(None);
     let mut gas = initial_gas;
 
     loop {
@@ -229,7 +207,7 @@ pub fn run_top(
         // we can mutate `stack` (push/pop) inside each arm.
         match info.exit_reason {
             EXIT_HALT => {
-                if pop_and_reflect(&mut stack, &mut transient_owned, info.regs[7])? {
+                if pop_and_reflect(&mut stack, info.regs[7]) {
                     // Top frame halted — pass the JIT's own exit
                     // reason through so callers that distinguish
                     // EXIT_HALT (explicit) from EXIT_HOST_CALL(0)
@@ -249,9 +227,7 @@ pub fn run_top(
                     info.regs[11] as u32
                 };
                 match op {
-                    OP_REPLY
-                        if pop_and_reflect(&mut stack, &mut transient_owned, info.regs[7])? =>
-                    {
+                    OP_REPLY if pop_and_reflect(&mut stack, info.regs[7]) => {
                         // Preserve the JIT exit shape so the host bench
                         // harness, which asserts `(reason=4, arg=0)` for
                         // the subsoil trampoline halt, doesn't trip.
@@ -274,7 +250,7 @@ pub fn run_top(
                         if stack.len() >= MAX_DEPTH {
                             return Err(ERR_DEPTH_LIMIT);
                         }
-                        let (child, owns) = {
+                        let child = {
                             let parent = stack.last().expect("non-empty");
                             dispatch_host_call(parent)?
                         };
@@ -291,7 +267,6 @@ pub fn run_top(
                             stack[evict_idx].runtime = None;
                         }
                         stack.push(child);
-                        transient_owned.push(owns);
                     }
                     // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
                     // arbitrary `ecalli imm`, …) is not in-kernel-
@@ -330,259 +305,49 @@ pub fn run_top(
 /// re-entries — the parent's writes survive the child's execution.
 fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
     if frame.runtime.is_none() {
-        let mut regions: [(u32, &[u8]); 3] = [(0, &[]), (0, &[]), (0, &[])];
-        for (slot, ov) in regions.iter_mut().zip(frame.overlays.iter()).take(3) {
-            *slot = (ov.0, ov.1.as_slice());
-        }
-        let [arg, ro, rw] = regions;
-
-        let rt = unsafe {
-            jit_run::build_frame_runtime(
-                &frame.image_hash,
-                &frame.code,
-                &frame.bitmask,
-                &frame.jump_table,
-                frame.pc,
-                frame.mem_size,
-                MemRegion {
-                    start: arg.0,
-                    data: arg.1,
-                },
-                MemRegion {
-                    start: ro.0,
-                    data: ro.1,
-                },
-                MemRegion {
-                    start: rw.0,
-                    data: rw.1,
-                },
-            )
-        }
-        .ok_or(ERR_JIT_FAILED)?;
+        let rt = build_runtime(frame)?;
         frame.runtime = Some(rt);
     }
-
     let rt = frame.runtime.as_mut().expect("just built");
     let info = unsafe { jit_run::enter_frame(rt, gas, frame.pc, frame.regs) };
     Ok(info)
 }
 
-/// Pop the top frame; if a parent exists, reflect the popped child's
-/// `return_value` into the parent's φ[7]. Returns `true` when the
-/// stack has been drained — the RPC caller uses this to know it's
-/// time to hand a result back to the host.
-fn pop_and_reflect(
-    stack: &mut Vec<KernelFrame>,
-    transient_owned: &mut Vec<Option<CapHash>>,
-    return_value: u64,
-) -> Result<bool, u32> {
-    let _popped = stack.pop().expect("non-empty");
-    let owned = transient_owned.pop().expect("paired with stack");
-    if let Some(h) = owned {
-        forget_transient(&h);
-    }
-    if stack.is_empty() {
-        return Ok(true);
-    }
-    let parent = stack.last_mut().unwrap();
-    parent.regs[7] = return_value;
-    Ok(false)
-}
+/// Build the per-frame ring-3 runtime. Reads image bytes via the
+/// frame's `CapHandle`, resolves the active mem overlays from image
+/// `mappings` + cnode, and calls into [`jit_run::build_frame_runtime`].
+fn build_runtime<'a>(frame: &'a KernelFrame) -> Result<FrameRuntime, u32> {
+    let img = image_cap(&frame.image)?;
 
-/// `host_derive_spawn(image_slot=φ[7], cnode_slot=φ[8],
-/// dst_slot=φ[9])`. V1: ignores `cnode_slot` (no prepared cnode
-/// support — the child inherits the parent's cnode at CALL time).
-/// Computes `child_chain = blake2b(running.chain, image_hash)`,
-/// inserts a transient-instances entry, writes the chain hash to
-/// the parent's `dst_slot`.
-fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<(), u32> {
-    let image_slot = (frame.regs[7] & 0xFF) as usize;
-    let _cnode_slot = (frame.regs[8] & 0xFF) as usize;
-    let dst_slot = (frame.regs[9] & 0xFF) as usize;
-
-    if image_slot >= CNODE_SLOTS || dst_slot >= CNODE_SLOTS {
-        return Err(ERR_DERIVE_SLOT_OOB);
-    }
-    // V1: cnode lookup is best-effort. We can't walk the published
-    // `Cap::CNode` from the guest (SparseList's inner BTreeMap lives
-    // in the host's Global allocator, so the pointers don't map),
-    // so empty slots fall back to the running frame's own image_hash.
-    // That matches the recursive-spawn bench's usage exactly — it
-    // wants to spawn its own image — and is a reasonable default for
-    // any caller that just wants to re-enter its own program with
-    // fresh state.
-    let image_hash = frame.cnode[image_slot].unwrap_or(frame.image_hash);
-    let child_chain = Blake2b256::hash_pair(&frame.image_hash_chain, &image_hash);
-    transient_insert(
-        child_chain,
-        TransientInstance {
-            image_hash,
-            image_hash_chain: child_chain,
-        },
-    );
-    frame.cnode[dst_slot] = Some(child_chain);
-    Ok(())
-}
-
-/// `host_call(instance_slot=φ[7], endpoint_idx=φ[8])`. Reads the
-/// target hash from the parent's cnode, builds a fresh
-/// [`KernelFrame`] for the child. Parent's φ[9..=12] become child's
-/// φ[7..=10] (arg-passing convention — used by the recursive-spawn
-/// bench to thread the remaining depth count).
-fn dispatch_host_call(parent: &KernelFrame) -> Result<(KernelFrame, Option<CapHash>), u32> {
-    let instance_slot = (parent.regs[7] & 0xFF) as usize;
-    let endpoint_idx = (parent.regs[8] & 0xFF) as u32;
-    if instance_slot >= CNODE_SLOTS {
-        return Err(ERR_HOST_CALL_SLOT_EMPTY);
-    }
-    let instance_hash = parent.cnode[instance_slot].ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
-
-    // Arg-passing convention: parent's φ[9..=10] → child's φ[7..=8].
-    // φ[11] holds the ecall op-code on a kernel-mode ecall exit (not
-    // a usable arg), and φ[12] is reserved; both default to 0 for
-    // the child. The bench guest threads `depth` through φ[9] alone.
-    let args = [parent.regs[9], parent.regs[10], 0, 0];
-
-    // Look up the child instance: transient table first (in-kernel
-    // derives don't hit the shared cache), then fall back to shared
-    // cache for host-pre-published `Cap::Instance`s.
-    let (mut child, owns) = if let Some(t) = transient_get(&instance_hash) {
-        let frame =
-            build_frame_from_image(&t.image_hash, t.image_hash_chain, endpoint_idx, args, None)?;
-        (frame, Some(instance_hash))
-    } else {
-        (
-            build_frame_from_published(&instance_hash, endpoint_idx, args)?,
-            None,
-        )
-    };
-    // Child inherits the parent's cnode entries that the child's
-    // image didn't pre-populate. Lets the bench guest reach
-    // `SLOT_IMAGE` without the harness re-installing it per level.
-    for (i, slot) in parent.cnode.iter().enumerate() {
-        if child.cnode[i].is_none() {
-            child.cnode[i] = *slot;
-        }
-    }
-    Ok((child, owns))
-}
-
-/// Build a frame from a `Cap::Instance` published in the shared talc
-/// cache (the top-level invocation path, plus host_call to host-
-/// pre-published Instances).
-fn build_frame_from_published(
-    instance_hash: &CapHash,
-    endpoint_idx: u32,
-    args: [u64; 4],
-) -> Result<KernelFrame, u32> {
-    let inst_cap = state_cache::lookup_cap(instance_hash).ok_or(ERR_INSTANCE_NOT_FOUND)?;
-    let inst = match inst_cap {
-        Cap::Instance(i) => i,
-        _ => return Err(ERR_INSTANCE_KIND),
-    };
-    let mut frame = build_frame_from_image(
-        &inst.image_hash,
-        inst.image_hash_chain,
-        endpoint_idx,
-        args,
-        Some(&inst.regs),
-    )?;
-
-    // V1 limitation: we deliberately do NOT walk the published
-    // `Cap::CNode` from inside the guest sandbox. `CNodeCap.slots`
-    // is a `SparseList<…>` whose inner `entries` field is a `Global`-
-    // allocated `BTreeMap` — even for `Cap<TalcAlloc>`. The deep-
-    // clone path leaves those BTreeMap nodes in host memory, so a
-    // guest-side walk would deref host VAs and page-fault. Top-frame
-    // cnode seeding still picks up the image's pinned + initial
-    // overlay slots (handled in `build_frame_from_image`), and
-    // [`dispatch_derive_spawn`] falls back to the parent's
-    // image_hash for the recursive-spawn case where no explicit
-    // image slot lookup is needed.
-
-    // Override the frame's overlay set with the published Instance's
-    // `rw_overlays` so the host driver's `instance_with_overlays`
-    // call (which bakes mem-region content directly into the
-    // InstanceCap, bypassing image.mappings + cnode resolution) keeps
-    // working. The image-mappings path
-    // ([`build_frame_from_image`]) only kicks in when the Instance
-    // has no overlays of its own — the case for transient sub-VM
-    // children created by `derive_spawn`.
-    if !inst.rw_overlays.is_empty() {
-        frame.overlays.clear();
-        for ov in inst.rw_overlays.iter() {
-            if !ov.bytes.is_empty() {
-                frame
-                    .overlays
-                    .push((ov.start, ov.bytes.as_slice().to_vec()));
-            }
-        }
-    }
-    if inst.mem_size > frame.mem_size {
-        frame.mem_size = inst.mem_size;
-    }
-
-    Ok(frame)
-}
-
-/// Core frame builder shared by published + transient instance
-/// paths. Looks up the image (in the shared cache, unconditionally —
-/// images are always content-addressed and never transient), copies
-/// code/bitmask/jt, seeds regs + cnode from image pinned/initial.
-fn build_frame_from_image(
-    image_hash: &CapHash,
-    image_hash_chain: CapHash,
-    endpoint_idx: u32,
-    args: [u64; 4],
-    inst_regs: Option<&[u64; NUM_REGS]>,
-) -> Result<KernelFrame, u32> {
-    let img_cap = state_cache::lookup_cap(image_hash).ok_or(ERR_IMAGE_NOT_FOUND)?;
-    let img = match img_cap {
-        Cap::Image(i) => i,
-        _ => return Err(ERR_IMAGE_KIND),
-    };
-
-    let endpoint = endpoint_idx as usize;
-    if endpoint >= img.endpoints.len() {
-        return Err(ERR_ENDPOINT_OOB);
-    }
-    let ep = &img.endpoints[endpoint];
-    if ep.entry_pc == 0 {
-        return Err(ERR_ENDPOINT_UNDEFINED);
-    }
-
-    let code: Vec<u8> = img.code.as_slice().to_vec();
-    let bitmask: Vec<u8> = javm_exec::unpack_bitmask(img.bitmask.as_slice(), code.len());
-    let jump_table: Vec<u32> = img.jump_table.as_slice().to_vec();
-
-    let mut regs = ep.initial_regs;
-    if let Some(inst_regs) = inst_regs {
-        for (i, v) in inst_regs.iter().enumerate() {
-            if *v != 0 {
-                regs[i] = *v;
-            }
-        }
-    }
-    for (i, v) in args.iter().enumerate() {
-        regs[7 + i] = *v;
-    }
-
-    let mut cnode: Vec<Option<CapHash>> = vec![None; CNODE_SLOTS];
-    for e in img.pinned.iter() {
-        let s = e.slot.get() as usize;
-        if s < CNODE_SLOTS {
-            cnode[s] = Some(e.cap_hash);
-        }
-    }
-    for e in img.initial.iter() {
-        let s = e.slot.get() as usize;
-        if s < CNODE_SLOTS && cnode[s].is_none() {
-            cnode[s] = Some(e.cap_hash);
-        }
-    }
-
+    // Collect at most three (start, &[u8]) regions to feed mem-
+    // population. Today's bench guest has no DataCap mappings; this
+    // walk is a no-op in that case. Top-level frames sourced from a
+    // host-published Instance with `rw_overlays` may carry mem-baked
+    // content there.
+    let mut regions: [(u32, &'a [u8]); 3] = [(0, &[]), (0, &[]), (0, &[])];
+    let mut n = 0usize;
     let mut mem_size: u32 = 0;
-    let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
+
+    // First: any host-published rw_overlays (instance-baked content).
+    if let Some(inst) = instance_cap(&frame.instance) {
+        for ov in inst.rw_overlays.iter() {
+            let end = ov.start.saturating_add(ov.bytes.len() as u32);
+            if end > mem_size {
+                mem_size = end;
+            }
+            if n < regions.len() && !ov.bytes.is_empty() {
+                regions[n] = (ov.start, ov.bytes.as_slice());
+                n += 1;
+            }
+        }
+        if inst.mem_size > mem_size {
+            mem_size = inst.mem_size;
+        }
+    }
+
+    // Then: image mappings resolved through the per-frame cnode.
+    // Only blob-hash slot entries yield mappable data; transient
+    // instance refs in the cnode are sub-VM children, not data.
     for m in img.mappings.iter() {
         let end = (m.start + m.size) as u32;
         if end > mem_size {
@@ -591,30 +356,318 @@ fn build_frame_from_image(
         if m.source_path_len == 0 {
             continue;
         }
-        let src_slot = m.source_path[0];
-        let target_hash = match cnode.get(src_slot.get() as usize).and_then(|s| s.as_ref()) {
-            Some(h) => *h,
-            None => continue,
+        let src_slot = m.source_path[0].get() as usize;
+        let Some(Some(target)) = frame.cnode.get(src_slot) else {
+            continue;
+        };
+        let target_hash = match target {
+            CapHashOrRef::Hash(h) => *h,
+            CapHashOrRef::Ref(_) => continue,
         };
         if let Some(Cap::Data(d)) = state_cache::lookup_cap(&target_hash)
             && let javm_cap::DataContent::Inline(bytes) = &d.content
             && !bytes.is_empty()
+            && n < regions.len()
         {
-            overlays.push((m.start as u32, bytes.as_slice().to_vec()));
+            regions[n] = (m.start as u32, bytes.as_slice());
+            n += 1;
         }
     }
 
-    Ok(KernelFrame {
-        image_hash: *image_hash,
+    let [arg, ro, rw] = regions;
+
+    // `img.bitmask` is the packed form (1 bit per code byte);
+    // `build_frame_runtime` / `Compiler::new` expect the unpacked
+    // form (1 byte per code byte). Unpack into a local Vec — the
+    // jit_cache copies the result into the per-Image arena on first
+    // compile and reuses it thereafter, so this allocation only
+    // matters on cache miss.
+    let bitmask = javm_exec::unpack_bitmask(img.bitmask.as_slice(), img.code.len());
+
+    // SAFETY: caller keeps `frame.image` alive for the runtime's
+    // lifetime (it's owned by the frame). Code/jt slices come from
+    // the cap-resident memory and live as long as `frame.image`.
+    unsafe {
+        jit_run::build_frame_runtime(
+            &frame.image_hash,
+            img.code.as_slice(),
+            &bitmask,
+            img.jump_table.as_slice(),
+            frame.pc,
+            mem_size,
+            MemRegion {
+                start: arg.0,
+                data: arg.1,
+            },
+            MemRegion {
+                start: ro.0,
+                data: ro.1,
+            },
+            MemRegion {
+                start: rw.0,
+                data: rw.1,
+            },
+        )
+    }
+    .ok_or(ERR_JIT_FAILED)
+}
+
+/// Pop the top frame; if a parent exists, reflect the popped child's
+/// `return_value` into the parent's φ[7]. Returns `true` when the
+/// stack has been drained — the RPC caller uses this to know it's
+/// time to hand a result back to the host. The dropped frame's
+/// `CapHandle`s decrement their refcounts automatically; the per-
+/// RPC scratch sweep at end of `run_top` reclaims any orphaned
+/// `cache.instances` slots.
+fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
+    let _popped = stack.pop().expect("non-empty");
+    if stack.is_empty() {
+        return true;
+    }
+    let parent = stack.last_mut().unwrap();
+    parent.regs[7] = return_value;
+    false
+}
+
+/// `host_derive_spawn(image_slot=φ[7], cnode_slot=φ[8],
+/// dst_slot=φ[9])`. V1: ignores `cnode_slot` (no prepared cnode
+/// support — the child inherits the parent's cnode at CALL time).
+/// Computes `child_chain = blake2b(running.chain, image_hash)`,
+/// publishes a fresh `Cap::Instance` to `cache.instances` via
+/// [`state_cache::publish_instance`], and writes the resulting
+/// `CapRef` into the parent's `dst_slot`.
+fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<(), u32> {
+    let image_slot = (frame.regs[7] & 0xFF) as usize;
+    let _cnode_slot = (frame.regs[8] & 0xFF) as usize;
+    let dst_slot = (frame.regs[9] & 0xFF) as usize;
+
+    if image_slot >= CNODE_SLOTS || dst_slot >= CNODE_SLOTS {
+        return Err(ERR_DERIVE_SLOT_OOB);
+    }
+    // Cnode-slot fallback: empty slots default to the running
+    // frame's own image_hash. Matches the recursive-spawn bench
+    // exactly and is reasonable for any caller that wants to
+    // re-enter its own program with fresh state.
+    let image_hash = match frame.cnode[image_slot] {
+        Some(CapHashOrRef::Hash(h)) => h,
+        Some(CapHashOrRef::Ref(_)) | None => frame.image_hash,
+    };
+    let child_chain = Blake2b256::hash_pair(&frame.image_hash_chain, &image_hash);
+
+    let child_inst = build_transient_instance_cap(image_hash, child_chain);
+    let child_ref = state_cache::publish_instance(child_inst).map_err(|_| ERR_DERIVE_PUBLISH)?;
+    frame.cnode[dst_slot] = Some(CapHashOrRef::Ref(child_ref));
+    Ok(())
+}
+
+/// `host_call(instance_slot=φ[7], endpoint_idx=φ[8])`. Reads the
+/// target instance ref from the parent's cnode, builds a fresh
+/// [`KernelFrame`] for the child. Parent's φ[9..=12] become child's
+/// φ[7..=10] (arg-passing convention — used by the recursive-spawn
+/// bench to thread the remaining depth count).
+fn dispatch_host_call(parent: &KernelFrame) -> Result<KernelFrame, u32> {
+    let instance_slot = (parent.regs[7] & 0xFF) as usize;
+    let endpoint_idx = (parent.regs[8] & 0xFF) as u32;
+    if instance_slot >= CNODE_SLOTS {
+        return Err(ERR_HOST_CALL_SLOT_EMPTY);
+    }
+    let target = parent.cnode[instance_slot].ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
+
+    // Arg-passing convention: parent's φ[9..=10] → child's φ[7..=8].
+    // φ[11] holds the ecall op-code on a kernel-mode ecall exit (not
+    // a usable arg), and φ[12] is reserved; both default to 0 for
+    // the child. The bench guest threads `depth` through φ[9] alone.
+    let args = [parent.regs[9], parent.regs[10], 0, 0];
+
+    let mut child = match target {
+        CapHashOrRef::Hash(h) => build_frame_from_published(&h, endpoint_idx, args)?,
+        CapHashOrRef::Ref(r) => build_frame_from_instance_ref(r, endpoint_idx, args)?,
+    };
+
+    // Child inherits the parent's cnode entries that the child's
+    // image didn't pre-populate. Lets the bench guest reach
+    // `SLOT_IMAGE` without the harness re-installing it per level.
+    for (i, slot) in parent.cnode.iter().enumerate() {
+        if child.cnode[i].is_none() {
+            child.cnode[i] = *slot;
+        }
+    }
+    Ok(child)
+}
+
+/// Build a frame from a `Cap::Instance` blob published in the shared
+/// talc cache (the top-level invocation path; also used by
+/// `host_call` when the cnode slot points at a host-pre-published
+/// instance hash). Acquires refcount-pinning handles on both the
+/// Instance and its Image.
+fn build_frame_from_published(
+    instance_hash: &CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+) -> Result<KernelFrame, u32> {
+    let instance_handle: CapHandle<TalcAlloc> =
+        state_cache::lookup_blob_handle(instance_hash).ok_or(ERR_INSTANCE_NOT_FOUND)?;
+    let inst = match &instance_handle.cap {
+        Cap::Instance(i) => i,
+        _ => return Err(ERR_INSTANCE_KIND),
+    };
+    let image_hash = inst.image_hash;
+    let image_hash_chain = inst.image_hash_chain;
+    let inst_regs = inst.regs;
+
+    let image_handle: CapHandle<TalcAlloc> =
+        state_cache::lookup_blob_handle(&image_hash).ok_or(ERR_IMAGE_NOT_FOUND)?;
+    build_frame_from_image_handle(
+        image_handle,
+        image_hash,
         image_hash_chain,
-        code,
-        bitmask,
-        jump_table,
+        instance_handle,
+        endpoint_idx,
+        args,
+        Some(&inst_regs),
+    )
+}
+
+/// Build a frame from a `Cap::Instance` resident in `cache.instances`
+/// (kernel-derived sub-VM). Acquires refcount-pinning handles on
+/// both the Instance and its Image.
+fn build_frame_from_instance_ref(
+    ref_id: CapRef,
+    endpoint_idx: u32,
+    args: [u64; 4],
+) -> Result<KernelFrame, u32> {
+    let instance_handle: CapHandle<TalcAlloc> =
+        state_cache::lookup_instance_handle(ref_id).ok_or(ERR_INSTANCE_NOT_FOUND)?;
+    let inst = match &instance_handle.cap {
+        Cap::Instance(i) => i,
+        _ => return Err(ERR_INSTANCE_KIND),
+    };
+    let image_hash = inst.image_hash;
+    let image_hash_chain = inst.image_hash_chain;
+
+    let image_handle: CapHandle<TalcAlloc> =
+        state_cache::lookup_blob_handle(&image_hash).ok_or(ERR_IMAGE_NOT_FOUND)?;
+    build_frame_from_image_handle(
+        image_handle,
+        image_hash,
+        image_hash_chain,
+        instance_handle,
+        endpoint_idx,
+        args,
+        None,
+    )
+}
+
+/// Core frame builder: takes refcount-pinning handles on Image and
+/// Instance plus the resolved identity hashes, seeds regs from
+/// endpoint + optional instance overrides, then seeds the per-frame
+/// cnode from `image.pinned + initial`.
+fn build_frame_from_image_handle(
+    image: CapHandle<TalcAlloc>,
+    image_hash: CapHash,
+    image_hash_chain: CapHash,
+    instance: CapHandle<TalcAlloc>,
+    endpoint_idx: u32,
+    args: [u64; 4],
+    inst_regs: Option<&[u64; NUM_REGS]>,
+) -> Result<KernelFrame, u32> {
+    // Read everything we need from `image` first; the struct
+    // construction below moves `image` into the returned `KernelFrame`
+    // so any borrows on it must release before that point.
+    let (regs, pc, cnode) = {
+        let img = image_cap(&image)?;
+
+        let endpoint = endpoint_idx as usize;
+        if endpoint >= img.endpoints.len() {
+            return Err(ERR_ENDPOINT_OOB);
+        }
+        let ep = &img.endpoints[endpoint];
+        if ep.entry_pc == 0 {
+            return Err(ERR_ENDPOINT_UNDEFINED);
+        }
+
+        let mut regs = ep.initial_regs;
+        if let Some(inst_regs) = inst_regs {
+            for (i, v) in inst_regs.iter().enumerate() {
+                if *v != 0 {
+                    regs[i] = *v;
+                }
+            }
+        }
+        for (i, v) in args.iter().enumerate() {
+            regs[7 + i] = *v;
+        }
+
+        let mut cnode: Vec<Option<CapHashOrRef>> = vec![None; CNODE_SLOTS];
+        for e in img.pinned.iter() {
+            let s = e.slot.get() as usize;
+            if s < CNODE_SLOTS {
+                cnode[s] = Some(CapHashOrRef::Hash(e.cap_hash));
+            }
+        }
+        for e in img.initial.iter() {
+            let s = e.slot.get() as usize;
+            if s < CNODE_SLOTS && cnode[s].is_none() {
+                cnode[s] = Some(CapHashOrRef::Hash(e.cap_hash));
+            }
+        }
+        (regs, ep.entry_pc as u32, cnode)
+    };
+
+    Ok(KernelFrame {
+        image,
+        image_hash,
+        image_hash_chain,
+        instance,
         regs,
-        pc: ep.entry_pc as u32,
-        mem_size,
-        overlays,
+        pc,
         cnode,
         runtime: None,
+    })
+}
+
+/// Helper: borrow the inner `Cap::Image` from a handle, or return
+/// an error if the entry is the wrong kind.
+fn image_cap(
+    handle: &CapHandle<TalcAlloc>,
+) -> Result<&javm_cap::image_cap::ImageCap<TalcAlloc>, u32> {
+    match &handle.cap {
+        Cap::Image(i) => Ok(i),
+        _ => Err(ERR_IMAGE_KIND),
+    }
+}
+
+/// Helper: borrow the inner `Cap::Instance` from a handle.
+fn instance_cap(
+    handle: &CapHandle<TalcAlloc>,
+) -> Option<&javm_cap::instance::InstanceCap<TalcAlloc>> {
+    match &handle.cap {
+        Cap::Instance(i) => Some(i),
+        _ => None,
+    }
+}
+
+/// Construct a fresh `Cap::Instance` for a kernel-derived sub-VM.
+/// Inherits the parent's chain via `image_hash_chain`; `regs`, `pc`,
+/// `gas_remaining`, `rw_overlays` start empty (the in-kernel
+/// recurse-spawn pattern doesn't persist any of these via the
+/// instance cap — the frame's own `regs`/`pc` carry per-call state,
+/// settled back at HALT in Phase 4).
+fn build_transient_instance_cap(image_hash: CapHash, image_hash_chain: CapHash) -> Cap<TalcAlloc> {
+    use allocator_api2::vec::Vec as AVec;
+    let alloc = state_cache::talc_alloc();
+    Cap::Instance(javm_cap::instance::InstanceCap {
+        image_hash_chain,
+        image_hash,
+        // Sub-VMs inherit the parent's cnode operationally via the
+        // per-frame `cnode` Vec (set in `dispatch_host_call`); the
+        // cap-resident `root_cnode` is a placeholder until Phase 4
+        // moves cnode mutation into the cache.
+        root_cnode: CapHashOrRef::Hash([0u8; 32]),
+        rw_overlays: AVec::new_in(alloc),
+        mem_size: 0,
+        regs: [0u64; NUM_REGS],
+        pc: 0,
+        gas_remaining: 0,
     })
 }

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -36,18 +36,26 @@ use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 use javm_cap::CapHash;
 
 use crate::page_alloc::PageBuf;
-use crate::paging::PAGE_SIZE;
+use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
 
 /// One cached Image's worth of compiled artifacts.
 ///
 /// The arena holds BB / JT / DISPATCH / JIT / TRAMP regions
-/// contiguously, page-aligned. The kernel maps the arena's pages
-/// (with per-region permissions) into the per-call page table.
+/// contiguously, page-aligned. The `template` is a pre-built PD
+/// subtree (one PD + up to a handful of PT pages) whose leaf PTEs
+/// already point at the arena's pages with the right permissions —
+/// per-call page tables install the PD via
+/// [`PageTable::install_borrowed_pd`](crate::paging::PageTable::install_borrowed_pd)
+/// instead of running `pt.map` over the arena.
 ///
 /// The `trap_table` is kept outside the arena — `jit_pf_handler` reads
 /// it via static atomics and never needs it mapped into ring-3.
 pub struct CompiledImage {
     /// Page-aligned buffer holding the five regions.
+    ///
+    /// Kept solely to own the backing pages — referenced by the
+    /// template's leaf PTEs and freed when the cache entry is evicted.
+    #[allow(dead_code)]
     pub arena: PageBuf,
     /// Offsets into `arena` for each region (in bytes from arena base).
     pub bb_offset: usize,
@@ -56,11 +64,17 @@ pub struct CompiledImage {
     pub jit_offset: usize,
     pub tramp_offset: usize,
     /// Byte sizes of the regions as stored in the arena (each rounded
-    /// up to the next page boundary).
+    /// up to the next page boundary). `jit_size` is read by the #PF
+    /// handler to bound the JIT-window check; the others are kept for
+    /// diagnostics.
+    #[allow(dead_code)]
     pub bb_size: usize,
+    #[allow(dead_code)]
     pub jt_size: usize,
+    #[allow(dead_code)]
     pub dispatch_size: usize,
     pub jit_size: usize,
+    #[allow(dead_code)]
     pub tramp_size: usize,
     /// Native-code offset (within the JIT region) of the exit label
     /// — `jit_pf_handler` redirects the saved RIP here on page fault.
@@ -68,6 +82,15 @@ pub struct CompiledImage {
     /// (native_offset, pvm_pc) pairs the #PF handler binary-searches
     /// to recover the PVM PC from a faulting RIP.
     pub trap_table: Vec<(u32, u32)>,
+    /// Template PD subtree mapping the arena pages at per-call VAs.
+    /// Per-call PTs install [`template_pd_pa`] into PDPT[1] of the
+    /// META PML4 slot; this `template` owns the backing PD + PT pages
+    /// and frees them on eviction (V1: effectively never).
+    #[allow(dead_code)]
+    pub template: TemplatePT,
+    /// Physical address of `template`'s PD page, cached for fast
+    /// install on the per-call hot path.
+    pub template_pd_pa: u64,
 }
 
 /// Process-wide compile cache.
@@ -195,6 +218,30 @@ pub fn get_or_compile(
         buf[tramp_start + 24] = 0x0F;
         buf[tramp_start + 25] = 0x0B;
 
+        // ---- build the template PD ------------------------------------
+        // One PD covers 1 GiB of VA starting at `arena_base_va`; leaf
+        // PTEs point at each 4 KiB arena page with the appropriate
+        // permission (RO for BB/JT/DISPATCH, RX for JIT/TRAMP).
+        let arena_pa = arena.pa();
+        let mut template = TemplatePT::new().expect("TemplatePT alloc");
+        let ro_end = jit_offset; // bytes covered by RO range (BB+JT+DISPATCH)
+        let arena_total = total;
+        let mut off = 0usize;
+        while off < arena_total {
+            let perm = if off < ro_end {
+                Perm::user_ro()
+            } else {
+                Perm::user_rx()
+            };
+            template
+                .map_leaf(off as u64, arena_pa + off as u64, perm)
+                .expect("TemplatePT::map_leaf");
+            off += PAGE_SIZE;
+        }
+        let template_pd_pa = template
+            .pd_pa()
+            .expect("template PD must be in kernel half");
+
         map.insert(
             *image_hash,
             CompiledImage {
@@ -211,6 +258,8 @@ pub fn get_or_compile(
                 tramp_size,
                 exit_label_offset,
                 trap_table,
+                template,
+                template_pd_pa,
             },
         );
     }

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -63,19 +63,9 @@ pub struct CompiledImage {
     pub dispatch_offset: usize,
     pub jit_offset: usize,
     pub tramp_offset: usize,
-    /// Byte sizes of the regions as stored in the arena (each rounded
-    /// up to the next page boundary). `jit_size` is read by the #PF
-    /// handler to bound the JIT-window check; the others are kept for
-    /// diagnostics.
-    #[allow(dead_code)]
-    pub bb_size: usize,
-    #[allow(dead_code)]
-    pub jt_size: usize,
-    #[allow(dead_code)]
-    pub dispatch_size: usize,
+    /// Byte size of the JIT region (page-rounded). Read by the #PF
+    /// handler to bound the JIT-window check.
     pub jit_size: usize,
-    #[allow(dead_code)]
-    pub tramp_size: usize,
     /// Native-code offset (within the JIT region) of the exit label
     /// — `jit_pf_handler` redirects the saved RIP here on page fault.
     pub exit_label_offset: u32,
@@ -251,11 +241,7 @@ pub fn get_or_compile(
                 dispatch_offset,
                 jit_offset,
                 tramp_offset,
-                bb_size,
-                jt_size,
-                dispatch_size,
                 jit_size,
-                tramp_size,
                 exit_label_offset,
                 trap_table,
                 template,

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -1,19 +1,27 @@
-//! Per-image JIT code cache.
+//! Per-Image JIT code cache + page-aligned arena.
 //!
-//! `Compiler::compile` emits native x86-64 bytes whose RIP-relative
-//! references hard-code the per-invocation VA layout: `CTX_VA` (4 GiB),
-//! `JIT_VA_M` (META_BASE + 64 MiB), `BB_VA_M`, `JT_VA_M`,
-//! `DISPATCH_VA_M`. Those VAs are *constants* in this crate, so the
-//! compiled bytes are reusable across every ring-3 entry — the JIT
-//! page-table sets up the same layout each time. Only the per-frame
-//! memory (CTX page, mem region, stack, PT skeleton) changes.
+//! Each Image gets one [`PageBuf`] arena containing five regions
+//! laid out contiguously, each starting on a page boundary:
 //!
-//! Caching the compile result keyed by `image_hash` (the `Cap::Image`
-//! content hash) lets the recursive-spawn bench reuse one compile pass
-//! across thousands of CALLs of the same Image. Without the cache,
-//! `Compiler::compile` runs once per invocation (~100–500 µs per
-//! call) and dwarfs the ~10 µs ring-3 context switch we're trying to
-//! measure.
+//! ```text
+//!   arena base (page-aligned)
+//!     + bb_offset       : BB (bitmask)      RO
+//!     + jt_offset       : JT (jump table)   RO
+//!     + dispatch_offset : DISPATCH table    RO
+//!     + jit_offset      : JIT native code   RX
+//!     + tramp_offset    : trampoline (26B)  RX
+//! ```
+//!
+//! The arena lives for the cache entry's lifetime and is mapped into
+//! every Instance's page table that runs this Image — so we only pay
+//! the alloc + memcpy + perm setup once per Image (not per call).
+//!
+//! `Compiler::compile` emits RIP-relative references to `CTX_VA`
+//! (a fixed constant) and embeds the per-Image `JIT_VA` for any
+//! within-JIT branch fix-ups. The dispatch table contains `i32`
+//! offsets relative to that `JIT_VA`; runtime resolution adds
+//! `code_base` (a `JitContext` field) to land on absolute native
+//! addresses.
 
 #![cfg(target_os = "none")]
 
@@ -27,19 +35,39 @@ use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 
 use javm_cap::CapHash;
 
-/// One cached compile result, retained by `image_hash`.
+use crate::page_alloc::PageBuf;
+use crate::paging::PAGE_SIZE;
+
+/// One cached Image's worth of compiled artifacts.
 ///
-/// The fields mirror [`CompileResult`] but live in long-term storage.
-/// Each ring-3 entry copies `native` into the per-invocation user-RX
-/// page and `dispatch_table` into the user-RO dispatch page. The
-/// `trap_table` is consulted by `jit_pf_handler` to translate native
-/// offsets back to PVM PCs on page faults; we hand a borrowed slice
-/// to the handler via static atomics.
+/// The arena holds BB / JT / DISPATCH / JIT / TRAMP regions
+/// contiguously, page-aligned. The kernel maps the arena's pages
+/// (with per-region permissions) into the per-call page table.
+///
+/// The `trap_table` is kept outside the arena — `jit_pf_handler` reads
+/// it via static atomics and never needs it mapped into ring-3.
 pub struct CompiledImage {
-    pub native: Vec<u8>,
-    pub dispatch_table: Vec<i32>,
-    pub trap_table: Vec<(u32, u32)>,
+    /// Page-aligned buffer holding the five regions.
+    pub arena: PageBuf,
+    /// Offsets into `arena` for each region (in bytes from arena base).
+    pub bb_offset: usize,
+    pub jt_offset: usize,
+    pub dispatch_offset: usize,
+    pub jit_offset: usize,
+    pub tramp_offset: usize,
+    /// Byte sizes of the regions as stored in the arena (each rounded
+    /// up to the next page boundary).
+    pub bb_size: usize,
+    pub jt_size: usize,
+    pub dispatch_size: usize,
+    pub jit_size: usize,
+    pub tramp_size: usize,
+    /// Native-code offset (within the JIT region) of the exit label
+    /// — `jit_pf_handler` redirects the saved RIP here on page fault.
     pub exit_label_offset: u32,
+    /// (native_offset, pvm_pc) pairs the #PF handler binary-searches
+    /// to recover the PVM PC from a faulting RIP.
+    pub trap_table: Vec<(u32, u32)>,
 }
 
 /// Process-wide compile cache.
@@ -58,64 +86,139 @@ static CACHE: CompileCache = CompileCache {
     inner: UnsafeCell::new(BTreeMap::new()),
 };
 
-/// Look up the compile cache by `image_hash`. On miss, run
-/// `Compiler::compile` and insert the result. Returns a `'static`
-/// borrow into the cache entry — caller may freely read `native`,
-/// `dispatch_table`, `trap_table`, `exit_label_offset` for the
-/// duration of the invocation.
+/// Round a byte count up to the next [`PAGE_SIZE`] boundary, with a
+/// minimum of one page (so even empty regions occupy a single page
+/// in the arena — keeps the per-region PTEs uniform).
+fn page_round_up_min1(n: usize) -> usize {
+    n.next_multiple_of(PAGE_SIZE).max(PAGE_SIZE)
+}
+
+/// Look up the compile cache by `image_hash`. On miss, compile the
+/// Image and materialise the per-Image arena. Returns a `'static`
+/// borrow into the cache entry.
+///
+/// `arena_base_va` is the ring-3 VA where the arena will be mapped
+/// (used to compute the per-Image `JIT_VA` so codegen embeds correct
+/// RIP-relative displacements). Callers must map the arena at this
+/// exact VA on every entry.
 ///
 /// # Safety
 ///
-/// Hyperlight serialises host calls, so concurrent access is not
-/// possible. The returned reference is valid until the cache entry is
-/// evicted; in V1 we never evict, so the borrow lifetime is
-/// effectively `'static`.
+/// Hyperlight serialises host calls; the returned reference is valid
+/// until eviction (V1 never evicts), effectively `'static`.
+#[allow(clippy::too_many_arguments)]
 pub fn get_or_compile(
     image_hash: &CapHash,
     code: &[u8],
     bitmask: &[u8],
     jump_table: &[u32],
-    jit_va_m: u64,
+    arena_base_va: u64,
+    ctx_va: u64,
     mem_cycles: u8,
     helpers: HelperFns,
 ) -> &'static CompiledImage {
-    // SAFETY: single-threaded guest. Reentrant access from inside the
-    // closure below is impossible because `Compiler::compile` doesn't
-    // call back into this module.
+    // SAFETY: single-threaded guest.
     let map = unsafe { &mut *CACHE.inner.get() };
     if !map.contains_key(image_hash) {
-        let compiler = Compiler::new(
-            bitmask,
-            jump_table,
-            helpers,
-            code.len(),
-            jit_va_m,
-            mem_cycles,
-        );
+        // ---- compute region sizes and offsets --------------------------
+        let bb_size = page_round_up_min1(bitmask.len());
+        let jt_size = page_round_up_min1(core::mem::size_of_val(jump_table));
+        // Dispatch table sized at worst-case (one i32 per code byte) so
+        // every PC index lands in range; only the prefix produced by
+        // compile is filled, rest stays zero.
+        let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
+
+        let bb_offset = 0usize;
+        let jt_offset = bb_offset + bb_size;
+        let dispatch_offset = jt_offset + jt_size;
+        let jit_offset = dispatch_offset + dispatch_size;
+        // jit_va is the absolute VA where the JIT region will be mapped;
+        // codegen embeds this for its internal jump resolution.
+        let jit_va = arena_base_va + jit_offset as u64;
+
+        // ---- run codegen ----------------------------------------------
+        let compiler = Compiler::new(bitmask, jump_table, helpers, code.len(), jit_va, mem_cycles);
         let CompileResult {
             native_code,
             dispatch_table,
             trap_table,
             exit_label_offset,
         } = compiler.compile(code, bitmask);
+
+        let jit_size = page_round_up_min1(native_code.len());
+        let tramp_offset = jit_offset + jit_size;
+        let tramp_size = PAGE_SIZE; // 26 bytes; one page is plenty.
+
+        let total = tramp_offset + tramp_size;
+
+        // ---- allocate arena --------------------------------------------
+        let mut arena = PageBuf::new(total).expect("PageBuf alloc for Image arena");
+
+        // ---- fill BB / JT / DISPATCH / JIT / TRAMP into arena ----------
+        let buf = arena.as_mut_slice();
+        // BB
+        buf[bb_offset..bb_offset + bitmask.len()].copy_from_slice(bitmask);
+        // JT
+        let jt_bytes_len = core::mem::size_of_val(jump_table);
+        // Reinterpret &[u32] as &[u8] for the memcpy.
+        let jt_ptr = jump_table.as_ptr() as *const u8;
+        // SAFETY: jt_ptr is valid for jt_bytes_len bytes (jump_table
+        // length × size_of::<u32>).
+        let jt_slice = unsafe { core::slice::from_raw_parts(jt_ptr, jt_bytes_len) };
+        buf[jt_offset..jt_offset + jt_bytes_len].copy_from_slice(jt_slice);
+        // DISPATCH
+        let dispatch_bytes_len = core::mem::size_of_val(dispatch_table.as_slice());
+        let dispatch_ptr = dispatch_table.as_ptr() as *const u8;
+        // SAFETY: dispatch_ptr is valid for dispatch_bytes_len bytes.
+        let dispatch_slice =
+            unsafe { core::slice::from_raw_parts(dispatch_ptr, dispatch_bytes_len) };
+        buf[dispatch_offset..dispatch_offset + dispatch_bytes_len].copy_from_slice(dispatch_slice);
+        // JIT
+        buf[jit_offset..jit_offset + native_code.len()].copy_from_slice(&native_code);
+        // TRAMP — 26 bytes encoding the per-Image entry sequence.
+        //   mov rdi, ctx_va     ; 48 BF <imm64>  (10)
+        //   mov rax, jit_va     ; 48 B8 <imm64>  (10)
+        //   call rax            ; FF D0          (2)
+        //   int 0x81            ; CD 81          (2)
+        //   ud2                 ; 0F 0B          (2)
+        let tramp_start = tramp_offset;
+        buf[tramp_start] = 0x48;
+        buf[tramp_start + 1] = 0xBF;
+        buf[tramp_start + 2..tramp_start + 10].copy_from_slice(&ctx_va.to_le_bytes());
+        buf[tramp_start + 10] = 0x48;
+        buf[tramp_start + 11] = 0xB8;
+        buf[tramp_start + 12..tramp_start + 20].copy_from_slice(&jit_va.to_le_bytes());
+        buf[tramp_start + 20] = 0xFF;
+        buf[tramp_start + 21] = 0xD0;
+        buf[tramp_start + 22] = 0xCD;
+        buf[tramp_start + 23] = 0x81;
+        buf[tramp_start + 24] = 0x0F;
+        buf[tramp_start + 25] = 0x0B;
+
         map.insert(
             *image_hash,
             CompiledImage {
-                native: native_code,
-                dispatch_table,
-                trap_table,
+                arena,
+                bb_offset,
+                jt_offset,
+                dispatch_offset,
+                jit_offset,
+                tramp_offset,
+                bb_size,
+                jt_size,
+                dispatch_size,
+                jit_size,
+                tramp_size,
                 exit_label_offset,
+                trap_table,
             },
         );
     }
-    // SAFETY: just inserted (or already present); BTreeMap never
-    // moves entries by value once allocated through the global
-    // allocator, so the reference is stable for the cache's lifetime.
+    // SAFETY: present; BTreeMap entries don't move once inserted.
     map.get(image_hash).expect("inserted above")
 }
 
-/// Diagnostic: number of cached images. Useful for tests that assert
-/// the cache is being hit.
+/// Diagnostic: number of cached images. Useful for tests.
 #[allow(dead_code)]
 pub fn cached_count() -> usize {
     // SAFETY: single-threaded guest.

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -196,35 +196,57 @@ pub struct MemRegion<'a> {
     pub data: &'a [u8],
 }
 
-/// Run a PVM program with a real flat-memory mapping at ring 3.
+/// Per-frame ring-3 resources retained across re-entries.
 ///
-/// All backing memory (mem, perms, ctx, bb, jt, dispatch, JIT code,
-/// trampoline, stack, page tables) is allocated from talc for this
-/// invocation only, then freed when this function returns. Per call:
-///   1. Compile the PVM program.
-///   2. Allocate per-buffer pages sized to the program.
-///   3. Copy program bitmask + jump_table + dispatch + JIT code in.
-///   4. Mark `[0, mem_size)` pages RW in perms.
-///   5. Populate arg / ro / rw regions.
-///   6. Build a fresh page table, drop to ring 3, read back ctx.
+/// Holds the per-call page table + private mem/ctx/stack pages, plus
+/// the cached `CompiledImage` fields needed to publish #PF-handler
+/// atomics on every entry. Built once per `KernelFrame` (lazily on
+/// first [`enter_frame`]); reused across re-entries on the same frame
+/// — saves N PageTable + 3 PageBuf allocations in a depth-N recursion.
+///
+/// Frame-constant `JitContext` fields (jt_ptr, bb_starts,
+/// dispatch_table, code_base, flat_buf, …) are written once when the
+/// runtime is built. [`enter_frame`] only updates regs/pc/gas/exit_*.
+pub struct FrameRuntime {
+    pt: PageTable,
+    #[allow(dead_code)] // kept solely to own the backing page (referenced by `pt`).
+    mem_buf: PageBuf,
+    #[allow(dead_code)] // kept solely to own the backing page (referenced by `pt`).
+    ctx_buf: PageBuf,
+    stack_buf: PageBuf,
+    jit_va: u64,
+    jit_size: u64,
+    exit_label_va: u64,
+    trap_table_ptr: *const (u32, u32),
+    trap_table_len: u64,
+    tramp_va: u64,
+    new_cr3: u64,
+    ctx_kva: u64,
+}
+
+/// Build a per-frame runtime: compile the Image (cached), allocate
+/// per-call mem/ctx/stack pages, populate mem from `arg`/`ro`/`rw`,
+/// initialise the frame-constant `JitContext` fields, and build the
+/// per-call page table.
+///
+/// Per-entry mutable state (regs, pc, gas, exit_*) is written by
+/// [`enter_frame`]; this function only touches frame-constant fields.
 ///
 /// # Safety
-/// Modifies CR3 + GDT + IDT during the call. Single-threaded by
-/// Hyperlight construction.
+/// Caller must keep the returned `FrameRuntime` alive for the lifetime
+/// of the [`KernelFrame`] (the PT references the buf pages by PA).
 #[allow(clippy::too_many_arguments)]
-pub unsafe fn run_pvm_with_mem(
+pub unsafe fn build_frame_runtime(
     image_hash: &javm_cap::CapHash,
     code: &[u8],
     bitmask: &[u8],
     jump_table: &[u32],
-    initial_gas: i64,
     entry_pc: u32,
-    initial_regs: [u64; 13],
     mem_size: u32,
     arg: MemRegion,
     ro: MemRegion,
     rw: MemRegion,
-) -> Option<ExitInfo> {
+) -> Option<FrameRuntime> {
     assert_eq!(code.len(), bitmask.len());
 
     // ---- compile (cached by image_hash) into per-Image arena --------------
@@ -271,14 +293,14 @@ pub unsafe fn run_pvm_with_mem(
 
     let mem_bytes = (mem_size as usize).next_multiple_of(PAGE_SIZE);
 
-    // ---- allocate per-invocation buffers ---------------------------------
-    // CTX (mutable, written by JIT every instruction) and per-call MEM /
+    // ---- allocate per-frame buffers --------------------------------------
+    // CTX (mutable, written by JIT every instruction) and per-frame MEM /
     // STACK stay private. The five Image-shared regions live in `cached.arena`.
     let mem_buf = PageBuf::new(mem_bytes.max(PAGE_SIZE))?;
     let ctx_buf = PageBuf::new(PAGE_SIZE)?;
     let stack_buf = PageBuf::new(PAGE_SIZE)?;
 
-    // ---- populate mem regions ----------------------------------------------
+    // ---- populate mem regions (once, on build) ---------------------------
     // (mem_buf is already zeroed by alloc_zeroed.)
     for region in [arg, ro, rw] {
         if region.data.is_empty() {
@@ -299,17 +321,13 @@ pub unsafe fn run_pvm_with_mem(
         }
     }
 
-    // ---- build JitContext in the ctx page ----------------------------------
+    // ---- init frame-constant JitContext fields ----------------------------
     let ctx_kva = ctx_buf.kva();
     let ctx = ctx_kva as *mut JitContext;
-
     // SAFETY: ctx points to a fresh zeroed ctx page. Pointer fields use
-    // the per-Image VAs computed above (not the old fixed constants).
+    // the per-Image VAs computed above. Per-entry fields (regs/pc/gas/
+    // exit_*) are zeroed and will be overwritten by `enter_frame`.
     unsafe {
-        (*ctx).regs = initial_regs;
-        (*ctx).gas = initial_gas;
-        (*ctx).exit_reason = 0;
-        (*ctx).exit_arg = 0;
         (*ctx).heap_base = 0;
         (*ctx).heap_top = 0;
         (*ctx).jt_ptr = jt_va as *const u32;
@@ -319,7 +337,6 @@ pub unsafe fn run_pvm_with_mem(
         (*ctx).bb_len = bitmask.len() as u32;
         (*ctx)._pad1 = 0;
         (*ctx).entry_pc = entry_pc;
-        (*ctx).pc = entry_pc;
         (*ctx).dispatch_table = dispatch_va as *const i32;
         (*ctx).code_base = jit_va;
         (*ctx).flat_buf = MEM_VA_M as *mut u8;
@@ -329,8 +346,8 @@ pub unsafe fn run_pvm_with_mem(
         (*ctx)._pad3 = 0;
     }
 
-    // ---- build the page table ----------------------------------------------
-    // CTX + MEM + STACK are per-call: each maps fresh PD/PT pages owned
+    // ---- build the page table --------------------------------------------
+    // CTX + MEM + STACK are per-frame: each maps fresh PD/PT pages owned
     // by this PageTable. The per-Image arena lives under a shared PD
     // owned by the Image's TemplatePT; install_borrowed_pd writes its
     // PA into PDPT[1] of the META PML4 slot without per-call alloc.
@@ -348,34 +365,74 @@ pub unsafe fn run_pvm_with_mem(
     )?;
     let new_cr3 = pt.cr3()?;
 
-    // ---- install ring-3 GDT/IDT + JIT #PF handler --------------------------
+    Some(FrameRuntime {
+        pt,
+        mem_buf,
+        ctx_buf,
+        stack_buf,
+        jit_va,
+        jit_size: cached.jit_size as u64,
+        exit_label_va: jit_va + cached.exit_label_offset as u64,
+        trap_table_ptr: cached.trap_table.as_ptr(),
+        trap_table_len: cached.trap_table.len() as u64,
+        tramp_va,
+        new_cr3,
+        ctx_kva,
+    })
+}
+
+/// Enter ring 3 on `rt`. Updates per-entry `JitContext` fields (regs,
+/// pc, gas, exit_*), publishes the #PF handler atomics, drops to
+/// ring 3, then reads back the post-exit state.
+///
+/// # Safety
+/// Mutates CR3 + GDT + IDT during the call. Single-threaded by
+/// Hyperlight construction.
+pub unsafe fn enter_frame(
+    rt: &mut FrameRuntime,
+    initial_gas: i64,
+    entry_pc: u32,
+    initial_regs: [u64; 13],
+) -> ExitInfo {
+    let ctx = rt.ctx_kva as *mut JitContext;
+    // SAFETY: ctx_kva owned by `rt.ctx_buf`, alive across this call.
+    unsafe {
+        (*ctx).regs = initial_regs;
+        (*ctx).gas = initial_gas;
+        (*ctx).exit_reason = 0;
+        (*ctx).exit_arg = 0;
+        (*ctx).entry_pc = entry_pc;
+        (*ctx).pc = entry_pc;
+    }
+
+    // ---- install ring-3 GDT/IDT + JIT #PF handler ------------------------
     // SAFETY: ring-0 mutation of GDT/IDT; serialised by Hyperlight.
     unsafe { ring3::install_ring3_exit_gate() };
 
-    JIT_CODE_BASE.store(jit_va, Ordering::SeqCst);
-    JIT_CODE_LEN.store(cached.jit_size as u64, Ordering::SeqCst);
-    EXIT_LABEL_VA.store(jit_va + cached.exit_label_offset as u64, Ordering::SeqCst);
-    TRAP_TABLE_PTR.store(
-        cached.trap_table.as_ptr() as *mut (u32, u32),
-        Ordering::SeqCst,
-    );
-    TRAP_TABLE_LEN.store(cached.trap_table.len() as u64, Ordering::SeqCst);
-    CTX_KVA.store(ctx_kva, Ordering::SeqCst);
+    JIT_CODE_BASE.store(rt.jit_va, Ordering::SeqCst);
+    JIT_CODE_LEN.store(rt.jit_size, Ordering::SeqCst);
+    EXIT_LABEL_VA.store(rt.exit_label_va, Ordering::SeqCst);
+    TRAP_TABLE_PTR.store(rt.trap_table_ptr as *mut (u32, u32), Ordering::SeqCst);
+    TRAP_TABLE_LEN.store(rt.trap_table_len, Ordering::SeqCst);
+    CTX_KVA.store(rt.ctx_kva, Ordering::SeqCst);
     HANDLERS[14].store(jit_pf_handler as *const () as u64, Ordering::Release);
 
-    // ---- drop to ring 3 ----------------------------------------------------
-    let user_stack_top = STACK_VA_M + stack_buf.size();
+    let user_stack_top = STACK_VA_M + rt.stack_buf.size();
     // SAFETY: trampoline (inside the Image arena) + stack mapped above;
     // new_cr3 carries kernel half.
-    let _user_rax = unsafe { ring3::nub_enter_ring3(tramp_va, user_stack_top, new_cr3) };
+    let _user_rax = unsafe { ring3::nub_enter_ring3(rt.tramp_va, user_stack_top, rt.new_cr3) };
 
     HANDLERS[14].store(0, Ordering::Release);
     TRAP_TABLE_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);
     TRAP_TABLE_LEN.store(0, Ordering::SeqCst);
     JIT_CODE_LEN.store(0, Ordering::SeqCst);
 
-    // SAFETY: ctx_kva still points to the same page (ctx_buf alive until end of fn).
-    let info = unsafe {
+    // Suppress unused-field warning: `pt` is referenced indirectly via
+    // `new_cr3` (the PML4's PA) and kept alive by owning the page tables.
+    let _ = &rt.pt;
+
+    // SAFETY: ctx_kva still points to the same page (ctx_buf alive).
+    unsafe {
         ExitInfo {
             exit_reason: (*ctx).exit_reason,
             exit_arg: (*ctx).exit_arg,
@@ -383,11 +440,5 @@ pub unsafe fn run_pvm_with_mem(
             regs: (*ctx).regs,
             pc: (*ctx).pc,
         }
-    };
-
-    // PageTable + all PageBufs drop here, freeing per-invocation memory
-    // back to talc.
-    drop(pt);
-
-    Some(info)
+    }
 }

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -164,7 +164,7 @@ pub struct ExitInfo {
 
 const MEM_VA_M: u64 = 0;
 /// PML4 slot 1 (base 512 GiB) hosts CTX + the per-Image arena + STACK.
-/// MEM stays in PML4[0] at VA 0 so PVM addresses are still native VAs.
+/// MEM stays in `PML4[0]` at VA 0 so PVM addresses are still native VAs.
 /// Placing CTX in this slot too keeps it within ±2 GiB of the JIT
 /// region so codegen's RIP-relative addressing reaches it.
 ///

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -23,33 +23,35 @@
 //! META, which is within ±2 GiB.
 //!
 //! ```text
-//!   MEM_VA   = 0                               mem_size bytes guest memory
-//!   CTX_VA   = 4 GiB                           4 KiB JitContext
+//!   MEM_VA   = 0                  mem_size bytes guest memory     (user-RW)
+//!   CTX_VA   = 4 GiB              4 KiB JitContext                (user-RW)
 //!
-//!   META_BASE= 4 GiB + 16 MiB                  clear of CTX, well-aligned
-//!   BB_VA    = META_BASE                       bitmask scratch (user-RO)
-//!   JT_VA    = META_BASE + 16 MiB              jump-table scratch (user-RO)
-//!   DISPATCH = META_BASE + 32 MiB              dispatch table (user-RO)
-//!   JIT_VA   = META_BASE + 64 MiB              JIT'd native (user-RX)
-//!   TRAMP    = META_BASE + 128 MiB             trampoline (user-RX)
-//!   STACK    = TRAMP + 4 KiB                   stack (user-RW)
+//!   META_BASE= 4 GiB + 16 MiB     per-Image arena base
+//!                                 (BB | JT | DISPATCH | JIT | TRAMP)
+//!     BB / JT / DISPATCH                                          (user-RO)
+//!     JIT / TRAMP                                                 (user-RX)
+//!
+//!   STACK    = META + 1 GiB       ring-3 x86 stack, 4 KiB         (user-RW)
 //! ```
 //!
-//! All backing pages come from the global heap (talc). Per-page PVM
-//! `RO`/`RW` enforcement was removed alongside the PERMS sweep — the
-//! per-invocation PT itself enforces bounds (faults outside
-//! `[MEM_VA, MEM_VA + mem_size)` route via `jit_pf_handler`).
+//! The Image arena lives in [`jit_cache::CompiledImage`] (one per
+//! Image, allocated once and mapped read-only into every Instance's
+//! PT). Per-call work allocates only CTX / MEM / STACK pages from
+//! talc, then maps the cached arena's pages into the per-invocation
+//! page table.
+//!
+//! Per-page PVM `RO`/`RW` enforcement is delegated to the page table —
+//! faults outside `[MEM_VA, MEM_VA + mem_size)` route via
+//! `jit_pf_handler`.
 
 #![cfg(target_os = "none")]
 
 extern crate alloc;
 
 use crate::jit_cache;
+use crate::page_alloc::PageBuf;
 use crate::paging::{PAGE_SIZE, PageTable, Perm};
 use crate::ring3;
-use alloc::alloc::{alloc_zeroed, dealloc};
-use core::alloc::Layout;
-use core::ptr::NonNull;
 use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
 use javm_recompiler_x86::JitContext;
@@ -161,64 +163,27 @@ pub struct ExitInfo {
 // 4 GiB; CTX must be outside that range to avoid spoofing.
 
 const MEM_VA_M: u64 = 0;
-const CTX_VA_M: u64 = 1u64 << 32; // 4 GiB — first page above PVM u32 range
-const META_BASE_M: u64 = CTX_VA_M + (1u64 << 24); // CTX + 16 MiB headroom
-const BB_VA_M: u64 = META_BASE_M;
-const JT_VA_M: u64 = META_BASE_M + (1u64 << 24); // +16 MiB
-const DISPATCH_VA_M: u64 = META_BASE_M + (1u64 << 25); // +32 MiB
-const JIT_VA_M: u64 = META_BASE_M + (1u64 << 26); // +64 MiB
-const TRAMP_VA_M: u64 = META_BASE_M + (1u64 << 27); // +128 MiB
-const STACK_VA_M: u64 = TRAMP_VA_M + PAGE_SIZE as u64;
+/// PML4 slot 1 (base 512 GiB) hosts CTX + the per-Image arena. MEM
+/// stays in PML4[0] at VA 0 so PVM addresses are still native VAs.
+/// Placing CTX in this slot too keeps it within ±2 GiB of the JIT
+/// region so codegen's RIP-relative addressing reaches it.
+const META_PML4_BASE: u64 = 1u64 << 39; // 512 GiB
+/// CTX sits at the slot base; the per-Image arena follows the CTX
+/// page. CTX_VA_M must match `javm_recompiler_x86::codegen::CTX_VA`.
+const CTX_VA_M: u64 = META_PML4_BASE;
+/// Base of the per-Image arena (BB | JT | DISPATCH | JIT | TRAMP),
+/// one page past CTX so CTX gets its own page-table leaf entry.
+const META_BASE_M: u64 = CTX_VA_M + PAGE_SIZE as u64;
+/// STACK_VA must sit at a fixed location outside the Image arena.
+/// 1 GiB past META_BASE — comfortably > any single Image's compiled
+/// arena footprint and still in PML4 slot 1.
+const STACK_VA_M: u64 = META_PML4_BASE + (1u64 << 30); // META + 1 GiB
 
 /// One PVM region (arg / ro / rw) to populate before entry.
 #[derive(Clone, Copy)]
 pub struct MemRegion<'a> {
     pub start: u32,
     pub data: &'a [u8],
-}
-
-/// Page-aligned heap allocation. Frees on drop.
-struct PageBuf {
-    ptr: NonNull<u8>,
-    layout: Layout,
-}
-
-impl PageBuf {
-    /// Allocate `size` bytes (rounded up to a page boundary), zeroed,
-    /// aligned to a page.
-    fn new(size: usize) -> Option<Self> {
-        let size = size.next_multiple_of(PAGE_SIZE).max(PAGE_SIZE);
-        let layout = Layout::from_size_align(size, PAGE_SIZE).ok()?;
-        // SAFETY: layout is non-zero and well-formed.
-        let raw = unsafe { alloc_zeroed(layout) };
-        let ptr = NonNull::new(raw)?;
-        Some(Self { ptr, layout })
-    }
-
-    /// Kernel VA of the buffer.
-    fn kva(&self) -> u64 {
-        self.ptr.as_ptr() as u64
-    }
-
-    /// Physical address. Talc heap lives at high kernel VA (Stage F);
-    /// `va_to_pa` walks back through the kernel-half offset.
-    fn pa(&self) -> u64 {
-        crate::paging::va_to_pa(self.kva()).expect("talc kva must lie in kernel half")
-    }
-
-    /// Total size in bytes (multiple of `PAGE_SIZE`).
-    fn size(&self) -> u64 {
-        self.layout.size() as u64
-    }
-}
-
-impl Drop for PageBuf {
-    fn drop(&mut self) {
-        // SAFETY: layout matches the one we passed to `alloc_zeroed`.
-        unsafe {
-            dealloc(self.ptr.as_ptr(), self.layout);
-        }
-    }
 }
 
 /// Run a PVM program with a real flat-memory mapping at ring 3.
@@ -252,7 +217,7 @@ pub unsafe fn run_pvm_with_mem(
 ) -> Option<ExitInfo> {
     assert_eq!(code.len(), bitmask.len());
 
-    // ---- compile (cached by image_hash) -----------------------------------
+    // ---- compile (cached by image_hash) into per-Image arena --------------
     //
     // The codegen reads the helper-fn addresses to look up the access
     // width (`if fn_addr == helpers.mem_write_u8 { width = 1 }`).
@@ -278,54 +243,30 @@ pub unsafe fn run_pvm_with_mem(
         code,
         bitmask,
         jump_table,
-        JIT_VA_M,
+        META_BASE_M,
+        CTX_VA_M,
         javm_exec::gas_cost::DEFAULT_MEM_CYCLES,
         helpers,
     );
-    let native: &[u8] = cached.native.as_slice();
-    let dispatch_table: &[i32] = cached.dispatch_table.as_slice();
-    let trap_table: &[(u32, u32)] = cached.trap_table.as_slice();
-    let exit_label_offset = cached.exit_label_offset;
-    if native.is_empty() {
+    if cached.jit_size == 0 {
         return None;
     }
 
-    // ---- size each buffer to the actual program --------------------------
+    // ---- per-region VAs derived from the cached arena offsets -------------
+    let bb_va = META_BASE_M + cached.bb_offset as u64;
+    let jt_va = META_BASE_M + cached.jt_offset as u64;
+    let dispatch_va = META_BASE_M + cached.dispatch_offset as u64;
+    let jit_va = META_BASE_M + cached.jit_offset as u64;
+    let tramp_va = META_BASE_M + cached.tramp_offset as u64;
+
     let mem_bytes = (mem_size as usize).next_multiple_of(PAGE_SIZE);
-    let bb_bytes = bitmask.len();
-    let jt_bytes = jump_table.len().checked_mul(core::mem::size_of::<u32>())?;
-    let dispatch_bytes = dispatch_table
-        .len()
-        .checked_mul(core::mem::size_of::<i32>())?;
-    let dispatch_size_bytes = code.len().checked_mul(core::mem::size_of::<i32>())?;
-    let jit_bytes = native.len();
 
     // ---- allocate per-invocation buffers ---------------------------------
+    // CTX (mutable, written by JIT every instruction) and per-call MEM /
+    // STACK stay private. The five Image-shared regions live in `cached.arena`.
     let mem_buf = PageBuf::new(mem_bytes.max(PAGE_SIZE))?;
     let ctx_buf = PageBuf::new(PAGE_SIZE)?;
-    let bb_buf = PageBuf::new(bb_bytes.max(PAGE_SIZE))?;
-    let jt_buf = PageBuf::new(jt_bytes.max(PAGE_SIZE))?;
-    let dispatch_buf = PageBuf::new(dispatch_size_bytes.max(PAGE_SIZE))?;
-    let jit_buf = PageBuf::new(jit_bytes)?;
-    let tramp_buf = PageBuf::new(PAGE_SIZE)?;
     let stack_buf = PageBuf::new(PAGE_SIZE)?;
-
-    // ---- write the JIT code ------------------------------------------------
-    // SAFETY: jit_buf has at least `jit_bytes` of capacity.
-    unsafe {
-        core::ptr::copy_nonoverlapping(native.as_ptr(), jit_buf.kva() as *mut u8, jit_bytes);
-    }
-
-    // ---- write bb_starts / jt scratch --------------------------------------
-    // SAFETY: bb_buf/jt_buf are sized to fit the actual lengths.
-    unsafe {
-        core::ptr::copy_nonoverlapping(bitmask.as_ptr(), bb_buf.kva() as *mut u8, bb_bytes);
-        core::ptr::copy_nonoverlapping(
-            jump_table.as_ptr() as *const u8,
-            jt_buf.kva() as *mut u8,
-            jt_bytes,
-        );
-    }
 
     // ---- populate mem regions ----------------------------------------------
     // (mem_buf is already zeroed by alloc_zeroed.)
@@ -348,22 +289,12 @@ pub unsafe fn run_pvm_with_mem(
         }
     }
 
-    // ---- write the dispatch table -----------------------------------------
-    // SAFETY: dispatch_buf is sized to dispatch_size_bytes (capped at code.len() * 4);
-    // dispatch_bytes ≤ dispatch_size_bytes since dispatch_table.len() ≤ code.len().
-    unsafe {
-        core::ptr::copy_nonoverlapping(
-            dispatch_table.as_ptr() as *const u8,
-            dispatch_buf.kva() as *mut u8,
-            dispatch_bytes,
-        );
-    }
-
     // ---- build JitContext in the ctx page ----------------------------------
     let ctx_kva = ctx_buf.kva();
     let ctx = ctx_kva as *mut JitContext;
 
-    // SAFETY: ctx points to a fresh zeroed ctx page.
+    // SAFETY: ctx points to a fresh zeroed ctx page. Pointer fields use
+    // the per-Image VAs computed above (not the old fixed constants).
     unsafe {
         (*ctx).regs = initial_regs;
         (*ctx).gas = initial_gas;
@@ -371,45 +302,21 @@ pub unsafe fn run_pvm_with_mem(
         (*ctx).exit_arg = 0;
         (*ctx).heap_base = 0;
         (*ctx).heap_top = 0;
-        (*ctx).jt_ptr = JT_VA_M as *const u32;
+        (*ctx).jt_ptr = jt_va as *const u32;
         (*ctx).jt_len = jump_table.len() as u32;
         (*ctx)._pad0 = 0;
-        (*ctx).bb_starts = BB_VA_M as *const u8;
+        (*ctx).bb_starts = bb_va as *const u8;
         (*ctx).bb_len = bitmask.len() as u32;
         (*ctx)._pad1 = 0;
         (*ctx).entry_pc = entry_pc;
         (*ctx).pc = entry_pc;
-        (*ctx).dispatch_table = DISPATCH_VA_M as *const i32;
-        (*ctx).code_base = JIT_VA_M;
+        (*ctx).dispatch_table = dispatch_va as *const i32;
+        (*ctx).code_base = jit_va;
         (*ctx).flat_buf = MEM_VA_M as *mut u8;
         (*ctx).fast_reentry = 0;
         (*ctx)._pad2 = 0;
         (*ctx).max_heap_pages = 0;
         (*ctx)._pad3 = 0;
-    }
-
-    // ---- write the trampoline ----------------------------------------------
-    // mov rdi, ctx_va    ; 48 BF <imm64>  (10)
-    // mov rax, jit_va    ; 48 B8 <imm64>  (10)
-    // call rax           ; FF D0          (2)
-    // int 0x81           ; CD 81          (2)
-    // ud2                ; 0F 0B          (2)
-    let mut tramp = [0u8; 26];
-    tramp[0] = 0x48;
-    tramp[1] = 0xBF;
-    tramp[2..10].copy_from_slice(&CTX_VA_M.to_le_bytes());
-    tramp[10] = 0x48;
-    tramp[11] = 0xB8;
-    tramp[12..20].copy_from_slice(&JIT_VA_M.to_le_bytes());
-    tramp[20] = 0xFF;
-    tramp[21] = 0xD0;
-    tramp[22] = 0xCD;
-    tramp[23] = 0x81;
-    tramp[24] = 0x0F;
-    tramp[25] = 0x0B;
-    // SAFETY: tramp_buf is a 4 KiB page.
-    unsafe {
-        core::ptr::copy_nonoverlapping(tramp.as_ptr(), tramp_buf.kva() as *mut u8, tramp.len());
     }
 
     // ---- build the page table ----------------------------------------------
@@ -418,19 +325,17 @@ pub unsafe fn run_pvm_with_mem(
     if mem_bytes > 0 {
         pt.map(MEM_VA_M, mem_buf.pa(), mem_buf.size(), Perm::user_rw())?;
     }
-    pt.map(BB_VA_M, bb_buf.pa(), bb_buf.size(), Perm::user_ro())?;
-    pt.map(JT_VA_M, jt_buf.pa(), jt_buf.size(), Perm::user_ro())?;
+    // Map the Image arena: BB / JT / DISPATCH as user-RO, JIT / TRAMP as
+    // user-RX. Three `pt.map` calls in place of the old five (and they
+    // reference the per-Image cached arena, not per-call buffers).
+    let arena_pa = cached.arena.pa();
+    let ro_region_size = (cached.bb_size + cached.jt_size + cached.dispatch_size) as u64;
+    let rx_region_size = (cached.jit_size + cached.tramp_size) as u64;
+    pt.map(bb_va, arena_pa, ro_region_size, Perm::user_ro())?;
     pt.map(
-        DISPATCH_VA_M,
-        dispatch_buf.pa(),
-        dispatch_buf.size(),
-        Perm::user_ro(),
-    )?;
-    pt.map(JIT_VA_M, jit_buf.pa(), jit_buf.size(), Perm::user_rx())?;
-    pt.map(
-        TRAMP_VA_M,
-        tramp_buf.pa(),
-        tramp_buf.size(),
+        jit_va,
+        arena_pa + cached.jit_offset as u64,
+        rx_region_size,
         Perm::user_rx(),
     )?;
     pt.map(
@@ -445,18 +350,22 @@ pub unsafe fn run_pvm_with_mem(
     // SAFETY: ring-0 mutation of GDT/IDT; serialised by Hyperlight.
     unsafe { ring3::install_ring3_exit_gate() };
 
-    JIT_CODE_BASE.store(JIT_VA_M, Ordering::SeqCst);
-    JIT_CODE_LEN.store(jit_buf.size(), Ordering::SeqCst);
-    EXIT_LABEL_VA.store(JIT_VA_M + exit_label_offset as u64, Ordering::SeqCst);
-    TRAP_TABLE_PTR.store(trap_table.as_ptr() as *mut (u32, u32), Ordering::SeqCst);
-    TRAP_TABLE_LEN.store(trap_table.len() as u64, Ordering::SeqCst);
+    JIT_CODE_BASE.store(jit_va, Ordering::SeqCst);
+    JIT_CODE_LEN.store(cached.jit_size as u64, Ordering::SeqCst);
+    EXIT_LABEL_VA.store(jit_va + cached.exit_label_offset as u64, Ordering::SeqCst);
+    TRAP_TABLE_PTR.store(
+        cached.trap_table.as_ptr() as *mut (u32, u32),
+        Ordering::SeqCst,
+    );
+    TRAP_TABLE_LEN.store(cached.trap_table.len() as u64, Ordering::SeqCst);
     CTX_KVA.store(ctx_kva, Ordering::SeqCst);
     HANDLERS[14].store(jit_pf_handler as *const () as u64, Ordering::Release);
 
     // ---- drop to ring 3 ----------------------------------------------------
     let user_stack_top = STACK_VA_M + stack_buf.size();
-    // SAFETY: trampoline + stack mapped above; new_cr3 carries kernel half.
-    let _user_rax = unsafe { ring3::nub_enter_ring3(TRAMP_VA_M, user_stack_top, new_cr3) };
+    // SAFETY: trampoline (inside the Image arena) + stack mapped above;
+    // new_cr3 carries kernel half.
+    let _user_rax = unsafe { ring3::nub_enter_ring3(tramp_va, user_stack_top, new_cr3) };
 
     HANDLERS[14].store(0, Ordering::Release);
     TRAP_TABLE_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -163,21 +163,31 @@ pub struct ExitInfo {
 // 4 GiB; CTX must be outside that range to avoid spoofing.
 
 const MEM_VA_M: u64 = 0;
-/// PML4 slot 1 (base 512 GiB) hosts CTX + the per-Image arena. MEM
-/// stays in PML4[0] at VA 0 so PVM addresses are still native VAs.
+/// PML4 slot 1 (base 512 GiB) hosts CTX + the per-Image arena + STACK.
+/// MEM stays in PML4[0] at VA 0 so PVM addresses are still native VAs.
 /// Placing CTX in this slot too keeps it within ±2 GiB of the JIT
 /// region so codegen's RIP-relative addressing reaches it.
+///
+/// The three sub-regions occupy distinct 1 GiB PDPT slots within the
+/// PML4 slot so the per-Image template PT can own the META PD without
+/// colliding with the per-call CTX/STACK PDs.
+///
+/// ```text
+///   PML4[1] (512..1024 GiB)
+///     PDPT[0] (512..513 GiB)  ← CTX, per-call alloc
+///     PDPT[1] (513..514 GiB)  ← META arena, template-owned
+///     PDPT[2] (514..515 GiB)  ← STACK, per-call alloc
+/// ```
 const META_PML4_BASE: u64 = 1u64 << 39; // 512 GiB
-/// CTX sits at the slot base; the per-Image arena follows the CTX
-/// page. CTX_VA_M must match `javm_recompiler_x86::codegen::CTX_VA`.
+/// CTX sits at the slot base. CTX_VA_M must match
+/// `javm_recompiler_x86::codegen::CTX_VA`.
 const CTX_VA_M: u64 = META_PML4_BASE;
-/// Base of the per-Image arena (BB | JT | DISPATCH | JIT | TRAMP),
-/// one page past CTX so CTX gets its own page-table leaf entry.
-const META_BASE_M: u64 = CTX_VA_M + PAGE_SIZE as u64;
-/// STACK_VA must sit at a fixed location outside the Image arena.
-/// 1 GiB past META_BASE — comfortably > any single Image's compiled
-/// arena footprint and still in PML4 slot 1.
-const STACK_VA_M: u64 = META_PML4_BASE + (1u64 << 30); // META + 1 GiB
+/// Base of the per-Image arena (BB | JT | DISPATCH | JIT | TRAMP).
+/// 1 GiB past CTX so the arena occupies its own PDPT slot, enabling
+/// template-PT sharing of the entire PD subtree.
+const META_BASE_M: u64 = META_PML4_BASE + (1u64 << 30);
+/// STACK_VA — 2 GiB past the PML4 base, in its own PDPT slot.
+const STACK_VA_M: u64 = META_PML4_BASE + (2u64 << 30);
 
 /// One PVM region (arg / ro / rw) to populate before entry.
 #[derive(Clone, Copy)]
@@ -320,24 +330,16 @@ pub unsafe fn run_pvm_with_mem(
     }
 
     // ---- build the page table ----------------------------------------------
+    // CTX + MEM + STACK are per-call: each maps fresh PD/PT pages owned
+    // by this PageTable. The per-Image arena lives under a shared PD
+    // owned by the Image's TemplatePT; install_borrowed_pd writes its
+    // PA into PDPT[1] of the META PML4 slot without per-call alloc.
     let mut pt = PageTable::new()?;
     pt.map(CTX_VA_M, ctx_buf.pa(), ctx_buf.size(), Perm::user_rw())?;
     if mem_bytes > 0 {
         pt.map(MEM_VA_M, mem_buf.pa(), mem_buf.size(), Perm::user_rw())?;
     }
-    // Map the Image arena: BB / JT / DISPATCH as user-RO, JIT / TRAMP as
-    // user-RX. Three `pt.map` calls in place of the old five (and they
-    // reference the per-Image cached arena, not per-call buffers).
-    let arena_pa = cached.arena.pa();
-    let ro_region_size = (cached.bb_size + cached.jt_size + cached.dispatch_size) as u64;
-    let rx_region_size = (cached.jit_size + cached.tramp_size) as u64;
-    pt.map(bb_va, arena_pa, ro_region_size, Perm::user_ro())?;
-    pt.map(
-        jit_va,
-        arena_pa + cached.jit_offset as u64,
-        rx_region_size,
-        Perm::user_rx(),
-    )?;
+    pt.install_borrowed_pd(META_BASE_M, cached.template_pd_pa)?;
     pt.map(
         STACK_VA_M,
         stack_buf.pa(),

--- a/rust/nub-arch-x86/src/main.rs
+++ b/rust/nub-arch-x86/src/main.rs
@@ -36,6 +36,8 @@ mod jit_cache;
 #[cfg(target_os = "none")]
 mod jit_run;
 #[cfg(target_os = "none")]
+mod page_alloc;
+#[cfg(target_os = "none")]
 mod paging;
 #[cfg(target_os = "none")]
 mod ring3;

--- a/rust/nub-arch-x86/src/page_alloc.rs
+++ b/rust/nub-arch-x86/src/page_alloc.rs
@@ -1,0 +1,72 @@
+//! Page-aligned allocations from talc.
+//!
+//! Used by both [`jit_cache`](crate::jit_cache) (per-Image arenas
+//! holding the BB/JT/DISPATCH/JIT/TRAMP regions) and
+//! [`jit_run`](crate::jit_run) (per-call CTX, MEM, STACK pages).
+//!
+//! All allocations come from the global heap (talc); the page-aligned
+//! [`Layout`] guarantees physical pages we can plug into a ring-3
+//! page table directly.
+
+#![cfg(target_os = "none")]
+
+extern crate alloc;
+
+use alloc::alloc::{alloc_zeroed, dealloc};
+use core::alloc::Layout;
+use core::ptr::NonNull;
+
+use crate::paging::PAGE_SIZE;
+
+/// Page-aligned heap allocation. Frees on drop. Used for buffers that
+/// need a stable physical address mappable into a ring-3 page table.
+pub struct PageBuf {
+    ptr: NonNull<u8>,
+    layout: Layout,
+}
+
+impl PageBuf {
+    /// Allocate `size` bytes (rounded up to a page boundary), zeroed,
+    /// aligned to a page.
+    pub fn new(size: usize) -> Option<Self> {
+        let size = size.next_multiple_of(PAGE_SIZE).max(PAGE_SIZE);
+        let layout = Layout::from_size_align(size, PAGE_SIZE).ok()?;
+        // SAFETY: layout is non-zero and well-formed.
+        let raw = unsafe { alloc_zeroed(layout) };
+        let ptr = NonNull::new(raw)?;
+        Some(Self { ptr, layout })
+    }
+
+    /// Kernel VA of the buffer.
+    pub fn kva(&self) -> u64 {
+        self.ptr.as_ptr() as u64
+    }
+
+    /// Physical address. Talc heap lives at high kernel VA (Stage F);
+    /// `va_to_pa` walks back through the kernel-half offset.
+    pub fn pa(&self) -> u64 {
+        crate::paging::va_to_pa(self.kva()).expect("talc kva must lie in kernel half")
+    }
+
+    /// Total size in bytes (multiple of `PAGE_SIZE`).
+    pub fn size(&self) -> u64 {
+        self.layout.size() as u64
+    }
+
+    /// Borrow the buffer as a mutable byte slice. Useful for filling
+    /// the arena layout from compile output.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: ptr is valid for `layout.size()` bytes; we hold
+        // unique access through `&mut self`.
+        unsafe { core::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.layout.size()) }
+    }
+}
+
+impl Drop for PageBuf {
+    fn drop(&mut self) {
+        // SAFETY: layout matches the one we passed to `alloc_zeroed`.
+        unsafe {
+            dealloc(self.ptr.as_ptr(), self.layout);
+        }
+    }
+}

--- a/rust/nub-arch-x86/src/paging.rs
+++ b/rust/nub-arch-x86/src/paging.rs
@@ -176,6 +176,80 @@ fn alloc_table() -> Option<NonNull<Table>> {
     NonNull::new(ptr as *mut Table)
 }
 
+/// Per-Image template page-directory subtree. Owns a single PD page
+/// covering 1 GiB of VA space and all PT pages it references, with
+/// leaf PTEs prefilled to point at the Image's arena pages.
+///
+/// Multiple per-call [`PageTable`]s install this template via
+/// [`PageTable::install_borrowed_pd`], which writes the template's PD
+/// physical address into one PDPT entry of the per-call PT. The
+/// per-call PT does NOT own the template's pages — they live for as
+/// long as the parent `CompiledImage` (effectively `'static` in V1).
+///
+/// The PD covers a 1 GiB-aligned VA range; leaf PTEs are addressed by
+/// the offset within that range (`0..1 GiB`).
+pub struct TemplatePT {
+    pd: NonNull<Table>,
+    /// PD page + every PT page allocated under it. Freed in Drop.
+    owned: Vec<NonNull<Table>>,
+}
+
+impl TemplatePT {
+    /// Allocate a fresh PD page. The PD starts empty; populate it with
+    /// [`TemplatePT::map_leaf`] before installing the template.
+    pub fn new() -> Option<Self> {
+        let pd = alloc_table()?;
+        let mut owned = Vec::with_capacity(4);
+        owned.push(pd);
+        Some(Self { pd, owned })
+    }
+
+    /// Add a leaf PTE for a single 4 KiB page at `offset` bytes into
+    /// the 1 GiB region this PD covers. `offset` must be 4 KiB-aligned
+    /// and strictly less than 1 GiB.
+    pub fn map_leaf(&mut self, offset: u64, pa: u64, perm: Perm) -> Option<()> {
+        assert!(offset.is_multiple_of(PAGE_SIZE as u64));
+        assert!(offset < (1u64 << 30));
+        let idx2 = ((offset >> 21) & 0x1FF) as usize;
+        let idx1 = ((offset >> 12) & 0x1FF) as usize;
+        // SAFETY: self.pd is a fresh table this template owns.
+        let pd = unsafe { &mut *self.pd.as_ptr() };
+        let inner_flags = flag::P | flag::RW | flag::US;
+        let pt_ptr = if pd[idx2] & flag::P != 0 {
+            let pa = pd[idx2] & PA_MASK;
+            pa_to_va(pa)? as *mut Table
+        } else {
+            let new_pt = alloc_table()?;
+            self.owned.push(new_pt);
+            let va = new_pt.as_ptr() as u64;
+            let pa = va_to_pa(va)?;
+            pd[idx2] = (pa & PA_MASK) | inner_flags;
+            new_pt.as_ptr()
+        };
+        // SAFETY: pt_ptr is a table allocated by us (either fresh or
+        // recovered from a present PDE); 512 entries are writable.
+        let pt = unsafe { &mut *pt_ptr };
+        pt[idx1] = (pa & PA_MASK) | perm.pte_flags();
+        Some(())
+    }
+
+    /// Physical address of the PD page — what per-call PTs install.
+    pub fn pd_pa(&self) -> Option<u64> {
+        va_to_pa(self.pd.as_ptr() as u64)
+    }
+}
+
+impl Drop for TemplatePT {
+    fn drop(&mut self) {
+        for table in self.owned.drain(..) {
+            // SAFETY: every entry came from `alloc_table` with TABLE_LAYOUT.
+            unsafe {
+                dealloc(table.as_ptr() as *mut u8, TABLE_LAYOUT);
+            }
+        }
+    }
+}
+
 /// Per-invocation page table. Owns its PML4 plus every intermediate
 /// table allocated via [`PageTable::map`]. All backing pages are freed
 /// when the `PageTable` is dropped.
@@ -263,6 +337,30 @@ impl PageTable {
 
         let pt = unsafe { &mut *pt };
         pt[idx1] = (pa & PA_MASK) | perm.pte_flags();
+        Some(())
+    }
+
+    /// Install a borrowed PD pointer (from a [`TemplatePT`]) at the
+    /// PDPT entry covering `va`. The PDPT is auto-allocated and owned
+    /// by this `PageTable` (freed on Drop); the PD (and the PT pages
+    /// it references) belong to the template and survive `Drop`.
+    ///
+    /// `va` must be 1 GiB-aligned — it identifies which PDPT entry
+    /// receives the template's PD. Any existing entry at that PDPT
+    /// slot is overwritten (intended: caller has not mapped anything
+    /// in this 1 GiB range yet).
+    pub fn install_borrowed_pd(&mut self, va: u64, pd_pa: u64) -> Option<()> {
+        assert!(va.is_multiple_of(1u64 << 30));
+        let idx4 = ((va >> 39) & 0x1FF) as usize;
+        let idx3 = ((va >> 30) & 0x1FF) as usize;
+        let inner_flags = flag::P | flag::RW | flag::US;
+        // SAFETY: self.pml4 is owned by this PT.
+        let pml4 = unsafe { &mut *self.pml4.as_ptr() };
+        let pdpt = self.ensure_inner(&mut pml4[idx4], inner_flags)?;
+        // SAFETY: pdpt is a table this PT owns (just allocated or
+        // shallow-copied from the active CR3).
+        let pdpt = unsafe { &mut *pdpt };
+        pdpt[idx3] = (pd_pa & PA_MASK) | inner_flags;
         Some(())
     }
 

--- a/rust/nub-arch-x86/src/state_cache.rs
+++ b/rust/nub-arch-x86/src/state_cache.rs
@@ -11,9 +11,28 @@
 //! ([`STATE_CACHE_VA`]) via `MAP_FIXED_NOREPLACE` on the host side,
 //! which means every pointer the host wrote inside the region is
 //! directly dereferenceable here. The directory at
-//! [`CACHE_DIRECTORY_OFFSET`] holds `(CapHash, entry_va)` pairs that
-//! resolve cap-hash queries into a `&CacheEntry<TalcAlloc>` we can
-//! walk by pointer.
+//! [`CACHE_DIRECTORY_OFFSET`] holds `(CapHash, entry_va)` /
+//! `(CapRef, entry_va)` pairs that resolve cap queries into a
+//! `&CacheEntry<TalcAlloc>` we can walk by pointer.
+//!
+//! ## Handles vs. raw references
+//!
+//! Two flavors of lookup coexist:
+//!
+//! - The legacy `lookup_blob<A>` / `lookup_instance<A>` /
+//!   [`lookup_cap`] return `&'static CacheEntry<A>` / `&'static
+//!   Cap<TalcAlloc>` directly. The `'static` is a polite fiction —
+//!   the cache can free entries between RPCs — but it's safe within
+//!   a single RPC because Hyperlight serialises calls and the
+//!   per-RPC scratch-clear runs only after dispatch returns.
+//!
+//! - The new handle-returning variants
+//!   [`lookup_blob_handle`] / [`lookup_instance_handle`] return a
+//!   [`CacheHandle`] that bumps the entry's refcount on acquire and
+//!   decrements on drop. Storage is still cache-owned; the handle
+//!   only pins the entry against eviction during its lifetime.
+//!   These are the future-default — the legacy `'static` API will
+//!   migrate when callers can be updated incrementally.
 
 #![cfg(target_os = "none")]
 
@@ -29,13 +48,34 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use javm_cap::cap::Cap;
 use javm_cap::entry::CacheEntry;
 use nub_host_common::cache::{
-    CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheTalcLock, STATE_CACHE_GPA, STATE_CACHE_SIZE,
-    STATE_CACHE_VA, TalcAlloc,
+    CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheHandle, CacheTalcLock, STATE_CACHE_GPA,
+    STATE_CACHE_SIZE, STATE_CACHE_VA, TalcAlloc,
 };
 
 use crate::paging::{Perm, install_persistent_kernel_mapping};
 
+/// Refcount-bumping handle to a `CacheEntry<A>` resident in shared
+/// cache memory. The entry's storage is owned by the cache; the
+/// handle only protects the entry against eviction while it lives.
+pub type CapHandle<A> = CacheHandle<CacheEntry<A>>;
+
 static CACHE_MAPPED: AtomicBool = AtomicBool::new(false);
+
+/// One scratch entry tracked for end-of-RPC cleanup. Either a blob
+/// (keyed by hash slot index) or an instance (keyed by instance
+/// slot index). The directory slot is zeroed and the `CacheEntry`
+/// storage is reclaimed when the corresponding cleanup fires —
+/// provided no live [`CapHandle`] still references it.
+enum ScratchEntry {
+    Blob {
+        slot_idx: usize,
+        entry: NonNull<CacheEntry<TalcAlloc>>,
+    },
+    Instance {
+        slot_idx: usize,
+        entry: NonNull<CacheEntry<TalcAlloc>>,
+    },
+}
 
 /// Per-RPC tracker of guest-published cap entries so we can clear
 /// them at end of dispatch. The guest writes new caps into the
@@ -44,7 +84,7 @@ static CACHE_MAPPED: AtomicBool = AtomicBool::new(false);
 /// `derive_spawn`); they're cleared before the RPC returns so the
 /// host doesn't see stale "scratch" entries.
 struct ScratchTracker {
-    entries: Vec<(usize, NonNull<CacheEntry<TalcAlloc>>)>,
+    entries: Vec<ScratchEntry>,
 }
 
 /// SAFETY: single-threaded guest (Hyperlight serialises calls).
@@ -113,6 +153,19 @@ pub fn lookup_blob<A: Allocator + Clone>(hash: &[u8; 32]) -> Option<&'static Cac
     Some(unsafe { &*(va as *const CacheEntry<A>) })
 }
 
+/// Refcount-bumping variant of [`lookup_blob`]. Returns a
+/// [`CapHandle`] that pins the entry against eviction for its
+/// lifetime. Cheap to clone (one atomic increment); drop decrements.
+#[allow(dead_code)]
+pub fn lookup_blob_handle<A: Allocator + Clone + 'static>(hash: &[u8; 32]) -> Option<CapHandle<A>> {
+    let entry = lookup_blob::<A>(hash)?;
+    let ptr = NonNull::from(entry);
+    // SAFETY: entry came from `lookup_blob`, so the pointer is live;
+    // CacheHandle::acquire bumps the refcount under that liveness
+    // assumption.
+    Some(unsafe { CacheHandle::acquire(ptr) })
+}
+
 /// Resolve an instance ref to its `CacheEntry`.
 #[allow(dead_code)]
 pub fn lookup_instance<A: Allocator + Clone>(ref_id: u64) -> Option<&'static CacheEntry<A>> {
@@ -126,6 +179,15 @@ pub fn lookup_instance<A: Allocator + Clone>(ref_id: u64) -> Option<&'static Cac
     Some(unsafe { &*(va as *const CacheEntry<A>) })
 }
 
+/// Refcount-bumping variant of [`lookup_instance`].
+#[allow(dead_code)]
+pub fn lookup_instance_handle<A: Allocator + Clone + 'static>(ref_id: u64) -> Option<CapHandle<A>> {
+    let entry = lookup_instance::<A>(ref_id)?;
+    let ptr = NonNull::from(entry);
+    // SAFETY: entry came from `lookup_instance`; pointer is live.
+    Some(unsafe { CacheHandle::acquire(ptr) })
+}
+
 /// Convenience: resolve a blob hash directly to its inner `Cap`.
 pub fn lookup_cap(hash: &[u8; 32]) -> Option<&'static Cap<TalcAlloc>> {
     lookup_blob::<TalcAlloc>(hash).map(|e| &e.cap)
@@ -133,7 +195,6 @@ pub fn lookup_cap(hash: &[u8; 32]) -> Option<&'static Cap<TalcAlloc>> {
 
 /// `TalcAlloc` handle pointing at the shared cache region's lock at
 /// `STATE_CACHE_VA + 0`. Cheap to obtain (just wraps a pointer).
-#[allow(dead_code)]
 pub fn talc_alloc() -> TalcAlloc {
     ensure_mapped().expect("cache mapping");
     let lock_ptr =
@@ -168,11 +229,11 @@ pub fn publish_blob(hash: [u8; 32], cap: Cap<TalcAlloc>) -> Result<(), &'static 
 
     let dir_ptr = (STATE_CACHE_VA + CACHE_DIRECTORY_OFFSET as u64) as *mut CacheDirectory;
     // SAFETY: directory ptr is in the persistent kernel mapping.
-    let idx = unsafe { CacheDirectory::first_empty_blob(dir_ptr) }
+    let slot_idx = unsafe { CacheDirectory::first_empty_blob(dir_ptr) }
         .ok_or("publish_blob: directory full")?;
-    // SAFETY: idx < MAX_BLOB_SLOTS; directory ptr is valid.
+    // SAFETY: slot_idx < MAX_BLOB_SLOTS; directory ptr is valid.
     unsafe {
-        let slot = CacheDirectory::blob_slot_ptr(dir_ptr, idx);
+        let slot = CacheDirectory::blob_slot_ptr(dir_ptr, slot_idx);
         (*slot).hash = hash;
         (*slot).entry_va = entry_va;
         (*dir_ptr).blob_count_incr();
@@ -181,13 +242,77 @@ pub fn publish_blob(hash: [u8; 32], cap: Cap<TalcAlloc>) -> Result<(), &'static 
     // Record for cleanup at end of RPC.
     // SAFETY: single-threaded guest.
     let tracker = unsafe { &mut *SCRATCH.inner.get() };
-    tracker.entries.push((idx, entry_nn));
+    tracker.entries.push(ScratchEntry::Blob {
+        slot_idx,
+        entry: entry_nn,
+    });
     Ok(())
 }
 
-/// Clear all entries this RPC published via [`publish_blob`]. Walks
-/// the scratch tracker, zeroes each directory slot, and frees the
-/// `CacheEntry` storage on the shared talc heap. Idempotent.
+/// Publish a fresh `Cap::Instance` (or any mutable Cap variant) to
+/// the shared cache's instance bucket. Allocates a `CapRef` via the
+/// directory's shared `alloc_ref`, writes the `(ref_id, entry_va)`
+/// pair to the instance slot, and records the entry in [`SCRATCH`]
+/// for end-of-RPC cleanup.
+///
+/// Returns the assigned `CapRef` for cnode-slot insertion etc.
+#[allow(dead_code)]
+pub fn publish_instance(cap: Cap<TalcAlloc>) -> Result<u64, &'static str> {
+    let alloc = talc_alloc();
+    let entry = CacheEntry::new(cap);
+    let boxed = ABox::try_new_in(entry, alloc).map_err(|_| "publish_instance: alloc failed")?;
+    let entry_ptr: *mut CacheEntry<TalcAlloc> = ABox::into_raw(boxed);
+    let entry_nn = NonNull::new(entry_ptr).expect("just allocated");
+    let entry_va = entry_ptr as u64;
+
+    let dir_ptr = (STATE_CACHE_VA + CACHE_DIRECTORY_OFFSET as u64) as *mut CacheDirectory;
+    // SAFETY: dir_ptr is in the persistent kernel mapping; alloc_ref
+    // takes a const ptr and works through atomic ops.
+    let (ref_id, slot_idx) = match unsafe { CacheDirectory::alloc_ref(dir_ptr) } {
+        Some(pair) => pair,
+        None => {
+            // Roll back the allocation we made before bailing.
+            // SAFETY: we just got `entry_ptr` from `ABox::into_raw`.
+            unsafe {
+                let restored = ABox::from_raw_in(entry_ptr, talc_alloc());
+                drop(restored);
+            }
+            return Err("publish_instance: instance directory full");
+        }
+    };
+    // SAFETY: slot_idx < MAX_INSTANCE_SLOTS; alloc_ref's contract
+    // guarantees the slot is currently empty.
+    unsafe {
+        let slot = CacheDirectory::instance_slot_ptr(dir_ptr, slot_idx);
+        (*slot).ref_id = ref_id;
+        (*slot).entry_va = entry_va;
+        (*dir_ptr).instance_count_incr();
+    }
+
+    // Record for cleanup at end of RPC.
+    // SAFETY: single-threaded guest.
+    let tracker = unsafe { &mut *SCRATCH.inner.get() };
+    tracker.entries.push(ScratchEntry::Instance {
+        slot_idx,
+        entry: entry_nn,
+    });
+    Ok(ref_id)
+}
+
+/// Clear all entries this RPC published via [`publish_blob`] /
+/// [`publish_instance`]. Walks the scratch tracker; for each entry:
+///
+/// 1. If the entry's refcount is still > 1 (a [`CapHandle`] outside
+///    the now-dropped per-RPC stack still references it), log via
+///    debug-assert and SKIP the slot — leaving it live for the host
+///    to reclaim out of band. This is a safety net for bugs; in a
+///    well-disciplined RPC the stack drop should bring every handle
+///    down to refcount==1 (the scratch tracker's own reference).
+/// 2. Otherwise zero the directory slot and free the talc-heap
+///    `CacheEntry` storage.
+///
+/// MUST be called AFTER the call-loop's `Vec<KernelFrame>` has been
+/// dropped, so frame-held handles decrement their refcounts first.
 #[allow(dead_code)]
 pub fn clear_scratch() {
     let alloc = talc_alloc();
@@ -195,21 +320,52 @@ pub fn clear_scratch() {
 
     // SAFETY: single-threaded guest.
     let tracker = unsafe { &mut *SCRATCH.inner.get() };
-    for (idx, entry_ptr) in tracker.entries.drain(..) {
-        // SAFETY: idx is < MAX_BLOB_SLOTS; we wrote (hash, entry_va)
-        // when publishing.
-        unsafe {
-            let slot = CacheDirectory::blob_slot_ptr(dir_ptr, idx);
-            (*slot).hash = [0u8; 32];
-            (*slot).entry_va = 0;
-            (*dir_ptr).blob_count_decr();
+    for scratch in tracker.entries.drain(..) {
+        // Refcount safety net: if anyone still holds a handle, leave
+        // the entry alone. The publish protocol initialises refcount
+        // to 1 ("the scratch tracker's reference"); a refcount > 1
+        // means a live CapHandle is still pointing here.
+        let entry_ptr = match &scratch {
+            ScratchEntry::Blob { entry, .. } => entry.as_ptr(),
+            ScratchEntry::Instance { entry, .. } => entry.as_ptr(),
+        };
+        let count = unsafe { (*entry_ptr).refcount.load(Ordering::Acquire) };
+        if count > 1 {
+            // Leak rather than free under a live handle.
+            debug_assert!(
+                false,
+                "clear_scratch: entry still held (refcount={count}); skipping free"
+            );
+            continue;
         }
-        // SAFETY: we allocated this CacheEntry via `ABox::try_new_in`
-        // in `publish_blob` and leaked it; reconstruct + drop frees
-        // it through the same TalcAlloc.
-        unsafe {
-            let boxed = ABox::from_raw_in(entry_ptr.as_ptr(), alloc);
-            drop(boxed);
+
+        match scratch {
+            ScratchEntry::Blob { slot_idx, entry } => {
+                // SAFETY: slot_idx < MAX_BLOB_SLOTS by construction.
+                unsafe {
+                    let slot = CacheDirectory::blob_slot_ptr(dir_ptr, slot_idx);
+                    (*slot).hash = [0u8; 32];
+                    (*slot).entry_va = 0;
+                    (*dir_ptr).blob_count_decr();
+                }
+                // SAFETY: allocated via `ABox::try_new_in` in publish.
+                unsafe {
+                    let boxed = ABox::from_raw_in(entry.as_ptr(), alloc);
+                    drop(boxed);
+                }
+            }
+            ScratchEntry::Instance { slot_idx, entry } => {
+                // SAFETY: slot_idx < MAX_INSTANCE_SLOTS by construction.
+                unsafe {
+                    CacheDirectory::free_instance(dir_ptr, slot_idx);
+                    (*dir_ptr).instance_count_decr();
+                }
+                // SAFETY: allocated via `ABox::try_new_in` in publish.
+                unsafe {
+                    let boxed = ABox::from_raw_in(entry.as_ptr(), alloc);
+                    drop(boxed);
+                }
+            }
         }
     }
 }

--- a/rust/nub-arch-x86/src/state_cache.rs
+++ b/rust/nub-arch-x86/src/state_cache.rs
@@ -45,7 +45,7 @@ use core::cell::UnsafeCell;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use javm_cap::cap::Cap;
+use javm_cap::cap::{Cap, CapHashOrRef};
 use javm_cap::entry::CacheEntry;
 use nub_host_common::cache::{
     CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheHandle, CacheTalcLock, STATE_CACHE_GPA,
@@ -191,6 +191,26 @@ pub fn lookup_instance_handle<A: Allocator + Clone + 'static>(ref_id: u64) -> Op
 /// Convenience: resolve a blob hash directly to its inner `Cap`.
 pub fn lookup_cap(hash: &[u8; 32]) -> Option<&'static Cap<TalcAlloc>> {
     lookup_blob::<TalcAlloc>(hash).map(|e| &e.cap)
+}
+
+/// Convenience: resolve a `CapHashOrRef` to its inner `Cap`. Hashes
+/// hit `cache.blobs`; refs hit `cache.instances`.
+#[allow(dead_code)]
+pub fn lookup_cap_either(key: CapHashOrRef) -> Option<&'static Cap<TalcAlloc>> {
+    match key {
+        CapHashOrRef::Hash(h) => lookup_cap(&h),
+        CapHashOrRef::Ref(r) => lookup_instance::<TalcAlloc>(r).map(|e| &e.cap),
+    }
+}
+
+/// Refcount-bumping resolution of a [`CapHashOrRef`]. The returned
+/// handle pins the underlying entry for its lifetime.
+#[allow(dead_code)]
+pub fn lookup_handle(key: CapHashOrRef) -> Option<CapHandle<TalcAlloc>> {
+    match key {
+        CapHashOrRef::Hash(h) => lookup_blob_handle(&h),
+        CapHashOrRef::Ref(r) => lookup_instance_handle(r),
+    }
 }
 
 /// `TalcAlloc` handle pointing at the shared cache region's lock at

--- a/rust/nub-host-common/src/cache/cache_handle.rs
+++ b/rust/nub-host-common/src/cache/cache_handle.rs
@@ -1,0 +1,238 @@
+//! `CacheHandle<T>` — refcount-bumping pointer to a cache entry that
+//! does NOT own the slab.
+//!
+//! Distinct from [`super::Aarc`] in one key respect: an `Aarc<T, A>`'s
+//! `Drop` deallocates the slab on the last reference (matching
+//! `Arc<T>`'s semantics). A `CacheHandle<T>` only manipulates the
+//! refcount — storage is owned by the cache (host: `TBox` in a
+//! `BTreeMap`; guest: shared-memory directory entry pointing at a
+//! talc-heap allocation), and the cache decides when refcount==0
+//! entries should be reclaimed.
+//!
+//! This is the right shape for the in-kernel guest path: a
+//! `KernelFrame` holds a handle on its `Cap::Image` blob, the
+//! refcount bump pins the blob against eviction, but the frame
+//! shouldn't be responsible for freeing the entry — that's the
+//! cache's job.
+//!
+//! Reuses the [`AarcRefCounted`] trait so any type with an embedded
+//! `AtomicU32` refcount can be handle-wrapped.
+
+use core::ops::Deref;
+use core::ptr::NonNull;
+use core::sync::atomic::Ordering;
+
+use super::talc_arc::AarcRefCounted;
+
+/// Refcount-bumping handle to a `T` whose storage is owned by the
+/// cache. Clone bumps refcount; Drop decrements but does NOT free.
+pub struct CacheHandle<T: AarcRefCounted> {
+    ptr: NonNull<T>,
+}
+
+// SAFETY: a `CacheHandle` is a refcounted pointer to a shared `T`;
+// thread-safety is inherited from `T` and from `AtomicU32`.
+unsafe impl<T: AarcRefCounted + Send + Sync> Send for CacheHandle<T> {}
+unsafe impl<T: AarcRefCounted + Send + Sync> Sync for CacheHandle<T> {}
+
+impl<T: AarcRefCounted> CacheHandle<T> {
+    /// Acquire a handle to an existing entry; bumps refcount by 1.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point at a valid `T` that outlives the handle and
+    /// every clone made from it. The cache (owner of the slab) must
+    /// keep the entry resident at least until refcount drops back to
+    /// where it was before this call.
+    #[inline]
+    pub unsafe fn acquire(ptr: NonNull<T>) -> Self {
+        // SAFETY: caller asserts `ptr` is live.
+        unsafe {
+            (*ptr.as_ptr()).refcount().fetch_add(1, Ordering::Relaxed);
+        }
+        Self { ptr }
+    }
+
+    /// Construct a handle WITHOUT bumping refcount. Used when the
+    /// caller has already accounted for this handle's refcount
+    /// (e.g., during cache publish where the entry starts at
+    /// refcount=1 and the publisher hands its initial reference to
+    /// the handle).
+    ///
+    /// # Safety
+    ///
+    /// Same lifetime invariant as [`acquire`]. Additionally, the
+    /// caller must have already incremented the refcount by 1 to
+    /// account for this handle, or be transferring a pre-existing
+    /// count to the handle.
+    #[inline]
+    pub unsafe fn from_raw_no_bump(ptr: NonNull<T>) -> Self {
+        Self { ptr }
+    }
+
+    /// Current refcount (loaded with Acquire ordering).
+    #[inline]
+    pub fn refcount(&self) -> u32 {
+        // SAFETY: ptr is valid for the lifetime of this handle.
+        unsafe { (*self.ptr.as_ptr()).refcount().load(Ordering::Acquire) }
+    }
+
+    /// Raw pointer to the underlying `T`. Useful for handing the VA
+    /// to other cache-API entry points without taking an additional
+    /// refcount.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<T: AarcRefCounted> Clone for CacheHandle<T> {
+    fn clone(&self) -> Self {
+        // SAFETY: ptr is valid for the lifetime of this handle.
+        unsafe {
+            (*self.ptr.as_ptr())
+                .refcount()
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        Self { ptr: self.ptr }
+    }
+}
+
+impl<T: AarcRefCounted> Drop for CacheHandle<T> {
+    fn drop(&mut self) {
+        // SAFETY: ptr is valid for the lifetime of this handle.
+        // Storage is NOT freed here — the cache reclaims entries when
+        // it observes refcount==0 (out of band).
+        unsafe {
+            (*self.ptr.as_ptr())
+                .refcount()
+                .fetch_sub(1, Ordering::Release);
+        }
+    }
+}
+
+impl<T: AarcRefCounted> Deref for CacheHandle<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: ptr is valid for the lifetime of this handle.
+        unsafe { &*self.ptr.as_ptr() }
+    }
+}
+
+impl<T: AarcRefCounted + core::fmt::Debug> core::fmt::Debug for CacheHandle<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("CacheHandle")
+            .field(&self.refcount())
+            .field(&&**self)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::AtomicU32;
+
+    #[repr(C)]
+    struct Counted {
+        refcount: AtomicU32,
+        payload: u64,
+    }
+    impl AarcRefCounted for Counted {
+        fn refcount(&self) -> &AtomicU32 {
+            &self.refcount
+        }
+    }
+
+    /// Helper: simulate the cache by leaking a `Box` so the entry
+    /// stays live for the test's duration.
+    fn make_entry(payload: u64, initial_count: u32) -> NonNull<Counted> {
+        let boxed = alloc::boxed::Box::new(Counted {
+            refcount: AtomicU32::new(initial_count),
+            payload,
+        });
+        NonNull::new(alloc::boxed::Box::into_raw(boxed)).expect("non-null")
+    }
+
+    /// Helper: free the simulated cache entry after the test.
+    /// Reconstructs the `Box` from the raw pointer and drops it.
+    unsafe fn drop_entry(ptr: NonNull<Counted>) {
+        // SAFETY: caller passes a pointer obtained from `make_entry`.
+        unsafe {
+            drop(alloc::boxed::Box::from_raw(ptr.as_ptr()));
+        }
+    }
+
+    #[test]
+    fn acquire_bumps_refcount() {
+        // Cache pre-publishes with refcount=1.
+        let ptr = make_entry(42, 1);
+        // Lookup acquires; refcount → 2.
+        let h = unsafe { CacheHandle::acquire(ptr) };
+        assert_eq!(h.refcount(), 2);
+        assert_eq!(h.payload, 42);
+        drop(h);
+        // Back to 1 (the cache's published count).
+        assert_eq!(
+            unsafe { (*ptr.as_ptr()).refcount.load(Ordering::Acquire) },
+            1
+        );
+        unsafe { drop_entry(ptr) };
+    }
+
+    #[test]
+    fn clone_bumps_drop_decrements() {
+        let ptr = make_entry(7, 1);
+        let a = unsafe { CacheHandle::acquire(ptr) };
+        assert_eq!(a.refcount(), 2);
+        let b = a.clone();
+        let c = a.clone();
+        assert_eq!(a.refcount(), 4);
+        drop(b);
+        assert_eq!(a.refcount(), 3);
+        drop(c);
+        assert_eq!(a.refcount(), 2);
+        drop(a);
+        assert_eq!(
+            unsafe { (*ptr.as_ptr()).refcount.load(Ordering::Acquire) },
+            1
+        );
+        unsafe { drop_entry(ptr) };
+    }
+
+    #[test]
+    fn drop_does_not_free_storage() {
+        // Pre-publish at refcount=1, acquire to refcount=2, drop both —
+        // the entry remains live (the cache, not the handle, owns the
+        // slab). We verify by reading payload after all handles drop.
+        let ptr = make_entry(99, 1);
+        let h = unsafe { CacheHandle::acquire(ptr) };
+        assert_eq!(h.payload, 99);
+        drop(h);
+        // Refcount went 1 → 2 → 1; storage still live.
+        assert_eq!(unsafe { (*ptr.as_ptr()).payload }, 99);
+        assert_eq!(
+            unsafe { (*ptr.as_ptr()).refcount.load(Ordering::Acquire) },
+            1
+        );
+        unsafe { drop_entry(ptr) };
+    }
+
+    #[test]
+    fn from_raw_no_bump_does_not_change_count() {
+        // Caller publishes at refcount=1 and transfers that initial
+        // reference to a handle without bumping again.
+        let ptr = make_entry(13, 1);
+        let h = unsafe { CacheHandle::from_raw_no_bump(ptr) };
+        assert_eq!(h.refcount(), 1);
+        drop(h);
+        // Drop decremented; entry should now be at refcount=0, which
+        // signals to the cache that it can reclaim — but the storage
+        // itself is still live (cache hasn't run reclaim yet).
+        assert_eq!(
+            unsafe { (*ptr.as_ptr()).refcount.load(Ordering::Acquire) },
+            0
+        );
+        unsafe { drop_entry(ptr) };
+    }
+}

--- a/rust/nub-host-common/src/cache/cache_handle.rs
+++ b/rust/nub-host-common/src/cache/cache_handle.rs
@@ -61,8 +61,8 @@ impl<T: AarcRefCounted> CacheHandle<T> {
     ///
     /// # Safety
     ///
-    /// Same lifetime invariant as [`acquire`]. Additionally, the
-    /// caller must have already incremented the refcount by 1 to
+    /// Same lifetime invariant as [`Self::acquire`]. Additionally,
+    /// the caller must have already incremented the refcount by 1 to
     /// account for this handle, or be transferring a pre-existing
     /// count to the handle.
     #[inline]

--- a/rust/nub-host-common/src/cache/directory.rs
+++ b/rust/nub-host-common/src/cache/directory.rs
@@ -27,10 +27,11 @@
 //!
 //! ## Instance-slot allocation
 //!
-//! [`alloc_ref`] atomically reads `next_ref` and increments it,
-//! retrying on slot collision. Allocation is therefore O(1)
-//! amortised; lookup via [`find_instance`] is O(1) deterministic
-//! (compute the natural slot, validate `ref_id` matches).
+//! [`CacheDirectory::alloc_ref`] atomically reads `next_ref` and
+//! increments it, retrying on slot collision. Allocation is therefore
+//! O(1) amortised; lookup via [`CacheDirectory::find_instance`] is
+//! O(1) deterministic (compute the natural slot, validate `ref_id`
+//! matches).
 //!
 //! With `MAX_INSTANCE_SLOTS = 32768` and live-ref counts well below
 //! that (deep recursion is bounded by `MAX_DEPTH = 32768` from the
@@ -242,7 +243,7 @@ impl CacheDirectory {
 
     /// Free an instance slot. Sets `ref_id = 0` and `entry_va = 0`,
     /// returning the slot to the pool for reuse by a future
-    /// [`alloc_ref`] whose natural slot collides here.
+    /// [`Self::alloc_ref`] whose natural slot collides here.
     ///
     /// # Safety
     ///

--- a/rust/nub-host-common/src/cache/directory.rs
+++ b/rust/nub-host-common/src/cache/directory.rs
@@ -1,39 +1,63 @@
 //! `CacheDirectory` — guest-readable index of cache-resident caps.
 //!
-//! Lives in shared memory; the host populates it when publishing caps
-//! via `javm_cap::Cache`, and the guest scans it to resolve
-//! `CapHashOrRef` keys into a usable virtual address for the
-//! corresponding `CacheEntry`.
+//! Lives in shared memory; the host populates blob slots when
+//! publishing caps via `javm_cap::Cache`, and both host + guest may
+//! populate instance slots (host for pre-published Instances; guest
+//! for sub-VM Instances derived in-kernel). The directory is the
+//! only piece of cache state the guest sees directly — it scans here
+//! to resolve `CapHashOrRef` keys into a usable virtual address for
+//! the corresponding `CacheEntry`.
 //!
-//! Two flat arrays of fixed size, scanned linearly:
+//! Two arrays of fixed size:
 //!
 //! - `blob_slots: [BlobSlot; MAX_BLOB_SLOTS]` — content-addressed
-//!   caps keyed by 32-byte hash. Sentinel for empty: `hash == [0; 32]`.
+//!   caps keyed by 32-byte hash. Scanned linearly. Sentinel: `hash
+//!   == [0; 32]`.
 //! - `instance_slots: [InstanceSlot; MAX_INSTANCE_SLOTS]` — identity-
 //!   keyed mutable caps keyed by `CapRef` (a monotonic `u64`).
-//!   Sentinel for empty: `ref_id == 0` (the cache reserves `CapRef(0)`
-//!   so this never collides with a real ref).
+//!   Direct-indexed by `slot_idx = (ref_id - 1) & (MAX_INSTANCE_SLOTS - 1)`.
+//!   Sentinel: `ref_id == 0` (the cache reserves `CapRef(0)` so this never
+//!   collides with a real ref).
 //!
 //! `entry_va` is the host-or-guest VA pointing at the `CacheEntry`
 //! whose `cap` field holds the actual cap. Because host and guest map
 //! the cache region at different VAs, *each party* writes the VA it
-//! observes. The host writes its own VA when populating a slot; on
-//! guest read, the directory entry's `entry_va` must be translated via
-//! the cache-region offset (`entry_va - host_cache_va + guest_cache_va`).
-//! In V1 host and guest share the same VA layout, so this is identity.
+//! observes. In V1 host and guest share the same VA layout, so the
+//! translation is identity.
 //!
-//! **Linear scan is fine at this size.** 256 + 256 slots × ~40 bytes
-//! each fits in 20 KiB; a hash compare is 4 quadword loads. We expect
-//! cache hit rates well above 90% for the JIT-path Image lookups so
-//! the absolute scan cost is rarely on the hot path.
+//! ## Instance-slot allocation
+//!
+//! [`alloc_ref`] atomically reads `next_ref` and increments it,
+//! retrying on slot collision. Allocation is therefore O(1)
+//! amortised; lookup via [`find_instance`] is O(1) deterministic
+//! (compute the natural slot, validate `ref_id` matches).
+//!
+//! With `MAX_INSTANCE_SLOTS = 32768` and live-ref counts well below
+//! that (deep recursion is bounded by `MAX_DEPTH = 32768` from the
+//! call-loop), collision probability per allocation is sparse-table:
+//! at 1000 live refs, ≈ 3 % chance of a single retry, average ≈
+//! 1.03 attempts.
+//!
+//! The simpler "retry on collision" allocator replaces what would
+//! otherwise be a freelist. A freelist saves the wasted ref_ids
+//! consumed by collisions; at our table sparsity that waste is
+//! negligible (< 3 % at 1000 live refs), and the freelist's
+//! additional shared state (`freelist_head` + per-slot `next_free`)
+//! isn't worth its complexity.
 
-use core::sync::atomic::{AtomicU16, Ordering};
+use core::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 
 /// Maximum number of content-addressed blobs the V1 directory tracks.
 pub const MAX_BLOB_SLOTS: usize = 256;
 
 /// Maximum number of identity-keyed instances the V1 directory tracks.
-pub const MAX_INSTANCE_SLOTS: usize = 256;
+/// Power-of-2 so direct-indexing uses a cheap bitmask.
+pub const MAX_INSTANCE_SLOTS: usize = 32768;
+
+/// Mask for direct-indexing: `slot_idx = (ref_id - 1) & INSTANCE_MASK`.
+pub const INSTANCE_MASK: u64 = (MAX_INSTANCE_SLOTS as u64) - 1;
+
+const _: () = assert!(MAX_INSTANCE_SLOTS.is_power_of_two(), "must be power-of-2");
 
 /// One blob entry. `hash == [0; 32]` is the empty-slot sentinel; the
 /// chance of a real Blake2b256 digest colliding with all-zero is
@@ -52,8 +76,8 @@ impl BlobSlot {
 }
 
 /// One instance entry. `ref_id == 0` is the empty-slot sentinel; the
-/// cache's `next_ref` allocator starts at 1, so real refs never
-/// collide with the sentinel.
+/// allocator's `next_ref` starts at 1, so real refs never collide
+/// with the sentinel.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct InstanceSlot {
@@ -76,6 +100,10 @@ pub struct CacheDirectory {
     /// Informational populated-instance counter.
     pub instance_count: AtomicU16,
     _pad: [u8; 4],
+    /// Monotonic ref-id allocator, shared between host + guest. Starts
+    /// at 1 (`CapRef(0)` is reserved as the empty-slot sentinel).
+    /// Wraps after `2^64` allocations (effectively never).
+    pub next_ref: AtomicU64,
     pub blob_slots: [BlobSlot; MAX_BLOB_SLOTS],
     pub instance_slots: [InstanceSlot; MAX_INSTANCE_SLOTS],
 }
@@ -83,7 +111,8 @@ pub struct CacheDirectory {
 impl CacheDirectory {
     pub const SIZE: usize = core::mem::size_of::<Self>();
 
-    /// Zero-initialise a `CacheDirectory` at `ptr`.
+    /// Zero-initialise a `CacheDirectory` at `ptr`, then set
+    /// `next_ref = 1` so the first allocation yields `CapRef(1)`.
     ///
     /// # Safety
     ///
@@ -92,6 +121,9 @@ impl CacheDirectory {
     pub unsafe fn init_at(ptr: *mut CacheDirectory) {
         unsafe {
             core::ptr::write_bytes(ptr, 0, 1);
+            // `write_bytes` zeroed the atomic; bump to 1 so the first
+            // `fetch_add` yields `CapRef(1)` rather than `CapRef(0)`.
+            (*ptr).next_ref.store(1, Ordering::Release);
         }
     }
 
@@ -115,7 +147,12 @@ impl CacheDirectory {
         None
     }
 
-    /// Linear scan for a populated instance slot with the given ref id.
+    /// Direct-indexed lookup of an instance slot by `ref_id`.
+    /// O(1): compute natural slot, validate `ref_id` matches.
+    ///
+    /// Returns `None` if the slot is empty OR holds a different
+    /// `ref_id` (a stale entry from a prior collision-retry that has
+    /// since been overwritten).
     ///
     /// # Safety
     ///
@@ -125,17 +162,16 @@ impl CacheDirectory {
         ref_id: u64,
     ) -> Option<(usize, *const InstanceSlot)> {
         if ref_id == 0 {
-            // 0 is the empty sentinel; bail out before scanning.
             return None;
         }
-        for idx in 0..MAX_INSTANCE_SLOTS {
-            let slot_ptr = unsafe { core::ptr::addr_of!((*this).instance_slots[idx]) };
-            let slot_ref = unsafe { (*slot_ptr).ref_id };
-            if slot_ref == ref_id {
-                return Some((idx, slot_ptr));
-            }
+        let slot_idx = ((ref_id - 1) & INSTANCE_MASK) as usize;
+        let slot_ptr = unsafe { core::ptr::addr_of!((*this).instance_slots[slot_idx]) };
+        let slot_ref = unsafe { (*slot_ptr).ref_id };
+        if slot_ref == ref_id {
+            Some((slot_idx, slot_ptr))
+        } else {
+            None
         }
-        None
     }
 
     /// First slot with `hash == [0; 32]`. Used by host publish to pick
@@ -155,17 +191,30 @@ impl CacheDirectory {
         None
     }
 
-    /// First slot with `ref_id == 0`.
+    /// Allocate a fresh `ref_id` + its corresponding slot index.
+    /// Returns `None` if the entire instance table is occupied.
+    ///
+    /// Loops on collision: if the natural slot for the next
+    /// `next_ref` value is already occupied, increments `next_ref`
+    /// again and retries. Bounded by `MAX_INSTANCE_SLOTS` iterations
+    /// — beyond that, the table is genuinely full.
     ///
     /// # Safety
     ///
     /// `this` must point at a live `CacheDirectory`.
-    pub unsafe fn first_empty_instance(this: *const CacheDirectory) -> Option<usize> {
-        for idx in 0..MAX_INSTANCE_SLOTS {
-            let slot_ptr = unsafe { core::ptr::addr_of!((*this).instance_slots[idx]) };
-            if unsafe { (*slot_ptr).ref_id == 0 } {
-                return Some(idx);
+    pub unsafe fn alloc_ref(this: *const CacheDirectory) -> Option<(u64, usize)> {
+        for _attempts in 0..MAX_INSTANCE_SLOTS {
+            let candidate = unsafe { (*this).next_ref.fetch_add(1, Ordering::Relaxed) };
+            if candidate == 0 {
+                // `next_ref` wrapped; CapRef(0) is reserved. Skip.
+                continue;
             }
+            let slot_idx = ((candidate - 1) & INSTANCE_MASK) as usize;
+            let slot_ref = unsafe { (*this).instance_slots[slot_idx].ref_id };
+            if slot_ref == 0 {
+                return Some((candidate, slot_idx));
+            }
+            // Slot occupied — try the next ref_id.
         }
         None
     }
@@ -189,6 +238,24 @@ impl CacheDirectory {
     pub unsafe fn instance_slot_ptr(this: *mut CacheDirectory, idx: usize) -> *mut InstanceSlot {
         debug_assert!(idx < MAX_INSTANCE_SLOTS);
         unsafe { core::ptr::addr_of_mut!((*this).instance_slots[idx]) }
+    }
+
+    /// Free an instance slot. Sets `ref_id = 0` and `entry_va = 0`,
+    /// returning the slot to the pool for reuse by a future
+    /// [`alloc_ref`] whose natural slot collides here.
+    ///
+    /// # Safety
+    ///
+    /// `this` must point at a live `CacheDirectory`; the slot must
+    /// not be concurrently read by another thread (Hyperlight
+    /// serialises host + guest, so this is automatic in V1).
+    pub unsafe fn free_instance(this: *mut CacheDirectory, slot_idx: usize) {
+        debug_assert!(slot_idx < MAX_INSTANCE_SLOTS);
+        unsafe {
+            let slot = core::ptr::addr_of_mut!((*this).instance_slots[slot_idx]);
+            (*slot).ref_id = 0;
+            (*slot).entry_va = 0;
+        }
     }
 
     /// Atomically increment the populated-blob counter. Called *after*
@@ -236,6 +303,7 @@ mod tests {
         };
         assert_eq!(boxed.blob_count.load(Ordering::Acquire), 0);
         assert_eq!(boxed.instance_count.load(Ordering::Acquire), 0);
+        assert_eq!(boxed.next_ref.load(Ordering::Acquire), 1);
         boxed
     }
 
@@ -243,7 +311,6 @@ mod tests {
     fn init_zero_sentinels_observed() {
         let dir = fresh();
         let raw = &*dir as *const CacheDirectory;
-        // All blob and instance slots are sentinel.
         for i in 0..MAX_BLOB_SLOTS {
             unsafe {
                 assert_eq!((*raw).blob_slots[i].hash, [0u8; 32]);
@@ -256,17 +323,6 @@ mod tests {
                 assert_eq!((*raw).instance_slots[i].entry_va, 0);
             }
         }
-    }
-
-    #[test]
-    fn first_empty_returns_zero_on_fresh_directory() {
-        let dir = fresh();
-        let raw = &*dir as *const CacheDirectory;
-        assert_eq!(unsafe { CacheDirectory::first_empty_blob(raw) }, Some(0));
-        assert_eq!(
-            unsafe { CacheDirectory::first_empty_instance(raw) },
-            Some(0)
-        );
     }
 
     #[test]
@@ -288,48 +344,120 @@ mod tests {
         unsafe {
             assert_eq!((*slot_ptr).entry_va, 0xDEAD_BEEF_CAFE_BABE);
         }
-
-        // Empty slot starts at the next index since 0..6 are still empty.
-        assert_eq!(unsafe { CacheDirectory::first_empty_blob(raw) }, Some(0));
-        unsafe {
-            // Fill 0..7
-            for i in 0..7 {
-                let s = CacheDirectory::blob_slot_ptr(raw, i);
-                (*s).hash[0] = (i as u8) + 1;
-            }
-        }
-        // Now 8 is the first empty.
-        assert_eq!(unsafe { CacheDirectory::first_empty_blob(raw) }, Some(8));
     }
 
     #[test]
-    fn populate_and_find_instance_slot() {
+    fn alloc_ref_assigns_monotonic_ids_to_natural_slots() {
         let mut dir = fresh();
         let raw = &mut *dir as *mut CacheDirectory;
-        let ref_id: u64 = 42;
+        // First three allocations should yield (1, 0), (2, 1), (3, 2).
+        for expected_ref in 1u64..=3 {
+            let (ref_id, slot_idx) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
+            assert_eq!(ref_id, expected_ref);
+            assert_eq!(slot_idx, (expected_ref - 1) as usize);
+            // Populate the slot so subsequent allocs see it occupied.
+            unsafe {
+                let slot = CacheDirectory::instance_slot_ptr(raw, slot_idx);
+                (*slot).ref_id = ref_id;
+                (*slot).entry_va = 0x1000_0000 + ref_id;
+            }
+            dir.instance_count_incr();
+        }
+        assert_eq!(dir.instance_count.load(Ordering::Acquire), 3);
+    }
+
+    #[test]
+    fn find_instance_direct_index() {
+        let mut dir = fresh();
+        let raw = &mut *dir as *mut CacheDirectory;
+        let (ref_id, slot_idx) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
         unsafe {
-            let slot = CacheDirectory::instance_slot_ptr(raw, 3);
+            let slot = CacheDirectory::instance_slot_ptr(raw, slot_idx);
             (*slot).ref_id = ref_id;
-            (*slot).entry_va = 0x1000_2000_3000_4000;
+            (*slot).entry_va = 0xCAFE_BABE;
+        }
+        let found = unsafe { CacheDirectory::find_instance(raw, ref_id).expect("found") };
+        assert_eq!(found.0, slot_idx);
+        unsafe {
+            assert_eq!((*found.1).entry_va, 0xCAFE_BABE);
+        }
+        // Sentinel ref 0 never found.
+        assert!(unsafe { CacheDirectory::find_instance(raw, 0) }.is_none());
+        // A ref the directory never issued is not found.
+        assert!(unsafe { CacheDirectory::find_instance(raw, 999_999) }.is_none());
+    }
+
+    #[test]
+    fn alloc_ref_retries_on_collision() {
+        // Pre-fill slot 0 with a synthetic occupied entry. alloc_ref's
+        // first attempt asks for ref_id=1 which maps to slot 0 (now
+        // occupied), so it should retry with ref_id=2 → slot 1.
+        let mut dir = fresh();
+        let raw = &mut *dir as *mut CacheDirectory;
+        unsafe {
+            let slot = CacheDirectory::instance_slot_ptr(raw, 0);
+            (*slot).ref_id = 0xDEAD_BEEF;
+            (*slot).entry_va = 1;
+        }
+        let (ref_id, slot_idx) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
+        assert_eq!(ref_id, 2, "first non-colliding ref_id");
+        assert_eq!(slot_idx, 1);
+        // next_ref has been incremented twice (1 was consumed by the
+        // collision, 2 succeeded), so the next allocation yields 3.
+        assert_eq!(dir.next_ref.load(Ordering::Acquire), 3);
+    }
+
+    #[test]
+    fn free_instance_clears_slot() {
+        let mut dir = fresh();
+        let raw = &mut *dir as *mut CacheDirectory;
+        let (ref_id, slot_idx) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
+        unsafe {
+            let slot = CacheDirectory::instance_slot_ptr(raw, slot_idx);
+            (*slot).ref_id = ref_id;
+            (*slot).entry_va = 0x1234;
         }
         dir.instance_count_incr();
 
-        let found = unsafe { CacheDirectory::find_instance(raw, ref_id) };
-        let (idx, slot_ptr) = found.expect("found");
-        assert_eq!(idx, 3);
-        unsafe {
-            assert_eq!((*slot_ptr).entry_va, 0x1000_2000_3000_4000);
-        }
-
-        // Sentinel ref 0 is never found.
-        assert!(unsafe { CacheDirectory::find_instance(raw, 0) }.is_none());
+        assert!(unsafe { CacheDirectory::find_instance(raw, ref_id) }.is_some());
+        unsafe { CacheDirectory::free_instance(raw, slot_idx) };
+        dir.instance_count_decr();
+        assert!(unsafe { CacheDirectory::find_instance(raw, ref_id) }.is_none());
+        // The slot is reusable: a future alloc may land here if its
+        // natural slot collides.
     }
 
     #[test]
-    fn missing_lookup_returns_none() {
+    fn freed_slot_reused_by_future_alloc() {
+        let mut dir = fresh();
+        let raw = &mut *dir as *mut CacheDirectory;
+        // Alloc 1 -> slot 0; free it.
+        let (r1, s1) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
+        assert_eq!((r1, s1), (1, 0));
+        unsafe {
+            (*CacheDirectory::instance_slot_ptr(raw, s1)).ref_id = r1;
+        }
+        unsafe { CacheDirectory::free_instance(raw, s1) };
+
+        // Manually rewind next_ref so the next alloc maps back to slot 0.
+        // (In real usage, slot 0 is reused only after next_ref wraps;
+        // this test exercises the reuse mechanism directly.)
+        dir.next_ref.store(1, Ordering::Release);
+        let (r2, s2) = unsafe { CacheDirectory::alloc_ref(raw).expect("alloc") };
+        assert_eq!((r2, s2), (1, 0));
+    }
+
+    #[test]
+    fn missing_blob_lookup_returns_none() {
         let dir = fresh();
         let raw = &*dir as *const CacheDirectory;
         assert!(unsafe { CacheDirectory::find_blob(raw, &[0x11u8; 32]) }.is_none());
-        assert!(unsafe { CacheDirectory::find_instance(raw, 999) }.is_none());
+    }
+
+    #[test]
+    fn first_empty_returns_zero_on_fresh_directory() {
+        let dir = fresh();
+        let raw = &*dir as *const CacheDirectory;
+        assert_eq!(unsafe { CacheDirectory::first_empty_blob(raw) }, Some(0));
     }
 }

--- a/rust/nub-host-common/src/cache/mod.rs
+++ b/rust/nub-host-common/src/cache/mod.rs
@@ -27,11 +27,13 @@
 //! - Layout constants ([`STATE_CACHE_VA`], [`STATE_CACHE_SIZE`],
 //!   [`CACHE_DIRECTORY_OFFSET`], [`TALC_HEAP_OFFSET`]).
 
+pub mod cache_handle;
 pub mod directory;
 pub mod talc_alloc;
 pub mod talc_arc;
 pub mod talc_box;
 
+pub use cache_handle::CacheHandle;
 pub use directory::{BlobSlot, CacheDirectory, InstanceSlot, MAX_BLOB_SLOTS, MAX_INSTANCE_SLOTS};
 pub use talc_alloc::TalcAlloc;
 pub use talc_arc::{Aarc, AarcRefCounted, TalcArc, TalcRefCounted};

--- a/rust/nub-host-common/src/cache/mod.rs
+++ b/rust/nub-host-common/src/cache/mod.rs
@@ -34,7 +34,9 @@ pub mod talc_arc;
 pub mod talc_box;
 
 pub use cache_handle::CacheHandle;
-pub use directory::{BlobSlot, CacheDirectory, InstanceSlot, MAX_BLOB_SLOTS, MAX_INSTANCE_SLOTS};
+pub use directory::{
+    BlobSlot, CacheDirectory, INSTANCE_MASK, InstanceSlot, MAX_BLOB_SLOTS, MAX_INSTANCE_SLOTS,
+};
 pub use talc_alloc::TalcAlloc;
 pub use talc_arc::{Aarc, AarcRefCounted, TalcArc, TalcRefCounted};
 pub use talc_box::{CacheTalcLock, TalcBox, TalcSlice};

--- a/rust/nub-host-kvm/src/cache.rs
+++ b/rust/nub-host-kvm/src/cache.rs
@@ -28,8 +28,8 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use javm_cap::{Cache as TypedCache, CapHashOrRef, CapRef};
 use nub_arch_x86_abi::CapHash;
 use nub_host_common::cache::{
-    BlobSlot, CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheTalcLock, InstanceSlot,
-    STATE_CACHE_SIZE, STATE_CACHE_VA, TALC_HEAP_OFFSET, TALC_HEAP_SIZE, TalcAlloc,
+    BlobSlot, CACHE_DIRECTORY_OFFSET, CacheDirectory, CacheTalcLock, STATE_CACHE_SIZE,
+    STATE_CACHE_VA, TALC_HEAP_OFFSET, TALC_HEAP_SIZE, TalcAlloc,
 };
 use talc::source::Manual;
 
@@ -365,26 +365,37 @@ impl Cache {
         Ok(())
     }
 
-    /// Record an instance ref in the directory. Used after a `get_mut`
-    /// promotes a blob to an instance entry, or after a fresh instance
-    /// publish (not currently used in V1 — Instances live as blobs).
+    /// Record an instance ref in the directory at its direct-indexed
+    /// slot (`slot_idx = (r - 1) & INSTANCE_MASK`). Used after a
+    /// `get_mut` promotes a blob to an instance entry, or after a
+    /// fresh instance publish (not currently used in V1 — Instances
+    /// live as blobs).
+    ///
+    /// `r` is expected to have come from `CacheDirectory::alloc_ref`
+    /// so the natural slot is guaranteed empty (or already holds the
+    /// same ref_id, in which case this acts as an entry_va update).
     #[allow(dead_code)]
     fn touch_instance(&mut self, r: CapRef) -> Result<()> {
+        use nub_host_common::cache::INSTANCE_MASK;
         let va = self
             .typed_cache
             .entry_va(CapHashOrRef::Ref(r))
             .ok_or_else(|| new_error!("cache: instance {r} missing"))?;
         let dir_ptr = self.directory.as_ptr();
-        if let Some((_, slot_ptr)) = unsafe { CacheDirectory::find_instance(dir_ptr, r) } {
-            unsafe {
-                (*(slot_ptr as *mut InstanceSlot)).entry_va = va;
-            }
+        let slot_idx = ((r - 1) & INSTANCE_MASK) as usize;
+        let slot = unsafe { CacheDirectory::instance_slot_ptr(dir_ptr, slot_idx) };
+        let existing = unsafe { (*slot).ref_id };
+        if existing == r {
+            // Idempotent update: same ref, refresh entry_va.
+            unsafe { (*slot).entry_va = va };
             return Ok(());
         }
-        let idx = unsafe { CacheDirectory::first_empty_instance(dir_ptr) }.ok_or(
-            CacheError::InstanceDirectoryFull(nub_host_common::cache::MAX_INSTANCE_SLOTS),
-        )?;
-        let slot = unsafe { CacheDirectory::instance_slot_ptr(dir_ptr, idx) };
+        if existing != 0 {
+            return Err(CacheError::InstanceDirectoryFull(
+                nub_host_common::cache::MAX_INSTANCE_SLOTS,
+            )
+            .into());
+        }
         unsafe {
             (*slot).ref_id = r;
             (*slot).entry_va = va;

--- a/rust/ssz/src/sparse.rs
+++ b/rust/ssz/src/sparse.rs
@@ -16,8 +16,7 @@
 //!   use case (N ≤ 256, typically very sparse), the linear shift is
 //!   trivial.
 //! - **O(log n) range queries** via `partition_point`, used by
-//!   [`compute_subtree_root`](SparseList::compute_subtree_root) to
-//!   short-circuit empty subtrees.
+//!   `compute_subtree_root` to short-circuit empty subtrees.
 //! - **Iteration in sorted order**, byte-equivalent to `BTreeMap::iter`.
 //! - **Allocator-genericity** — `allocator_api2::vec::Vec<T, A>` carries
 //!   the allocator handle on every allocation, so a `SparseList<_, N,

--- a/rust/ssz/src/sparse.rs
+++ b/rust/ssz/src/sparse.rs
@@ -5,8 +5,30 @@
 //! `List<T, N>` with the same effective contents. The algorithm walks the
 //! implicit balanced binary tree of depth `ceil_log2(N)` iteratively,
 //! using a fixed-size stack — never materialising the full `N` leaves.
+//!
+//! ## Storage
+//!
+//! Both inner maps are sorted `Vec`s keyed by `u64`, allocated through
+//! the caller-provided `A: Allocator + Clone`. Sorted Vec gives us:
+//!
+//! - **O(log n) lookup** via `binary_search_by_key`.
+//! - **O(n) insert/remove** at the sorted position. For the cnode-slot
+//!   use case (N ≤ 256, typically very sparse), the linear shift is
+//!   trivial.
+//! - **O(log n) range queries** via `partition_point`, used by
+//!   [`compute_subtree_root`](SparseList::compute_subtree_root) to
+//!   short-circuit empty subtrees.
+//! - **Iteration in sorted order**, byte-equivalent to `BTreeMap::iter`.
+//! - **Allocator-genericity** — `allocator_api2::vec::Vec<T, A>` carries
+//!   the allocator handle on every allocation, so a `SparseList<_, N,
+//!   TalcAlloc>` keeps no state on the host's `Global` allocator. This
+//!   is what makes `Cap::CNode` walkable from the guest's view of the
+//!   shared state cache.
+//!
+//! Previous versions used `alloc::collections::BTreeMap` (stable, but
+//! hardwired to `Global`); the switch preserves wire-format and
+//! hash-tree-root output byte-identically.
 
-use alloc::collections::BTreeMap;
 use allocator_api2::alloc::{Allocator, Global};
 use allocator_api2::vec::Vec;
 use core::fmt;
@@ -25,27 +47,23 @@ use crate::{BYTES_PER_LENGTH_OFFSET, Decode, DecodeError, Encode, HashTreeRoot};
 /// same effective contents.
 pub struct SparseList<T, const N: u64, A: Allocator + Clone = Global> {
     len: u64,
-    /// Map from leaf index to optional materialized entry (or precomputed
-    /// hash). Absent indices contribute `zero_hash(0)` to the root unless
-    /// covered by `cached_subtree_roots`.
-    entries: BTreeMap<u64, MissingOr<T>>,
-    /// Optional precomputed roots for whole subtrees. Key is a tree
-    /// coordinate `(depth, index_at_depth)` flattened to a `u64` via
-    /// `coord_to_key(depth, idx) = (1u64 << depth) | idx` — this is the
-    /// standard "heap index" of a node in a complete binary tree.
-    cached_subtree_roots: BTreeMap<u64, [u8; 32]>,
-    _alloc: A,
+    /// Sorted (by `u64` key) entries: leaf index → optional materialized
+    /// value (or precomputed hash). Absent indices contribute
+    /// `zero_hash(0)` to the root unless covered by
+    /// [`cached_subtree_roots`].
+    entries: Vec<(u64, MissingOr<T>), A>,
+    /// Sorted (by `u64` key) cache of precomputed subtree roots. Key is
+    /// a tree coordinate `(depth, index_at_depth)` flattened via
+    /// `coord_to_key(depth, idx) = (1u64 << depth) | idx` — the standard
+    /// "heap index" of a node in a complete binary tree.
+    cached_subtree_roots: Vec<(u64, [u8; 32]), A>,
+    alloc: A,
 }
 
 impl<T, const N: u64> SparseList<T, N, Global> {
     /// Build an empty `Global`-allocated sparse list.
     pub fn new() -> Self {
-        Self {
-            len: 0,
-            entries: BTreeMap::new(),
-            cached_subtree_roots: BTreeMap::new(),
-            _alloc: Global,
-        }
+        Self::new_in(Global)
     }
 }
 
@@ -60,10 +78,16 @@ impl<T, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
     pub fn new_in(alloc: A) -> Self {
         Self {
             len: 0,
-            entries: BTreeMap::new(),
-            cached_subtree_roots: BTreeMap::new(),
-            _alloc: alloc,
+            entries: Vec::new_in(alloc.clone()),
+            cached_subtree_roots: Vec::new_in(alloc.clone()),
+            alloc,
         }
+    }
+
+    /// Borrow the captured allocator handle.
+    #[inline]
+    pub fn allocator(&self) -> &A {
+        &self.alloc
     }
 
     /// Logical length.
@@ -88,18 +112,23 @@ impl<T, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
         self.entries.iter_mut().map(|(k, v)| (*k, v))
     }
 
-    /// Number of materialized entries (BTreeMap length). Distinct from
-    /// [`len`](Self::len), which is the logical length (max index + 1).
+    /// Number of materialized entries. Distinct from [`len`](Self::len),
+    /// which is the logical length (max index + 1).
     pub fn entries_count(&self) -> usize {
         self.entries.len()
     }
 
-    /// Look up a single entry by leaf index.
+    /// Look up a single entry by leaf index. O(log n).
     pub fn get(&self, idx: u64) -> Option<&MissingOr<T>> {
-        self.entries.get(&idx)
+        match self.entries.binary_search_by_key(&idx, |(k, _)| *k) {
+            Ok(pos) => Some(&self.entries[pos].1),
+            Err(_) => None,
+        }
     }
 
     /// Insert a materialized entry. Updates `len` to `max(len, idx + 1)`.
+    /// O(n) — sorted shift on insert. If `idx` is already present, the
+    /// existing value is overwritten (matching `BTreeMap::insert` semantics).
     pub fn insert(&mut self, idx: u64, value: MissingOr<T>) -> Result<(), DecodeError> {
         if idx >= N {
             return Err(DecodeError::BoundExceeded {
@@ -108,7 +137,14 @@ impl<T, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
             });
         }
         self.len = self.len.max(idx + 1);
-        self.entries.insert(idx, value);
+        match self.entries.binary_search_by_key(&idx, |(k, _)| *k) {
+            Ok(pos) => {
+                self.entries[pos].1 = value;
+            }
+            Err(pos) => {
+                self.entries.insert(pos, (idx, value));
+            }
+        }
         Ok(())
     }
 
@@ -116,7 +152,10 @@ impl<T, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
     /// Does **not** decrement `len` — the logical length is independent
     /// of which indices are materialized.
     pub fn remove(&mut self, idx: u64) -> Option<MissingOr<T>> {
-        self.entries.remove(&idx)
+        match self.entries.binary_search_by_key(&idx, |(k, _)| *k) {
+            Ok(pos) => Some(self.entries.remove(pos).1),
+            Err(_) => None,
+        }
     }
 
     /// Set the logical length explicitly (does not affect entries).
@@ -130,14 +169,41 @@ impl<T, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
 
     /// Cache a precomputed subtree root at tree position `(depth, idx)`.
     /// `depth == 0` corresponds to the root; deeper means closer to leaves.
+    /// O(n) — sorted insert into `cached_subtree_roots`.
     pub fn cache_subtree_root(&mut self, depth: usize, idx: u64, root: [u8; 32]) {
         let key = coord_to_key(depth, idx);
-        self.cached_subtree_roots.insert(key, root);
+        match self
+            .cached_subtree_roots
+            .binary_search_by_key(&key, |(k, _)| *k)
+        {
+            Ok(pos) => {
+                self.cached_subtree_roots[pos].1 = root;
+            }
+            Err(pos) => {
+                self.cached_subtree_roots.insert(pos, (key, root));
+            }
+        }
     }
 
-    /// Borrow the cached-subtree-root map.
-    pub fn cached_subtree_roots(&self) -> &BTreeMap<u64, [u8; 32]> {
-        &self.cached_subtree_roots
+    /// Number of cached subtree roots. Used by [`fmt::Debug`].
+    pub fn cached_subtree_roots_count(&self) -> usize {
+        self.cached_subtree_roots.len()
+    }
+
+    /// Iterator over cached subtree roots in sorted-by-key order.
+    pub fn cached_subtree_roots(&self) -> impl Iterator<Item = (u64, &[u8; 32])> {
+        self.cached_subtree_roots.iter().map(|(k, v)| (*k, v))
+    }
+
+    /// Internal: look up a cached subtree root by its `coord_to_key`-encoded key.
+    fn cached_subtree_root(&self, key: u64) -> Option<&[u8; 32]> {
+        match self
+            .cached_subtree_roots
+            .binary_search_by_key(&key, |(k, _)| *k)
+        {
+            Ok(pos) => Some(&self.cached_subtree_roots[pos].1),
+            Err(_) => None,
+        }
     }
 }
 
@@ -159,20 +225,50 @@ impl<T: fmt::Debug, const N: u64, A: Allocator + Clone> fmt::Debug for SparseLis
 
 impl<T: Clone, const N: u64, A: Allocator + Clone> Clone for SparseList<T, N, A> {
     fn clone(&self) -> Self {
+        let mut entries: Vec<(u64, MissingOr<T>), A> =
+            Vec::with_capacity_in(self.entries.len(), self.alloc.clone());
+        for (k, v) in self.entries.iter() {
+            entries.push((*k, v.clone()));
+        }
+        let mut cached: Vec<(u64, [u8; 32]), A> =
+            Vec::with_capacity_in(self.cached_subtree_roots.len(), self.alloc.clone());
+        for (k, v) in self.cached_subtree_roots.iter() {
+            cached.push((*k, *v));
+        }
         Self {
             len: self.len,
-            entries: self.entries.clone(),
-            cached_subtree_roots: self.cached_subtree_roots.clone(),
-            _alloc: self._alloc.clone(),
+            entries,
+            cached_subtree_roots: cached,
+            alloc: self.alloc.clone(),
         }
     }
 }
 
 impl<T: PartialEq, const N: u64, A: Allocator + Clone> PartialEq for SparseList<T, N, A> {
     fn eq(&self, other: &Self) -> bool {
-        self.len == other.len
-            && self.entries == other.entries
-            && self.cached_subtree_roots == other.cached_subtree_roots
+        if self.len != other.len
+            || self.entries.len() != other.entries.len()
+            || self.cached_subtree_roots.len() != other.cached_subtree_roots.len()
+        {
+            return false;
+        }
+        // Both vectors are sorted by key, so element-wise comparison
+        // suffices.
+        for ((ka, va), (kb, vb)) in self.entries.iter().zip(other.entries.iter()) {
+            if ka != kb || va != vb {
+                return false;
+            }
+        }
+        for ((ka, va), (kb, vb)) in self
+            .cached_subtree_roots
+            .iter()
+            .zip(other.cached_subtree_roots.iter())
+        {
+            if ka != kb || va != vb {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -200,8 +296,8 @@ impl<T: Encode, const N: u64, A: Allocator + Clone> Encode for SparseList<T, N, 
         let n_entries = self.entries.len();
         let entry_var_size: usize = self
             .entries
-            .values()
-            .map(|v| v.ssz_bytes_len())
+            .iter()
+            .map(|(_, v)| v.ssz_bytes_len())
             .sum::<usize>();
         // Each entry is (u64 key, MissingOr<T> value). u64 is fixed (8B);
         // MissingOr<T> is variable, so each entry has a 4B offset slot.
@@ -224,15 +320,13 @@ impl<T: Encode, const N: u64, A: Allocator + Clone> Encode for SparseList<T, N, 
         buf.extend_from_slice(&12u32.to_le_bytes());
         // Now encode the entries list. SSZ list of container elements
         // where the container is (u64 key, MissingOr<T> value).
-        let entries: alloc::vec::Vec<(u64, &MissingOr<T>)> =
-            self.entries.iter().map(|(k, v)| (*k, v)).collect();
-        encode_sparse_entries_list(&entries, buf);
+        encode_sparse_entries_list(&self.entries, buf);
     }
 }
 
-fn encode_sparse_entries_list<T: Encode, A: Allocator + Clone>(
-    entries: &[(u64, &MissingOr<T>)],
-    buf: &mut Vec<u8, A>,
+fn encode_sparse_entries_list<T: Encode, A: Allocator + Clone, A2: Allocator + Clone>(
+    entries: &Vec<(u64, MissingOr<T>), A>,
+    buf: &mut Vec<u8, A2>,
 ) {
     let n = entries.len();
     // Each entry container: (u64 key, MissingOr<T> value).
@@ -303,10 +397,12 @@ impl<T: Decode, const N: u64, A: Allocator + Clone + Default> Decode for SparseL
             });
         }
         let payload = &bytes[12..];
-        let entries = decode_sparse_entries_list::<T, A2>(payload, alloc)?;
-        let mut map: BTreeMap<u64, MissingOr<T>> = BTreeMap::new();
+        let entries_in = decode_sparse_entries_list::<T, A2>(payload, alloc)?;
+        let target_alloc = A::default();
+        let mut entries: Vec<(u64, MissingOr<T>), A> =
+            Vec::with_capacity_in(entries_in.len(), target_alloc.clone());
         let mut prev_key: Option<u64> = None;
-        for (k, v) in entries {
+        for (k, v) in entries_in {
             if k >= N {
                 return Err(DecodeError::BoundExceeded {
                     len: k + 1,
@@ -319,13 +415,13 @@ impl<T: Decode, const N: u64, A: Allocator + Clone + Default> Decode for SparseL
                 return Err(DecodeError::NotSorted);
             }
             prev_key = Some(k);
-            map.insert(k, v);
+            entries.push((k, v));
         }
         Ok(Self {
             len,
-            entries: map,
-            cached_subtree_roots: BTreeMap::new(),
-            _alloc: A::default(),
+            entries,
+            cached_subtree_roots: Vec::new_in(target_alloc.clone()),
+            alloc: target_alloc,
         })
     }
 }
@@ -443,9 +539,8 @@ impl<T: HashTreeRoot, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
         total_depth: usize,
     ) -> [u8; 32] {
         // Fast path: explicitly cached subtree root for this coordinate.
-        if let Some(cached) = self
-            .cached_subtree_roots
-            .get(&coord_to_key(node_depth, node_index_at_depth))
+        if let Some(cached) =
+            self.cached_subtree_root(coord_to_key(node_depth, node_index_at_depth))
         {
             return *cached;
         }
@@ -454,8 +549,7 @@ impl<T: HashTreeRoot, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
         if node_depth == total_depth {
             // Leaf index is `node_index_at_depth`. Return the chunk root.
             return self
-                .entries
-                .get(&node_index_at_depth)
+                .get(node_index_at_depth)
                 .map(|e| e.hash_tree_root::<D>())
                 .unwrap_or([0u8; 32]);
         }
@@ -468,7 +562,11 @@ impl<T: HashTreeRoot, const N: u64, A: Allocator + Clone> SparseList<T, N, A> {
 
         // If no materialized entries fall in [lo, hi), this subtree is
         // entirely empty → it's a zero-hash at the appropriate depth.
-        let has_entries = self.entries.range(lo..hi).next().is_some();
+        // `partition_point` gives us the index of the first entry with
+        // key >= lo. If that entry's key is < hi, there's at least one
+        // materialized entry in range.
+        let pos = self.entries.partition_point(|(k, _)| *k < lo);
+        let has_entries = self.entries.get(pos).is_some_and(|(k, _)| *k < hi);
         if !has_entries {
             return zero_hash::<D>(levels_below);
         }

--- a/website/content/spec/_index.md
+++ b/website/content/spec/_index.md
@@ -384,12 +384,18 @@ Image {                        -- content-addressed; Cap::Image kind
 }
 
 MemoryMapping {
-  start:   u64                  -- virtual address
-  size:    u64                  -- bytes (any size; not page-aligned)
+  start:   u64                  -- virtual address; MUST be 4 KiB-aligned
+  size:    u64                  -- bytes; MUST be a multiple of 4 KiB
   source:  Persistent(SlotPath) -- cnode-DataCap-backed; mutations COW'd
         |  Ephemeral            -- kernel-allocated per-apply; not in cnode;
                                 --   captured into Paused on yield
 }
+
+-- Page-alignment rationale: DataCap content is page-multiple by
+-- construction (see §2). Page-aligning mappings lets the kernel map
+-- DataCap pages directly into ring-3 page tables without copying
+-- bytes through an intermediate per-call buffer. Pinned-RO mappings
+-- of the same DataCap across multiple Instances share physical pages.
 
 EndpointDef {
   entry_pc:          u64
@@ -602,32 +608,48 @@ in the apply's address space. Pinned source slots → mapped
 read-only. Unpinned → mapped read-write with copy-on-write per page.
 Ephemeral mappings are kernel-allocated zeroed at apply start.
 
-### DataCap canonical form: trailing-zero-stripped
+### DataCap shape: page-multiple content, no separate size
 
 ```
-DataCap.content has size N (the "stripped size" — no trailing zeros).
-hash(DataCap("Hello\0\0\0")) ≡ hash(DataCap("Hello"))
-DataCap.size = position of last non-zero byte + 1; or 0 if all zero.
+DataCap {
+  content: Bytes              -- length is always a multiple of 4 KiB
+}
+
+hash(DataCap) = hash_tree_root(content)
 ```
 
-Kernel strips trailing zeros at every mint operation. The
-content_hash and size both reflect the stripped representation.
+`DataCap.content.len()` is the only authoritative size — there is no
+separate `size` field. The kernel does NOT canonicalize content by
+stripping trailing zeros. `DataCap("Hello\0\0...\0")` (4 KiB) and
+`DataCap("Hello\0...\0")` (8 KiB) are distinct caps with distinct
+hashes; they coexist in the cache without dedup.
+
+Rationale: the previous "trailing-zero-stripped canonical form" rule
+existed to deduplicate logically-identical short caps. In practice
+nothing produces caps in both stripped and padded shapes for the same
+logical content — caps come from `host_mint_data_cap` (caller-supplied
+bytes, padded up to a page boundary at mint) or from HALT auto-mint
+(page-aligned dirty-page content). Both paths produce page-multiple
+caps. Removing the strip rule simplifies the kernel without losing
+any observable dedup.
 
 ### Size handling at map time
 
 ```
-DataCap.size = N
-region.size = S
+DataCap.content.len() = N      (both 4 KiB-multiples)
+region.size           = S      (both 4 KiB-multiples)
 
-if N == S:  direct mapping.
-if N <  S:  map bytes 0..N from DataCap; zero-fill bytes N..S in
-            address space.
-if N >  S:  CALL faults. Caller is responsible for ensuring DataCaps
-            fit the regions they'll be mapped into.
+if N == S:  direct page-by-page mapping.
+if N <  S:  map the N bytes of the DataCap; map the remaining S − N
+            bytes from the shared global zero page (RO).
+if N >  S:  CALL faults. Caller is responsible for sizing.
 ```
 
-Zero-padding small DataCaps lets callers pass variable-size args
-without explicit length encoding.
+Variable-length payloads (e.g., caller args via slot[0]) flow through
+a DataCap whose content's logical meaning is interpreted by the
+receiver — either via a length-prefix encoding inside the bytes or by
+zero-terminator scanning. The kernel does not carry a logical-length
+hint.
 
 ### Persistence of mapped regions at HALT
 
@@ -638,8 +660,8 @@ At HALT:
   If apply explicitly replaced the source slot via cap-table ops:
     Use the replaced cap. Discard memory modifications from this region.
   Else if any pages in the region are dirty:
-    Mint a new DataCap from the modified region content (trailing
-      zeros stripped). Place at source slot.
+    Mint a new DataCap whose content is the modified pages verbatim
+      (page-multiple, no trailing-zero stripping). Place at source slot.
   Else:
     Source slot unchanged.
 ```


### PR DESCRIPTION
## Summary

Refactor the in-kernel sub-VM lifecycle around the existing cache infrastructure: page-aligned DataCap, per-Image compiled arena, refcount-pinning `CapHandle`, direct-indexed instance directory, allocator-parameterized `SparseList`, and a slimmed `KernelFrame` that holds refcount-pinned handles instead of cloning cap-resident data.

`sub_vm_recurse` (depth=1000) drops from ~43 ms → ~24 ms — about a 9× improvement in VMs/sec versus master.

## Commits

| Commit | What |
|---|---|
| [`db83db56`](https://github.com/jarchain/jar/commit/db83db56) | Page-aligned DataCap by default (spec + impl) |
| [`9d2f76ca`](https://github.com/jarchain/jar/commit/9d2f76ca) | Per-Image arena + META PML4 slot |
| [`9758b11f`](https://github.com/jarchain/jar/commit/9758b11f) | Per-Image template PT for arena PD subtree |
| [`306b8640`](https://github.com/jarchain/jar/commit/306b8640) | Cache per-frame PT + bufs across re-entries |
| [`8ae8cad1`](https://github.com/jarchain/jar/commit/8ae8cad1) | Drop unused `CompiledImage` region size fields |
| [`a8bdfc3f`](https://github.com/jarchain/jar/commit/a8bdfc3f) | Drop release-profile LTO/codegen-units overrides |
| [`01996143`](https://github.com/jarchain/jar/commit/01996143) | `CacheHandle<T>` — non-owning refcount handle |
| [`d4d8f56a`](https://github.com/jarchain/jar/commit/d4d8f56a) | Direct-indexed instance directory + 32k slots |
| [`9256696d`](https://github.com/jarchain/jar/commit/9256696d) | Guest-side cache handles + `publish_instance` |
| [`de2ffe6f`](https://github.com/jarchain/jar/commit/de2ffe6f) | SparseList allocator-parameterized storage |
| [`78ee18a9`](https://github.com/jarchain/jar/commit/78ee18a9) | Slim KernelFrame, replace TransientTable with cache.instances |

## Design highlights

**Page-aligned DataCap**: `DataCap.content` storage is always a page-multiple; the separate `size` field is gone, hash is `hash_tree_root(content)` over the full buffer. Spec doc updated alongside the Rust impl. Enables direct PT-mapping of DataCap pages in future work.

**Per-Image arena**: BB/JT/DISPATCH/JIT/TRAMP regions live in one page-aligned arena owned by the compile cache. Per-call work allocates only CTX/MEM/STACK; the arena pages are mapped from a per-Image *template PD* via a single `install_borrowed_pd` PDPT write.

**Per-frame runtime caching**: `KernelFrame` retains its page table + mem/ctx/stack `PageBuf`s across re-entries (parent resumes after child HALTs). Bounded at 256 resident runtimes so deep recursion can't blow up memory.

**`CacheHandle<T>` + refcount-pinning**: A new handle type in `nub-host-common` lets a `KernelFrame` pin a cap entry against eviction without owning the slab. Distinct from `Aarc<T, A>` which deallocates on last drop — cache entries belong to the cache.

**Direct-indexed instance directory**: `InstanceSlot[N]` lookup is now O(1) via `slot_idx = (ref_id - 1) & (N - 1)`. `MAX_INSTANCE_SLOTS` bumped from 256 to 32 768 so deep recursion can have a real `Cap::Instance` per frame. Allocation via a shared `next_ref: AtomicU64` in the directory with retry-on-collision (~3% retry probability at 1000 live refs).

**SparseList allocator-genericity**: Replaced `BTreeMap<u64, _>` (hardwired to `Global`) with sorted `Vec<(u64, _), A>` end-to-end. Wire format and `hash_tree_root` output are byte-identical (verified by existing ssz vectors). Unblocks guest-side `Cap::CNode` walks because the storage now lives in the same allocator as the cap.

**KernelFrame slimdown**: Drops `code` / `bitmask` / `jump_table` / `mem_size` / `overlays` (all read on-demand through `frame.image.cap`). `dispatch_derive_spawn` publishes a fresh `Cap::Instance` into `cache.instances` via `publish_instance` instead of writing to a kernel-private `TransientTable`; cnode slots widen to `CapHashOrRef` to carry either blob hashes or instance refs. End-of-RPC `clear_scratch` reclaims dropped instance slots (refcount-aware safety net).

## Bench results (`sub_vm_recurse`)

| | master | this PR | Δ |
|---|---:|---:|---|
| depth=10 | ~304 µs | ~137 µs | −55% |
| depth=100 | ~3.24 ms | ~1.35 ms | −58% |
| depth=1000 | ~43.7 ms | ~23.8 ms | −46% |

Per-VM at depth=10: ~30 µs → ~14 µs, roughly halving the per-call overhead.

## Test plan

- [x] `cargo test --workspace --tests` — full suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo bench -p javm-bench --bench sub_vm_recurse` — numbers above
- [x] `cargo bench -p javm-bench --bench pvm_bench` — host-side recompiler stays within noise
- [x] `cargo bench -p javm-bench --bench stark_bench` — stark workloads within noise
- [x] Hyperlight smoke test (`cargo test -p nub --test smoke`) — passes

## Deferred

Tracked in #855 — independent of this PR:

- **Direct DataCap → PT mapping + CoW + HALT auto-mint** (Phase 4 from the original optimization plan). This refactor's `CacheHandle` is the prerequisite for the safe-lifetime story; the cache-side refcount discipline now correctly pins DataCap pages mapped into a per-call PT.
- **Global page bits on template PT entries** (Phase 3c). Independent ~1 µs CR3-reload optimization needing cross-Image INVLPG correctness work.