### PR TITLE
feat(pvm2): enable +unaligned-scalar-mem + Zicclsm

### DIFF
--- a/rust/build-javm/src/riscv64emc-pvm2.json
+++ b/rust/build-javm/src/riscv64emc-pvm2.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S64",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m,+c,+zbb,+zba,+zbs,+zicond",
+  "features": "+e,+m,+c,+zbb,+zba,+zbs,+zicond,+zicclsm,+unaligned-scalar-mem",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64e",

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -61,7 +61,7 @@ fn ed25519() {
         "ed25519",
         include_bytes!(env!("ED25519_BLOB")),
         0x1,
-        2_362_040,
+        2_346_101,
     );
 }
 
@@ -71,7 +71,7 @@ fn keccak() {
         "keccak",
         include_bytes!(env!("KECCAK_BLOB")),
         0x39e5_0259,
-        101_642,
+        100_644,
     );
 }
 
@@ -81,7 +81,7 @@ fn blake2b() {
         "blake2b",
         include_bytes!(env!("BLAKE2B_BLOB")),
         0xee1f_55f1,
-        63_192,
+        62_120,
     );
 }
 
@@ -91,7 +91,7 @@ fn ecrecover() {
         "ecrecover",
         include_bytes!(env!("ECRECOVER_BLOB")),
         0x1,
-        6_819_891,
+        6_783_744,
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `+zicclsm` and `+unaligned-scalar-mem` to the PVM2 target spec.
Together they let LLVM emit single-instruction unaligned scalar loads
instead of byte-by-byte shift-and-OR sequences, with the biggest wins
on byte-buffer-heavy workloads (Keccak, BLAKE2b, ECDSA recovery).

PVM2's spec already declares Zicclsm in [05-pvm2-rv-diff.md §4.13](https://github.com/jarchain/jar/blob/master/docs/pvm-isa/05-pvm2-rv-diff.md) as the standard-extension restatement of its existing EEI guarantee that misaligned loads/stores succeed. This PR just surfaces the flag to LLVM so it actually exploits the guarantee.

## Bench impact (criterion, cold path)

| workload      | time Δ              | code Δ              | gas Δ              |
|---------------|---------------------|---------------------|--------------------|
| **keccak**    | 60.7 → 47.9 µs (**−21%**) | 3334 → 1856 B (**−44%**) | 101 642 → 100 644 (−1%) |
| **blake2b**   | 103.7 → 91.0 µs (**−12%**) | 8296 → 6952 B (**−16%**) | 63 192 → 62 120 (−1.7%) |
| prime_sieve   | 288.7 → 297.3 µs (+3%) | 186 → 182 B (−2%)   | (unchanged)        |
| ed25519       | 628.3 → 620.4 µs (−1.3%) | 42 198 → 41 438 B (−1.8%) | 2 362 040 → 2 346 101 (−0.7%) |
| **ecrecover** | 1591 → 1546 µs (**−2.8%**) | 97 680 → 96 158 B (−1.6%) | 6 819 891 → 6 783 744 (−0.5%) |
| goldilocks_mul, poseidon2_perm, mini_verifier, poly_eval, fri_fold_tree, sub_vm_* | all ≤ 0.5% | (unchanged) | (unchanged) |

Gas drops on the affected workloads because we now charge for fewer
RV instructions doing the same observable work. Smoke still passes
12/12 with **bit-identical gas between interpreter and recompiler**.

## Portability rationale

Spec change: none — PVM2 already declares Zicclsm. The question this
PR actually answers is "is this safe on hosts other than x86-64?".

Companion doc commit lands `~/docs/pvm-isa/09-portability.md` (223
lines) walking through PVM2's spec-level and host-level portability
assumptions across x86-64 (today), AArch64 (likely next, including
Apple Silicon via Hypervisor.framework), and RISC-V (speculative).
Key findings:

- **x86-64**: native unaligned, near-zero cost. Free win.
- **AArch64**: native unaligned on cacheable memory. Free win.
- **RISC-V**: RVA22 (2022) and RVA23 (Oct 2024) both mandate Zicclsm.
  Every application-class RISC-V we'd realistically JIT to supports
  unaligned access. First-gen RVA23 silicon shipping mid-2026
  (SiFive P570 Gen3, Tenstorrent Ascalon, Ventana Veyron V2). The
  ecosystem is consolidating (Ubuntu 25.10 mandates RVA23; Android,
  CUDA-on-RISC-V both target it).
- **Apple Silicon page-size concern**: dissolved. We always run the
  nub microkernel inside a hypervisor (Hypervisor.framework on
  macOS), stage-1 page size is set by the guest's TCR_EL1, and is
  decoupled from the host's 16 KiB pages. 4 KiB guest stage-1 over
  16 KiB stage-2 works correctly per the ARMv8 spec.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all pass (with the four workload-test gas baselines updated to match the new instruction counts)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo run --release -p javm-bench --example smoke` — 12/12 PASS with bit-identical gas between interp and recomp
- [x] `cargo bench -p javm-bench --bench bench` — see bench table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)