### PR TITLE
bench: measure recompile+execute, not warm-cache execute

### DIFF
--- a/rust/javm-bench/benches/pvm_bench.rs
+++ b/rust/javm-bench/benches/pvm_bench.rs
@@ -3,13 +3,21 @@
 //! Each guest crate at `components/benches/<workload>` builds to a
 //! single-endpoint Image; this bench loads each Image, runs a sanity
 //! check (which primes the cached Hyperlight sandbox), then runs
-//! criterion on both backends. The cache is content-addressed and
-//! re-publishing the same Image is idempotent, so the per-iter cost
-//! stays in `invoke_cached`.
+//! criterion on both backends.
+//!
+//! Two recompiler arms are reported per workload:
+//!
+//! - `recompiler_warm` — the JIT cache hits after iteration 1; the
+//!   timed body is steady-state execute. Comparable across runs and
+//!   to PolkaVM's warm path.
+//! - `recompiler_cold` — the JIT cache is evicted before every
+//!   invocation; the timed body is **predecode + JIT + execute**.
+//!   Models a PolkaVM-shaped workload where each guest invocation
+//!   may face a fresh Image hash.
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use javm_cap::image::Image;
 use ssz::Decode;
 
@@ -54,8 +62,40 @@ macro_rules! bench_workload {
             g.bench_function("interpreter", |b| {
                 b.iter(|| javm_bench::run_interpreter(&built))
             });
-            g.bench_function("recompiler", |b| {
-                b.iter(|| javm_bench::run_recompiler(&built))
+            // Both recompiler arms use iter_batched(PerIteration). The
+            // timed body covers `put_cap_with_hash` × 4 + `invoke_cached`,
+            // i.e. the per-call publish-and-invoke cost real callers pay.
+            // The merkle-hash computation that `put_cap` would normally do
+            // is amortised away at warmup (`BuiltCaps::for_image` records
+            // every hash once) and short-circuits at runtime via the
+            // host-side `GuestCacheReader::contains(hash)` check, so the
+            // routine measures the realistic publish+invoke, never the
+            // merkle. Setup (untimed) holds the mutex and — for cold —
+            // does JIT-cache eviction so eviction's ~7 µs RPC doesn't
+            // get counted against recompile time.
+            g.bench_function("recompiler_warm", |b| {
+                b.iter_batched(
+                    || javm_bench::nub_hyperlight_lock(),
+                    |mut nub| {
+                        built.put_into(&mut nub);
+                        javm_bench::invoke(&mut *nub, &built)
+                    },
+                    BatchSize::PerIteration,
+                )
+            });
+            g.bench_function("recompiler_cold", |b| {
+                b.iter_batched(
+                    || {
+                        let mut nub = javm_bench::nub_hyperlight_lock();
+                        nub.evict_jit_all().expect("evict_jit_all");
+                        nub
+                    },
+                    |mut nub| {
+                        built.put_into(&mut nub);
+                        javm_bench::invoke(&mut *nub, &built)
+                    },
+                    BatchSize::PerIteration,
+                )
             });
             g.finish();
         }

--- a/rust/javm-bench/benches/stark_bench.rs
+++ b/rust/javm-bench/benches/stark_bench.rs
@@ -20,10 +20,16 @@
 //! All three share the no_std hand-written Goldilocks + Poseidon2
 //! implementation in `components/benches/goldilocks-poseidon2`,
 //! bit-exact with `p3-goldilocks::default_goldilocks_poseidon2_8`.
+//!
+//! Two recompiler arms are reported per workload:
+//!
+//! - `recompiler_warm` — JIT cache hits; timed body is steady-state execute.
+//! - `recompiler_cold` — JIT cache evicted per iteration; timed body is
+//!   **predecode + JIT + execute**.
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use javm_cap::image::Image;
 use ssz::Decode;
 
@@ -62,8 +68,32 @@ macro_rules! bench_workload {
             g.bench_function("interpreter", |b| {
                 b.iter(|| javm_bench::run_interpreter(&built))
             });
-            g.bench_function("recompiler", |b| {
-                b.iter(|| javm_bench::run_recompiler(&built))
+            // See pvm_bench.rs for rationale. Timed body =
+            // put_cap_with_hash×4 + invoke_cached; untimed setup =
+            // mutex + (cold) evict_jit_all.
+            g.bench_function("recompiler_warm", |b| {
+                b.iter_batched(
+                    || javm_bench::nub_hyperlight_lock(),
+                    |mut nub| {
+                        built.put_into(&mut nub);
+                        javm_bench::invoke(&mut *nub, &built)
+                    },
+                    BatchSize::PerIteration,
+                )
+            });
+            g.bench_function("recompiler_cold", |b| {
+                b.iter_batched(
+                    || {
+                        let mut nub = javm_bench::nub_hyperlight_lock();
+                        nub.evict_jit_all().expect("evict_jit_all");
+                        nub
+                    },
+                    |mut nub| {
+                        built.put_into(&mut nub);
+                        javm_bench::invoke(&mut *nub, &built)
+                    },
+                    BatchSize::PerIteration,
+                )
             });
             g.finish();
         }

--- a/rust/javm-bench/examples/opcode_stats.rs
+++ b/rust/javm-bench/examples/opcode_stats.rs
@@ -1,0 +1,295 @@
+//! Image-size and opcode-frequency statistics for every bench guest.
+//!
+//! For each of the 12 bench workloads (pvm_bench + stark_bench + sub_vm),
+//! report:
+//!
+//!   - Total wire-format Image size (SSZ-encoded blob length).
+//!   - Code / packed-bitmask / jump-table byte breakdown.
+//!   - Static instruction count (number of opcodes in the code stream).
+//!   - Average bytes per static instruction.
+//!   - Per-opcode static frequency (count + % of static insns).
+//!
+//! Both per-workload and aggregated-across-all-workloads outputs are
+//! printed. Used to inform the PVM2 encoding design — confirms which
+//! opcodes earn their slot and which are rarely used.
+//!
+//! Linux x86-64 only (matches the bench harness).
+//!
+//! Run with:
+//! ```
+//! cargo run --release -p javm-bench --example opcode_stats
+//! ```
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::Image;
+use javm_exec::instruction::Opcode;
+use javm_exec::unpack_bitmask;
+use ssz::Decode;
+use std::collections::BTreeMap;
+
+struct WorkloadStats {
+    name: &'static str,
+    image_bytes: usize,
+    code_bytes: usize,
+    bitmask_bytes_packed: usize,
+    jump_table_bytes: usize,
+    insn_count: usize,
+    insn_bytes_total: usize,
+    /// opcode byte → count
+    opcode_hist: BTreeMap<u8, usize>,
+    /// invalid-opcode byte → count (should be 0 for valid programs)
+    unknown_hist: BTreeMap<u8, usize>,
+    /// category (Debug string) → count
+    category_hist: BTreeMap<String, usize>,
+}
+
+fn opcode_name(op: u8) -> String {
+    match Opcode::from_byte(op) {
+        Some(o) => format!("{o:?}"),
+        None => format!("UNKNOWN({op})"),
+    }
+}
+
+fn compute_skip(pc: usize, bitmask: &[u8]) -> usize {
+    for j in 0..25 {
+        let idx = pc + 1 + j;
+        let bit = if idx < bitmask.len() { bitmask[idx] } else { 1 };
+        if bit == 1 {
+            return j;
+        }
+    }
+    24
+}
+
+fn analyze(name: &'static str, blob: &[u8]) -> WorkloadStats {
+    let image = Image::from_ssz_bytes(blob).unwrap_or_else(|e| {
+        panic!("[{name}] decode Image: {e:?}");
+    });
+    let code = image.code.as_slice();
+    let bitmask = unpack_bitmask(&image.packed_bitmask, code.len());
+
+    let mut opcode_hist: BTreeMap<u8, usize> = BTreeMap::new();
+    let mut unknown_hist: BTreeMap<u8, usize> = BTreeMap::new();
+    let mut category_hist: BTreeMap<String, usize> = BTreeMap::new();
+    let mut insn_count = 0usize;
+    let mut insn_bytes_total = 0usize;
+
+    let mut pc = 0usize;
+    while pc < code.len() {
+        // Skip non-opcode bytes (continuation bytes within an instruction).
+        if pc < bitmask.len() && bitmask[pc] != 1 {
+            pc += 1;
+            continue;
+        }
+        let byte = code[pc];
+        match Opcode::from_byte(byte) {
+            Some(op) => {
+                *opcode_hist.entry(byte).or_default() += 1;
+                *category_hist.entry(format!("{:?}", op.category())).or_default() += 1;
+            }
+            None => {
+                *unknown_hist.entry(byte).or_default() += 1;
+            }
+        }
+        insn_count += 1;
+
+        let skip = compute_skip(pc, &bitmask);
+        let insn_len = 1 + skip;
+        insn_bytes_total += insn_len;
+        pc += insn_len;
+    }
+
+    WorkloadStats {
+        name,
+        image_bytes: blob.len(),
+        code_bytes: code.len(),
+        bitmask_bytes_packed: image.packed_bitmask.len(),
+        jump_table_bytes: image.jump_table.len() * core::mem::size_of::<u32>(),
+        insn_count,
+        insn_bytes_total,
+        opcode_hist,
+        unknown_hist,
+        category_hist,
+    }
+}
+
+fn print_workload_summary(s: &WorkloadStats) {
+    let bytes_per_insn = if s.insn_count > 0 {
+        s.insn_bytes_total as f64 / s.insn_count as f64
+    } else {
+        0.0
+    };
+    println!(
+        "{:<22} | image={:>7} code={:>7} bitmask={:>6} jt={:>6} | insns={:>6} bytes/insn={:.2}",
+        s.name,
+        s.image_bytes,
+        s.code_bytes,
+        s.bitmask_bytes_packed,
+        s.jump_table_bytes,
+        s.insn_count,
+        bytes_per_insn,
+    );
+}
+
+fn print_opcode_hist(label: &str, hist: &BTreeMap<u8, usize>, total: usize, top_n: usize) {
+    let mut entries: Vec<(u8, usize)> = hist.iter().map(|(&k, &v)| (k, v)).collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    println!("\n{label} — top {top_n} opcodes (total static insns = {total}):");
+    println!(
+        "  {:<5} {:<22} {:>10} {:>8}",
+        "byte", "name", "count", "%"
+    );
+    for (op, count) in entries.iter().take(top_n) {
+        let pct = if total > 0 {
+            100.0 * (*count as f64) / (total as f64)
+        } else {
+            0.0
+        };
+        println!(
+            "  {:>5} {:<22} {:>10} {:>7.2}%",
+            op,
+            opcode_name(*op),
+            count,
+            pct,
+        );
+    }
+    if entries.len() > top_n {
+        let tail_count: usize = entries.iter().skip(top_n).map(|(_, c)| c).sum();
+        let pct = if total > 0 {
+            100.0 * (tail_count as f64) / (total as f64)
+        } else {
+            0.0
+        };
+        println!(
+            "  ... {} more opcodes accounting for {} ({:.2}%)",
+            entries.len() - top_n,
+            tail_count,
+            pct,
+        );
+    }
+}
+
+fn print_category_hist(hist: &BTreeMap<String, usize>, total: usize) {
+    let mut entries: Vec<(String, usize)> =
+        hist.iter().map(|(k, &v)| (k.clone(), v)).collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    println!("\nBy instruction category:");
+    for (cat, count) in &entries {
+        let pct = if total > 0 {
+            100.0 * (*count as f64) / (total as f64)
+        } else {
+            0.0
+        };
+        println!("  {:<22} {:>10} {:>7.2}%", cat, count, pct);
+    }
+}
+
+fn aggregate(per_wl: &[WorkloadStats]) -> WorkloadStats {
+    let mut agg = WorkloadStats {
+        name: "AGGREGATE",
+        image_bytes: 0,
+        code_bytes: 0,
+        bitmask_bytes_packed: 0,
+        jump_table_bytes: 0,
+        insn_count: 0,
+        insn_bytes_total: 0,
+        opcode_hist: BTreeMap::new(),
+        unknown_hist: BTreeMap::new(),
+        category_hist: BTreeMap::new(),
+    };
+    for s in per_wl {
+        agg.image_bytes += s.image_bytes;
+        agg.code_bytes += s.code_bytes;
+        agg.bitmask_bytes_packed += s.bitmask_bytes_packed;
+        agg.jump_table_bytes += s.jump_table_bytes;
+        agg.insn_count += s.insn_count;
+        agg.insn_bytes_total += s.insn_bytes_total;
+        for (k, v) in &s.opcode_hist {
+            *agg.opcode_hist.entry(*k).or_default() += v;
+        }
+        for (k, v) in &s.unknown_hist {
+            *agg.unknown_hist.entry(*k).or_default() += v;
+        }
+        for (k, v) in &s.category_hist {
+            *agg.category_hist.entry(k.clone()).or_default() += v;
+        }
+    }
+    agg
+}
+
+/// Print which valid opcodes have ZERO uses across all measured workloads.
+/// These are candidates for removal in a PVM2 encoding redesign.
+fn print_unused_opcodes(agg_hist: &BTreeMap<u8, usize>) {
+    let all_valid_opcodes: &[u8] = &[
+        0, 1, 2, 3, 10, 20, 30, 31, 32, 33, 40, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+        70, 71, 72, 73, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 100, 101, 102, 103, 104, 105,
+        106, 107, 108, 109, 110, 111, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+        132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+        150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 170, 171, 172, 173, 174, 175,
+        180, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206,
+        207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+        225, 226, 227, 228, 229, 230,
+    ];
+    let unused: Vec<u8> = all_valid_opcodes
+        .iter()
+        .copied()
+        .filter(|op| !agg_hist.contains_key(op))
+        .collect();
+    println!(
+        "\nUnused opcodes ({} of {} valid PVM opcodes have zero static uses across all benches):",
+        unused.len(),
+        all_valid_opcodes.len(),
+    );
+    for op in &unused {
+        println!("  {:>5}  {}", op, opcode_name(*op));
+    }
+}
+
+fn main() {
+    let workloads: &[(&'static str, &[u8])] = &[
+        ("prime_sieve",         include_bytes!(env!("PRIME_SIEVE_BLOB"))),
+        ("ed25519",             include_bytes!(env!("ED25519_BLOB"))),
+        ("keccak",              include_bytes!(env!("KECCAK_BLOB"))),
+        ("blake2b",             include_bytes!(env!("BLAKE2B_BLOB"))),
+        ("ecrecover",           include_bytes!(env!("ECRECOVER_BLOB"))),
+        ("goldilocks_mul",      include_bytes!(env!("GOLDILOCKS_MUL_BLOB"))),
+        ("poseidon2_perm",      include_bytes!(env!("POSEIDON2_PERM_BLOB"))),
+        ("mini_verifier",       include_bytes!(env!("MINI_VERIFIER_BLOB"))),
+        ("poly_eval",           include_bytes!(env!("POLY_EVAL_BLOB"))),
+        ("fri_fold_tree",       include_bytes!(env!("FRI_FOLD_TREE_BLOB"))),
+        ("sub_vm_recurse",      include_bytes!(env!("SUB_VM_RECURSE_BLOB"))),
+        ("sub_vm_data_recurse", include_bytes!(env!("SUB_VM_DATA_RECURSE_BLOB"))),
+    ];
+
+    let stats: Vec<WorkloadStats> = workloads
+        .iter()
+        .map(|(n, b)| analyze(n, b))
+        .collect();
+
+    println!("=== Per-workload size + instruction count ===\n");
+    println!(
+        "{:<22} | {:>7} {:>7} {:>6} {:>6} | {:>6} {:>9}",
+        "workload", "image", "code", "bitmsk", "jt", "insns", "B/insn"
+    );
+    println!("{}", "-".repeat(96));
+    for s in &stats {
+        print_workload_summary(s);
+    }
+
+    let agg = aggregate(&stats);
+    println!("{}", "-".repeat(96));
+    print_workload_summary(&agg);
+
+    // Aggregate-level histograms (most informative for design decisions).
+    print_category_hist(&agg.category_hist, agg.insn_count);
+    print_opcode_hist("AGGREGATE", &agg.opcode_hist, agg.insn_count, 30);
+    print_unused_opcodes(&agg.opcode_hist);
+
+    if !agg.unknown_hist.is_empty() {
+        println!("\nWARNING: invalid opcode bytes found in code stream:");
+        for (op, count) in &agg.unknown_hist {
+            println!("  byte {op} → {count} occurrences");
+        }
+    }
+}

--- a/rust/javm-bench/examples/opcode_stats.rs
+++ b/rust/javm-bench/examples/opcode_stats.rs
@@ -20,276 +20,294 @@
 //! cargo run --release -p javm-bench --example opcode_stats
 //! ```
 
-#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
-
-use javm_cap::image::Image;
-use javm_exec::instruction::Opcode;
-use javm_exec::unpack_bitmask;
-use ssz::Decode;
-use std::collections::BTreeMap;
-
-struct WorkloadStats {
-    name: &'static str,
-    image_bytes: usize,
-    code_bytes: usize,
-    bitmask_bytes_packed: usize,
-    jump_table_bytes: usize,
-    insn_count: usize,
-    insn_bytes_total: usize,
-    /// opcode byte → count
-    opcode_hist: BTreeMap<u8, usize>,
-    /// invalid-opcode byte → count (should be 0 for valid programs)
-    unknown_hist: BTreeMap<u8, usize>,
-    /// category (Debug string) → count
-    category_hist: BTreeMap<String, usize>,
-}
-
-fn opcode_name(op: u8) -> String {
-    match Opcode::from_byte(op) {
-        Some(o) => format!("{o:?}"),
-        None => format!("UNKNOWN({op})"),
-    }
-}
-
-fn compute_skip(pc: usize, bitmask: &[u8]) -> usize {
-    for j in 0..25 {
-        let idx = pc + 1 + j;
-        let bit = if idx < bitmask.len() { bitmask[idx] } else { 1 };
-        if bit == 1 {
-            return j;
-        }
-    }
-    24
-}
-
-fn analyze(name: &'static str, blob: &[u8]) -> WorkloadStats {
-    let image = Image::from_ssz_bytes(blob).unwrap_or_else(|e| {
-        panic!("[{name}] decode Image: {e:?}");
-    });
-    let code = image.code.as_slice();
-    let bitmask = unpack_bitmask(&image.packed_bitmask, code.len());
-
-    let mut opcode_hist: BTreeMap<u8, usize> = BTreeMap::new();
-    let mut unknown_hist: BTreeMap<u8, usize> = BTreeMap::new();
-    let mut category_hist: BTreeMap<String, usize> = BTreeMap::new();
-    let mut insn_count = 0usize;
-    let mut insn_bytes_total = 0usize;
-
-    let mut pc = 0usize;
-    while pc < code.len() {
-        // Skip non-opcode bytes (continuation bytes within an instruction).
-        if pc < bitmask.len() && bitmask[pc] != 1 {
-            pc += 1;
-            continue;
-        }
-        let byte = code[pc];
-        match Opcode::from_byte(byte) {
-            Some(op) => {
-                *opcode_hist.entry(byte).or_default() += 1;
-                *category_hist.entry(format!("{:?}", op.category())).or_default() += 1;
-            }
-            None => {
-                *unknown_hist.entry(byte).or_default() += 1;
-            }
-        }
-        insn_count += 1;
-
-        let skip = compute_skip(pc, &bitmask);
-        let insn_len = 1 + skip;
-        insn_bytes_total += insn_len;
-        pc += insn_len;
-    }
-
-    WorkloadStats {
-        name,
-        image_bytes: blob.len(),
-        code_bytes: code.len(),
-        bitmask_bytes_packed: image.packed_bitmask.len(),
-        jump_table_bytes: image.jump_table.len() * core::mem::size_of::<u32>(),
-        insn_count,
-        insn_bytes_total,
-        opcode_hist,
-        unknown_hist,
-        category_hist,
-    }
-}
-
-fn print_workload_summary(s: &WorkloadStats) {
-    let bytes_per_insn = if s.insn_count > 0 {
-        s.insn_bytes_total as f64 / s.insn_count as f64
-    } else {
-        0.0
-    };
-    println!(
-        "{:<22} | image={:>7} code={:>7} bitmask={:>6} jt={:>6} | insns={:>6} bytes/insn={:.2}",
-        s.name,
-        s.image_bytes,
-        s.code_bytes,
-        s.bitmask_bytes_packed,
-        s.jump_table_bytes,
-        s.insn_count,
-        bytes_per_insn,
-    );
-}
-
-fn print_opcode_hist(label: &str, hist: &BTreeMap<u8, usize>, total: usize, top_n: usize) {
-    let mut entries: Vec<(u8, usize)> = hist.iter().map(|(&k, &v)| (k, v)).collect();
-    entries.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-    println!("\n{label} — top {top_n} opcodes (total static insns = {total}):");
-    println!(
-        "  {:<5} {:<22} {:>10} {:>8}",
-        "byte", "name", "count", "%"
-    );
-    for (op, count) in entries.iter().take(top_n) {
-        let pct = if total > 0 {
-            100.0 * (*count as f64) / (total as f64)
-        } else {
-            0.0
-        };
-        println!(
-            "  {:>5} {:<22} {:>10} {:>7.2}%",
-            op,
-            opcode_name(*op),
-            count,
-            pct,
-        );
-    }
-    if entries.len() > top_n {
-        let tail_count: usize = entries.iter().skip(top_n).map(|(_, c)| c).sum();
-        let pct = if total > 0 {
-            100.0 * (tail_count as f64) / (total as f64)
-        } else {
-            0.0
-        };
-        println!(
-            "  ... {} more opcodes accounting for {} ({:.2}%)",
-            entries.len() - top_n,
-            tail_count,
-            pct,
-        );
-    }
-}
-
-fn print_category_hist(hist: &BTreeMap<String, usize>, total: usize) {
-    let mut entries: Vec<(String, usize)> =
-        hist.iter().map(|(k, &v)| (k.clone(), v)).collect();
-    entries.sort_by(|a, b| b.1.cmp(&a.1));
-    println!("\nBy instruction category:");
-    for (cat, count) in &entries {
-        let pct = if total > 0 {
-            100.0 * (*count as f64) / (total as f64)
-        } else {
-            0.0
-        };
-        println!("  {:<22} {:>10} {:>7.2}%", cat, count, pct);
-    }
-}
-
-fn aggregate(per_wl: &[WorkloadStats]) -> WorkloadStats {
-    let mut agg = WorkloadStats {
-        name: "AGGREGATE",
-        image_bytes: 0,
-        code_bytes: 0,
-        bitmask_bytes_packed: 0,
-        jump_table_bytes: 0,
-        insn_count: 0,
-        insn_bytes_total: 0,
-        opcode_hist: BTreeMap::new(),
-        unknown_hist: BTreeMap::new(),
-        category_hist: BTreeMap::new(),
-    };
-    for s in per_wl {
-        agg.image_bytes += s.image_bytes;
-        agg.code_bytes += s.code_bytes;
-        agg.bitmask_bytes_packed += s.bitmask_bytes_packed;
-        agg.jump_table_bytes += s.jump_table_bytes;
-        agg.insn_count += s.insn_count;
-        agg.insn_bytes_total += s.insn_bytes_total;
-        for (k, v) in &s.opcode_hist {
-            *agg.opcode_hist.entry(*k).or_default() += v;
-        }
-        for (k, v) in &s.unknown_hist {
-            *agg.unknown_hist.entry(*k).or_default() += v;
-        }
-        for (k, v) in &s.category_hist {
-            *agg.category_hist.entry(k.clone()).or_default() += v;
-        }
-    }
-    agg
-}
-
-/// Print which valid opcodes have ZERO uses across all measured workloads.
-/// These are candidates for removal in a PVM2 encoding redesign.
-fn print_unused_opcodes(agg_hist: &BTreeMap<u8, usize>) {
-    let all_valid_opcodes: &[u8] = &[
-        0, 1, 2, 3, 10, 20, 30, 31, 32, 33, 40, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
-        70, 71, 72, 73, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 100, 101, 102, 103, 104, 105,
-        106, 107, 108, 109, 110, 111, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
-        132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
-        150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 170, 171, 172, 173, 174, 175,
-        180, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206,
-        207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
-        225, 226, 227, 228, 229, 230,
-    ];
-    let unused: Vec<u8> = all_valid_opcodes
-        .iter()
-        .copied()
-        .filter(|op| !agg_hist.contains_key(op))
-        .collect();
-    println!(
-        "\nUnused opcodes ({} of {} valid PVM opcodes have zero static uses across all benches):",
-        unused.len(),
-        all_valid_opcodes.len(),
-    );
-    for op in &unused {
-        println!("  {:>5}  {}", op, opcode_name(*op));
-    }
-}
-
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 fn main() {
-    let workloads: &[(&'static str, &[u8])] = &[
-        ("prime_sieve",         include_bytes!(env!("PRIME_SIEVE_BLOB"))),
-        ("ed25519",             include_bytes!(env!("ED25519_BLOB"))),
-        ("keccak",              include_bytes!(env!("KECCAK_BLOB"))),
-        ("blake2b",             include_bytes!(env!("BLAKE2B_BLOB"))),
-        ("ecrecover",           include_bytes!(env!("ECRECOVER_BLOB"))),
-        ("goldilocks_mul",      include_bytes!(env!("GOLDILOCKS_MUL_BLOB"))),
-        ("poseidon2_perm",      include_bytes!(env!("POSEIDON2_PERM_BLOB"))),
-        ("mini_verifier",       include_bytes!(env!("MINI_VERIFIER_BLOB"))),
-        ("poly_eval",           include_bytes!(env!("POLY_EVAL_BLOB"))),
-        ("fri_fold_tree",       include_bytes!(env!("FRI_FOLD_TREE_BLOB"))),
-        ("sub_vm_recurse",      include_bytes!(env!("SUB_VM_RECURSE_BLOB"))),
-        ("sub_vm_data_recurse", include_bytes!(env!("SUB_VM_DATA_RECURSE_BLOB"))),
-    ];
+    eprintln!("opcode_stats is Linux x86-64 only");
+}
 
-    let stats: Vec<WorkloadStats> = workloads
-        .iter()
-        .map(|(n, b)| analyze(n, b))
-        .collect();
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn main() {
+    linux_x86_64::main();
+}
 
-    println!("=== Per-workload size + instruction count ===\n");
-    println!(
-        "{:<22} | {:>7} {:>7} {:>6} {:>6} | {:>6} {:>9}",
-        "workload", "image", "code", "bitmsk", "jt", "insns", "B/insn"
-    );
-    println!("{}", "-".repeat(96));
-    for s in &stats {
-        print_workload_summary(s);
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+mod linux_x86_64 {
+    use javm_cap::image::Image;
+    use javm_exec::instruction::Opcode;
+    use javm_exec::unpack_bitmask;
+    use ssz::Decode;
+    use std::collections::BTreeMap;
+
+    struct WorkloadStats {
+        name: &'static str,
+        image_bytes: usize,
+        code_bytes: usize,
+        bitmask_bytes_packed: usize,
+        jump_table_bytes: usize,
+        insn_count: usize,
+        insn_bytes_total: usize,
+        /// opcode byte → count
+        opcode_hist: BTreeMap<u8, usize>,
+        /// invalid-opcode byte → count (should be 0 for valid programs)
+        unknown_hist: BTreeMap<u8, usize>,
+        /// category (Debug string) → count
+        category_hist: BTreeMap<String, usize>,
     }
 
-    let agg = aggregate(&stats);
-    println!("{}", "-".repeat(96));
-    print_workload_summary(&agg);
+    fn opcode_name(op: u8) -> String {
+        match Opcode::from_byte(op) {
+            Some(o) => format!("{o:?}"),
+            None => format!("UNKNOWN({op})"),
+        }
+    }
 
-    // Aggregate-level histograms (most informative for design decisions).
-    print_category_hist(&agg.category_hist, agg.insn_count);
-    print_opcode_hist("AGGREGATE", &agg.opcode_hist, agg.insn_count, 30);
-    print_unused_opcodes(&agg.opcode_hist);
+    fn compute_skip(pc: usize, bitmask: &[u8]) -> usize {
+        for j in 0..25 {
+            let idx = pc + 1 + j;
+            let bit = if idx < bitmask.len() { bitmask[idx] } else { 1 };
+            if bit == 1 {
+                return j;
+            }
+        }
+        24
+    }
 
-    if !agg.unknown_hist.is_empty() {
-        println!("\nWARNING: invalid opcode bytes found in code stream:");
-        for (op, count) in &agg.unknown_hist {
-            println!("  byte {op} → {count} occurrences");
+    fn analyze(name: &'static str, blob: &[u8]) -> WorkloadStats {
+        let image = Image::from_ssz_bytes(blob).unwrap_or_else(|e| {
+            panic!("[{name}] decode Image: {e:?}");
+        });
+        let code = image.code.as_slice();
+        let bitmask = unpack_bitmask(&image.packed_bitmask, code.len());
+
+        let mut opcode_hist: BTreeMap<u8, usize> = BTreeMap::new();
+        let mut unknown_hist: BTreeMap<u8, usize> = BTreeMap::new();
+        let mut category_hist: BTreeMap<String, usize> = BTreeMap::new();
+        let mut insn_count = 0usize;
+        let mut insn_bytes_total = 0usize;
+
+        let mut pc = 0usize;
+        while pc < code.len() {
+            // Skip non-opcode bytes (continuation bytes within an instruction).
+            if pc < bitmask.len() && bitmask[pc] != 1 {
+                pc += 1;
+                continue;
+            }
+            let byte = code[pc];
+            match Opcode::from_byte(byte) {
+                Some(op) => {
+                    *opcode_hist.entry(byte).or_default() += 1;
+                    *category_hist
+                        .entry(format!("{:?}", op.category()))
+                        .or_default() += 1;
+                }
+                None => {
+                    *unknown_hist.entry(byte).or_default() += 1;
+                }
+            }
+            insn_count += 1;
+
+            let skip = compute_skip(pc, &bitmask);
+            let insn_len = 1 + skip;
+            insn_bytes_total += insn_len;
+            pc += insn_len;
+        }
+
+        WorkloadStats {
+            name,
+            image_bytes: blob.len(),
+            code_bytes: code.len(),
+            bitmask_bytes_packed: image.packed_bitmask.len(),
+            jump_table_bytes: image.jump_table.len() * core::mem::size_of::<u32>(),
+            insn_count,
+            insn_bytes_total,
+            opcode_hist,
+            unknown_hist,
+            category_hist,
+        }
+    }
+
+    fn print_workload_summary(s: &WorkloadStats) {
+        let bytes_per_insn = if s.insn_count > 0 {
+            s.insn_bytes_total as f64 / s.insn_count as f64
+        } else {
+            0.0
+        };
+        println!(
+            "{:<22} | image={:>7} code={:>7} bitmask={:>6} jt={:>6} | insns={:>6} bytes/insn={:.2}",
+            s.name,
+            s.image_bytes,
+            s.code_bytes,
+            s.bitmask_bytes_packed,
+            s.jump_table_bytes,
+            s.insn_count,
+            bytes_per_insn,
+        );
+    }
+
+    fn print_opcode_hist(label: &str, hist: &BTreeMap<u8, usize>, total: usize, top_n: usize) {
+        let mut entries: Vec<(u8, usize)> = hist.iter().map(|(&k, &v)| (k, v)).collect();
+        entries.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        println!("\n{label} — top {top_n} opcodes (total static insns = {total}):");
+        println!("  {:<5} {:<22} {:>10} {:>8}", "byte", "name", "count", "%");
+        for (op, count) in entries.iter().take(top_n) {
+            let pct = if total > 0 {
+                100.0 * (*count as f64) / (total as f64)
+            } else {
+                0.0
+            };
+            println!(
+                "  {:>5} {:<22} {:>10} {:>7.2}%",
+                op,
+                opcode_name(*op),
+                count,
+                pct,
+            );
+        }
+        if entries.len() > top_n {
+            let tail_count: usize = entries.iter().skip(top_n).map(|(_, c)| c).sum();
+            let pct = if total > 0 {
+                100.0 * (tail_count as f64) / (total as f64)
+            } else {
+                0.0
+            };
+            println!(
+                "  ... {} more opcodes accounting for {} ({:.2}%)",
+                entries.len() - top_n,
+                tail_count,
+                pct,
+            );
+        }
+    }
+
+    fn print_category_hist(hist: &BTreeMap<String, usize>, total: usize) {
+        let mut entries: Vec<(String, usize)> = hist.iter().map(|(k, &v)| (k.clone(), v)).collect();
+        entries.sort_by_key(|e| core::cmp::Reverse(e.1));
+        println!("\nBy instruction category:");
+        for (cat, count) in &entries {
+            let pct = if total > 0 {
+                100.0 * (*count as f64) / (total as f64)
+            } else {
+                0.0
+            };
+            println!("  {:<22} {:>10} {:>7.2}%", cat, count, pct);
+        }
+    }
+
+    fn aggregate(per_wl: &[WorkloadStats]) -> WorkloadStats {
+        let mut agg = WorkloadStats {
+            name: "AGGREGATE",
+            image_bytes: 0,
+            code_bytes: 0,
+            bitmask_bytes_packed: 0,
+            jump_table_bytes: 0,
+            insn_count: 0,
+            insn_bytes_total: 0,
+            opcode_hist: BTreeMap::new(),
+            unknown_hist: BTreeMap::new(),
+            category_hist: BTreeMap::new(),
+        };
+        for s in per_wl {
+            agg.image_bytes += s.image_bytes;
+            agg.code_bytes += s.code_bytes;
+            agg.bitmask_bytes_packed += s.bitmask_bytes_packed;
+            agg.jump_table_bytes += s.jump_table_bytes;
+            agg.insn_count += s.insn_count;
+            agg.insn_bytes_total += s.insn_bytes_total;
+            for (k, v) in &s.opcode_hist {
+                *agg.opcode_hist.entry(*k).or_default() += v;
+            }
+            for (k, v) in &s.unknown_hist {
+                *agg.unknown_hist.entry(*k).or_default() += v;
+            }
+            for (k, v) in &s.category_hist {
+                *agg.category_hist.entry(k.clone()).or_default() += v;
+            }
+        }
+        agg
+    }
+
+    /// Print which valid opcodes have ZERO uses across all measured workloads.
+    /// These are candidates for removal in a PVM2 encoding redesign.
+    fn print_unused_opcodes(agg_hist: &BTreeMap<u8, usize>) {
+        let all_valid_opcodes: &[u8] = &[
+            0, 1, 2, 3, 10, 20, 30, 31, 32, 33, 40, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+            62, 70, 71, 72, 73, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 100, 101, 102, 103,
+            104, 105, 106, 107, 108, 109, 110, 111, 120, 121, 122, 123, 124, 125, 126, 127, 128,
+            129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145,
+            146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 170,
+            171, 172, 173, 174, 175, 180, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
+            201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
+            218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230,
+        ];
+        let unused: Vec<u8> = all_valid_opcodes
+            .iter()
+            .copied()
+            .filter(|op| !agg_hist.contains_key(op))
+            .collect();
+        println!(
+            "\nUnused opcodes ({} of {} valid PVM opcodes have zero static uses across all benches):",
+            unused.len(),
+            all_valid_opcodes.len(),
+        );
+        for op in &unused {
+            println!("  {:>5}  {}", op, opcode_name(*op));
+        }
+    }
+
+    pub fn main() {
+        let workloads: &[(&'static str, &[u8])] = &[
+            ("prime_sieve", include_bytes!(env!("PRIME_SIEVE_BLOB"))),
+            ("ed25519", include_bytes!(env!("ED25519_BLOB"))),
+            ("keccak", include_bytes!(env!("KECCAK_BLOB"))),
+            ("blake2b", include_bytes!(env!("BLAKE2B_BLOB"))),
+            ("ecrecover", include_bytes!(env!("ECRECOVER_BLOB"))),
+            (
+                "goldilocks_mul",
+                include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
+            ),
+            (
+                "poseidon2_perm",
+                include_bytes!(env!("POSEIDON2_PERM_BLOB")),
+            ),
+            ("mini_verifier", include_bytes!(env!("MINI_VERIFIER_BLOB"))),
+            ("poly_eval", include_bytes!(env!("POLY_EVAL_BLOB"))),
+            ("fri_fold_tree", include_bytes!(env!("FRI_FOLD_TREE_BLOB"))),
+            (
+                "sub_vm_recurse",
+                include_bytes!(env!("SUB_VM_RECURSE_BLOB")),
+            ),
+            (
+                "sub_vm_data_recurse",
+                include_bytes!(env!("SUB_VM_DATA_RECURSE_BLOB")),
+            ),
+        ];
+
+        let stats: Vec<WorkloadStats> = workloads.iter().map(|(n, b)| analyze(n, b)).collect();
+
+        println!("=== Per-workload size + instruction count ===\n");
+        println!(
+            "{:<22} | {:>7} {:>7} {:>6} {:>6} | {:>6} {:>9}",
+            "workload", "image", "code", "bitmsk", "jt", "insns", "B/insn"
+        );
+        println!("{}", "-".repeat(96));
+        for s in &stats {
+            print_workload_summary(s);
+        }
+
+        let agg = aggregate(&stats);
+        println!("{}", "-".repeat(96));
+        print_workload_summary(&agg);
+
+        // Aggregate-level histograms (most informative for design decisions).
+        print_category_hist(&agg.category_hist, agg.insn_count);
+        print_opcode_hist("AGGREGATE", &agg.opcode_hist, agg.insn_count, 30);
+        print_unused_opcodes(&agg.opcode_hist);
+
+        if !agg.unknown_hist.is_empty() {
+            println!("\nWARNING: invalid opcode bytes found in code stream:");
+            for (op, count) in &agg.unknown_hist {
+                println!("  byte {op} → {count} occurrences");
+            }
         }
     }
 }

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -37,7 +37,7 @@ use std::sync::{Mutex, OnceLock};
 const EXIT_HOSTCALL: u32 = 4;
 
 /// Default initial-gas budget for the bench.
-const INITIAL_GAS: u64 = 100_000_000_000;
+pub const INITIAL_GAS: u64 = 100_000_000_000;
 
 /// Pre-built `Cap` graph for one (image, endpoint) bench cell.
 ///
@@ -150,7 +150,7 @@ impl BuiltCaps {
 
     /// Put every cap into `nub`'s cache via `put_cap_with_hash`.
     /// Idempotent re-puts after the first call are refcount bumps only.
-    fn put_into(&self, nub: &mut Nub) {
+    pub fn put_into(&self, nub: &mut Nub) {
         for (h, cap) in &self.data_caps {
             nub.put_cap_with_hash(*h, cap)
                 .unwrap_or_else(|e| panic!("put_cap_with_hash data: {e}"));
@@ -162,6 +162,24 @@ impl BuiltCaps {
         nub.put_cap_with_hash(self.instance_hash, &self.instance_cap)
             .unwrap_or_else(|e| panic!("put_cap_with_hash instance: {e}"));
     }
+}
+
+/// Bench-side accessor for the long-lived Hyperlight Nub. Returned
+/// guard holds the singleton mutex for the duration of one
+/// criterion `iter_batched` step (setup + routine).
+pub fn nub_hyperlight_lock() -> std::sync::MutexGuard<'static, Nub> {
+    nub_hyperlight().lock().expect("nub mutex")
+}
+
+/// Bench helper: drive one invocation through an already-locked Nub.
+/// Used inside `iter_batched`'s routine closure so the timed body is
+/// just the host-call round-trip + JIT path (no mutex acquire, no
+/// cap publish, no eviction).
+pub fn invoke(nub: &mut Nub, built: &BuiltCaps) -> (u64, u64) {
+    let result = nub
+        .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
+        .unwrap_or_else(|e| panic!("invoke_cached: {e}"));
+    finish(&result)
 }
 
 /// Drive `built[endpoint_idx]` through the byte-PVM interpreter via a
@@ -178,10 +196,27 @@ pub fn run_interpreter(built: &BuiltCaps) -> (u64, u64) {
 }
 
 /// Drive `built[endpoint_idx]` through the in-kernel JIT via the long-
-/// lived Hyperlight `Nub`.
+/// lived Hyperlight `Nub`. **Warm-cache** path: subsequent calls with
+/// the same Image hit the JIT compile cache. Useful for measuring
+/// steady-state execute throughput in isolation.
 pub fn run_recompiler(built: &BuiltCaps) -> (u64, u64) {
     let mut nub = nub_hyperlight().lock().expect("nub mutex");
     built.put_into(&mut nub);
+    let result = nub
+        .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
+        .unwrap_or_else(|e| panic!("recompiler invoke_cached: {e}"));
+    finish(&result)
+}
+
+/// Cold-cache variant: clear the JIT compile cache before each
+/// invocation so the call pays the full predecode + recompile cost
+/// alongside execute. Models a PolkaVM-shaped workload where each
+/// guest invocation may face a fresh Image hash.
+pub fn run_recompiler_cold(built: &BuiltCaps) -> (u64, u64) {
+    let mut nub = nub_hyperlight().lock().expect("nub mutex");
+    built.put_into(&mut nub);
+    nub.evict_jit_all()
+        .unwrap_or_else(|e| panic!("recompiler evict_jit_all: {e}"));
     let result = nub
         .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
         .unwrap_or_else(|e| panic!("recompiler invoke_cached: {e}"));

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -42,6 +42,13 @@ pub const FN_ID_NUB_PUT_CAP: u32 = 4;
 /// belt-and-braces fallback in case the ELF symbol lookup misses.
 pub const FN_ID_NUB_GET_BOOT_INFO: u32 = 5;
 
+/// `fn_id` for the bench-only "evict the entire JIT compile cache"
+/// RPC. Empty payload; empty response. Used by `javm-bench` to force
+/// each criterion iteration to pay the recompile cost (otherwise the
+/// JIT cache turns the loop into pure warm-cache execute, which isn't
+/// what we want to measure for PolkaVM-shaped workloads).
+pub const FN_ID_NUB_EVICT_JIT_ALL: u32 = 6;
+
 /// Number of guest-function slots reserved in the dispatch table.
 /// Must be at least `max(FN_ID_*) + 1`.
 pub const GUEST_FN_TABLE_SIZE: usize = 8;

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -9,8 +9,8 @@ use javm_cap::cap::Cap;
 #[cfg(feature = "heap-diag")]
 use nub_arch_x86_abi::FN_ID_NUB_HEAP_STATS;
 use nub_arch_x86_abi::{
-    BootInfo, FN_ID_NUB_GET_BOOT_INFO, FN_ID_NUB_INVOKE_CACHED, FN_ID_NUB_PUT_CAP,
-    InvocationResult, InvokePacket,
+    BootInfo, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_GET_BOOT_INFO, FN_ID_NUB_INVOKE_CACHED,
+    FN_ID_NUB_PUT_CAP, InvocationResult, InvokePacket,
 };
 
 fn encode_result_error(exit_arg: u32) -> Vec<u8> {
@@ -115,6 +115,17 @@ pub fn nub_put_cap(payload: &[u8]) -> Vec<u8> {
     let mut out: Vec<u8> = Vec::with_capacity(32);
     out.extend_from_slice(&hash);
     out
+}
+
+/// Bench-only: drop every entry in the JIT compile cache so the
+/// next `nub_invoke_cached` call pays a full recompile. Empty
+/// payload, empty response. Not meant for production paths — the
+/// cache is content-addressed and re-compiling the same Image
+/// produces identical native code.
+#[guest_function(fn_id = FN_ID_NUB_EVICT_JIT_ALL)]
+pub fn nub_evict_jit_all(_input: &[u8]) -> Vec<u8> {
+    crate::jit_cache::evict_all();
+    Vec::new()
 }
 
 /// Read the current `BootInfo` block out as raw bytes. Used by

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -106,6 +106,20 @@ fn page_round_up_min1(n: usize) -> usize {
     n.next_multiple_of(PAGE_SIZE).max(PAGE_SIZE)
 }
 
+/// Drop every compiled image from the cache.
+///
+/// Bench-only: each `CompiledImage`'s `Drop` releases its arena pages
+/// and template PD/PT pages, which is fine between invocations (no
+/// in-flight call references them). The next `get_or_compile` will
+/// pay full recompile cost. Safe under Hyperlight serialisation; not
+/// meant for production paths.
+pub fn evict_all() {
+    // SAFETY: single-threaded guest (Hyperlight serialisation), no
+    // concurrent call in progress when this RPC fires.
+    let map = unsafe { &mut *CACHE.inner.get() };
+    map.clear();
+}
+
 /// Look up the compile cache by `image_hash`. On miss, compile the
 /// Image and materialise the per-Image arena. Returns a `'static`
 /// borrow into the cache entry.

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -30,7 +30,9 @@ use nub_kernel::Kernel;
 
 #[cfg(feature = "heap-diag")]
 use nub_arch_x86_abi::FN_ID_NUB_HEAP_STATS;
-use nub_arch_x86_abi::{ArchivedInvocationResult, FN_ID_NUB_INVOKE_CACHED, InvokePacket};
+use nub_arch_x86_abi::{
+    ArchivedInvocationResult, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_INVOKE_CACHED, InvokePacket,
+};
 pub use nub_arch_x86_abi::{CapHash as AbiCapHash, InvocationResult};
 pub use nub_kernel::{CapHash, InstanceRef, InvokeOptions, InvokeOutcome};
 
@@ -121,6 +123,19 @@ impl Nub {
         match &self.backend {
             Backend::Local { kernel, .. } => kernel.state_root(),
             Backend::Hyperlight(h) => h.state_root_cache,
+        }
+    }
+
+    /// Bench-only: clear the guest's JIT compile cache so the next
+    /// `invoke_cached` pays a full recompile. No-op on the Local
+    /// backend (which uses the interpreter and has no JIT cache).
+    pub fn evict_jit_all(&mut self) -> Result<()> {
+        match &mut self.backend {
+            Backend::Local { .. } => Ok(()),
+            Backend::Hyperlight(h) => {
+                let _ = h.sandbox.call_raw(FN_ID_NUB_EVICT_JIT_ALL, &[])?;
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The recompiler arm of `javm-bench` was reusing the JIT cache across criterion iterations, so after iter 1 the timed body was pure steady-state execute — not the publish + recompile + execute that real callers pay in a PolkaVM-shaped workload.

- Add `FN_ID_NUB_EVICT_JIT_ALL` host call that clears `jit_cache::CACHE`. Bench-only; production code never reaches it.
- Add `Nub::evict_jit_all()` host wrapper.
- Split the recompiler arm into `recompiler_warm` (no eviction) and `recompiler_cold` (eviction before each iter via `iter_batched(PerIteration)` setup). Setup is untimed, so the ~7 µs eviction RPC stays out of the recompile measurement.
- Timed body covers `put_cap_with_hash` × 4 + `invoke_cached`. Hashes are precomputed at warmup so `put_cap_with_hash` short-circuits via the host-side `GuestCacheReader::contains(hash)` check — no merkle, no rkyv encode, no VMEXIT — matching the per-call cost real callers pay.

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo test --workspace`
- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo bench -p javm-bench` — verify `recompiler_cold` ≫ `recompiler_warm` (cold should now reflect the publish + recompile path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)