### PR TITLE
PVM2: native jalr/auipc ISA — recompiler + runtime at parity with master

### DIFF
--- a/rust/build-javm/src/lib.rs
+++ b/rust/build-javm/src/lib.rs
@@ -21,7 +21,7 @@ fn watch_transpiler_sources() {
 
 /// Build a PVM2 blob from a service crate. The guest is built for the
 /// RV+C+Zbb+Zba+Zbs+Zicond target and the ELF is linked via
-/// [`javm_transpiler::linker::link_elf`] — `Image.codes[0]` holds raw
+/// [`javm_transpiler::linker::link_elf`] — `Image::code` holds raw
 /// RV+C+custom-0 bytes consumed directly by the recompiler / interpreter.
 pub fn build(manifest_dir: &str, bin_name: &str) -> PathBuf {
     watch_transpiler_sources();

--- a/rust/build-javm/src/lib.rs
+++ b/rust/build-javm/src/lib.rs
@@ -21,7 +21,7 @@ fn watch_transpiler_sources() {
 
 /// Build a PVM2 blob from a service crate. The guest is built for the
 /// RV+C+Zbb+Zba+Zbs+Zicond target and the ELF is linked via
-/// [`javm_transpiler::linker::link_elf`] — `Image.code` holds raw
+/// [`javm_transpiler::linker::link_elf`] — `Image.codes[0]` holds raw
 /// RV+C+custom-0 bytes consumed directly by the recompiler / interpreter.
 pub fn build(manifest_dir: &str, bin_name: &str) -> PathBuf {
     watch_transpiler_sources();

--- a/rust/jar-kernel/src/genesis.rs
+++ b/rust/jar-kernel/src/genesis.rs
@@ -287,17 +287,24 @@ pub fn genesis(chain_image: Image) -> Result<Genesis, KernelError> {
 /// Returns `(mem_size, overlays)` where `mem_size = max(start+size)`
 /// over all mappings.
 pub(crate) fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
-    use javm_cap::image::PinnedCap;
+    use javm_cap::image::{MappingSource, PinnedCap};
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
     for mapping in &image.memory_mappings {
+        // Code regions are RO-mapped separately by the runtime (a
+        // direct-map at CODE_BASE), not copied into the flat RW buffer —
+        // so they neither contribute an overlay nor extend mem_size.
+        let target = match &mapping.source {
+            MappingSource::Slot(path) => path.target(),
+            MappingSource::Code(_) => continue,
+        };
+
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;
         }
 
-        let target = mapping.source.target();
         if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
             if !content.is_empty() {
                 overlays.push((mapping.start as u32, content.clone()));
@@ -316,11 +323,12 @@ pub(crate) fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
 /// issued unit caps. The image is never actually invoked — kernel
 /// caps short-circuit at the host-call layer.
 fn placeholder_kernel_image() -> Image {
+    use javm_cap::image::CodeRegion;
     use std::collections::BTreeMap;
     Image {
-        code: vec![0u8], // single TRAP byte
-        jump_table: Vec::new(),
-        jump_table_offsets: Vec::new(),
+        // Single TRAP byte. No code mapping: kernel caps short-circuit
+        // at the host-call layer and this image is never invoked.
+        codes: vec![CodeRegion { code: vec![0u8] }],
         endpoints: BTreeMap::new(),
         memory_mappings: Vec::new(),
         gas_slots: Vec::new(),

--- a/rust/jar-kernel/src/genesis.rs
+++ b/rust/jar-kernel/src/genesis.rs
@@ -287,18 +287,15 @@ pub fn genesis(chain_image: Image) -> Result<Genesis, KernelError> {
 /// Returns `(mem_size, overlays)` where `mem_size = max(start+size)`
 /// over all mappings.
 pub(crate) fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
-    use javm_cap::image::{MappingSource, PinnedCap};
+    use javm_cap::image::PinnedCap;
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
+    // `memory_mappings` describes data/slot regions only; code is
+    // RO-mapped separately by the runtime (a direct-map at CODE_BASE),
+    // so it neither contributes an overlay nor extends mem_size.
     for mapping in &image.memory_mappings {
-        // Code regions are RO-mapped separately by the runtime (a
-        // direct-map at CODE_BASE), not copied into the flat RW buffer —
-        // so they neither contribute an overlay nor extend mem_size.
-        let target = match &mapping.source {
-            MappingSource::Slot(path) => path.target(),
-            MappingSource::Code(_) => continue,
-        };
+        let target = mapping.source.target();
 
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
@@ -323,12 +320,11 @@ pub(crate) fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
 /// issued unit caps. The image is never actually invoked — kernel
 /// caps short-circuit at the host-call layer.
 fn placeholder_kernel_image() -> Image {
-    use javm_cap::image::CodeRegion;
     use std::collections::BTreeMap;
     Image {
-        // Single TRAP byte. No code mapping: kernel caps short-circuit
-        // at the host-call layer and this image is never invoked.
-        codes: vec![CodeRegion { code: vec![0u8] }],
+        // Single TRAP byte. Never actually invoked: kernel caps
+        // short-circuit at the host-call layer.
+        code: vec![0u8],
         endpoints: BTreeMap::new(),
         memory_mappings: Vec::new(),
         gas_slots: Vec::new(),

--- a/rust/jar-kernel/tests/end_to_end.rs
+++ b/rust/jar-kernel/tests/end_to_end.rs
@@ -17,7 +17,7 @@
 //! accumulates per-block event-payload entries.
 
 use jar_kernel::{Block, Event, EventOutcome, Kernel, abi};
-use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
+use javm_cap::image::{EndpointDef, Image};
 use std::collections::BTreeMap;
 
 /// Build a tiny chain image whose endpoint 0 program is a single
@@ -45,13 +45,10 @@ fn hello_world_chain_image() -> Image {
     );
 
     Image {
-        codes: vec![CodeRegion { code }],
+        code,
         endpoints,
-        memory_mappings: vec![MemoryMapping {
-            start: 0x4000_0000,
-            size: 4096,
-            source: MappingSource::Code(0),
-        }],
+        // Code is mapped at the fixed CODE_BASE; no data mappings.
+        memory_mappings: Vec::new(),
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/jar-kernel/tests/end_to_end.rs
+++ b/rust/jar-kernel/tests/end_to_end.rs
@@ -17,7 +17,7 @@
 //! accumulates per-block event-payload entries.
 
 use jar_kernel::{Block, Event, EventOutcome, Kernel, abi};
-use javm_cap::image::{EndpointDef, Image, MemoryMapping};
+use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
 use std::collections::BTreeMap;
 
 /// Build a tiny chain image whose endpoint 0 program is a single
@@ -45,11 +45,13 @@ fn hello_world_chain_image() -> Image {
     );
 
     Image {
-        code,
-        jump_table: Vec::new(),
-        jump_table_offsets: vec![0, 0],
+        codes: vec![CodeRegion { code }],
         endpoints,
-        memory_mappings: Vec::<MemoryMapping>::new(),
+        memory_mappings: vec![MemoryMapping {
+            start: 0x4000_0000,
+            size: 4096,
+            source: MappingSource::Code(0),
+        }],
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/jar-kernel/tests/genesis.rs
+++ b/rust/jar-kernel/tests/genesis.rs
@@ -1,17 +1,21 @@
 use jar_kernel::abi;
 use jar_kernel::genesis::genesis;
-use javm_cap::image::Image;
+use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
 use javm_cap::{Cap, CapHashOrRef};
 use std::collections::BTreeMap;
 
 fn empty_chain_image() -> Image {
     Image {
         // PVM2 `ecalli 0` (HALT): custom-0 opcode 0b00010_11, funct3 0b010.
-        code: 0x0000_200Bu32.to_le_bytes().to_vec(),
-        jump_table: Vec::new(),
-        jump_table_offsets: vec![0, 0],
+        codes: vec![CodeRegion {
+            code: 0x0000_200Bu32.to_le_bytes().to_vec(),
+        }],
         endpoints: BTreeMap::new(),
-        memory_mappings: Vec::new(),
+        memory_mappings: vec![MemoryMapping {
+            start: 0x4000_0000,
+            size: 4096,
+            source: MappingSource::Code(0),
+        }],
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/jar-kernel/tests/genesis.rs
+++ b/rust/jar-kernel/tests/genesis.rs
@@ -1,21 +1,16 @@
 use jar_kernel::abi;
 use jar_kernel::genesis::genesis;
-use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
+use javm_cap::image::Image;
 use javm_cap::{Cap, CapHashOrRef};
 use std::collections::BTreeMap;
 
 fn empty_chain_image() -> Image {
     Image {
         // PVM2 `ecalli 0` (HALT): custom-0 opcode 0b00010_11, funct3 0b010.
-        codes: vec![CodeRegion {
-            code: 0x0000_200Bu32.to_le_bytes().to_vec(),
-        }],
+        code: 0x0000_200Bu32.to_le_bytes().to_vec(),
         endpoints: BTreeMap::new(),
-        memory_mappings: vec![MemoryMapping {
-            start: 0x4000_0000,
-            size: 4096,
-            source: MappingSource::Code(0),
-        }],
+        // Code is mapped at the fixed CODE_BASE; no data mappings.
+        memory_mappings: Vec::new(),
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/jar-kernel/tests/kernel.rs
+++ b/rust/jar-kernel/tests/kernel.rs
@@ -1,7 +1,7 @@
 use jar_kernel::abi;
 use jar_kernel::apply::{Block, Event};
 use jar_kernel::kernel::Kernel;
-use javm_cap::image::{EndpointDef, Image};
+use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
 use std::collections::BTreeMap;
 
 fn minimal_chain_image() -> Image {
@@ -19,11 +19,15 @@ fn minimal_chain_image() -> Image {
         },
     );
     Image {
-        code: 0x0000_200Bu32.to_le_bytes().to_vec(),
-        jump_table: Vec::new(),
-        jump_table_offsets: vec![0, 0],
+        codes: vec![CodeRegion {
+            code: 0x0000_200Bu32.to_le_bytes().to_vec(),
+        }],
         endpoints,
-        memory_mappings: Vec::new(),
+        memory_mappings: vec![MemoryMapping {
+            start: 0x4000_0000,
+            size: 4096,
+            source: MappingSource::Code(0),
+        }],
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/jar-kernel/tests/kernel.rs
+++ b/rust/jar-kernel/tests/kernel.rs
@@ -1,7 +1,7 @@
 use jar_kernel::abi;
 use jar_kernel::apply::{Block, Event};
 use jar_kernel::kernel::Kernel;
-use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
+use javm_cap::image::{EndpointDef, Image};
 use std::collections::BTreeMap;
 
 fn minimal_chain_image() -> Image {
@@ -19,15 +19,10 @@ fn minimal_chain_image() -> Image {
         },
     );
     Image {
-        codes: vec![CodeRegion {
-            code: 0x0000_200Bu32.to_le_bytes().to_vec(),
-        }],
+        code: 0x0000_200Bu32.to_le_bytes().to_vec(),
         endpoints,
-        memory_mappings: vec![MemoryMapping {
-            start: 0x4000_0000,
-            size: 4096,
-            source: MappingSource::Code(0),
-        }],
+        // Code is mapped at the fixed CODE_BASE; no data mappings.
+        memory_mappings: Vec::new(),
         gas_slots: vec![abi::BARE_GAS_SLOT],
         quota_slots: vec![abi::BARE_QUOTA_SLOT],
         pinned_slots: BTreeMap::new(),

--- a/rust/javm-bench/benches/bench.rs
+++ b/rust/javm-bench/benches/bench.rs
@@ -27,7 +27,7 @@ macro_rules! bench_workload {
                 $label,
                 val,
                 gas,
-                image.code.len(),
+                image.codes[0].code.len(),
             );
 
             let mut g = c.benchmark_group($label);

--- a/rust/javm-bench/benches/bench.rs
+++ b/rust/javm-bench/benches/bench.rs
@@ -27,7 +27,7 @@ macro_rules! bench_workload {
                 $label,
                 val,
                 gas,
-                image.codes[0].code.len(),
+                image.code.len(),
             );
 
             let mut g = c.benchmark_group($label);

--- a/rust/javm-bench/benches/sub_vm_data_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_data_recurse.rs
@@ -26,7 +26,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use javm_cap::image::{Image, MappingSource, PinnedCap};
+use javm_cap::image::{Image, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CNodeCap, Cap, CapHash, CapHashOrRef, NUM_REGS};
 use nub::Nub;
@@ -100,12 +100,10 @@ fn build_and_publish(nub: &mut Nub) -> Built {
 
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
+    // Code is RO direct-mapped at CODE_BASE, not a flat-buffer overlay;
+    // `memory_mappings` lists data/slot regions only.
     for mapping in &image.memory_mappings {
-        // Code: RO direct-map at CODE_BASE, not a flat-buffer overlay.
-        let target = match &mapping.source {
-            MappingSource::Slot(path) => path.target(),
-            MappingSource::Code(_) => continue,
-        };
+        let target = mapping.source.target();
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;

--- a/rust/javm-bench/benches/sub_vm_data_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_data_recurse.rs
@@ -26,7 +26,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use javm_cap::image::{Image, PinnedCap};
+use javm_cap::image::{Image, MappingSource, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CNodeCap, Cap, CapHash, CapHashOrRef, NUM_REGS};
 use nub::Nub;
@@ -101,11 +101,15 @@ fn build_and_publish(nub: &mut Nub) -> Built {
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
     for mapping in &image.memory_mappings {
+        // Code: RO direct-map at CODE_BASE, not a flat-buffer overlay.
+        let target = match &mapping.source {
+            MappingSource::Slot(path) => path.target(),
+            MappingSource::Code(_) => continue,
+        };
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;
         }
-        let target = mapping.source.target();
         if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
             if !content.is_empty() {
                 overlays.push((mapping.start as u32, content.clone()));

--- a/rust/javm-bench/benches/sub_vm_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_recurse.rs
@@ -25,7 +25,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use javm_cap::image::{Image, PinnedCap};
+use javm_cap::image::{Image, MappingSource, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CNodeCap, Cap, CapHash, CapHashOrRef, NUM_REGS};
 use nub::Nub;
@@ -122,11 +122,15 @@ fn build_and_publish(nub: &mut Nub, depth_seed: u64) -> Built {
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
     for mapping in &image.memory_mappings {
+        // Code: RO direct-map at CODE_BASE, not a flat-buffer overlay.
+        let target = match &mapping.source {
+            MappingSource::Slot(path) => path.target(),
+            MappingSource::Code(_) => continue,
+        };
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;
         }
-        let target = mapping.source.target();
         if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
             if !content.is_empty() {
                 overlays.push((mapping.start as u32, content.clone()));

--- a/rust/javm-bench/benches/sub_vm_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_recurse.rs
@@ -25,7 +25,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use javm_cap::image::{Image, MappingSource, PinnedCap};
+use javm_cap::image::{Image, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CNodeCap, Cap, CapHash, CapHashOrRef, NUM_REGS};
 use nub::Nub;
@@ -121,12 +121,10 @@ fn build_and_publish(nub: &mut Nub, depth_seed: u64) -> Built {
     // overlays at the mapping's start.
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
+    // Code is RO direct-mapped at CODE_BASE, not a flat-buffer overlay;
+    // `memory_mappings` lists data/slot regions only.
     for mapping in &image.memory_mappings {
-        // Code: RO direct-map at CODE_BASE, not a flat-buffer overlay.
-        let target = match &mapping.source {
-            MappingSource::Slot(path) => path.target(),
-            MappingSource::Code(_) => continue,
-        };
+        let target = mapping.source.target();
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;

--- a/rust/javm-bench/examples/compile_profile.rs
+++ b/rust/javm-bench/examples/compile_profile.rs
@@ -38,7 +38,7 @@ mod imp {
 
     fn profile_one(name: &str, blob: &[u8]) {
         let image = Image::from_ssz_bytes(blob).expect("decode Image");
-        let code = image.codes.first().expect("code region").code.as_slice();
+        let code = image.code.as_slice();
         // Guest CODE_BASE (where the linker maps the code region).
         let code_base = 0x4000_0000u32;
 

--- a/rust/javm-bench/examples/compile_profile.rs
+++ b/rust/javm-bench/examples/compile_profile.rs
@@ -38,13 +38,14 @@ mod imp {
 
     fn profile_one(name: &str, blob: &[u8]) {
         let image = Image::from_ssz_bytes(blob).expect("decode Image");
-        let code = &image.code[..];
-        let jt_offsets = &image.jump_table_offsets[..];
+        let code = image.codes.first().expect("code region").code.as_slice();
+        // Guest CODE_BASE (where the linker maps the code region).
+        let code_base = 0x4000_0000u32;
 
         // Warm-up + report native_code size.
         let native_size = {
-            let c = Compiler::new(dummy_helpers(), code.len(), 0x4000_0000, 1);
-            let r = c.compile(code, jt_offsets);
+            let c = Compiler::new(dummy_helpers(), code.len(), 0x4000_0000, 1, code_base);
+            let r = c.compile(code);
             r.native_code.len()
         };
 
@@ -54,8 +55,8 @@ mod imp {
 
         for _ in 0..ITERS {
             let t0 = Instant::now();
-            let c = Compiler::new(dummy_helpers(), code.len(), 0x4000_0000, 1);
-            let _ = c.compile(code, jt_offsets);
+            let c = Compiler::new(dummy_helpers(), code.len(), 0x4000_0000, 1, code_base);
+            let _ = c.compile(code);
             let t1 = Instant::now();
             comp_ns += (t1 - t0).as_nanos();
 

--- a/rust/javm-bench/examples/disasm.rs
+++ b/rust/javm-bench/examples/disasm.rs
@@ -22,6 +22,6 @@ fn main() {
     let out = std::env::args()
         .nth(2)
         .unwrap_or_else(|| format!("/tmp/pvm2_{}.bin", which));
-    std::fs::write(&out, &img.codes[0].code).unwrap();
-    println!("wrote {} bytes to {}", img.codes[0].code.len(), out);
+    std::fs::write(&out, &img.code).unwrap();
+    println!("wrote {} bytes to {}", img.code.len(), out);
 }

--- a/rust/javm-bench/examples/disasm.rs
+++ b/rust/javm-bench/examples/disasm.rs
@@ -22,6 +22,6 @@ fn main() {
     let out = std::env::args()
         .nth(2)
         .unwrap_or_else(|| format!("/tmp/pvm2_{}.bin", which));
-    std::fs::write(&out, &img.code).unwrap();
-    println!("wrote {} bytes to {}", img.code.len(), out);
+    std::fs::write(&out, &img.codes[0].code).unwrap();
+    println!("wrote {} bytes to {}", img.codes[0].code.len(), out);
 }

--- a/rust/javm-bench/examples/dump.rs
+++ b/rust/javm-bench/examples/dump.rs
@@ -8,8 +8,8 @@ use ssz::Decode;
 fn dump(name: &str, blob: &[u8]) {
     let img = Image::from_ssz_bytes(blob).expect("decode");
     println!("=== {} ===", name);
-    println!("code = {} bytes", img.codes[0].code.len());
-    let pd = predecode(&img.codes[0].code);
+    println!("code = {} bytes", img.code.len());
+    let pd = predecode(&img.code);
     println!(
         "predecode: {} insts, decode_error_at = {:?}",
         pd.insts.len(),

--- a/rust/javm-bench/examples/dump.rs
+++ b/rust/javm-bench/examples/dump.rs
@@ -8,8 +8,8 @@ use ssz::Decode;
 fn dump(name: &str, blob: &[u8]) {
     let img = Image::from_ssz_bytes(blob).expect("decode");
     println!("=== {} ===", name);
-    println!("code = {} bytes", img.code.len());
-    let pd = predecode(&img.code);
+    println!("code = {} bytes", img.codes[0].code.len());
+    let pd = predecode(&img.codes[0].code);
     println!(
         "predecode: {} insts, decode_error_at = {:?}",
         pd.insts.len(),
@@ -90,7 +90,8 @@ fn dump(name: &str, blob: &[u8]) {
             Inst::Trap => "Trap",
             Inst::EcallJar => "EcallJar",
             Inst::Ecalli { .. } => "Ecalli",
-            Inst::BrTable { .. } => "BrTable",
+            Inst::Auipc { .. } => "Auipc",
+            Inst::Jalr { .. } => "Jalr",
             Inst::Fallthrough => "Fallthrough",
             Inst::CzeroEqz { .. } => "CzeroEqz",
             Inst::CzeroNez { .. } => "CzeroNez",

--- a/rust/javm-bench/examples/opcode_stats.rs
+++ b/rust/javm-bench/examples/opcode_stats.rs
@@ -240,7 +240,7 @@ fn rs1_of(inst: &Inst) -> Option<u8> {
 
 fn profile_one(name: &str, blob: &[u8]) {
     let image = Image::from_ssz_bytes(blob).expect("decode Image");
-    let code = &image.codes[0].code[..];
+    let code = &image.code[..];
 
     let mut single: BTreeMap<&'static str, usize> = BTreeMap::new();
     let mut total = 0usize;

--- a/rust/javm-bench/examples/opcode_stats.rs
+++ b/rust/javm-bench/examples/opcode_stats.rs
@@ -112,7 +112,8 @@ fn variant_name(inst: &Inst) -> &'static str {
         Bgeu { .. } => "Bgeu",
         EcallJar => "EcallJar",
         Ecalli { .. } => "Ecalli",
-        BrTable { .. } => "BrTable",
+        Auipc { .. } => "Auipc",
+        Jalr { .. } => "Jalr",
         Fallthrough => "Fallthrough",
         Trap => "Trap",
         Reserved { .. } => "Reserved",
@@ -239,7 +240,7 @@ fn rs1_of(inst: &Inst) -> Option<u8> {
 
 fn profile_one(name: &str, blob: &[u8]) {
     let image = Image::from_ssz_bytes(blob).expect("decode Image");
-    let code = &image.code[..];
+    let code = &image.codes[0].code[..];
 
     let mut single: BTreeMap<&'static str, usize> = BTreeMap::new();
     let mut total = 0usize;

--- a/rust/javm-bench/examples/smoke.rs
+++ b/rust/javm-bench/examples/smoke.rs
@@ -99,12 +99,7 @@ mod imp {
         for w in WORKLOADS {
             eprintln!("=== {} ===", w.name);
             let img = Image::from_ssz_bytes(w.blob).expect("decode Image");
-            eprintln!(
-                "  code={}B jt={}  jt_offsets={}",
-                img.code.len(),
-                img.jump_table.len(),
-                img.jump_table_offsets.len(),
-            );
+            eprintln!("  code={}B", img.codes.first().map_or(0, |c| c.code.len()));
 
             // Fresh Hyperlight sandbox per workload — pvm2_bench's
             // `reset_nub_hyperlight()` exists precisely because cap-publish

--- a/rust/javm-bench/examples/smoke.rs
+++ b/rust/javm-bench/examples/smoke.rs
@@ -99,7 +99,7 @@ mod imp {
         for w in WORKLOADS {
             eprintln!("=== {} ===", w.name);
             let img = Image::from_ssz_bytes(w.blob).expect("decode Image");
-            eprintln!("  code={}B", img.codes.first().map_or(0, |c| c.code.len()));
+            eprintln!("  code={}B", img.code.len());
 
             // Fresh Hyperlight sandbox per workload — pvm2_bench's
             // `reset_nub_hyperlight()` exists precisely because cap-publish

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use javm_cap::NUM_REGS;
-use javm_cap::image::{Image, PinnedCap};
+use javm_cap::image::{Image, MappingSource, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{Cap, CapHash};
 use nub::{InvocationResult, Nub};
@@ -295,12 +295,18 @@ fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
     for mapping in &image.memory_mappings {
+        // Code regions are RO direct-mapped at CODE_BASE by the runtime,
+        // not copied into the flat RW buffer — skip them here.
+        let target = match &mapping.source {
+            MappingSource::Slot(path) => path.target(),
+            MappingSource::Code(_) => continue,
+        };
+
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;
         }
 
-        let target = mapping.source.target();
         if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
             if !content.is_empty() {
                 overlays.push((mapping.start as u32, content.clone()));

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use javm_cap::NUM_REGS;
-use javm_cap::image::{Image, MappingSource, PinnedCap};
+use javm_cap::image::{Image, PinnedCap};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{Cap, CapHash};
 use nub::{InvocationResult, Nub};
@@ -294,13 +294,11 @@ fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
     let mut mem_size: u32 = 0;
     let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
+    // `memory_mappings` describes data/slot regions only; code is RO
+    // direct-mapped at CODE_BASE by the runtime, not copied into the
+    // flat RW buffer.
     for mapping in &image.memory_mappings {
-        // Code regions are RO direct-mapped at CODE_BASE by the runtime,
-        // not copied into the flat RW buffer — skip them here.
-        let target = match &mapping.source {
-            MappingSource::Slot(path) => path.target(),
-            MappingSource::Code(_) => continue,
-        };
+        let target = mapping.source.target();
 
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -51,7 +51,7 @@ fn prime_sieve() {
         "prime_sieve",
         include_bytes!(env!("PRIME_SIEVE_BLOB")),
         0x2578,
-        8_966_290,
+        8_966_299,
     );
 }
 
@@ -61,7 +61,7 @@ fn ed25519() {
         "ed25519",
         include_bytes!(env!("ED25519_BLOB")),
         0x1,
-        2_346_101,
+        2_360_437,
     );
 }
 
@@ -71,7 +71,7 @@ fn keccak() {
         "keccak",
         include_bytes!(env!("KECCAK_BLOB")),
         0x39e5_0259,
-        100_644,
+        100_674,
     );
 }
 
@@ -81,7 +81,7 @@ fn blake2b() {
         "blake2b",
         include_bytes!(env!("BLAKE2B_BLOB")),
         0xee1f_55f1,
-        62_120,
+        62_136,
     );
 }
 
@@ -91,7 +91,7 @@ fn ecrecover() {
         "ecrecover",
         include_bytes!(env!("ECRECOVER_BLOB")),
         0x1,
-        6_783_744,
+        6_810_020,
     );
 }
 
@@ -101,7 +101,7 @@ fn goldilocks_mul() {
         "goldilocks_mul",
         include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
         0x2cf7_3e57,
-        2_400_154,
+        2_400_162,
     );
 }
 
@@ -111,7 +111,7 @@ fn poseidon2_perm() {
         "poseidon2_perm",
         include_bytes!(env!("POSEIDON2_PERM_BLOB")),
         0x3ce3_3156,
-        14_561_189,
+        14_561_197,
     );
 }
 
@@ -121,7 +121,7 @@ fn mini_verifier() {
         "mini_verifier",
         include_bytes!(env!("MINI_VERIFIER_BLOB")),
         0xf98f_c4ab,
-        5_878_907,
+        5_878_915,
     );
 }
 
@@ -131,7 +131,7 @@ fn poly_eval() {
         "poly_eval",
         include_bytes!(env!("POLY_EVAL_BLOB")),
         0x01da_34e2,
-        9_003_090,
+        9_003_105,
     );
 }
 
@@ -141,6 +141,6 @@ fn fri_fold_tree() {
         "fri_fold_tree",
         include_bytes!(env!("FRI_FOLD_TREE_BLOB")),
         0x37e6_76f4,
-        6_189_475,
+        6_189_504,
     );
 }

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -61,7 +61,7 @@ fn ed25519() {
         "ed25519",
         include_bytes!(env!("ED25519_BLOB")),
         0x1,
-        2_360_437,
+        2_362_770,
     );
 }
 
@@ -81,7 +81,7 @@ fn blake2b() {
         "blake2b",
         include_bytes!(env!("BLAKE2B_BLOB")),
         0xee1f_55f1,
-        62_136,
+        62_504,
     );
 }
 
@@ -91,7 +91,7 @@ fn ecrecover() {
         "ecrecover",
         include_bytes!(env!("ECRECOVER_BLOB")),
         0x1,
-        6_810_020,
+        6_937_095,
     );
 }
 
@@ -121,7 +121,7 @@ fn mini_verifier() {
         "mini_verifier",
         include_bytes!(env!("MINI_VERIFIER_BLOB")),
         0xf98f_c4ab,
-        5_878_915,
+        5_960_515,
     );
 }
 

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -61,7 +61,7 @@ fn ed25519() {
         "ed25519",
         include_bytes!(env!("ED25519_BLOB")),
         0x1,
-        2_362_770,
+        2_360_437,
     );
 }
 
@@ -81,7 +81,7 @@ fn blake2b() {
         "blake2b",
         include_bytes!(env!("BLAKE2B_BLOB")),
         0xee1f_55f1,
-        62_504,
+        62_136,
     );
 }
 
@@ -91,7 +91,7 @@ fn ecrecover() {
         "ecrecover",
         include_bytes!(env!("ECRECOVER_BLOB")),
         0x1,
-        6_937_095,
+        6_810_020,
     );
 }
 
@@ -121,7 +121,7 @@ fn mini_verifier() {
         "mini_verifier",
         include_bytes!(env!("MINI_VERIFIER_BLOB")),
         0xf98f_c4ab,
-        5_960_515,
+        5_878_915,
     );
 }
 

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -350,12 +350,24 @@ pub fn image_cap(
     })
 }
 
-/// Copy `bytes` into a page-aligned, page-sized-rounded `Vec<u8>` so
-/// the kernel can `va_to_pa` + direct-map the code region RO. Mirrors
-/// `DataCap`'s page-alignment invariant.
+/// Copy `bytes` into a `Vec<u8>` whose backing allocation is
+/// page-aligned and page-size-rounded (so the kernel can `va_to_pa` +
+/// direct-map the code region RO), but whose **length is the real code
+/// length** — not the padded capacity.
+///
+/// The length must stay exact: the recompiler iterates `code.len()`
+/// bytes, so a page-padded length would make it compile thousands of
+/// trailing zero bytes as bogus instructions (a ~page-sized fixed cost
+/// per recompile that dominates small guests). The runtime rounds the
+/// mapping size up to a page separately; the trailing capacity bytes
+/// stay zeroed and mapped but are never executed.
 fn alloc_page_aligned_code(bytes: &[u8]) -> Vec<u8> {
     let mut v = super::data::alloc_page_aligned_zeroed(bytes.len());
     v[..bytes.len()].copy_from_slice(bytes);
+    // Keep the page-aligned allocation + zeroed tail (capacity), but
+    // expose only the real code length. `truncate` never reallocates,
+    // so the base pointer stays page-aligned for `va_to_pa`.
+    v.truncate(bytes.len());
     v
 }
 

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -106,8 +106,8 @@ pub const MAP_SRC_CODE: u8 = 1;
 /// because the `source_path` field is `[SlotIdx; MAX_SOURCE_DEPTH]` —
 /// an array of a local type, which Rust's orphan rules block from
 /// receiving a blanket impl in either `ssz` or `javm-cap`. The encoded
-/// form is field-by-field SSZ: `u64 || u64 || u8 || (MAX_SOURCE_DEPTH
-/// * 4 LE bytes) || u8 || u32`. All fields are fixed-length so the
+/// form is field-by-field SSZ (`u64 || u64 || u8 || MAX_SOURCE_DEPTH×4
+/// LE bytes || u8 || u32`); all fields are fixed-length, so the
 /// container is fixed-length too.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MemoryMapping {
@@ -281,11 +281,11 @@ pub enum ImageConvertError {
 ///   indexed by endpoint id. Empty slots use [`EndpointDef::empty`].
 ///   `stack_top` is extracted from the old `initial_regs[1]` (RISC-V
 ///   SP convention); `arg_cnode_slot` defaults to `SlotIdx(0)`.
-/// - `MappingSource::Slot(SlotPath)` becomes `source_kind = MAP_SRC_SLOT`
-///   + `source_path: [SlotIdx; MAX_SOURCE_DEPTH] + source_path_len`;
-///   paths deeper than 8 error. `MappingSource::Code(idx)` becomes
-///   `source_kind = MAP_SRC_CODE` + `code_index = idx` (validated
-///   against `image.codes`).
+/// - `MappingSource::Slot(SlotPath)` becomes `source_kind =
+///   MAP_SRC_SLOT` + `source_path: [SlotIdx; MAX_SOURCE_DEPTH]` +
+///   `source_path_len`; paths deeper than 8 error.
+/// - `MappingSource::Code(idx)` becomes `source_kind = MAP_SRC_CODE` +
+///   `code_index = idx` (validated against `image.codes`).
 pub fn image_cap(
     image: &crate::image::Image,
     pinned_hashes: &[(SlotIdx, CapHash)],

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -11,43 +11,13 @@ use crate::slot::SlotIdx;
 
 use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 
-/// One recompilable code region (raw RV+C+custom-0 bytes), mapped RO
-/// at its `MemoryMapping.start`. Page-aligned so the kernel can
-/// direct-map it.
-#[derive(
-    Debug,
-    ssz_derive::Encode,
-    ssz_derive::Decode,
-    ssz_derive::HashTreeRoot,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct CodeRegionCap {
-    pub code: Vec<u8>,
-}
-
-// Manual Clone: the derived impl uses `Vec::clone` (default 1-byte
-// alignment for `[u8]`). The kernel direct-maps the code region into a
-// ring-3 PT and asserts `phys.is_multiple_of(PAGE_SIZE)`, so a cloned
-// buffer on an unaligned page would panic. Re-allocate through
-// `alloc_page_aligned_zeroed` to preserve the invariant across clones
-// (mirrors `DataContent`'s manual Clone).
-impl Clone for CodeRegionCap {
-    fn clone(&self) -> Self {
-        let mut code = super::data::alloc_page_aligned_zeroed(self.code.len());
-        code[..self.code.len()].copy_from_slice(&self.code);
-        Self { code }
-    }
-}
-
-#[derive(
-    Clone, Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
-)]
+#[derive(Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ImageCap {
-    /// Code regions (raw RV+C+custom-0 bytes). Referenced by
-    /// `MAP_SRC_CODE` mappings.
-    pub codes: Vec<CodeRegionCap>,
+    /// The (single) code region: raw RV+C+custom-0 bytes, page-aligned
+    /// so the kernel can direct-map it RO at the fixed protocol
+    /// constant [`crate::layout::CODE_BASE`]. Empty for codeless
+    /// images. See [`ImageCap::code_mapping`].
+    pub code: Vec<u8>,
     /// Endpoint definitions. Stored as a dense array keyed by
     /// endpoint index — `endpoints[i].entry_pc == 0` means the
     /// endpoint at index `i` is not defined.
@@ -64,19 +34,36 @@ pub struct ImageCap {
     pub yield_marker_slot: Option<SlotIdx>,
 }
 
+// Manual Clone: the derived impl would `Vec::clone` the `code` bytes,
+// which goes through `Global::alloc` at the default 1-byte alignment
+// for `[u8]`. The kernel direct-maps the code region into a ring-3 PT
+// and asserts `phys.is_multiple_of(PAGE_SIZE)`, so a cloned buffer on
+// an unaligned page would panic. Re-allocate `code` through
+// `alloc_page_aligned_code` to preserve the invariant across clones
+// (mirrors `DataContent`'s manual Clone). Other fields clone normally.
+impl Clone for ImageCap {
+    fn clone(&self) -> Self {
+        Self {
+            code: alloc_page_aligned_code(&self.code),
+            endpoints: self.endpoints.clone(),
+            mappings: self.mappings.clone(),
+            pinned: self.pinned.clone(),
+            initial: self.initial.clone(),
+            yield_marker_slot: self.yield_marker_slot,
+        }
+    }
+}
+
 impl ImageCap {
-    /// The executable code region as `(code_base, bytes)`: the first
-    /// mapping whose source is `Code`, resolved to its [`CodeRegionCap`]
-    /// bytes. `code_base` is the guest VA the region maps at, so a PVM
-    /// PC is `code_base + byte_offset`. `None` if the image declares no
-    /// code mapping.
+    /// The executable code region as `(code_base, bytes)`. `code_base`
+    /// is the fixed protocol constant [`crate::layout::CODE_BASE`], so a
+    /// PVM PC is `code_base + byte_offset`. `None` if the image declares
+    /// no code (empty region) — such an image cannot execute.
     pub fn code_mapping(&self) -> Option<(u32, &[u8])> {
-        let m = self
-            .mappings
-            .iter()
-            .find(|m| m.source_kind == MAP_SRC_CODE)?;
-        let region = self.codes.get(m.code_index as usize)?;
-        Some((m.start as u32, region.code.as_slice()))
+        if self.code.is_empty() {
+            return None;
+        }
+        Some((crate::layout::CODE_BASE, self.code.as_slice()))
     }
 }
 
@@ -123,37 +110,27 @@ impl EndpointDef {
 /// One mapped region. The kernel resolves `source_path` at instance
 /// start, reads the bytes from the resulting `Cap::Data`, and lays
 /// them at `[start, start + size)`. `source_path` is a fixed-cap
-/// array; `source_path_len` is the actual depth.
+/// array (`source_path[..source_path_len]` is the live path);
+/// `source_path_len` is the actual depth.
 ///
-/// `source_kind` discriminates: `Slot` resolves a `Cap::Data` through
-/// `source_path[..source_path_len]`; `Code` maps `Image.codes[code_index]`
-/// RO at `start`.
-pub const MAP_SRC_SLOT: u8 = 0;
-pub const MAP_SRC_CODE: u8 = 1;
-
 /// **SSZ note**: `Encode`/`Decode`/`HashTreeRoot` are hand-written
 /// because the `source_path` field is `[SlotIdx; MAX_SOURCE_DEPTH]` —
 /// an array of a local type, which Rust's orphan rules block from
 /// receiving a blanket impl in either `ssz` or `javm-cap`. The encoded
-/// form is field-by-field SSZ (`u64 || u64 || u8 || MAX_SOURCE_DEPTH×4
-/// LE bytes || u8 || u32`); all fields are fixed-length, so the
-/// container is fixed-length too.
+/// form is field-by-field SSZ (`u64 || u64 || MAX_SOURCE_DEPTH×4 LE
+/// bytes || u8`); all fields are fixed-length, so the container is
+/// fixed-length too.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MemoryMapping {
     pub start: u64,
     pub size: u64,
-    /// `MAP_SRC_SLOT` or `MAP_SRC_CODE`.
-    pub source_kind: u8,
-    /// Valid iff `source_kind == MAP_SRC_SLOT`.
     pub source_path: [SlotIdx; MAX_SOURCE_DEPTH],
     pub source_path_len: u8,
-    /// Valid iff `source_kind == MAP_SRC_CODE`: index into `ImageCap.codes`.
-    pub code_index: u32,
 }
 
 impl MemoryMapping {
-    /// SSZ fixed encoded length: 8 + 8 + 1 + (MAX_SOURCE_DEPTH * 4) + 1 + 4.
-    const SSZ_LEN: usize = 8 + 8 + 1 + MAX_SOURCE_DEPTH * 4 + 1 + 4;
+    /// SSZ fixed encoded length: 8 + 8 + (MAX_SOURCE_DEPTH * 4) + 1.
+    const SSZ_LEN: usize = 8 + 8 + MAX_SOURCE_DEPTH * 4 + 1;
 }
 
 impl ssz::Encode for MemoryMapping {
@@ -169,12 +146,10 @@ impl ssz::Encode for MemoryMapping {
     fn ssz_append(&self, buf: &mut alloc::vec::Vec<u8>) {
         buf.extend_from_slice(&self.start.to_le_bytes());
         buf.extend_from_slice(&self.size.to_le_bytes());
-        buf.push(self.source_kind);
         for s in &self.source_path {
             buf.extend_from_slice(&s.get().to_le_bytes());
         }
         buf.push(self.source_path_len);
-        buf.extend_from_slice(&self.code_index.to_le_bytes());
     }
 }
 
@@ -194,24 +169,18 @@ impl ssz::Decode for MemoryMapping {
         }
         let start = u64::from_le_bytes(bytes[0..8].try_into().expect("len checked"));
         let size = u64::from_le_bytes(bytes[8..16].try_into().expect("len checked"));
-        let source_kind = bytes[16];
         let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
         for (i, slot) in source_path.iter_mut().enumerate() {
-            let s = 17 + i * 4;
+            let s = 16 + i * 4;
             let arr: [u8; 4] = bytes[s..s + 4].try_into().expect("len checked");
             *slot = SlotIdx(u32::from_le_bytes(arr));
         }
-        let source_path_len = bytes[17 + MAX_SOURCE_DEPTH * 4];
-        let ci_off = 17 + MAX_SOURCE_DEPTH * 4 + 1;
-        let code_index =
-            u32::from_le_bytes(bytes[ci_off..ci_off + 4].try_into().expect("len checked"));
+        let source_path_len = bytes[16 + MAX_SOURCE_DEPTH * 4];
         Ok(Self {
             start,
             size,
-            source_kind,
             source_path,
             source_path_len,
-            code_index,
         })
     }
 }
@@ -237,18 +206,16 @@ impl ssz::HashTreeRoot for MemoryMapping {
         let roots = [
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.start),
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.size),
-            ssz::HashTreeRoot::hash_tree_root::<D>(&self.source_kind),
             path_root,
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.source_path_len),
-            ssz::HashTreeRoot::hash_tree_root::<D>(&self.code_index),
         ];
-        ssz::merkleize::<D>(&roots, 6)
+        ssz::merkleize::<D>(&roots, 4)
     }
 }
 
 impl MemoryMapping {
-    /// Live slot indices (length = `source_path_len`). Only meaningful
-    /// for `MAP_SRC_SLOT` mappings.
+    /// Live slot indices (length = `source_path_len`) — the cnode path
+    /// to the `Cap::Data` backing this mapping.
     pub fn path(&self) -> &[SlotIdx] {
         &self.source_path[..self.source_path_len as usize]
     }
@@ -289,8 +256,6 @@ pub enum ImageConvertError {
     EndpointIndexOutOfRange(u8),
     #[error("register index {0} >= NUM_REGS")]
     RegisterIndexOutOfRange(u8),
-    #[error("code mapping index {0} out of range (codes.len()={1})")]
-    CodeIndexOutOfRange(u32, usize),
 }
 
 /// Build an [`ImageCap`] from the SCALE-encoded [`crate::image::Image`]
@@ -311,22 +276,17 @@ pub enum ImageConvertError {
 ///   indexed by endpoint id. Empty slots use [`EndpointDef::empty`].
 ///   `stack_top` is extracted from the old `initial_regs[1]` (RISC-V
 ///   SP convention); `arg_cnode_slot` defaults to `SlotIdx(0)`.
-/// - `MappingSource::Slot(SlotPath)` becomes `source_kind =
-///   MAP_SRC_SLOT` + `source_path: [SlotIdx; MAX_SOURCE_DEPTH]` +
-///   `source_path_len`; paths deeper than 8 error.
-/// - `MappingSource::Code(idx)` becomes `source_kind = MAP_SRC_CODE` +
-///   `code_index = idx` (validated against `image.codes`).
+/// - `MemoryMapping.source` (a `SlotPath`) becomes `source_path:
+///   [SlotIdx; MAX_SOURCE_DEPTH]` + `source_path_len`; paths deeper
+///   than `MAX_SOURCE_DEPTH` error.
 pub fn image_cap(
     image: &crate::image::Image,
     pinned_hashes: &[(SlotIdx, CapHash)],
     initial_hashes: &[(SlotIdx, CapHash)],
 ) -> Result<ImageCap, ImageConvertError> {
-    let mut codes = Vec::with_capacity(image.codes.len());
-    for region in &image.codes {
-        codes.push(CodeRegionCap {
-            code: alloc_page_aligned_code(&region.code),
-        });
-    }
+    // Code: page-aligned copy so the kernel can direct-map it RO at
+    // `layout::CODE_BASE`.
+    let code = alloc_page_aligned_code(&image.code);
 
     // Endpoints: dense `MAX_ENDPOINTS`-sized array; empty entries have
     // `entry_pc == 0`.
@@ -358,53 +318,30 @@ pub fn image_cap(
 
     let mut mappings = Vec::with_capacity(image.memory_mappings.len());
     for m in &image.memory_mappings {
-        let mapping = match &m.source {
-            crate::image::MappingSource::Slot(path) => {
-                let steps = &path.steps;
-                if steps.is_empty() {
-                    return Err(ImageConvertError::SourcePathEmpty);
-                }
-                if steps.len() > MAX_SOURCE_DEPTH {
-                    return Err(ImageConvertError::SourcePathTooDeep(steps.len()));
-                }
-                let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
-                for (i, s) in steps.iter().enumerate() {
-                    source_path[i] = *s;
-                }
-                MemoryMapping {
-                    start: m.start,
-                    size: m.size,
-                    source_kind: MAP_SRC_SLOT,
-                    source_path,
-                    source_path_len: steps.len() as u8,
-                    code_index: 0,
-                }
-            }
-            crate::image::MappingSource::Code(idx) => {
-                if (*idx as usize) >= image.codes.len() {
-                    return Err(ImageConvertError::CodeIndexOutOfRange(
-                        *idx,
-                        image.codes.len(),
-                    ));
-                }
-                MemoryMapping {
-                    start: m.start,
-                    size: m.size,
-                    source_kind: MAP_SRC_CODE,
-                    source_path: [SlotIdx(0); MAX_SOURCE_DEPTH],
-                    source_path_len: 0,
-                    code_index: *idx,
-                }
-            }
-        };
-        mappings.push(mapping);
+        let steps = &m.source.steps;
+        if steps.is_empty() {
+            return Err(ImageConvertError::SourcePathEmpty);
+        }
+        if steps.len() > MAX_SOURCE_DEPTH {
+            return Err(ImageConvertError::SourcePathTooDeep(steps.len()));
+        }
+        let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
+        for (i, s) in steps.iter().enumerate() {
+            source_path[i] = *s;
+        }
+        mappings.push(MemoryMapping {
+            start: m.start,
+            size: m.size,
+            source_path,
+            source_path_len: steps.len() as u8,
+        });
     }
 
     let pinned = build_image_slot_vec(pinned_hashes);
     let initial = build_image_slot_vec(initial_hashes);
 
     Ok(ImageCap {
-        codes,
+        code,
         endpoints,
         mappings,
         pinned,

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -51,6 +51,22 @@ pub struct ImageCap {
     pub yield_marker_slot: Option<SlotIdx>,
 }
 
+impl ImageCap {
+    /// The executable code region as `(code_base, bytes)`: the first
+    /// mapping whose source is `Code`, resolved to its [`CodeRegionCap`]
+    /// bytes. `code_base` is the guest VA the region maps at, so a PVM
+    /// PC is `code_base + byte_offset`. `None` if the image declares no
+    /// code mapping.
+    pub fn code_mapping(&self) -> Option<(u32, &[u8])> {
+        let m = self
+            .mappings
+            .iter()
+            .find(|m| m.source_kind == MAP_SRC_CODE)?;
+        let region = self.codes.get(m.code_index as usize)?;
+        Some((m.start as u32, region.code.as_slice()))
+    }
+}
+
 /// Endpoint definition. Dense `initial_regs` array; index `i`
 /// corresponds to PVM register `φ[i]`. `0` is "use default" (same
 /// semantics as the spec's old `BTreeMap<u8, u64>` when the key is

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -15,7 +15,6 @@ use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 /// at its `MemoryMapping.start`. Page-aligned so the kernel can
 /// direct-map it.
 #[derive(
-    Clone,
     Debug,
     ssz_derive::Encode,
     ssz_derive::Decode,
@@ -26,6 +25,20 @@ use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 )]
 pub struct CodeRegionCap {
     pub code: Vec<u8>,
+}
+
+// Manual Clone: the derived impl uses `Vec::clone` (default 1-byte
+// alignment for `[u8]`). The kernel direct-maps the code region into a
+// ring-3 PT and asserts `phys.is_multiple_of(PAGE_SIZE)`, so a cloned
+// buffer on an unaligned page would panic. Re-allocate through
+// `alloc_page_aligned_zeroed` to preserve the invariant across clones
+// (mirrors `DataContent`'s manual Clone).
+impl Clone for CodeRegionCap {
+    fn clone(&self) -> Self {
+        let mut code = super::data::alloc_page_aligned_zeroed(self.code.len());
+        code[..self.code.len()].copy_from_slice(&self.code);
+        Self { code }
+    }
 }
 
 #[derive(
@@ -190,7 +203,8 @@ impl ssz::Decode for MemoryMapping {
         }
         let source_path_len = bytes[17 + MAX_SOURCE_DEPTH * 4];
         let ci_off = 17 + MAX_SOURCE_DEPTH * 4 + 1;
-        let code_index = u32::from_le_bytes(bytes[ci_off..ci_off + 4].try_into().expect("len checked"));
+        let code_index =
+            u32::from_le_bytes(bytes[ci_off..ci_off + 4].try_into().expect("len checked"));
         Ok(Self {
             start,
             size,
@@ -368,7 +382,10 @@ pub fn image_cap(
             }
             crate::image::MappingSource::Code(idx) => {
                 if (*idx as usize) >= image.codes.len() {
-                    return Err(ImageConvertError::CodeIndexOutOfRange(*idx, image.codes.len()));
+                    return Err(ImageConvertError::CodeIndexOutOfRange(
+                        *idx,
+                        image.codes.len(),
+                    ));
                 }
                 MemoryMapping {
                     start: m.start,

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -1,9 +1,9 @@
 //! `ImageCap` — Image cap.
 //!
-//! Stores code, bitmask, jump_table, endpoints, mappings, and slot
-//! references as separate `Vec<T>` allocations. Allocation count
-//! per ImageCap is bounded (seven Vecs, regardless of content size);
-//! we accept that in exchange for direct field accessors.
+//! Stores code regions, endpoints, mappings, and slot references as
+//! separate `Vec<T>` allocations. Allocation count per ImageCap is
+//! bounded regardless of content size; we accept that in exchange for
+//! direct field accessors.
 
 use alloc::vec::Vec;
 
@@ -11,19 +11,30 @@ use crate::slot::SlotIdx;
 
 use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 
+/// One recompilable code region (raw RV+C+custom-0 bytes), mapped RO
+/// at its `MemoryMapping.start`. Page-aligned so the kernel can
+/// direct-map it.
+#[derive(
+    Clone,
+    Debug,
+    ssz_derive::Encode,
+    ssz_derive::Decode,
+    ssz_derive::HashTreeRoot,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct CodeRegionCap {
+    pub code: Vec<u8>,
+}
+
 #[derive(
     Clone, Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 pub struct ImageCap {
-    /// Bytecode bytes (raw RV+C+custom-0).
-    pub code: Vec<u8>,
-    /// Concatenated per-function `br_table` sub-tables. Sub-table
-    /// boundaries live in `jump_table_offsets` (CSR-style).
-    pub jump_table: Vec<u32>,
-    /// Per-table start offsets in `jump_table`, CSR-style.
-    /// `jump_table_offsets[t]..jump_table_offsets[t+1]` slices the
-    /// entries of table `t`. Length = `num_tables + 1`.
-    pub jump_table_offsets: Vec<u32>,
+    /// Code regions (raw RV+C+custom-0 bytes). Referenced by
+    /// `MAP_SRC_CODE` mappings.
+    pub codes: Vec<CodeRegionCap>,
     /// Endpoint definitions. Stored as a dense array keyed by
     /// endpoint index — `endpoints[i].entry_pc == 0` means the
     /// endpoint at index `i` is not defined.
@@ -85,24 +96,35 @@ impl EndpointDef {
 /// them at `[start, start + size)`. `source_path` is a fixed-cap
 /// array; `source_path_len` is the actual depth.
 ///
+/// `source_kind` discriminates: `Slot` resolves a `Cap::Data` through
+/// `source_path[..source_path_len]`; `Code` maps `Image.codes[code_index]`
+/// RO at `start`.
+pub const MAP_SRC_SLOT: u8 = 0;
+pub const MAP_SRC_CODE: u8 = 1;
+
 /// **SSZ note**: `Encode`/`Decode`/`HashTreeRoot` are hand-written
 /// because the `source_path` field is `[SlotIdx; MAX_SOURCE_DEPTH]` —
 /// an array of a local type, which Rust's orphan rules block from
 /// receiving a blanket impl in either `ssz` or `javm-cap`. The encoded
-/// form is field-by-field SSZ: `u64 || u64 || (MAX_SOURCE_DEPTH * 4
-/// LE bytes) || u8`. All fields are fixed-length so the container is
-/// fixed-length too.
+/// form is field-by-field SSZ: `u64 || u64 || u8 || (MAX_SOURCE_DEPTH
+/// * 4 LE bytes) || u8 || u32`. All fields are fixed-length so the
+/// container is fixed-length too.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct MemoryMapping {
     pub start: u64,
     pub size: u64,
+    /// `MAP_SRC_SLOT` or `MAP_SRC_CODE`.
+    pub source_kind: u8,
+    /// Valid iff `source_kind == MAP_SRC_SLOT`.
     pub source_path: [SlotIdx; MAX_SOURCE_DEPTH],
     pub source_path_len: u8,
+    /// Valid iff `source_kind == MAP_SRC_CODE`: index into `ImageCap.codes`.
+    pub code_index: u32,
 }
 
 impl MemoryMapping {
-    /// SSZ fixed encoded length: 8 + 8 + (MAX_SOURCE_DEPTH * 4) + 1.
-    const SSZ_LEN: usize = 8 + 8 + MAX_SOURCE_DEPTH * 4 + 1;
+    /// SSZ fixed encoded length: 8 + 8 + 1 + (MAX_SOURCE_DEPTH * 4) + 1 + 4.
+    const SSZ_LEN: usize = 8 + 8 + 1 + MAX_SOURCE_DEPTH * 4 + 1 + 4;
 }
 
 impl ssz::Encode for MemoryMapping {
@@ -118,10 +140,12 @@ impl ssz::Encode for MemoryMapping {
     fn ssz_append(&self, buf: &mut alloc::vec::Vec<u8>) {
         buf.extend_from_slice(&self.start.to_le_bytes());
         buf.extend_from_slice(&self.size.to_le_bytes());
+        buf.push(self.source_kind);
         for s in &self.source_path {
             buf.extend_from_slice(&s.get().to_le_bytes());
         }
         buf.push(self.source_path_len);
+        buf.extend_from_slice(&self.code_index.to_le_bytes());
     }
 }
 
@@ -141,18 +165,23 @@ impl ssz::Decode for MemoryMapping {
         }
         let start = u64::from_le_bytes(bytes[0..8].try_into().expect("len checked"));
         let size = u64::from_le_bytes(bytes[8..16].try_into().expect("len checked"));
+        let source_kind = bytes[16];
         let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
         for (i, slot) in source_path.iter_mut().enumerate() {
-            let s = 16 + i * 4;
+            let s = 17 + i * 4;
             let arr: [u8; 4] = bytes[s..s + 4].try_into().expect("len checked");
             *slot = SlotIdx(u32::from_le_bytes(arr));
         }
-        let source_path_len = bytes[16 + MAX_SOURCE_DEPTH * 4];
+        let source_path_len = bytes[17 + MAX_SOURCE_DEPTH * 4];
+        let ci_off = 17 + MAX_SOURCE_DEPTH * 4 + 1;
+        let code_index = u32::from_le_bytes(bytes[ci_off..ci_off + 4].try_into().expect("len checked"));
         Ok(Self {
             start,
             size,
+            source_kind,
             source_path,
             source_path_len,
+            code_index,
         })
     }
 }
@@ -162,7 +191,7 @@ impl ssz::HashTreeRoot for MemoryMapping {
         &self,
     ) -> [u8; 32] {
         // SSZ container root: merkleize the per-field roots with
-        // limit = number of fields (4). All four are fixed-size leaves.
+        // limit = number of fields (6). All are fixed-size leaves.
         let path_root = {
             // Treat the fixed-length path array as a `Vector<u32,
             // MAX_SOURCE_DEPTH>` for hashing: pack to bytes, merkleize
@@ -178,15 +207,18 @@ impl ssz::HashTreeRoot for MemoryMapping {
         let roots = [
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.start),
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.size),
+            ssz::HashTreeRoot::hash_tree_root::<D>(&self.source_kind),
             path_root,
             ssz::HashTreeRoot::hash_tree_root::<D>(&self.source_path_len),
+            ssz::HashTreeRoot::hash_tree_root::<D>(&self.code_index),
         ];
-        ssz::merkleize::<D>(&roots, 4)
+        ssz::merkleize::<D>(&roots, 6)
     }
 }
 
 impl MemoryMapping {
-    /// Live slot indices (length = `source_path_len`).
+    /// Live slot indices (length = `source_path_len`). Only meaningful
+    /// for `MAP_SRC_SLOT` mappings.
     pub fn path(&self) -> &[SlotIdx] {
         &self.source_path[..self.source_path_len as usize]
     }
@@ -227,6 +259,8 @@ pub enum ImageConvertError {
     EndpointIndexOutOfRange(u8),
     #[error("register index {0} >= NUM_REGS")]
     RegisterIndexOutOfRange(u8),
+    #[error("code mapping index {0} out of range (codes.len()={1})")]
+    CodeIndexOutOfRange(u32, usize),
 }
 
 /// Build an [`ImageCap`] from the SCALE-encoded [`crate::image::Image`]
@@ -247,23 +281,21 @@ pub enum ImageConvertError {
 ///   indexed by endpoint id. Empty slots use [`EndpointDef::empty`].
 ///   `stack_top` is extracted from the old `initial_regs[1]` (RISC-V
 ///   SP convention); `arg_cnode_slot` defaults to `SlotIdx(0)`.
-/// - `MemoryMapping.source: SlotPath` becomes `source_path: [SlotIdx;
-///   MAX_SOURCE_DEPTH] + source_path_len`; paths deeper than 8 error.
+/// - `MappingSource::Slot(SlotPath)` becomes `source_kind = MAP_SRC_SLOT`
+///   + `source_path: [SlotIdx; MAX_SOURCE_DEPTH] + source_path_len`;
+///   paths deeper than 8 error. `MappingSource::Code(idx)` becomes
+///   `source_kind = MAP_SRC_CODE` + `code_index = idx` (validated
+///   against `image.codes`).
 pub fn image_cap(
     image: &crate::image::Image,
     pinned_hashes: &[(SlotIdx, CapHash)],
     initial_hashes: &[(SlotIdx, CapHash)],
 ) -> Result<ImageCap, ImageConvertError> {
-    let mut code = Vec::with_capacity(image.code.len());
-    code.extend_from_slice(&image.code);
-
-    let mut jump_table = Vec::with_capacity(image.jump_table.len());
-    for &j in &image.jump_table {
-        jump_table.push(j);
-    }
-    let mut jump_table_offsets = Vec::with_capacity(image.jump_table_offsets.len());
-    for &o in &image.jump_table_offsets {
-        jump_table_offsets.push(o);
+    let mut codes = Vec::with_capacity(image.codes.len());
+    for region in &image.codes {
+        codes.push(CodeRegionCap {
+            code: alloc_page_aligned_code(&region.code),
+        });
     }
 
     // Endpoints: dense `MAX_ENDPOINTS`-sized array; empty entries have
@@ -296,38 +328,65 @@ pub fn image_cap(
 
     let mut mappings = Vec::with_capacity(image.memory_mappings.len());
     for m in &image.memory_mappings {
-        let steps = &m.source.steps;
-        if steps.is_empty() {
-            return Err(ImageConvertError::SourcePathEmpty);
-        }
-        if steps.len() > MAX_SOURCE_DEPTH {
-            return Err(ImageConvertError::SourcePathTooDeep(steps.len()));
-        }
-        let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
-        for (i, s) in steps.iter().enumerate() {
-            source_path[i] = *s;
-        }
-        mappings.push(MemoryMapping {
-            start: m.start,
-            size: m.size,
-            source_path,
-            source_path_len: steps.len() as u8,
-        });
+        let mapping = match &m.source {
+            crate::image::MappingSource::Slot(path) => {
+                let steps = &path.steps;
+                if steps.is_empty() {
+                    return Err(ImageConvertError::SourcePathEmpty);
+                }
+                if steps.len() > MAX_SOURCE_DEPTH {
+                    return Err(ImageConvertError::SourcePathTooDeep(steps.len()));
+                }
+                let mut source_path = [SlotIdx(0); MAX_SOURCE_DEPTH];
+                for (i, s) in steps.iter().enumerate() {
+                    source_path[i] = *s;
+                }
+                MemoryMapping {
+                    start: m.start,
+                    size: m.size,
+                    source_kind: MAP_SRC_SLOT,
+                    source_path,
+                    source_path_len: steps.len() as u8,
+                    code_index: 0,
+                }
+            }
+            crate::image::MappingSource::Code(idx) => {
+                if (*idx as usize) >= image.codes.len() {
+                    return Err(ImageConvertError::CodeIndexOutOfRange(*idx, image.codes.len()));
+                }
+                MemoryMapping {
+                    start: m.start,
+                    size: m.size,
+                    source_kind: MAP_SRC_CODE,
+                    source_path: [SlotIdx(0); MAX_SOURCE_DEPTH],
+                    source_path_len: 0,
+                    code_index: *idx,
+                }
+            }
+        };
+        mappings.push(mapping);
     }
 
     let pinned = build_image_slot_vec(pinned_hashes);
     let initial = build_image_slot_vec(initial_hashes);
 
     Ok(ImageCap {
-        code,
-        jump_table,
-        jump_table_offsets,
+        codes,
         endpoints,
         mappings,
         pinned,
         initial,
         yield_marker_slot: image.yield_marker_slot,
     })
+}
+
+/// Copy `bytes` into a page-aligned, page-sized-rounded `Vec<u8>` so
+/// the kernel can `va_to_pa` + direct-map the code region RO. Mirrors
+/// `DataCap`'s page-alignment invariant.
+fn alloc_page_aligned_code(bytes: &[u8]) -> Vec<u8> {
+    let mut v = super::data::alloc_page_aligned_zeroed(bytes.len());
+    v[..bytes.len()].copy_from_slice(bytes);
+    v
 }
 
 fn build_image_slot_vec(pairs: &[(SlotIdx, CapHash)]) -> Vec<ImageSlotEntry> {

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -40,32 +40,23 @@ use ssz_derive::{Decode, Encode};
 /// read-only thereafter.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub struct Image {
-    /// Bytecode bytes (raw RV+C+custom-0; validated at construction).
-    pub code: Vec<u8>,
-    /// Concatenation of variable-length sub-tables: per-function
-    /// return tables, per-vtable dispatch tables, per-switch jump
-    /// tables. Sub-table boundaries live in `jump_table_offsets`
-    /// (CSR-style). Each `br_table table_id, rs1` dispatches through
-    /// sub-table `table_id`.
-    pub jump_table: Vec<u32>,
-    /// Per-table start offsets in `jump_table`, CSR-style. Length =
-    /// `num_tables + 1`. The first entry is always 0; the last entry
-    /// equals `jump_table.len()`. Table `t` lives at
-    /// `jump_table[jump_table_offsets[t]..jump_table_offsets[t+1]]`,
-    /// and its size is `jump_table_offsets[t+1] - jump_table_offsets[t]`
-    /// — every table can have a different length.
-    ///
-    /// Example: 3 tables of sizes [5, 3, 7]:
-    /// - `jump_table` = `[a0..a4, b0..b2, c0..c6]` (15 u32 entries)
-    /// - `jump_table_offsets` = `[0, 5, 8, 15]` (4 entries)
-    pub jump_table_offsets: Vec<u32>,
+    /// Code regions (raw RV+C+custom-0 bytes). Each region "takes
+    /// effect" only when referenced by a `MemoryMapping` whose
+    /// `source` is `MappingSource::Code(idx)`; the mapping's `start`
+    /// is the region's load address (CODE_BASE — PC = CODE_BASE +
+    /// byte-offset). Code is mapped RO into the guest address space
+    /// so the guest can read its own bytes (AUIPC+load PIC); the JIT
+    /// executes the native translation.
+    pub codes: Vec<CodeRegion>,
     /// Endpoints addressable by `endpoint_idx` (u8). Sparse — only
     /// declared endpoints are present.
     pub endpoints: BTreeMap<u8, EndpointDef>,
-    /// Memory layout. Each entry maps a `Cap::Data` (resolved
-    /// through `source`) into the address space at `[start, start
-    /// + size)`. Permissions are derived from whether the target
-    /// slot appears in `pinned_slots` (RO) or not (RW).
+    /// Memory layout. Each entry maps either a `Cap::Data` (resolved
+    /// through a `MappingSource::Slot` path) or an inline code region
+    /// (`MappingSource::Code`) into the address space at `[start,
+    /// start + size)`. For slot sources, RO vs RW is derived from
+    /// whether the target slot appears in `pinned_slots`; code
+    /// sources are always RO.
     pub memory_mappings: Vec<MemoryMapping>,
     /// Cnode slots holding `Cap::Instance[Gas{meter_id}]`. Active
     /// gas debit comes from the first slot's meter; the rest are
@@ -103,16 +94,37 @@ pub struct EndpointDef {
     pub initial_regs: BTreeMap<u8, u64>,
 }
 
+/// One recompilable code region. Content lives inline in the Image
+/// (content-hash stable via `hash_tree_root`, exactly like the old
+/// `Image.code`).
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
+pub struct CodeRegion {
+    /// Raw RV+C+custom-0 bytes (validated at construction).
+    pub code: Vec<u8>,
+}
+
+/// Source of a [`MemoryMapping`]: either a cnode-resolved cap (Data,
+/// RO or RW) or an inline code region (always RO + recompiled).
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
+pub enum MappingSource {
+    #[ssz(selector = 0)]
+    /// Resolve a `Cap::Data` through this cnode path.
+    Slot(crate::slot::SlotPath),
+    #[ssz(selector = 1)]
+    /// Map `Image.codes[idx]` RO at the mapping's `start`.
+    Code(u32),
+}
+
 /// One mapped region. The kernel resolves `source` at instance
-/// start, reads the bytes from the resulting `Cap::Data`, and lays
-/// them at `[start, start + size)` in the address space. Whether
-/// the region is RO or RW is derived from whether `source.target()`
-/// is in `Image.pinned_slots`.
+/// start and lays the bytes at `[start, start + size)` in the
+/// address space. For `Slot` sources, RO vs RW is derived from
+/// whether the target slot is in `Image.pinned_slots`; `Code`
+/// sources are always RO.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub struct MemoryMapping {
     pub start: u64,
     pub size: u64,
-    pub source: crate::slot::SlotPath,
+    pub source: MappingSource,
 }
 
 /// Pinned slot content. Only content-addressed cap kinds can be
@@ -153,9 +165,7 @@ impl Image {
     /// Useful for tests and as a starting point.
     pub fn empty() -> Self {
         Self {
-            code: Vec::new(),
-            jump_table: Vec::new(),
-            jump_table_offsets: Vec::new(),
+            codes: Vec::new(),
             endpoints: BTreeMap::new(),
             memory_mappings: Vec::new(),
             gas_slots: Vec::new(),

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -40,23 +40,22 @@ use ssz_derive::{Decode, Encode};
 /// read-only thereafter.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub struct Image {
-    /// Code regions (raw RV+C+custom-0 bytes). Each region "takes
-    /// effect" only when referenced by a `MemoryMapping` whose
-    /// `source` is `MappingSource::Code(idx)`; the mapping's `start`
-    /// is the region's load address (CODE_BASE — PC = CODE_BASE +
-    /// byte-offset). Code is mapped RO into the guest address space
-    /// so the guest can read its own bytes (AUIPC+load PIC); the JIT
-    /// executes the native translation.
-    pub codes: Vec<CodeRegion>,
+    /// The (single) code region: raw RV+C+custom-0 bytes. Mapped RO at
+    /// the fixed protocol constant [`crate::layout::CODE_BASE`] (PC =
+    /// `CODE_BASE + byte_offset`) — the load address is *not* chosen by
+    /// the Image, so an untrusted Image cannot place code arbitrarily.
+    /// Code is mapped RO into the guest address space so the guest can
+    /// read its own bytes (AUIPC+load PIC); the JIT executes the native
+    /// translation. Empty for codeless images (kernel placeholders).
+    pub code: Vec<u8>,
     /// Endpoints addressable by `endpoint_idx` (u8). Sparse — only
     /// declared endpoints are present.
     pub endpoints: BTreeMap<u8, EndpointDef>,
-    /// Memory layout. Each entry maps either a `Cap::Data` (resolved
-    /// through a `MappingSource::Slot` path) or an inline code region
-    /// (`MappingSource::Code`) into the address space at `[start,
-    /// start + size)`. For slot sources, RO vs RW is derived from
-    /// whether the target slot appears in `pinned_slots`; code
-    /// sources are always RO.
+    /// Memory layout. Each entry maps a `Cap::Data` (resolved through
+    /// the `source` slot path) into the address space at `[start, start
+    /// + size)`. RO vs RW is derived from whether the target slot
+    /// appears in `pinned_slots`. Code is mapped separately at
+    /// [`crate::layout::CODE_BASE`] and is not described here.
     pub memory_mappings: Vec<MemoryMapping>,
     /// Cnode slots holding `Cap::Instance[Gas{meter_id}]`. Active
     /// gas debit comes from the first slot's meter; the rest are
@@ -94,37 +93,17 @@ pub struct EndpointDef {
     pub initial_regs: BTreeMap<u8, u64>,
 }
 
-/// One recompilable code region. Content lives inline in the Image
-/// (content-hash stable via `hash_tree_root`, exactly like the old
-/// `Image.code`).
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
-pub struct CodeRegion {
-    /// Raw RV+C+custom-0 bytes (validated at construction).
-    pub code: Vec<u8>,
-}
-
-/// Source of a [`MemoryMapping`]: either a cnode-resolved cap (Data,
-/// RO or RW) or an inline code region (always RO + recompiled).
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
-pub enum MappingSource {
-    #[ssz(selector = 0)]
-    /// Resolve a `Cap::Data` through this cnode path.
-    Slot(crate::slot::SlotPath),
-    #[ssz(selector = 1)]
-    /// Map `Image.codes[idx]` RO at the mapping's `start`.
-    Code(u32),
-}
-
-/// One mapped region. The kernel resolves `source` at instance
-/// start and lays the bytes at `[start, start + size)` in the
-/// address space. For `Slot` sources, RO vs RW is derived from
-/// whether the target slot is in `Image.pinned_slots`; `Code`
-/// sources are always RO.
+/// One mapped region. The kernel resolves `source` (a cnode slot path
+/// to a `Cap::Data`) at instance start and lays the bytes at `[start,
+/// start + size)` in the address space. RO vs RW is derived from
+/// whether the target slot is in `Image.pinned_slots`.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub struct MemoryMapping {
     pub start: u64,
     pub size: u64,
-    pub source: MappingSource,
+    /// Cnode path resolving to the `Cap::Data` whose bytes back this
+    /// region.
+    pub source: crate::slot::SlotPath,
 }
 
 /// Pinned slot content. Only content-addressed cap kinds can be
@@ -165,7 +144,7 @@ impl Image {
     /// Useful for tests and as a starting point.
     pub fn empty() -> Self {
         Self {
-            codes: Vec::new(),
+            code: Vec::new(),
             endpoints: BTreeMap::new(),
             memory_mappings: Vec::new(),
             gas_slots: Vec::new(),

--- a/rust/javm-cap/src/layout.rs
+++ b/rust/javm-cap/src/layout.rs
@@ -4,19 +4,38 @@
 //! data regions map in the guest's 32-bit address space. They are part
 //! of the PVM2 ABI contract: the transpiler (`javm-transpiler`) bakes
 //! `PC = CODE_BASE + byte_offset` into endpoint entry PCs and native
-//! `auipc`/`jalr` resolution, and every runtime (`nub-arch-x86`,
-//! `nub-arch-local`, `javm`) maps `Image.code` read-only at `CODE_BASE`.
+//! `auipc`/`jalr` resolution and lays data caps from [`DATA_BASE`] up,
+//! and every runtime (`nub-arch-x86`, `nub-arch-local`, `javm`) maps
+//! `Image.code` read-only at `CODE_BASE` and data at `DATA_BASE`.
 //!
 //! The constants live here in `javm-cap` because it is the only crate
 //! every producer (transpiler) and consumer (each runtime) depends on.
 //! Code placement is a fixed protocol constant rather than an
 //! Image-supplied mapping entry: an untrusted Image must not get to
 //! choose where its code lands.
+//!
+//! ```text
+//!   [0,         CODE_BASE)  unmapped — NULL guard (catch PC=0 / null deref)
+//!   [CODE_BASE, DATA_BASE)  CODE     — RO, ≤ MAX_CODE_SIZE bytes
+//!   [DATA_BASE, 4 GiB)      DATA     — stack / ro / rw / heap, RO|RW
+//! ```
+//!
+//! Code low (4 MiB) gives the null guard; data high (256 MiB) keeps the
+//! whole data region contiguous above code instead of wrapping around
+//! it. Both `[0, CODE_BASE)` and `[CODE_BASE + code, DATA_BASE)` are
+//! unmapped, so a stray fetch or load there faults.
 
 /// Guest virtual address where the (single) code region maps read-only.
-/// A PVM PC is `CODE_BASE + byte_offset`.
-///
-/// Sits at 1 GiB, above the data layout (which grows from the low
-/// address space upward) and below CTX. The high bit is clear so a
-/// 32-bit `ra` spill round-trips identically under `lw`/`lwu`.
-pub const CODE_BASE: u32 = 0x4000_0000;
+/// A PVM PC is `CODE_BASE + byte_offset`. Sits at 4 MiB so `[0, 4 MiB)`
+/// is an unmapped null guard.
+pub const CODE_BASE: u32 = 0x0040_0000;
+
+/// Guest virtual address where the data region begins. All data caps
+/// (stack / ro / rw / heap) and instance overlays live in `[DATA_BASE,
+/// 4 GiB)`. At 256 MiB, well clear of the largest permitted code region.
+pub const DATA_BASE: u32 = 0x1000_0000;
+
+/// Maximum byte length of the code region. Code occupies `[CODE_BASE,
+/// CODE_BASE + code_len)` and must stay below `DATA_BASE`, so
+/// `code_len ≤ DATA_BASE − CODE_BASE` = 252 MiB.
+pub const MAX_CODE_SIZE: u32 = DATA_BASE - CODE_BASE;

--- a/rust/javm-cap/src/layout.rs
+++ b/rust/javm-cap/src/layout.rs
@@ -1,0 +1,22 @@
+//! PVM2 guest virtual-address-space layout (ABI constants).
+//!
+//! These constants define where a transpiler-emitted Image's code and
+//! data regions map in the guest's 32-bit address space. They are part
+//! of the PVM2 ABI contract: the transpiler (`javm-transpiler`) bakes
+//! `PC = CODE_BASE + byte_offset` into endpoint entry PCs and native
+//! `auipc`/`jalr` resolution, and every runtime (`nub-arch-x86`,
+//! `nub-arch-local`, `javm`) maps `Image.code` read-only at `CODE_BASE`.
+//!
+//! The constants live here in `javm-cap` because it is the only crate
+//! every producer (transpiler) and consumer (each runtime) depends on.
+//! Code placement is a fixed protocol constant rather than an
+//! Image-supplied mapping entry: an untrusted Image must not get to
+//! choose where its code lands.
+
+/// Guest virtual address where the (single) code region maps read-only.
+/// A PVM PC is `CODE_BASE + byte_offset`.
+///
+/// Sits at 1 GiB, above the data layout (which grows from the low
+/// address space upward) and below CTX. The high bit is clear so a
+/// 32-bit `ra` spill round-trips identically under `lw`/`lwu`.
+pub const CODE_BASE: u32 = 0x4000_0000;

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -46,8 +46,8 @@ pub use cap::{Cap, CapHash, CapKind, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS, 
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash};
 pub use image::{
-    CodeRegion, EndpointDef as ImageEndpointDef, Image, InitialDataCap,
-    MappingSource, MemoryMapping as ImageMemoryMapping, PinnedCap, chain_extend, chain_genesis,
+    CodeRegion, EndpointDef as ImageEndpointDef, Image, InitialDataCap, MappingSource,
+    MemoryMapping as ImageMemoryMapping, PinnedCap, chain_extend, chain_genesis,
     image_content_hash,
 };
 pub use slot::{SlotIdx, SlotPath};

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -37,7 +37,8 @@ pub use cache::{CacheDirectory, CacheError, CapHasRefError, CapHashOrRef, CapRef
 pub use cap::cnode::{CNodeCap, CNodeSlotEntry};
 pub use cap::data::{DataCap, DataContent, PAGE_SIZE};
 pub use cap::image::{
-    EndpointDef, ImageCap, ImageConvertError, ImageSlotEntry, MemoryMapping, image_cap,
+    CodeRegionCap, EndpointDef, ImageCap, ImageConvertError, ImageSlotEntry, MAP_SRC_CODE,
+    MAP_SRC_SLOT, MemoryMapping, image_cap,
 };
 pub use cap::instance::{InstanceCap, RwOverlay};
 pub use cap::page::{PageBytes, PageRef, PageSlot};
@@ -45,7 +46,8 @@ pub use cap::{Cap, CapHash, CapKind, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS, 
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash};
 pub use image::{
-    EndpointDef as ImageEndpointDef, Image, InitialDataCap, MemoryMapping as ImageMemoryMapping,
-    PinnedCap, chain_extend, chain_genesis, image_content_hash,
+    CodeRegion, EndpointDef as ImageEndpointDef, Image, InitialDataCap,
+    MappingSource, MemoryMapping as ImageMemoryMapping, PinnedCap, chain_extend, chain_genesis,
+    image_content_hash,
 };
 pub use slot::{SlotIdx, SlotPath};

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -31,14 +31,14 @@ pub mod cap;
 pub mod error;
 pub mod hash;
 pub mod image;
+pub mod layout;
 pub mod slot;
 
 pub use cache::{CacheDirectory, CacheError, CapHasRefError, CapHashOrRef, CapRef};
 pub use cap::cnode::{CNodeCap, CNodeSlotEntry};
 pub use cap::data::{DataCap, DataContent, PAGE_SIZE};
 pub use cap::image::{
-    CodeRegionCap, EndpointDef, ImageCap, ImageConvertError, ImageSlotEntry, MAP_SRC_CODE,
-    MAP_SRC_SLOT, MemoryMapping, image_cap,
+    EndpointDef, ImageCap, ImageConvertError, ImageSlotEntry, MemoryMapping, image_cap,
 };
 pub use cap::instance::{InstanceCap, RwOverlay};
 pub use cap::page::{PageBytes, PageRef, PageSlot};
@@ -46,8 +46,7 @@ pub use cap::{Cap, CapHash, CapKind, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS, 
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash};
 pub use image::{
-    CodeRegion, EndpointDef as ImageEndpointDef, Image, InitialDataCap, MappingSource,
-    MemoryMapping as ImageMemoryMapping, PinnedCap, chain_extend, chain_genesis,
-    image_content_hash,
+    EndpointDef as ImageEndpointDef, Image, InitialDataCap, MemoryMapping as ImageMemoryMapping,
+    PinnedCap, chain_extend, chain_genesis, image_content_hash,
 };
 pub use slot::{SlotIdx, SlotPath};

--- a/rust/javm-cap/tests/cap_hash.rs
+++ b/rust/javm-cap/tests/cap_hash.rs
@@ -1,6 +1,6 @@
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, DataContent, ImageCap, InstanceCap,
-    NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotIdx, TypeCap,
+    CNodeCap, CacheDirectory, Cap, CapHashOrRef, CodeRegionCap, DataCap, DataContent, ImageCap,
+    InstanceCap, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotIdx, TypeCap,
 };
 
 #[test]
@@ -79,8 +79,12 @@ fn cnode_with_ref_target_panics() {
 fn image_hash_depends_on_code() {
     let mut img_a = empty_image();
     let mut img_b = empty_image();
-    img_a.code.extend_from_slice(b"foo");
-    img_b.code.extend_from_slice(b"bar");
+    img_a.codes = vec![CodeRegionCap {
+        code: b"foo".to_vec(),
+    }];
+    img_b.codes = vec![CodeRegionCap {
+        code: b"bar".to_vec(),
+    }];
     let a: Cap = Cap::Image(img_a);
     let b: Cap = Cap::Image(img_b);
     assert_ne!(a.cap_hash(), b.cap_hash());
@@ -88,9 +92,7 @@ fn image_hash_depends_on_code() {
 
 fn empty_image() -> ImageCap {
     ImageCap {
-        code: Vec::new(),
-        jump_table: Vec::new(),
-        jump_table_offsets: Vec::new(),
+        codes: Vec::new(),
         endpoints: Vec::new(),
         mappings: Vec::new(),
         pinned: Vec::new(),

--- a/rust/javm-cap/tests/cap_hash.rs
+++ b/rust/javm-cap/tests/cap_hash.rs
@@ -1,6 +1,6 @@
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, CodeRegionCap, DataCap, DataContent, ImageCap,
-    InstanceCap, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotIdx, TypeCap,
+    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, DataContent, ImageCap, InstanceCap,
+    NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotIdx, TypeCap,
 };
 
 #[test]
@@ -79,12 +79,8 @@ fn cnode_with_ref_target_panics() {
 fn image_hash_depends_on_code() {
     let mut img_a = empty_image();
     let mut img_b = empty_image();
-    img_a.codes = vec![CodeRegionCap {
-        code: b"foo".to_vec(),
-    }];
-    img_b.codes = vec![CodeRegionCap {
-        code: b"bar".to_vec(),
-    }];
+    img_a.code = b"foo".to_vec();
+    img_b.code = b"bar".to_vec();
     let a: Cap = Cap::Image(img_a);
     let b: Cap = Cap::Image(img_b);
     assert_ne!(a.cap_hash(), b.cap_hash());
@@ -92,7 +88,7 @@ fn image_hash_depends_on_code() {
 
 fn empty_image() -> ImageCap {
     ImageCap {
-        codes: Vec::new(),
+        code: Vec::new(),
         endpoints: Vec::new(),
         mappings: Vec::new(),
         pinned: Vec::new(),

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -3,17 +3,15 @@
 //! the source tree free of `_tests.rs` sidecars.
 
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, CodeRegionCap, DataCap, DataContent, EndpointDef,
-    ImageCap, ImageSlotEntry, InstanceCap, MAP_SRC_SLOT, MAX_SOURCE_DEPTH, MemoryMapping, NUM_REGS,
-    PAGE_SIZE, PageBytes, PageRef, PageSlot, RwOverlay, SlotIdx,
+    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, DataContent, EndpointDef, ImageCap,
+    ImageSlotEntry, InstanceCap, MAX_SOURCE_DEPTH, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes,
+    PageRef, PageSlot, RwOverlay, SlotIdx,
 };
 use std::sync::Arc;
 
 fn make_image_cap() -> ImageCap {
     ImageCap {
-        codes: vec![CodeRegionCap {
-            code: vec![0xAB, 0xCD],
-        }],
+        code: vec![0xAB, 0xCD],
         endpoints: Vec::new(),
         mappings: Vec::new(),
         pinned: Vec::new(),
@@ -34,7 +32,7 @@ fn cap_image_constructor() {
 fn cap_image_payload_preserved() {
     let img: Cap = Cap::Image(make_image_cap());
     match img {
-        Cap::Image(i) => assert_eq!(i.codes[0].code.as_slice(), &[0xAB, 0xCD]),
+        Cap::Image(i) => assert_eq!(i.code.as_slice(), &[0xAB, 0xCD]),
         _ => panic!("expected Image"),
     }
 }
@@ -226,10 +224,8 @@ fn memory_mapping_path_slice() {
     let m = MemoryMapping {
         start: 0x4000,
         size: 0x2000,
-        source_kind: MAP_SRC_SLOT,
         source_path: path,
         source_path_len: 2,
-        code_index: 0,
     };
     assert_eq!(m.path(), &[SlotIdx(3), SlotIdx(7)]);
 }

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -3,18 +3,17 @@
 //! the source tree free of `_tests.rs` sidecars.
 
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, DataContent, EndpointDef, ImageCap,
-    ImageSlotEntry, InstanceCap, MAX_SOURCE_DEPTH, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes,
-    PageRef, PageSlot, RwOverlay, SlotIdx,
+    CNodeCap, CacheDirectory, Cap, CapHashOrRef, CodeRegionCap, DataCap, DataContent, EndpointDef,
+    ImageCap, ImageSlotEntry, InstanceCap, MAP_SRC_SLOT, MAX_SOURCE_DEPTH, MemoryMapping, NUM_REGS,
+    PAGE_SIZE, PageBytes, PageRef, PageSlot, RwOverlay, SlotIdx,
 };
 use std::sync::Arc;
 
 fn make_image_cap() -> ImageCap {
-    let code: Vec<u8> = vec![0xAB, 0xCD];
     ImageCap {
-        code,
-        jump_table: Vec::new(),
-        jump_table_offsets: Vec::new(),
+        codes: vec![CodeRegionCap {
+            code: vec![0xAB, 0xCD],
+        }],
         endpoints: Vec::new(),
         mappings: Vec::new(),
         pinned: Vec::new(),
@@ -35,7 +34,7 @@ fn cap_image_constructor() {
 fn cap_image_payload_preserved() {
     let img: Cap = Cap::Image(make_image_cap());
     match img {
-        Cap::Image(i) => assert_eq!(i.code.as_slice(), &[0xAB, 0xCD]),
+        Cap::Image(i) => assert_eq!(i.codes[0].code.as_slice(), &[0xAB, 0xCD]),
         _ => panic!("expected Image"),
     }
 }
@@ -227,8 +226,10 @@ fn memory_mapping_path_slice() {
     let m = MemoryMapping {
         start: 0x4000,
         size: 0x2000,
+        source_kind: MAP_SRC_SLOT,
         source_path: path,
         source_path_len: 2,
+        code_index: 0,
     };
     assert_eq!(m.path(), &[SlotIdx(3), SlotIdx(7)]);
 }

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -1,4 +1,4 @@
-use javm_cap::image::{EndpointDef, MemoryMapping};
+use javm_cap::image::{CodeRegion, EndpointDef, MappingSource, MemoryMapping};
 use javm_cap::{
     Blake2b256, Image, InitialDataCap, PinnedCap, SlotIdx, SlotPath, chain_extend, chain_genesis,
     image_content_hash,
@@ -19,9 +19,9 @@ fn empty_image_hashes_deterministically() {
 #[test]
 fn image_ssz_roundtrip() {
     let mut img = Image::empty();
-    img.code = b"sample code".to_vec();
-    img.jump_table = vec![0u32, 4, 8];
-    img.jump_table_offsets = vec![0, 3];
+    img.codes = vec![CodeRegion {
+        code: b"sample code".to_vec(),
+    }];
     img.endpoints.insert(
         0,
         EndpointDef {
@@ -45,12 +45,12 @@ fn image_ssz_roundtrip() {
     img.memory_mappings.push(MemoryMapping {
         start: 0x1000,
         size: 0x4000,
-        source: SlotPath::root(SlotIdx(65)),
+        source: MappingSource::Slot(SlotPath::root(SlotIdx(65))),
     });
     img.memory_mappings.push(MemoryMapping {
         start: 0x5000,
         size: 0x2000,
-        source: SlotPath::root(SlotIdx(3)),
+        source: MappingSource::Slot(SlotPath::root(SlotIdx(3))),
     });
     img.gas_slots = vec![SlotIdx(7)];
     img.quota_slots = vec![SlotIdx(8)];
@@ -78,9 +78,13 @@ fn image_ssz_roundtrip() {
 #[test]
 fn different_code_different_hash() {
     let mut a = Image::empty();
-    a.code = b"AAAA".to_vec();
+    a.codes = vec![CodeRegion {
+        code: b"AAAA".to_vec(),
+    }];
     let mut b = Image::empty();
-    b.code = b"BBBB".to_vec();
+    b.codes = vec![CodeRegion {
+        code: b"BBBB".to_vec(),
+    }];
     assert_ne!(image_content_hash(&a), image_content_hash(&b));
 }
 
@@ -150,11 +154,15 @@ fn chain_genesis_equals_content_hash() {
 fn chain_extend_changes_with_new_image() {
     let img_a = Image::empty();
     let mut img_b = Image::empty();
-    img_b.code = b"B".to_vec();
+    img_b.codes = vec![CodeRegion {
+        code: b"B".to_vec(),
+    }];
     let prev = chain_genesis::<H>(&img_a);
     let extended_b = chain_extend::<H>(&prev, &img_b);
     let mut img_c = Image::empty();
-    img_c.code = b"C".to_vec();
+    img_c.codes = vec![CodeRegion {
+        code: b"C".to_vec(),
+    }];
     let extended_c = chain_extend::<H>(&prev, &img_c);
     assert_ne!(extended_b, extended_c);
 }
@@ -166,9 +174,13 @@ fn chain_extend_is_associative_under_sequence() {
     // gives different chains (as expected — chain order matters).
     let img_a = Image::empty();
     let mut img_b = Image::empty();
-    img_b.code = b"B".to_vec();
+    img_b.codes = vec![CodeRegion {
+        code: b"B".to_vec(),
+    }];
     let mut img_c = Image::empty();
-    img_c.code = b"C".to_vec();
+    img_c.codes = vec![CodeRegion {
+        code: b"C".to_vec(),
+    }];
 
     let chain_abc = {
         let g = chain_genesis::<H>(&img_a);

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -1,4 +1,4 @@
-use javm_cap::image::{CodeRegion, EndpointDef, MappingSource, MemoryMapping};
+use javm_cap::image::{EndpointDef, MemoryMapping};
 use javm_cap::{
     Blake2b256, Image, InitialDataCap, PinnedCap, SlotIdx, SlotPath, chain_extend, chain_genesis,
     image_content_hash,
@@ -19,9 +19,7 @@ fn empty_image_hashes_deterministically() {
 #[test]
 fn image_ssz_roundtrip() {
     let mut img = Image::empty();
-    img.codes = vec![CodeRegion {
-        code: b"sample code".to_vec(),
-    }];
+    img.code = b"sample code".to_vec();
     img.endpoints.insert(
         0,
         EndpointDef {
@@ -45,12 +43,12 @@ fn image_ssz_roundtrip() {
     img.memory_mappings.push(MemoryMapping {
         start: 0x1000,
         size: 0x4000,
-        source: MappingSource::Slot(SlotPath::root(SlotIdx(65))),
+        source: SlotPath::root(SlotIdx(65)),
     });
     img.memory_mappings.push(MemoryMapping {
         start: 0x5000,
         size: 0x2000,
-        source: MappingSource::Slot(SlotPath::root(SlotIdx(3))),
+        source: SlotPath::root(SlotIdx(3)),
     });
     img.gas_slots = vec![SlotIdx(7)];
     img.quota_slots = vec![SlotIdx(8)];
@@ -78,13 +76,9 @@ fn image_ssz_roundtrip() {
 #[test]
 fn different_code_different_hash() {
     let mut a = Image::empty();
-    a.codes = vec![CodeRegion {
-        code: b"AAAA".to_vec(),
-    }];
+    a.code = b"AAAA".to_vec();
     let mut b = Image::empty();
-    b.codes = vec![CodeRegion {
-        code: b"BBBB".to_vec(),
-    }];
+    b.code = b"BBBB".to_vec();
     assert_ne!(image_content_hash(&a), image_content_hash(&b));
 }
 
@@ -154,15 +148,11 @@ fn chain_genesis_equals_content_hash() {
 fn chain_extend_changes_with_new_image() {
     let img_a = Image::empty();
     let mut img_b = Image::empty();
-    img_b.codes = vec![CodeRegion {
-        code: b"B".to_vec(),
-    }];
+    img_b.code = b"B".to_vec();
     let prev = chain_genesis::<H>(&img_a);
     let extended_b = chain_extend::<H>(&prev, &img_b);
     let mut img_c = Image::empty();
-    img_c.codes = vec![CodeRegion {
-        code: b"C".to_vec(),
-    }];
+    img_c.code = b"C".to_vec();
     let extended_c = chain_extend::<H>(&prev, &img_c);
     assert_ne!(extended_b, extended_c);
 }
@@ -174,13 +164,9 @@ fn chain_extend_is_associative_under_sequence() {
     // gives different chains (as expected — chain order matters).
     let img_a = Image::empty();
     let mut img_b = Image::empty();
-    img_b.codes = vec![CodeRegion {
-        code: b"B".to_vec(),
-    }];
+    img_b.code = b"B".to_vec();
     let mut img_c = Image::empty();
-    img_c.codes = vec![CodeRegion {
-        code: b"C".to_vec(),
-    }];
+    img_c.code = b"C".to_vec();
 
     let chain_abc = {
         let g = chain_genesis::<H>(&img_a);

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -11,7 +11,7 @@
 use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::data::{DataCap, DataContent};
 use javm_cap::cap::page::{PageBytes, PageSlot};
-use javm_cap::image::{CodeRegion, EndpointDef};
+use javm_cap::image::EndpointDef;
 use javm_cap::{CNodeCap, Cap, NUM_REGS, TypeCap, image::Image};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -53,9 +53,7 @@ fn rkyv_archive_roundtrip_data_cap() {
 #[test]
 fn image_cap_roundtrip_preserves_hash() {
     let mut img = Image::empty();
-    img.codes = vec![CodeRegion {
-        code: vec![0u8, 10u8, 42],
-    }];
+    img.code = vec![0u8, 10u8, 42];
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
         0u8,

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -11,7 +11,7 @@
 use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::data::{DataCap, DataContent};
 use javm_cap::cap::page::{PageBytes, PageSlot};
-use javm_cap::image::EndpointDef;
+use javm_cap::image::{CodeRegion, EndpointDef};
 use javm_cap::{CNodeCap, Cap, NUM_REGS, TypeCap, image::Image};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -53,7 +53,9 @@ fn rkyv_archive_roundtrip_data_cap() {
 #[test]
 fn image_cap_roundtrip_preserves_hash() {
     let mut img = Image::empty();
-    img.code = vec![0u8, 10u8, 42];
+    img.codes = vec![CodeRegion {
+        code: vec![0u8, 10u8, 42],
+    }];
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
         0u8,

--- a/rust/javm-exec/src/gas_cost.rs
+++ b/rust/javm-exec/src/gas_cost.rs
@@ -101,6 +101,9 @@ pub fn rv_fast_cost(inst: &crate::instruction::Inst, mem_cycles: u8) -> FastCost
 
         // ---- Upper immediate (mirrors PVM load_imm_64 = 1/2/NONE) ----
         Inst::Lui { rd, .. } => mk(1, 2, EU_NONE, 0, r1(rd)),
+        // auipc folds to a compile-time constant materialise — same
+        // shape/cost as lui.
+        Inst::Auipc { rd, .. } => mk(1, 2, EU_NONE, 0, r1(rd)),
 
         // ---- 64-bit I-type ALU (mirrors PVM 132/133/134/149/151/.../110) ----
         Inst::Addi { rd, rs1, .. }
@@ -298,21 +301,20 @@ pub fn rv_fast_cost(inst: &crate::instruction::Inst, mem_cycles: u8) -> FastCost
         | Inst::Bltu { rs1, rs2, .. }
         | Inst::Bgeu { rs1, rs2, .. } => mkt(20, 1, EU_ALU, r2(rs1, rs2), 0),
 
-        // ---- JAL: static jump or linker-emitted call body ------------
-        // Mirrors PVM `jump` = 15/1/ALU. `rd != 0` writes ra (the call
-        // sequence's `addi ra, x0, idx ; jal x0, callee` emits rd=0
-        // jals; explicit `jal ra` from lld goes through the linker
-        // rewrite to `addi+jal x0`, so jal-with-link is rare).
+        // ---- JAL: static jump or call (`jal ra, callee`) -------------
+        // Mirrors PVM `jump` = 15/1/ALU. `rd != 0` writes the return
+        // address (a plain `jal ra, callee` call).
         Inst::Jal { rd, .. } => mkt(15, 1, EU_ALU, 0, r1(rd)),
+        // ---- JALR: indirect jump (return / indirect call) ------------
+        // Mirrors PVM `jump_ind` = 22/1/ALU. Reads rs1 (target),
+        // optionally writes rd (return address).
+        Inst::Jalr { rd, rs1, .. } => mkt(22, 1, EU_ALU, r1(rs1), r1(rd)),
 
         // ---- Custom-0 PVM2 control / host ops ------------------------
         Inst::Trap => mkt(2, 1, EU_NONE, 0, 0),
         Inst::Fallthrough => mkt(2, 1, EU_NONE, 0, 0),
         Inst::EcallJar => mkt(100, 4, EU_ALU, 0, 0),
         Inst::Ecalli { .. } => mkt(100, 4, EU_ALU, 0, 0),
-        // br_table → mirrors PVM jump_ind = 22/1/ALU. The encoded idx
-        // lives in rs1.
-        Inst::BrTable { rs1, .. } => mkt(22, 1, EU_ALU, r1(rs1), 0),
 
         // ---- Fences (no-op, minimal cost) ----------------------------
         Inst::Fence | Inst::FenceI => mk(1, 1, EU_NONE, 0, 0),
@@ -426,7 +428,7 @@ pub const RV_KIND_TRAP: u8 = 1;
 pub const RV_KIND_FALLTHROUGH: u8 = 2;
 pub const RV_KIND_ECALL_JAR: u8 = 3;
 pub const RV_KIND_ECALLI: u8 = 4;
-pub const RV_KIND_BR_TABLE: u8 = 5;
+pub const RV_KIND_JALR: u8 = 5; // indirect jump (return / indirect call); was br_table
 pub const RV_KIND_FENCE: u8 = 6;
 pub const RV_KIND_JAL: u8 = 7;
 pub const RV_KIND_BRANCH: u8 = 8;
@@ -471,8 +473,10 @@ static RV_GAS_COST_LUT: [RvGasCostEntry; RV_LUT_LEN] = {
     t[RV_KIND_FALLTHROUGH as usize] = rgc(2, 1, EU_NONE, 0, 0, RVF_TERM);
     t[RV_KIND_ECALL_JAR as usize] = rgc(100, 4, EU_ALU, 0, 0, RVF_TERM);
     t[RV_KIND_ECALLI as usize] = rgc(100, 4, EU_ALU, 0, 0, RVF_TERM);
-    // br_table: src = rs1, no dst, terminator (mirrors PVM jump_ind = 22/1/ALU)
-    t[RV_KIND_BR_TABLE as usize] = rgc(22, 1, EU_ALU, 1, 0, RVF_TERM);
+    // jalr: src = rs1 (target), no tracked dst (terminator — its rd
+    // write has no in-block successor), terminator. 22/1/ALU mirrors
+    // PVM jump_ind, identical cost to the former br_table.
+    t[RV_KIND_JALR as usize] = rgc(22, 1, EU_ALU, 1, 0, RVF_TERM);
     // Fences: no-op
     t[RV_KIND_FENCE as usize] = rgc(1, 1, EU_NONE, 0, 0, 0);
     // JAL: src=none, dst=rd, terminator (mirrors PVM jump = 15/1/ALU)
@@ -594,11 +598,12 @@ fn rv_op_metadata(inst: &crate::instruction::Inst) -> (u8, u8, u8, u8) {
         Fence | FenceI => (RV_KIND_FENCE, 0, 0, 0),
         Reserved { .. } => (RV_KIND_RESERVED, 0, 0, 0),
 
-        // Custom-0 br_table
-        BrTable { rs1, .. } => (RV_KIND_BR_TABLE, rs1, 0, 0),
-
         // JAL — terminator with link
         Jal { rd, .. } => (RV_KIND_JAL, 0, 0, rd),
+
+        // JALR — indirect-jump terminator. src = rs1 (target); rd
+        // (return addr) isn't tracked (terminator, no in-block successor).
+        Jalr { rs1, .. } => (RV_KIND_JALR, rs1, 0, 0),
 
         // Branches
         Beq { rs1, rs2, .. }
@@ -622,8 +627,9 @@ fn rv_op_metadata(inst: &crate::instruction::Inst) -> (u8, u8, u8, u8) {
             (RV_KIND_STORE, rs1, rs2, 0)
         }
 
-        // Upper immediate
+        // Upper immediate; auipc folds to a constant materialise (== lui cost).
         Lui { rd, .. } => (RV_KIND_LUI, 0, 0, rd),
+        Auipc { rd, .. } => (RV_KIND_LUI, 0, 0, rd),
 
         // 64-bit I-type ALU
         Addi { rd, rs1, .. }

--- a/rust/javm-exec/src/instruction.rs
+++ b/rust/javm-exec/src/instruction.rs
@@ -515,6 +515,14 @@ pub enum Inst {
         rd: u8,
         imm: i32,
     },
+    /// `auipc rd, imm` — `rd = pc + (imm << 12)`. With code mapped at
+    /// CODE_BASE, `pc` is the guest VA, so the recompiler folds this
+    /// to a compile-time constant. `imm` holds the already-shifted
+    /// upper-20 value (same shape as `Lui`).
+    Auipc {
+        rd: u8,
+        imm: i32,
+    },
 
     // -------- Control flow --------
     /// `jal rd, off` — Harvard semantics per PVM2.
@@ -526,9 +534,15 @@ pub enum Inst {
         rd: u8,
         imm: i32,
     },
-    // JALR removed: forbidden in PVM2. Function returns lower to
-    // `BrTable` (custom-0 funct3=011) dispatching through the
-    // callee's per-function entry in `Image.jump_table`.
+    /// `jalr rd, rs1, imm` — `rd = pc + sizeof; pc = (rs1 + imm) & !1`.
+    /// The runtime computes the target guest VA, validates it against
+    /// the basic-block-start set (`bb_starts`), and dispatches. Used
+    /// for returns (`jalr x0, ra, 0`) and indirect calls.
+    Jalr {
+        rd: u8,
+        rs1: u8,
+        imm: i32,
+    },
     Beq {
         rs1: u8,
         rs2: u8,
@@ -574,25 +588,6 @@ pub enum Inst {
     /// `custom-0` funct3=010: host-call with 20-bit signed immediate.
     Ecalli {
         imm: i32,
-    },
-    /// `custom-0` funct3=011 (I-type): indirect-jump terminator
-    /// dispatching through a per-table list of PVM2 PCs. The
-    /// runtime semantics:
-    ///
-    /// ```text
-    /// idx = ((rs1 - 1) >> 1) as u32          // decode 2*idx+1
-    /// if idx < table_size[table_id]:
-    ///     PC = jump_table[table_id][idx]    // table entry ∈ bb_starts
-    /// else:
-    ///     PC = next_pc                       // fall through (default arm)
-    /// ```
-    ///
-    /// `rs1 = 0` and `rs1` with LSB clear both produce a huge idx,
-    /// causing fallthrough. The linker validates every table entry
-    /// is a basic-block start at deblob.
-    BrTable {
-        table_id: u16,
-        rs1: u8,
     },
     /// `custom-0` funct3=100: terminator no-op. Acts as a basic-block
     /// start at the next byte. Linker injects this before branch / call
@@ -689,12 +684,20 @@ fn decode_32(w: u32) -> Inst {
             rd,
             imm: (w & 0xFFFFF000) as i32,
         },
-        OP_AUIPC => Inst::Reserved { raw: w }, // forbidden in PVM2
+        OP_AUIPC => Inst::Auipc {
+            rd,
+            imm: (w & 0xFFFFF000) as i32,
+        },
         OP_JAL => {
             let imm = imm_j(w);
             Inst::Jal { rd, imm }
         }
-        OP_JALR => Inst::Reserved { raw: w }, // forbidden in PVM2 — use br_table for returns
+        // jalr is I-type with funct3=000; other funct3 are reserved.
+        OP_JALR if funct3 == 0 => Inst::Jalr {
+            rd,
+            rs1,
+            imm: imm_i(w),
+        },
         OP_BRANCH => decode_branch(rs1, rs2, funct3, imm_b(w), w),
         OP_MISC_MEM => decode_misc_mem(funct3),
         OP_SYSTEM => Inst::Reserved { raw: w }, // standard ECALL/EBREAK/CSR reserved
@@ -956,27 +959,17 @@ fn decode_misc_mem(funct3: u8) -> Inst {
     }
 }
 
-fn decode_custom_0(w: u32, rd: u8, rs1: u8, funct3: u8) -> Inst {
+fn decode_custom_0(w: u32, _rd: u8, _rs1: u8, funct3: u8) -> Inst {
     // Sub-op layout (I-type wire shape; funct3 is the sub-op selector):
     //   funct3 = 000 -> trap         (other fields ignored)
     //   funct3 = 001 -> ecall.jar    (other fields ignored)
     //   funct3 = 010 -> ecalli       (imm12 in bits [31:20], rs1/rd zero)
-    //   funct3 = 011 -> br_table     (I-type: imm[11:0]=table_id (unsigned),
-    //                                  rs1=idx-carrier reg, rd=0)
     //   funct3 = 100 -> fallthrough  (other fields ignored)
+    //   funct3 = 011 (was br_table) -> reserved; PVM2 uses plain jalr.
     match funct3 {
         0b000 => Inst::Trap,
         0b001 => Inst::EcallJar,
         0b010 => Inst::Ecalli { imm: imm_i(w) },
-        0b011 => {
-            // br_table requires rd=0 (no destination — it's a terminator).
-            if rd != 0 {
-                return Inst::Reserved { raw: w };
-            }
-            // imm[11:0] is read as unsigned 12-bit (table_id ∈ 0..=4095).
-            let table_id = ((w >> 20) & 0xFFF) as u16;
-            Inst::BrTable { table_id, rs1 }
-        }
         0b100 => Inst::Fallthrough,
         _ => Inst::Reserved { raw: w },
     }
@@ -1323,21 +1316,27 @@ fn decompress_q2(h: u16, f3: u16) -> Inst {
         0b100 => {
             // c.jr / c.mv / c.ebreak / c.jalr / c.add
             //
-            // PVM2 forbids all JALR-style indirect jumps. The earlier
-            // "c.jr ra → retf" repurpose is gone: the linker now
-            // rewrites c.jr ra to a 4-byte `br_table` (custom-0
-            // funct3=011, I-type) before deblob. Any leftover c.jr /
-            // c.jalr form decoded here is therefore Reserved.
+            // PVM2 re-enables JALR, so the compressed forms expand
+            // naturally: `c.jr rs1` → `jalr x0, rs1, 0`; `c.jalr rs1`
+            // → `jalr x1, rs1, 0`. `c.ebreak` stays reserved.
             let bit12 = (h >> 12) & 1;
             match (bit12, rdrs1, rs2) {
-                (0, r, 0) if r != 0 => Inst::Reserved { raw: h as u32 }, // c.jr — forbidden
+                (0, r, 0) if r != 0 => Inst::Jalr {
+                    rd: 0,
+                    rs1: r,
+                    imm: 0,
+                }, // c.jr
                 (0, r, s) if r != 0 && s != 0 => Inst::Add {
                     rd: r,
                     rs1: 0,
                     rs2: s,
                 }, // c.mv
                 (1, 0, 0) => Inst::Reserved { raw: h as u32 }, // c.ebreak → forbidden in PVM2
-                (1, r, 0) if r != 0 => Inst::Reserved { raw: h as u32 }, // c.jalr → forbidden in PVM2
+                (1, r, 0) if r != 0 => Inst::Jalr {
+                    rd: 1,
+                    rs1: r,
+                    imm: 0,
+                }, // c.jalr
                 (1, r, s) if r != 0 && s != 0 => Inst::Add {
                     rd: r,
                     rs1: r,

--- a/rust/javm-exec/src/instruction.rs
+++ b/rust/javm-exec/src/instruction.rs
@@ -1518,13 +1518,19 @@ mod tests {
     }
 
     #[test]
-    fn decode_auipc_reserved() {
-        // auipc x5, 0x10 = 0x000102B7? actually 0x00010297
+    fn decode_auipc_native() {
+        // auipc x5, 0x10 (= 0x00010297) — PVM2 decodes it natively now.
         let bytes = 0x00010297u32.to_le_bytes();
-        match decode(&bytes) {
-            Some((Inst::Reserved { .. }, 4)) => {}
-            other => panic!("auipc should be Reserved, got {:?}", other),
-        }
+        assert_eq!(
+            decode(&bytes),
+            Some((
+                Inst::Auipc {
+                    rd: 5,
+                    imm: 0x0001_0000,
+                },
+                4,
+            ))
+        );
     }
 
     #[test]
@@ -1628,31 +1634,47 @@ mod tests {
     }
 
     #[test]
-    fn decode_custom_br_table() {
-        // br_table table_id=42, rs1=x1 (ra): custom-0, funct3=011, rd=0
-        // wire: (42<<20) | (1<<15) | (0b011<<12) | (0<<7) | (0b00010<<2) | 0b11
+    fn decode_custom0_funct3_011_reserved() {
+        // custom-0 funct3=011 used to be br_table; PVM2 reverted to
+        // native control flow and no longer defines it — reserved.
         let w = (42u32 << 20) | (1u32 << 15) | (0b011u32 << 12) | (0b00010u32 << 2) | 0b11;
+        let bytes = w.to_le_bytes();
+        assert!(matches!(decode(&bytes).unwrap().0, Inst::Reserved { .. }));
+    }
+
+    #[test]
+    fn decode_auipc() {
+        // auipc x5, 0x12345 — U-type, opcode 0b0010111.
+        let w = (0x12345u32 << 12) | (5 << 7) | 0b001_0111;
         let bytes = w.to_le_bytes();
         assert_eq!(
             decode(&bytes),
             Some((
-                Inst::BrTable {
-                    table_id: 42,
-                    rs1: 1
+                Inst::Auipc {
+                    rd: 5,
+                    imm: 0x1234_5000,
                 },
-                4
+                4,
             ))
         );
     }
 
     #[test]
-    fn decode_custom_br_table_rd_nonzero_reserved() {
-        // br_table with rd != 0 must decode to Reserved.
-        let w =
-            (1u32 << 20) | (1u32 << 15) | (0b011u32 << 12) | (1u32 << 7) | (0b00010u32 << 2) | 0b11;
+    fn decode_jalr() {
+        // jalr x1, x6, 16 — I-type, opcode 0b1100111, funct3=0.
+        let w = (16u32 << 20) | (6 << 15) | (1 << 7) | 0b110_0111;
         let bytes = w.to_le_bytes();
-        let decoded = decode(&bytes).unwrap().0;
-        assert!(matches!(decoded, Inst::Reserved { .. }));
+        assert_eq!(
+            decode(&bytes),
+            Some((
+                Inst::Jalr {
+                    rd: 1,
+                    rs1: 6,
+                    imm: 16,
+                },
+                4,
+            ))
+        );
     }
 
     #[test]
@@ -1666,11 +1688,29 @@ mod tests {
     }
 
     #[test]
-    fn decompress_c_jr_ra_now_reserved() {
-        // `c.jr ra` (= 0x8082) — used to decompress to Retf;
-        // PVM2 now rejects it. Linker rewrites returns to br_table.
+    fn decompress_c_jr_ra_is_jalr() {
+        // `c.jr ra` (= 0x8082) decompresses to `jalr x0, x1, 0` — the
+        // canonical return. A terminator validated against bb_starts at
+        // runtime.
         let bytes = 0x8082u16.to_le_bytes();
-        let decoded = decode(&bytes).unwrap().0;
-        assert!(matches!(decoded, Inst::Reserved { .. }));
+        assert_eq!(
+            decode(&bytes),
+            Some((Inst::Jalr { rd: 0, rs1: 1, imm: 0 }, 2))
+        );
+    }
+
+    #[test]
+    fn decompress_c_jalr_ra_is_jalr_link() {
+        // `c.jalr ra` (= 0x9082) decompresses to `jalr x1, x1, 0` — an
+        // indirect call (writes the link register). c.ebreak (0x9002,
+        // rs1=0) stays Reserved.
+        assert_eq!(
+            decode(&0x9082u16.to_le_bytes()),
+            Some((Inst::Jalr { rd: 1, rs1: 1, imm: 0 }, 2))
+        );
+        assert!(matches!(
+            decode(&0x9002u16.to_le_bytes()).unwrap().0,
+            Inst::Reserved { .. }
+        ));
     }
 }

--- a/rust/javm-exec/src/instruction.rs
+++ b/rust/javm-exec/src/instruction.rs
@@ -1695,7 +1695,14 @@ mod tests {
         let bytes = 0x8082u16.to_le_bytes();
         assert_eq!(
             decode(&bytes),
-            Some((Inst::Jalr { rd: 0, rs1: 1, imm: 0 }, 2))
+            Some((
+                Inst::Jalr {
+                    rd: 0,
+                    rs1: 1,
+                    imm: 0
+                },
+                2
+            ))
         );
     }
 
@@ -1706,7 +1713,14 @@ mod tests {
         // rs1=0) stays Reserved.
         assert_eq!(
             decode(&0x9082u16.to_le_bytes()),
-            Some((Inst::Jalr { rd: 1, rs1: 1, imm: 0 }, 2))
+            Some((
+                Inst::Jalr {
+                    rd: 1,
+                    rs1: 1,
+                    imm: 0
+                },
+                2
+            ))
         );
         assert!(matches!(
             decode(&0x9002u16.to_le_bytes()).unwrap().0,

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -36,10 +36,10 @@ use crate::regs::Regs;
 pub struct Program {
     pub code: Vec<u8>,
     pub predecode: Predecode,
-    /// Guest VA at which this code region is mapped. PC = `code_base`
-    /// + byte-offset. `regs.pc` and `predecode.insts[].pc` are
-    /// offsets; register-held code addresses (return addresses, auipc
-    /// results) are VAs (`code_base + offset`).
+    /// Guest VA at which this code region is mapped, so that
+    /// `PC = code_base + byte_offset`. `regs.pc` and
+    /// `predecode.insts[].pc` are offsets; register-held code addresses
+    /// (return addresses, auipc results) are VAs (`code_base + offset`).
     pub code_base: u32,
 }
 
@@ -884,7 +884,7 @@ mod tests {
         let mut mem = CopyingMemory::new();
         let mut gas = GasCounter::new(initial_gas);
         let mut h = PanickingHandler;
-        let reason = Interpreter::run(&pre, &[], &[], &mut regs, &mut mem, &mut gas, &mut h);
+        let reason = Interpreter::run(&pre, 0, &mut regs, &mut mem, &mut gas, &mut h);
         let used = initial_gas.saturating_sub(gas.remaining());
         (regs, reason, used)
     }
@@ -986,7 +986,7 @@ mod tests {
         let mut mem = CopyingMemory::new();
         let mut gas = GasCounter::new(1_000_000);
         let mut h = PanickingHandler;
-        let reason = Interpreter::run(&pre, &[], &[0, 0], &mut regs, &mut mem, &mut gas, &mut h);
+        let reason = Interpreter::run(&pre, 0, &mut regs, &mut mem, &mut gas, &mut h);
         assert_eq!(reason, ExitReason::Panic);
     }
 }

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -7,9 +7,10 @@
 //!
 //! Mirrors the recompiler's semantics — same per-block gas charging at
 //! `Predecode::block_costs`, same RV-spec ALU/branch behaviour, same
-//! `Ecalli`/`BrTable` runtime contracts. Cross-checked against the
-//! recompiler in `pvm2_smoke`: bit-identical `gas_used` and side-effects
-//! on every workload.
+//! `Ecalli`/`Jalr` runtime contracts (jalr targets validated against
+//! the basic-block-start set). Cross-checked against the recompiler in
+//! the `smoke` example: bit-identical `gas_used` and side-effects on
+//! every workload.
 //!
 //! Dispatch is a `match` over `Inst` variants. Instructions come from
 //! [`Predecode::insts`] (one entry per static instruction); static
@@ -35,20 +36,22 @@ use crate::regs::Regs;
 pub struct Program {
     pub code: Vec<u8>,
     pub predecode: Predecode,
-    pub jump_table: Vec<u32>,
-    pub jump_table_offsets: Vec<u32>,
+    /// Guest VA at which this code region is mapped. PC = `code_base`
+    /// + byte-offset. `regs.pc` and `predecode.insts[].pc` are
+    /// offsets; register-held code addresses (return addresses, auipc
+    /// results) are VAs (`code_base + offset`).
+    pub code_base: u32,
 }
 
 impl Program {
-    /// Predecode `code` and wrap it together with the Image's jump
-    /// table. The predecode pass is O(code.len()); cache the result.
-    pub fn new(code: Vec<u8>, jump_table: Vec<u32>, jump_table_offsets: Vec<u32>) -> Self {
+    /// Predecode `code`. The predecode pass is O(code.len()); cache
+    /// the result. `code_base` is the guest VA the region is mapped at.
+    pub fn new(code: Vec<u8>, code_base: u32) -> Self {
         let predecode = predecode(&code);
         Self {
             code,
             predecode,
-            jump_table,
-            jump_table_offsets,
+            code_base,
         }
     }
 }
@@ -69,8 +72,7 @@ impl Interpreter {
     ) -> ExitReason {
         Self::run(
             &program.predecode,
-            &program.jump_table,
-            &program.jump_table_offsets,
+            program.code_base,
             regs,
             mem,
             gas,
@@ -78,13 +80,13 @@ impl Interpreter {
         )
     }
 
-    /// Execute the predecoded PVM2 program starting at `regs.pc`.
-    /// `jump_table` and `jump_table_offsets` come from the Image
-    /// (see `javm_cap::image::Image`).
+    /// Execute the predecoded PVM2 program starting at `regs.pc` (a
+    /// byte-offset into the code region). `code_base` is the guest VA
+    /// the region is mapped at: jal/jalr/auipc produce and consume
+    /// code addresses as `code_base + offset`.
     pub fn run<M: Memory>(
         predecode: &Predecode,
-        jump_table: &[u32],
-        jump_table_offsets: &[u32],
+        code_base: u32,
         regs: &mut Regs,
         mem: &mut M,
         gas: &mut GasCounter,
@@ -635,16 +637,43 @@ impl Interpreter {
                 Inst::Lui { rd, imm } => {
                     reg_write(regs, rd, imm as i64 as u64);
                 }
+                // auipc rd = pc_va + imm, where pc_va = code_base + pc.
+                // Folds to a constant the recompiler bakes in identically.
+                Inst::Auipc { rd, imm } => {
+                    let v = code_base.wrapping_add(pc).wrapping_add(imm as u32);
+                    reg_write(regs, rd, v as i32 as i64 as u64);
+                }
 
                 // ---- Control flow -------------------------------------------
                 Inst::Jal { rd, imm } => {
                     if rd != 0 {
-                        reg_write(regs, rd, next_pc as u64);
+                        // Return address is a guest VA (code_base + offset).
+                        reg_write(regs, rd, code_base.wrapping_add(next_pc) as u64);
                     }
                     let target = (pc as i64).wrapping_add(imm as i64) as u32;
                     next_idx_override = Some(match find_idx_for_pc(insts, target) {
                         Some(i) => i,
                         None => {
+                            regs.pc = pc as u64;
+                            return ExitReason::Panic;
+                        }
+                    });
+                }
+                // jalr rd, rs1, imm — indirect jump. target_va =
+                // (rs1 + imm) & 0xFFFFFFFF; offset = target_va - code_base.
+                // The target must be a basic-block start (gas precharge
+                // happens at block entry) — else Panic (security-critical:
+                // rejects mid-block / mid-instruction targets).
+                Inst::Jalr { rd, rs1, imm } => {
+                    let target_va =
+                        (reg_read(regs, rs1) as u32).wrapping_add(imm as u32);
+                    if rd != 0 {
+                        reg_write(regs, rd, code_base.wrapping_add(next_pc) as u64);
+                    }
+                    let target_off = target_va.wrapping_sub(code_base);
+                    next_idx_override = Some(match find_idx_for_pc(insts, target_off) {
+                        Some(i) if insts[i].is_gas_block_start => i,
+                        _ => {
                             regs.pc = pc as u64;
                             return ExitReason::Panic;
                         }
@@ -751,36 +780,6 @@ impl Interpreter {
                         EcallResult::Exit(r) => return r,
                     }
                 }
-                Inst::BrTable { table_id, rs1 } => {
-                    // Spec: idx = (rs1 - 1) >> 1; if rs1 == 0 or idx OOB,
-                    // recompiler routes to PANIC (not fallthrough — see
-                    // `rv_br_table` comment). Match exactly.
-                    let rs1_v = reg_read(regs, rs1);
-                    if rs1_v == 0 {
-                        regs.pc = pc as u64;
-                        return ExitReason::Panic;
-                    }
-                    let entry_idx = ((rs1_v - 1) >> 1) as usize;
-                    let nt = jump_table_offsets.len().saturating_sub(1);
-                    if (table_id as usize) >= nt {
-                        regs.pc = pc as u64;
-                        return ExitReason::Panic;
-                    }
-                    let start = jump_table_offsets[table_id as usize] as usize;
-                    let end = jump_table_offsets[(table_id as usize) + 1] as usize;
-                    if entry_idx >= end - start {
-                        regs.pc = pc as u64;
-                        return ExitReason::Panic;
-                    }
-                    let target = jump_table[start + entry_idx];
-                    match find_idx_for_pc(insts, target) {
-                        Some(i) => next_idx_override = Some(i),
-                        None => {
-                            regs.pc = pc as u64;
-                            return ExitReason::Panic;
-                        }
-                    }
-                }
                 Inst::Fallthrough => {
                     // Terminator no-op: just advance. The next instruction is
                     // already marked as a block start so its cost gets
@@ -793,7 +792,7 @@ impl Interpreter {
                 }
             }
 
-            // Advance to the next instruction. Branches / Jal / BrTable /
+            // Advance to the next instruction. Branches / Jal / Jalr /
             // post-handler Ecalli set `next_idx_override`; everything else
             // falls through to the sequential next.
             match next_idx_override {

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -1,9 +1,9 @@
 //! PVM2 (RV+C+Zbb+Zba+Zbs+Zicond+custom-0) interpreter.
 //!
 //! [`Program`] bundles the constituents an interpreter run needs
-//! (code bytes, predecode output, jump table + offsets) so the
-//! integration layer can cache the predecode alongside the bytecode
-//! and pass a single Arc to the executor.
+//! (code bytes, predecode output, code base) so the integration layer
+//! can cache the predecode alongside the bytecode and pass a single Arc
+//! to the executor.
 //!
 //! Mirrors the recompiler's semantics — same per-block gas charging at
 //! `Predecode::block_costs`, same RV-spec ALU/branch behaviour, same
@@ -665,8 +665,7 @@ impl Interpreter {
                 // happens at block entry) — else Panic (security-critical:
                 // rejects mid-block / mid-instruction targets).
                 Inst::Jalr { rd, rs1, imm } => {
-                    let target_va =
-                        (reg_read(regs, rs1) as u32).wrapping_add(imm as u32);
+                    let target_va = (reg_read(regs, rs1) as u32).wrapping_add(imm as u32);
                     if rd != 0 {
                         reg_write(regs, rd, code_base.wrapping_add(next_pc) as u64);
                     }

--- a/rust/javm-exec/src/mem.rs
+++ b/rust/javm-exec/src/mem.rs
@@ -125,10 +125,19 @@ pub trait Memory {
 /// concrete callers don't need to import the trait.
 #[derive(Clone, Debug)]
 pub struct CopyingMemory {
-    /// Contiguous byte buffer covering `0..flat_mem.len()`.
+    /// Base guest address `flat_mem[0]` corresponds to. Guest address
+    /// `addr` indexes `flat_mem[addr - base]`; accesses below `base` (or
+    /// past the buffer) fault. Lets the buffer cover only the high data
+    /// region `[DATA_BASE, …)` without allocating the `[0, DATA_BASE)`
+    /// null-guard hole — matching the recompiler's page table, which
+    /// leaves that range unmapped. `0` for the addr-0-based memories used
+    /// in unit tests.
+    pub base: u32,
+    /// Contiguous byte buffer covering `[base, base + flat_mem.len())`.
     pub flat_mem: Vec<u8>,
     /// One permission byte per `PAGE_SIZE`-page in `flat_mem`.
-    /// `perms.len() == flat_mem.len() / PAGE_SIZE` (rounded up).
+    /// `perms.len() == flat_mem.len() / PAGE_SIZE` (rounded up). Indexed
+    /// by page *relative to `base`*.
     pub perms: Vec<u8>,
     /// Heap base address (for sbrk).
     pub heap_base: u32,
@@ -150,9 +159,10 @@ impl Default for CopyingMemory {
 pub type Mem = CopyingMemory;
 
 impl CopyingMemory {
-    /// Empty memory; no pages allocated.
+    /// Empty memory; no pages allocated. `base = 0` (addr-0-based).
     pub fn new() -> Self {
         Self {
+            base: 0,
             flat_mem: Vec::new(),
             perms: Vec::new(),
             heap_base: 0,
@@ -161,11 +171,21 @@ impl CopyingMemory {
         }
     }
 
+    /// Byte offset into `flat_mem` for guest address `addr`. Wraps for
+    /// `addr < base` so the subsequent `… < flat_mem.len()` bounds check
+    /// rejects sub-`base` accesses (the null-guard / code region) as a
+    /// fault — no separate check needed.
+    #[inline(always)]
+    fn off(&self, addr: u32) -> usize {
+        addr.wrapping_sub(self.base) as usize
+    }
+
     /// Construct with a pre-sized flat buffer (zero-initialized).
-    /// `n_pages` is the number of `PAGE_SIZE`-pages.
+    /// `n_pages` is the number of `PAGE_SIZE`-pages. `base = 0`.
     pub fn with_pages(n_pages: u32, default_perm: u8) -> Self {
         let bytes = (n_pages as usize) * (PAGE_SIZE as usize);
         Self {
+            base: 0,
             flat_mem: vec![0u8; bytes],
             perms: vec![default_perm; n_pages as usize],
             heap_base: 0,
@@ -177,13 +197,13 @@ impl CopyingMemory {
     /// Returns true iff `addr` is within `flat_mem`.
     #[inline(always)]
     pub fn is_in_bounds(&self, addr: u32) -> bool {
-        (addr as usize) < self.flat_mem.len()
+        self.off(addr) < self.flat_mem.len()
     }
 
     /// Per-page permission for the page containing `addr`. Returns
-    /// `perm::NONE` if the address is out of range.
+    /// `perm::NONE` if the address is out of range (incl. below `base`).
     pub fn perm_of(&self, addr: u32) -> u8 {
-        let page = (addr / PAGE_SIZE) as usize;
+        let page = self.off(addr) / (PAGE_SIZE as usize);
         self.perms.get(page).copied().unwrap_or(perm::NONE)
     }
 
@@ -191,7 +211,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn read_u8(&self, addr: u32) -> Option<u8> {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a < self.flat_mem.len() {
             // SAFETY: bounds-checked.
             Some(unsafe { *self.flat_mem.get_unchecked(a) })
@@ -202,7 +222,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn read_u16_le(&self, addr: u32) -> Option<u16> {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 2 <= self.flat_mem.len() {
             Some(unsafe { self.flat_mem.as_ptr().add(a).cast::<u16>().read_unaligned() })
         } else {
@@ -212,7 +232,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn read_u32_le(&self, addr: u32) -> Option<u32> {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 4 <= self.flat_mem.len() {
             Some(unsafe { self.flat_mem.as_ptr().add(a).cast::<u32>().read_unaligned() })
         } else {
@@ -222,7 +242,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn read_u64_le(&self, addr: u32) -> Option<u64> {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 8 <= self.flat_mem.len() {
             Some(unsafe { self.flat_mem.as_ptr().add(a).cast::<u64>().read_unaligned() })
         } else {
@@ -234,7 +254,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn write_u8(&mut self, addr: u32, val: u8) -> bool {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a < self.flat_mem.len() {
             unsafe {
                 *self.flat_mem.get_unchecked_mut(a) = val;
@@ -247,7 +267,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn write_u16_le(&mut self, addr: u32, val: u16) -> bool {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 2 <= self.flat_mem.len() {
             unsafe {
                 self.flat_mem
@@ -264,7 +284,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn write_u32_le(&mut self, addr: u32, val: u32) -> bool {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 4 <= self.flat_mem.len() {
             unsafe {
                 self.flat_mem
@@ -281,7 +301,7 @@ impl CopyingMemory {
 
     #[inline(always)]
     pub fn write_u64_le(&mut self, addr: u32, val: u64) -> bool {
-        let a = addr as usize;
+        let a = self.off(addr);
         if a + 8 <= self.flat_mem.len() {
             unsafe {
                 self.flat_mem
@@ -324,13 +344,19 @@ impl CopyingMemory {
         if !size.is_multiple_of(page) {
             return Err(MapError::UnalignedSize(size));
         }
-        let end = start.checked_add(size).ok_or(MapError::Overflow)?;
-        let end_usize: usize = end.try_into().map_err(|_| MapError::Overflow)?;
+        if start < u64::from(self.base) {
+            return Err(MapError::UnalignedStart(start));
+        }
+        // Work in offsets relative to `base` (the buffer covers
+        // `[base, base + flat_mem.len())`).
+        let rel_start = start - u64::from(self.base);
+        let rel_end = rel_start.checked_add(size).ok_or(MapError::Overflow)?;
+        let rel_end_usize: usize = rel_end.try_into().map_err(|_| MapError::Overflow)?;
 
-        // Grow flat_mem + perms to cover [0, end).
-        if end_usize > self.flat_mem.len() {
-            self.flat_mem.resize(end_usize, 0);
-            let needed_pages = end_usize.div_ceil(PAGE_SIZE as usize);
+        // Grow flat_mem + perms to cover [0, rel_end) (relative to base).
+        if rel_end_usize > self.flat_mem.len() {
+            self.flat_mem.resize(rel_end_usize, 0);
+            let needed_pages = rel_end_usize.div_ceil(PAGE_SIZE as usize);
             if self.perms.len() < needed_pages {
                 self.perms.resize(needed_pages, perm::NONE);
             }
@@ -341,8 +367,8 @@ impl CopyingMemory {
             Access::ReadOnly => perm::RO,
             Access::ReadWrite => perm::RW,
         };
-        let first_page = (start / page) as usize;
-        let last_page = ((end / page) as usize).saturating_sub(1);
+        let first_page = (rel_start / page) as usize;
+        let last_page = ((rel_end / page) as usize).saturating_sub(1);
         if size > 0 {
             for p in first_page..=last_page {
                 self.perms[p] = perm_byte;
@@ -354,7 +380,7 @@ impl CopyingMemory {
         // trailing region beyond `init` is implicitly zero.
         if let Some(bytes) = init {
             let n = bytes.len().min(size as usize);
-            let s = start as usize;
+            let s = rel_start as usize;
             self.flat_mem[s..s + n].copy_from_slice(&bytes[..n]);
         }
 
@@ -365,7 +391,7 @@ impl CopyingMemory {
 
     /// Read `len` bytes from `addr`. Returns `Err` on out-of-range.
     pub fn read(&self, addr: u32, len: usize) -> Result<Vec<u8>, MemAccess> {
-        let a = addr as usize;
+        let a = self.off(addr);
         let end = a
             .checked_add(len)
             .ok_or(MemAccess::PageFault(addr & !(PAGE_SIZE - 1)))?;
@@ -379,7 +405,7 @@ impl CopyingMemory {
     /// or write-protected page. Writes are NOT rolled back on partial
     /// failure (test-only API).
     pub fn write(&mut self, addr: u32, data: &[u8]) -> Result<(), MemAccess> {
-        let a = addr as usize;
+        let a = self.off(addr);
         let end = a
             .checked_add(data.len())
             .ok_or(MemAccess::PageFault(addr & !(PAGE_SIZE - 1)))?;

--- a/rust/javm-exec/src/predecode.rs
+++ b/rust/javm-exec/src/predecode.rs
@@ -93,6 +93,52 @@ pub fn predecode(code: &[u8]) -> Predecode {
 /// Used by callers that want to override the default L2-hit latency
 /// (e.g. for tier-specific gas modeling).
 pub fn predecode_rv_with_mem_cycles(code: &[u8], mem_cycles: u8) -> Predecode {
+    let (insts, valid_pc, decode_error_at) = decode_blocks(code);
+    // ---- Pass 3: per-block gas costs via pipeline simulation ---------
+    let block_costs = compute_block_costs(&insts, mem_cycles);
+    Predecode {
+        insts,
+        valid_pc,
+        block_costs,
+        decode_error_at,
+    }
+}
+
+/// Lightweight whole-blob gas-block-start scan for the lazy recompiler.
+///
+/// Returns the byte-indexed block-start bitmap (`bb[off] == 1` iff an
+/// instruction begins at `off` and that instruction starts a gas block)
+/// plus the first decode/layout error offset, if any. Same partition as
+/// [`predecode`] (both share [`decode_blocks`]) but skips the per-block
+/// gas-cost simulation — the recompiler recomputes per-block gas as it
+/// compiles each page.
+///
+/// Lazy per-page compilation needs the *whole-blob* block-start set up
+/// front: a `jalr`/branch in one page can target a block in a
+/// not-yet-compiled page, and that target must validate against the
+/// complete set (`bb[off] == 1`) before its page exists.
+pub fn bb_start_bitmap(code: &[u8]) -> (Vec<u8>, Option<u32>) {
+    let (insts, _valid_pc, decode_error_at) = decode_blocks(code);
+    let mut bb = vec![0u8; code.len()];
+    for ip in &insts {
+        if ip.is_gas_block_start {
+            bb[ip.pc as usize] = 1;
+        }
+    }
+    (bb, decode_error_at)
+}
+
+/// Shared front half of the predecode pipeline: decode every
+/// instruction, enforce invariant 10 (no instruction crosses a 4 KiB
+/// page boundary), and mark gas-block starts (invariant 11). Returns
+/// the decoded instruction array (with `is_gas_block_start` set), the
+/// byte-indexed instruction-start map, and the first decode/layout
+/// error offset, if any.
+///
+/// [`predecode`] (interp) and [`bb_start_bitmap`] (lazy recompiler)
+/// both build on this, so the two engines partition gas blocks
+/// identically by construction.
+fn decode_blocks(code: &[u8]) -> (Vec<RvPreDecodedInst>, Vec<bool>, Option<u32>) {
     let mut insts: Vec<RvPreDecodedInst> = Vec::with_capacity(code.len() / 4);
     let mut valid_pc: Vec<bool> = vec![false; code.len()];
     let mut decode_error_at: Option<u32> = None;
@@ -164,15 +210,7 @@ pub fn predecode_rv_with_mem_cycles(code: &[u8], mem_cycles: u8) -> Predecode {
         }
     }
 
-    // ---- Pass 3: per-block gas costs via pipeline simulation ---------
-    let block_costs = compute_block_costs(&insts, mem_cycles);
-
-    Predecode {
-        insts,
-        valid_pc,
-        block_costs,
-        decode_error_at,
-    }
+    (insts, valid_pc, decode_error_at)
 }
 
 /// Run the pipeline simulator once per basic block; write the

--- a/rust/javm-exec/src/predecode.rs
+++ b/rust/javm-exec/src/predecode.rs
@@ -9,18 +9,17 @@
 //!   offset where an instruction begins. Used at deblob for branch /
 //!   call target alignment checks (a static-target reaching a non-
 //!   instruction-start byte is a program error).
-//! - **Gas-block-start markers**: `{0} ∪ post-terminator PCs ∪ 4 KiB
-//!   page starts` (see Pass 2). All three are derived from the
-//!   instruction stream / PC — never trusted from linker metadata,
-//!   since the recompiler runs untrusted code. `jalr` targets are
-//!   validated against this set at runtime.
+//! - **Gas-block-start markers**: PC=0 plus every PC immediately
+//!   following a terminator. PVM2's pure-static-dispatch design lets us
+//!   tighten this to the strict post-terminator set (was: "every
+//!   instruction", a workaround for runtime JALR validation back when
+//!   PVM2 still had JALR).
 //!
 //! Per-block gas costs are computed by running the pipeline simulator
 //! in [`crate::gas_cost::rv_gas_cost_for_block`] once per basic block;
 //! the results are stored in [`Predecode::block_costs`].
 
 use crate::instruction::{Inst, decode};
-use crate::mem::PAGE_SIZE;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -93,52 +92,6 @@ pub fn predecode(code: &[u8]) -> Predecode {
 /// Used by callers that want to override the default L2-hit latency
 /// (e.g. for tier-specific gas modeling).
 pub fn predecode_rv_with_mem_cycles(code: &[u8], mem_cycles: u8) -> Predecode {
-    let (insts, valid_pc, decode_error_at) = decode_blocks(code);
-    // ---- Pass 3: per-block gas costs via pipeline simulation ---------
-    let block_costs = compute_block_costs(&insts, mem_cycles);
-    Predecode {
-        insts,
-        valid_pc,
-        block_costs,
-        decode_error_at,
-    }
-}
-
-/// Lightweight whole-blob gas-block-start scan for the lazy recompiler.
-///
-/// Returns the byte-indexed block-start bitmap (`bb[off] == 1` iff an
-/// instruction begins at `off` and that instruction starts a gas block)
-/// plus the first decode/layout error offset, if any. Same partition as
-/// [`predecode`] (both share [`decode_blocks`]) but skips the per-block
-/// gas-cost simulation — the recompiler recomputes per-block gas as it
-/// compiles each page.
-///
-/// Lazy per-page compilation needs the *whole-blob* block-start set up
-/// front: a `jalr`/branch in one page can target a block in a
-/// not-yet-compiled page, and that target must validate against the
-/// complete set (`bb[off] == 1`) before its page exists.
-pub fn bb_start_bitmap(code: &[u8]) -> (Vec<u8>, Option<u32>) {
-    let (insts, _valid_pc, decode_error_at) = decode_blocks(code);
-    let mut bb = vec![0u8; code.len()];
-    for ip in &insts {
-        if ip.is_gas_block_start {
-            bb[ip.pc as usize] = 1;
-        }
-    }
-    (bb, decode_error_at)
-}
-
-/// Shared front half of the predecode pipeline: decode every
-/// instruction, enforce invariant 10 (no instruction crosses a 4 KiB
-/// page boundary), and mark gas-block starts (invariant 11). Returns
-/// the decoded instruction array (with `is_gas_block_start` set), the
-/// byte-indexed instruction-start map, and the first decode/layout
-/// error offset, if any.
-///
-/// [`predecode`] (interp) and [`bb_start_bitmap`] (lazy recompiler)
-/// both build on this, so the two engines partition gas blocks
-/// identically by construction.
-fn decode_blocks(code: &[u8]) -> (Vec<RvPreDecodedInst>, Vec<bool>, Option<u32>) {
     let mut insts: Vec<RvPreDecodedInst> = Vec::with_capacity(code.len() / 4);
     let mut valid_pc: Vec<bool> = vec![false; code.len()];
     let mut decode_error_at: Option<u32> = None;
@@ -166,51 +119,41 @@ fn decode_blocks(code: &[u8]) -> (Vec<RvPreDecodedInst>, Vec<bool>, Option<u32>)
         pc = next_pc as usize;
     }
 
-    // ---- Invariant 10: no instruction crosses a 4 KiB page boundary --
+    // ---- Pass 2: mark gas-block starts (strict post-terminator) ------
     //
-    // A straddling instruction would let lazy per-page compilation split
-    // it across a compile boundary. The linker pads with `c.nop` to
-    // prevent this; reject a blob that violates it (defense — both
-    // engines trust the instruction stream, not an external layout
-    // guarantee). Only 4-byte instructions can straddle (RV+C is 2-byte
-    // aligned, pages are even).
-    if decode_error_at.is_none() {
-        for ip in &insts {
-            if ip.pc / PAGE_SIZE != (ip.next_pc - 1) / PAGE_SIZE {
-                decode_error_at = Some(ip.pc);
-                break;
-            }
-        }
+    // PVM2 has no runtime indirect dispatch (no JALR; calls go via
+    // `addi ra, x0, idx ; jal x0, callee`, returns via
+    // `br_table table_id, ra`). The set of legal gas-block-starts is:
+    //
+    //     {0} ∪ { pc | pc immediately follows a terminator instruction }
+    //
+    // The linker invariant (analogous to PVM's
+    // `ensure_branch_targets_are_block_starts`) guarantees every
+    // statically-reachable branch / br_table target lands in this set —
+    // it injects `Fallthrough` (a terminator no-op) before any target
+    // that isn't naturally post-terminator.
+    //
+    // OOG happens at the per-block gas check at the block start, so
+    // a paused PC is always in this set.
+    if !insts.is_empty() {
+        insts[0].is_gas_block_start = true;
     }
-
-    // ---- Pass 2: mark gas-block starts -------------------------------
-    //
-    // The set of legal gas-block-starts is
-    //
-    //     {0} ∪ { pc | pc follows a terminator } ∪ { pc | pc % 4 KiB == 0 }
-    //
-    // all derived purely from the instruction stream / PC, never trusted
-    // from linker metadata (the recompiler runs untrusted code). `jalr`
-    // targets are validated against this set at runtime.
-    //
-    //  - Post-terminator: the linker injects `Fallthrough` (a terminator
-    //    no-op) before any branch / jump / endpoint / code-pointer target
-    //    that isn't naturally post-terminator, so every reachable static
-    //    target is covered.
-    //  - Page starts: every 4 KiB page boundary partitions a gas block so
-    //    lazy per-page compilation enters each page at a dispatchable
-    //    block and both engines agree on the partition (invariant 11).
-    //
-    // OOG happens at the per-block gas check at the block start, so a
-    // paused PC is always in this set.
-    for i in 0..insts.len() {
-        let post_terminator = i > 0 && is_terminator(&insts[i - 1].inst);
-        if insts[i].pc.is_multiple_of(PAGE_SIZE) || post_terminator {
+    for i in 1..insts.len() {
+        let prev_is_terminator = is_terminator(&insts[i - 1].inst);
+        if prev_is_terminator {
             insts[i].is_gas_block_start = true;
         }
     }
 
-    (insts, valid_pc, decode_error_at)
+    // ---- Pass 3: per-block gas costs via pipeline simulation ---------
+    let block_costs = compute_block_costs(&insts, mem_cycles);
+
+    Predecode {
+        insts,
+        valid_pc,
+        block_costs,
+        decode_error_at,
+    }
 }
 
 /// Run the pipeline simulator once per basic block; write the
@@ -224,6 +167,33 @@ fn compute_block_costs(insts: &[RvPreDecodedInst], mem_cycles: u8) -> Vec<u32> {
         }
     }
     block_costs
+}
+
+/// Return the target byte offset of a statically-resolvable branch or
+/// jump. `None` for indirect jumps (`jalr`), non-control-flow ops, and
+/// other shapes.
+///
+/// Targets are computed as `pc + imm` (signed). For RV B-type and
+/// J-type, `imm` is in bytes. For RV+C, decompression has already
+/// converted to byte offsets so the same `pc + imm` rule applies.
+#[allow(dead_code)]
+fn static_target(ip: &RvPreDecodedInst) -> Option<usize> {
+    let pc = ip.pc as i64;
+    let off: i64 = match ip.inst {
+        Inst::Jal { imm, .. } => imm as i64,
+        Inst::Beq { imm, .. }
+        | Inst::Bne { imm, .. }
+        | Inst::Blt { imm, .. }
+        | Inst::Bge { imm, .. }
+        | Inst::Bltu { imm, .. }
+        | Inst::Bgeu { imm, .. } => imm as i64,
+        // br_table targets come from the Image's jump_table, not
+        // from an instruction-embedded immediate. They're listed
+        // separately by the linker for branch-target alignment.
+        _ => return None,
+    };
+    let t = pc + off;
+    if t < 0 { None } else { Some(t as usize) }
 }
 
 /// Block-terminating instructions: anything that *can* leave the

--- a/rust/javm-exec/src/predecode.rs
+++ b/rust/javm-exec/src/predecode.rs
@@ -9,17 +9,18 @@
 //!   offset where an instruction begins. Used at deblob for branch /
 //!   call target alignment checks (a static-target reaching a non-
 //!   instruction-start byte is a program error).
-//! - **Gas-block-start markers**: PC=0 plus every PC immediately
-//!   following a terminator. PVM2's pure-static-dispatch design lets us
-//!   tighten this to the strict post-terminator set (was: "every
-//!   instruction", a workaround for runtime JALR validation back when
-//!   PVM2 still had JALR).
+//! - **Gas-block-start markers**: `{0} ∪ post-terminator PCs ∪ 4 KiB
+//!   page starts` (see Pass 2). All three are derived from the
+//!   instruction stream / PC — never trusted from linker metadata,
+//!   since the recompiler runs untrusted code. `jalr` targets are
+//!   validated against this set at runtime.
 //!
 //! Per-block gas costs are computed by running the pipeline simulator
 //! in [`crate::gas_cost::rv_gas_cost_for_block`] once per basic block;
 //! the results are stored in [`Predecode::block_costs`].
 
 use crate::instruction::{Inst, decode};
+use crate::mem::PAGE_SIZE;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -119,28 +120,46 @@ pub fn predecode_rv_with_mem_cycles(code: &[u8], mem_cycles: u8) -> Predecode {
         pc = next_pc as usize;
     }
 
-    // ---- Pass 2: mark gas-block starts (strict post-terminator) ------
+    // ---- Invariant 10: no instruction crosses a 4 KiB page boundary --
     //
-    // PVM2 has no runtime indirect dispatch (no JALR; calls go via
-    // `addi ra, x0, idx ; jal x0, callee`, returns via
-    // `br_table table_id, ra`). The set of legal gas-block-starts is:
-    //
-    //     {0} ∪ { pc | pc immediately follows a terminator instruction }
-    //
-    // The linker invariant (analogous to PVM's
-    // `ensure_branch_targets_are_block_starts`) guarantees every
-    // statically-reachable branch / br_table target lands in this set —
-    // it injects `Fallthrough` (a terminator no-op) before any target
-    // that isn't naturally post-terminator.
-    //
-    // OOG happens at the per-block gas check at the block start, so
-    // a paused PC is always in this set.
-    if !insts.is_empty() {
-        insts[0].is_gas_block_start = true;
+    // A straddling instruction would let lazy per-page compilation split
+    // it across a compile boundary. The linker pads with `c.nop` to
+    // prevent this; reject a blob that violates it (defense — both
+    // engines trust the instruction stream, not an external layout
+    // guarantee). Only 4-byte instructions can straddle (RV+C is 2-byte
+    // aligned, pages are even).
+    if decode_error_at.is_none() {
+        for ip in &insts {
+            if ip.pc / PAGE_SIZE != (ip.next_pc - 1) / PAGE_SIZE {
+                decode_error_at = Some(ip.pc);
+                break;
+            }
+        }
     }
-    for i in 1..insts.len() {
-        let prev_is_terminator = is_terminator(&insts[i - 1].inst);
-        if prev_is_terminator {
+
+    // ---- Pass 2: mark gas-block starts -------------------------------
+    //
+    // The set of legal gas-block-starts is
+    //
+    //     {0} ∪ { pc | pc follows a terminator } ∪ { pc | pc % 4 KiB == 0 }
+    //
+    // all derived purely from the instruction stream / PC, never trusted
+    // from linker metadata (the recompiler runs untrusted code). `jalr`
+    // targets are validated against this set at runtime.
+    //
+    //  - Post-terminator: the linker injects `Fallthrough` (a terminator
+    //    no-op) before any branch / jump / endpoint / code-pointer target
+    //    that isn't naturally post-terminator, so every reachable static
+    //    target is covered.
+    //  - Page starts: every 4 KiB page boundary partitions a gas block so
+    //    lazy per-page compilation enters each page at a dispatchable
+    //    block and both engines agree on the partition (invariant 11).
+    //
+    // OOG happens at the per-block gas check at the block start, so a
+    // paused PC is always in this set.
+    for i in 0..insts.len() {
+        let post_terminator = i > 0 && is_terminator(&insts[i - 1].inst);
+        if insts[i].pc.is_multiple_of(PAGE_SIZE) || post_terminator {
             insts[i].is_gas_block_start = true;
         }
     }
@@ -167,33 +186,6 @@ fn compute_block_costs(insts: &[RvPreDecodedInst], mem_cycles: u8) -> Vec<u32> {
         }
     }
     block_costs
-}
-
-/// Return the target byte offset of a statically-resolvable branch or
-/// jump. `None` for indirect jumps (`jalr`), non-control-flow ops, and
-/// other shapes.
-///
-/// Targets are computed as `pc + imm` (signed). For RV B-type and
-/// J-type, `imm` is in bytes. For RV+C, decompression has already
-/// converted to byte offsets so the same `pc + imm` rule applies.
-#[allow(dead_code)]
-fn static_target(ip: &RvPreDecodedInst) -> Option<usize> {
-    let pc = ip.pc as i64;
-    let off: i64 = match ip.inst {
-        Inst::Jal { imm, .. } => imm as i64,
-        Inst::Beq { imm, .. }
-        | Inst::Bne { imm, .. }
-        | Inst::Blt { imm, .. }
-        | Inst::Bge { imm, .. }
-        | Inst::Bltu { imm, .. }
-        | Inst::Bgeu { imm, .. } => imm as i64,
-        // br_table targets come from the Image's jump_table, not
-        // from an instruction-embedded immediate. They're listed
-        // separately by the linker for branch-target alignment.
-        _ => return None,
-    };
-    let t = pc + off;
-    if t < 0 { None } else { Some(t as usize) }
 }
 
 /// Block-terminating instructions: anything that *can* leave the

--- a/rust/javm-exec/src/predecode.rs
+++ b/rust/javm-exec/src/predecode.rs
@@ -204,6 +204,8 @@ pub fn is_terminator(inst: &Inst) -> bool {
         inst,
         // PC-relative jumps.
         Inst::Jal { .. }
+            // Indirect jumps (returns, indirect calls).
+            | Inst::Jalr { .. }
             // Static branches.
             | Inst::Beq { .. }
             | Inst::Bne { .. }
@@ -215,7 +217,6 @@ pub fn is_terminator(inst: &Inst) -> bool {
             | Inst::Trap
             | Inst::EcallJar
             | Inst::Ecalli { .. }
-            | Inst::BrTable { .. }
             | Inst::Fallthrough
             // Reserved encodings panic at runtime.
             | Inst::Reserved { .. }
@@ -321,40 +322,43 @@ mod tests {
     }
 
     #[test]
-    fn br_table_is_terminator() {
-        // br_table table_id=5, rs1=x1 (custom-0 funct3=011, I-type, rd=0).
-        // Word = (table_id << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7)
-        //        | (custom_0 << 2) | 0b11
-        //      = (5 << 20)  | (1 << 15)  | (0b011 << 12) | (0 << 7)
-        //        | (0b00010 << 2) | 0b11
-        //      = 0x0050_B00B
-        let br_table_word =
-            (5u32 << 20) | (1u32 << 15) | (0b011u32 << 12) | (0b00010u32 << 2) | 0b11;
-        let code = enc(&[br_table_word, 0x00150513]);
+    fn jalr_is_terminator() {
+        // jalr x0, x1, 0 (= the `ret` idiom). I-type: rd=0, rs1=1,
+        // imm=0, funct3=0, opcode=1100111 → 0x00008067.
+        let jalr = 0x00008067u32;
+        let code = enc(&[jalr, 0x00150513]);
         let r = predecode(&code);
         assert_eq!(r.insts.len(), 2);
         assert!(matches!(
             r.insts[0].inst,
-            Inst::BrTable {
-                table_id: 5,
-                rs1: 1
+            Inst::Jalr {
+                rd: 0,
+                rs1: 1,
+                imm: 0
             }
         ));
         assert!(r.insts[0].is_gas_block_start); // PC=0
-        assert!(r.insts[1].is_gas_block_start); // post-br_table
+        assert!(r.insts[1].is_gas_block_start); // post-jalr (terminator)
+        assert_eq!(r.decode_error_at, None);
     }
 
     #[test]
-    fn jalr_is_rejected() {
-        // jalr x0, x1, 0 (= c.ret pattern in uncompressed form)
-        // I-type: rd=0, rs1=1, imm=0, funct3=0, opcode=1100111
-        // word = (0<<20) | (1<<15) | (0<<12) | (0<<7) | 0b1100111 = 0x00008067
-        let jalr = 0x00008067u32;
-        let code = enc(&[jalr]);
+    fn auipc_decodes() {
+        // auipc x10, 0x12 → rd=10, imm=(0x12<<12). opcode=0010111.
+        // word = (0x12 << 12) | (10 << 7) | 0b0010111 = 0x00012517
+        let auipc = 0x00012517u32;
+        let code = enc(&[auipc]);
         let r = predecode(&code);
         assert_eq!(r.insts.len(), 1);
-        assert!(matches!(r.insts[0].inst, Inst::Reserved { .. }));
-        assert_eq!(r.decode_error_at, Some(0));
+        assert!(matches!(
+            r.insts[0].inst,
+            Inst::Auipc {
+                rd: 10,
+                imm: 0x12000
+            }
+        ));
+        // auipc is a plain ALU op, NOT a terminator.
+        assert_eq!(r.decode_error_at, None);
     }
 
     #[test]

--- a/rust/javm-guest-tests/tests/conformance.rs
+++ b/rust/javm-guest-tests/tests/conformance.rs
@@ -55,7 +55,7 @@ fn run_interpreter(image: &Image, ep: u8) -> (u64, u64) {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod recomp {
     use super::*;
-    use javm_cap::image::{MappingSource, PinnedCap};
+    use javm_cap::image::PinnedCap;
     use javm_cap::NUM_REGS;
     use nub::Nub;
     use std::sync::{Mutex, OnceLock};
@@ -163,13 +163,10 @@ mod recomp {
         let mut mem_size: u32 = 0;
         let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
+        // Code is RO direct-mapped at CODE_BASE by the runtime, not a
+        // flat-buffer overlay; `memory_mappings` lists data/slot regions.
         for mapping in &image.memory_mappings {
-            // Code regions are RO direct-mapped at CODE_BASE by the
-            // runtime, not flat-buffer overlays — skip them here.
-            let target = match &mapping.source {
-                MappingSource::Slot(path) => path.target(),
-                MappingSource::Code(_) => continue,
-            };
+            let target = mapping.source.target();
 
             let end = (mapping.start + mapping.size) as u32;
             if end > mem_size {

--- a/rust/javm-guest-tests/tests/conformance.rs
+++ b/rust/javm-guest-tests/tests/conformance.rs
@@ -55,7 +55,7 @@ fn run_interpreter(image: &Image, ep: u8) -> (u64, u64) {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod recomp {
     use super::*;
-    use javm_cap::image::PinnedCap;
+    use javm_cap::image::{MappingSource, PinnedCap};
     use javm_cap::NUM_REGS;
     use nub::Nub;
     use std::sync::{Mutex, OnceLock};
@@ -164,12 +164,18 @@ mod recomp {
         let mut overlays: Vec<(u32, Vec<u8>)> = Vec::new();
 
         for mapping in &image.memory_mappings {
+            // Code regions are RO direct-mapped at CODE_BASE by the
+            // runtime, not flat-buffer overlays — skip them here.
+            let target = match &mapping.source {
+                MappingSource::Slot(path) => path.target(),
+                MappingSource::Code(_) => continue,
+            };
+
             let end = (mapping.start + mapping.size) as u32;
             if end > mem_size {
                 mem_size = end;
             }
 
-            let target = mapping.source.target();
             if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
                 if !content.is_empty() {
                     overlays.push((mapping.start as u32, content.clone()));

--- a/rust/javm-guest-tests/tests/sub_vm.rs
+++ b/rust/javm-guest-tests/tests/sub_vm.rs
@@ -19,7 +19,7 @@
 
 use javm::kernel_assist::{InProcessKernelAssist, KernelAssist};
 use javm::{CallResult, Vm};
-use javm_cap::image::{Image, PinnedCap};
+use javm_cap::image::{Image, MappingSource, PinnedCap};
 use javm_cap::{CacheDirectory, Cap, CapHashOrRef, SlotIdx, NUM_REGS};
 use ssz::Decode;
 
@@ -177,11 +177,16 @@ fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
     let mut mem_size: u32 = 0;
     let mut overlays = Vec::new();
     for mapping in &image.memory_mappings {
+        // Code regions are RO direct-mapped at CODE_BASE by the runtime,
+        // not flat-buffer overlays — skip them here.
+        let target = match &mapping.source {
+            MappingSource::Slot(path) => path.target(),
+            MappingSource::Code(_) => continue,
+        };
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;
         }
-        let target = mapping.source.target();
         if let Some(PinnedCap::Data { content, .. }) = image.pinned_slots.get(&target) {
             if !content.is_empty() {
                 overlays.push((mapping.start as u32, content.clone()));

--- a/rust/javm-guest-tests/tests/sub_vm.rs
+++ b/rust/javm-guest-tests/tests/sub_vm.rs
@@ -19,7 +19,7 @@
 
 use javm::kernel_assist::{InProcessKernelAssist, KernelAssist};
 use javm::{CallResult, Vm};
-use javm_cap::image::{Image, MappingSource, PinnedCap};
+use javm_cap::image::{Image, PinnedCap};
 use javm_cap::{CacheDirectory, Cap, CapHashOrRef, SlotIdx, NUM_REGS};
 use ssz::Decode;
 
@@ -176,13 +176,10 @@ fn collect_initial_hashes(
 fn build_overlays(image: &Image) -> (u32, Vec<(u32, Vec<u8>)>) {
     let mut mem_size: u32 = 0;
     let mut overlays = Vec::new();
+    // Code is RO direct-mapped at CODE_BASE by the runtime, not a
+    // flat-buffer overlay; `memory_mappings` lists data/slot regions only.
     for mapping in &image.memory_mappings {
-        // Code regions are RO direct-mapped at CODE_BASE by the runtime,
-        // not flat-buffer overlays — skip them here.
-        let target = match &mapping.source {
-            MappingSource::Slot(path) => path.target(),
-            MappingSource::Code(_) => continue,
-        };
+        let target = mapping.source.target();
         let end = (mapping.start + mapping.size) as u32;
         if end > mem_size {
             mem_size = end;

--- a/rust/javm-recompiler-x86/src/asm.rs
+++ b/rust/javm-recompiler-x86/src/asm.rs
@@ -127,6 +127,33 @@ pub enum Cc {
     G = 15,  // Greater (signed >)
 }
 
+impl Cc {
+    /// The inverse condition — taken exactly when `self` is not. (x86
+    /// encodes this as flipping the low bit of the condition code.) Used
+    /// to lower a conditional branch to a fall-through-on-not-taken
+    /// shape: `jcc.invert() skip; <taken body>; skip:`.
+    pub fn invert(self) -> Cc {
+        match self {
+            Cc::O => Cc::NO,
+            Cc::NO => Cc::O,
+            Cc::B => Cc::AE,
+            Cc::AE => Cc::B,
+            Cc::E => Cc::NE,
+            Cc::NE => Cc::E,
+            Cc::BE => Cc::A,
+            Cc::A => Cc::BE,
+            Cc::S => Cc::NS,
+            Cc::NS => Cc::S,
+            Cc::P => Cc::NP,
+            Cc::NP => Cc::P,
+            Cc::L => Cc::GE,
+            Cc::GE => Cc::L,
+            Cc::LE => Cc::G,
+            Cc::G => Cc::LE,
+        }
+    }
+}
+
 /// Label identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Label(pub u32);

--- a/rust/javm-recompiler-x86/src/asm.rs
+++ b/rust/javm-recompiler-x86/src/asm.rs
@@ -1915,7 +1915,15 @@ impl Assembler {
     }
 
     /// Resolve all label fixups in-place (works for both Vec and mmap buffers).
-    fn resolve_fixups(&mut self) {
+    ///
+    /// Public so the lazy per-page compile path can resolve a page's
+    /// intra-page forward branches as soon as that page is emitted
+    /// (without consuming the buffer via [`finalize`](Self::finalize)).
+    /// Idempotent: re-resolving an already-resolved fixup recomputes the
+    /// same rel32, so repeated calls across pages are harmless. Every
+    /// referenced label must be bound by call time (cross-page targets go
+    /// through the dispatch table, never a label, so this always holds).
+    pub fn resolve_fixups(&mut self) {
         for fixup in &self.fixups {
             let stored = self.labels[fixup.label.0 as usize];
             // All labels must be bound by finalization time.
@@ -1945,12 +1953,21 @@ impl Assembler {
         core::mem::take(code)
     }
 
-    /// Get a slice of the written code bytes (for tests). Syncs Vec len first.
-    #[cfg(test)]
-    pub fn code_bytes(&mut self) -> &[u8] {
+    /// All code bytes written so far (offsets `0..offset()`). Syncs the
+    /// Vec length to the write cursor first. Used by the lazy per-page
+    /// compile path to copy a freshly-emitted page's bytes into the
+    /// runtime arena (`&written()[start..end]`) without consuming the
+    /// buffer — the assembler keeps growing for the next page.
+    pub fn written(&mut self) -> &[u8] {
         self.sync_len();
         let CodeBuf::Vec(v) = &self.code_buf;
         v.as_slice()
+    }
+
+    /// Get a slice of the written code bytes (for tests). Syncs Vec len first.
+    #[cfg(test)]
+    pub fn code_bytes(&mut self) -> &[u8] {
+        self.written()
     }
 }
 

--- a/rust/javm-recompiler-x86/src/asm.rs
+++ b/rust/javm-recompiler-x86/src/asm.rs
@@ -127,33 +127,6 @@ pub enum Cc {
     G = 15,  // Greater (signed >)
 }
 
-impl Cc {
-    /// The inverse condition — taken exactly when `self` is not. (x86
-    /// encodes this as flipping the low bit of the condition code.) Used
-    /// to lower a conditional branch to a fall-through-on-not-taken
-    /// shape: `jcc.invert() skip; <taken body>; skip:`.
-    pub fn invert(self) -> Cc {
-        match self {
-            Cc::O => Cc::NO,
-            Cc::NO => Cc::O,
-            Cc::B => Cc::AE,
-            Cc::AE => Cc::B,
-            Cc::E => Cc::NE,
-            Cc::NE => Cc::E,
-            Cc::BE => Cc::A,
-            Cc::A => Cc::BE,
-            Cc::S => Cc::NS,
-            Cc::NS => Cc::S,
-            Cc::P => Cc::NP,
-            Cc::NP => Cc::P,
-            Cc::L => Cc::GE,
-            Cc::GE => Cc::L,
-            Cc::LE => Cc::G,
-            Cc::G => Cc::LE,
-        }
-    }
-}
-
 /// Label identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Label(pub u32);
@@ -1915,15 +1888,7 @@ impl Assembler {
     }
 
     /// Resolve all label fixups in-place (works for both Vec and mmap buffers).
-    ///
-    /// Public so the lazy per-page compile path can resolve a page's
-    /// intra-page forward branches as soon as that page is emitted
-    /// (without consuming the buffer via [`finalize`](Self::finalize)).
-    /// Idempotent: re-resolving an already-resolved fixup recomputes the
-    /// same rel32, so repeated calls across pages are harmless. Every
-    /// referenced label must be bound by call time (cross-page targets go
-    /// through the dispatch table, never a label, so this always holds).
-    pub fn resolve_fixups(&mut self) {
+    fn resolve_fixups(&mut self) {
         for fixup in &self.fixups {
             let stored = self.labels[fixup.label.0 as usize];
             // All labels must be bound by finalization time.
@@ -1953,21 +1918,12 @@ impl Assembler {
         core::mem::take(code)
     }
 
-    /// All code bytes written so far (offsets `0..offset()`). Syncs the
-    /// Vec length to the write cursor first. Used by the lazy per-page
-    /// compile path to copy a freshly-emitted page's bytes into the
-    /// runtime arena (`&written()[start..end]`) without consuming the
-    /// buffer — the assembler keeps growing for the next page.
-    pub fn written(&mut self) -> &[u8] {
-        self.sync_len();
-        let CodeBuf::Vec(v) = &self.code_buf;
-        v.as_slice()
-    }
-
     /// Get a slice of the written code bytes (for tests). Syncs Vec len first.
     #[cfg(test)]
     pub fn code_bytes(&mut self) -> &[u8] {
-        self.written()
+        self.sync_len();
+        let CodeBuf::Vec(v) = &self.code_buf;
+        v.as_slice()
     }
 }
 

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -599,14 +599,14 @@ impl Compiler {
         self.asm.jmp_reg(SCRATCH);
     }
 
-    /// Emit exit sequences and epilogue.
-    pub(crate) fn emit_exit_sequences(&mut self) {
-        // Reserve capacity for exit sequences + all OOG stubs.
-        // Each OOG stub is ~12 bytes.
-        let needed = 512 + self.oog_stubs.len() * 16;
-        self.asm.ensure_capacity(needed);
-        // Shared OOG handler that reads PC from SCRATCH — emitted BEFORE OOG
-        // stubs so backward jumps from stubs can use jmp rel8 (2 bytes).
+    /// Emit the shared exit / OOG / panic handlers (the runtime "stub").
+    /// Emitted once, up front (right after the prologue), so per-page
+    /// bodies — which under lazy compilation are compiled later and in
+    /// arbitrary order — can backward-reference them. The per-block OOG
+    /// stubs are emitted per page by `emit_page_oog_stubs`.
+    pub(crate) fn emit_stub_handlers(&mut self) {
+        self.asm.ensure_capacity(512);
+        // Shared OOG handler: PC already in SCRATCH.
         self.asm.bind_label(self.oog_pc_label);
         self.asm.mov_store32_rip_rel(CTX_PC, SCRATCH);
         // fall through to oog_label:
@@ -614,15 +614,6 @@ impl Compiler {
         self.asm
             .mov_store32_rip_rel_imm(CTX_EXIT_REASON, EXIT_OOG as i32);
         self.asm.jmp_label(self.exit_label);
-
-        // Per-gas-block OOG stubs: compact format — load PC into SCRATCH,
-        // jump to shared handler. Saves ~6 bytes per stub vs inline PC store.
-        let stubs = core::mem::take(&mut self.oog_stubs);
-        for (label, pvm_pc, _cost) in &stubs {
-            self.asm.bind_label(*label);
-            self.asm.mov_ri32(SCRATCH, *pvm_pc);
-            self.asm.jmp_label(self.oog_pc_label);
-        }
 
         // Page faults are handled by the SIGSEGV handler (signal.rs).
 
@@ -657,6 +648,20 @@ impl Compiler {
         self.asm.pop(Reg::RBP);
         self.asm.pop(Reg::RBX);
         self.asm.ret();
+    }
+
+    /// Emit the OOG stubs gathered while compiling the current page:
+    /// `mov SCRATCH, pvm_pc; jmp oog_pc_handler`. Each block's gas check
+    /// (`js stub`) targets one of these. Drains `self.oog_stubs` so the
+    /// next page starts clean.
+    pub(crate) fn emit_page_oog_stubs(&mut self) {
+        let stubs = core::mem::take(&mut self.oog_stubs);
+        self.asm.ensure_capacity(512 + stubs.len() * 16);
+        for (label, pvm_pc, _cost) in &stubs {
+            self.asm.bind_label(*label);
+            self.asm.mov_ri32(SCRATCH, *pvm_pc);
+            self.asm.jmp_label(self.oog_pc_label);
+        }
     }
 }
 
@@ -1207,81 +1212,20 @@ impl Compiler {
         self.bitmask_len = self.rv_valid_pc.len();
 
         self.emit_prologue();
+        // Shared exit/OOG/panic handlers up front, before any page body.
+        self.emit_stub_handlers();
 
-        let mut pending_gas: Option<(Label, u32, usize)> = None;
-        let mut pc: usize = 0;
-
-        while pc < code.len() {
-            self.asm.ensure_capacity(512);
-
-            // Length encoding lives in bits [1:0] of byte 0: `xx11` is
-            // 4-byte, anything else is 2-byte (RVC). Decode no further
-            // than that — the dispatcher inspects raw bits directly.
-            if pc + 2 > code.len() {
-                self.rv_emit_panic_at(pc as u32);
-                break;
-            }
-            let is_4byte = code[pc] & 0b11 == 0b11;
-            let base_len = if is_4byte { 4 } else { 2 };
-            if pc + base_len > code.len() {
-                self.rv_emit_panic_at(pc as u32);
-                break;
-            }
-
-            let inst_pc = pc as u32;
-
-            // Bind a gas block at every block start in the precomputed
-            // set ({0} ∪ post-terminator ∪ page starts). Same partition
-            // as predecode → identical per-block gas.
-            if self.is_basic_block_start(inst_pc) {
-                self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
-            }
-
-            // Byte-based dispatch. Each path returns
-            // `(is_terminator, preserve_cf, extra_bytes)`. `extra_bytes`
-            // counts the *additional* bytes consumed beyond `base_len`
-            // for lookahead fusion (e.g., Ld→Add fuses an extra 4-byte
-            // Add). `preserve_cf` tells us whether to keep `last_add_cf`
-            // alive for a following Sltu fusion.
-            //
-            // Suppress fusion across a block boundary: if the trailer
-            // starts a new gas block, fusing it into this block would
-            // diverge the recompiler's partition (and per-block gas) from
-            // predecode's. `rest` is lookahead-only — an empty slice
-            // defers the trailer to its own block next iteration. (Only
-            // page-boundary starts can fall between two fusable
-            // non-terminators; post-terminator starts follow a
-            // non-fusable terminator. Gating on the block-start set covers
-            // both uniformly.)
-            let next_inst_pc = inst_pc + base_len as u32;
-            let rest: &[u8] = if self.is_basic_block_start(next_inst_pc) {
-                &[]
-            } else {
-                &code[pc + base_len..]
-            };
-            let (_term, preserve_cf, extra) = if is_4byte {
-                let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
-                self.compile_rv4(w, inst_pc, 4, rest)
-            } else {
-                let h = u16::from_le_bytes([code[pc], code[pc + 1]]);
-                self.compile_rvc(h, inst_pc, rest)
-            };
-
-            if !preserve_cf {
-                self.last_add_cf = None;
-            }
-
-            pc += base_len + extra;
+        // Compile each 4 KiB page's body in order. The per-page structure
+        // (with the page-boundary fall-through dispatching through the
+        // table) is exactly what lazy compilation needs; here we drive it
+        // eagerly so every page is compiled up front.
+        let page = javm_exec::PAGE_SIZE as usize;
+        let n_pages = code.len().div_ceil(page);
+        for p in 0..n_pages {
+            let start = p * page;
+            let end = ((p + 1) * page).min(code.len());
+            self.compile_page(code, start, end);
         }
-
-        // Finalize the last gas block — patch its cost in.
-        if let Some((stub_label, block_pc, patch_offset)) = pending_gas.take() {
-            let cost = self.gas_sim.flush_and_get_cost();
-            self.asm.patch_i32(patch_offset, cost as i32);
-            self.oog_stubs.push((stub_label, block_pc, cost));
-        }
-
-        self.emit_exit_sequences();
 
         // Sparse dispatch entries — caller writes only these into the
         // (page-zero-filled) arena dispatch region. No code.len() + 1
@@ -1305,6 +1249,101 @@ impl Compiler {
             exit_label_offset,
             valid_pc,
         }
+    }
+
+    /// Compile the blocks in code byte range `[start, end)` — one 4 KiB
+    /// page — into the JIT buffer at the current cursor, then emit this
+    /// page's OOG stubs. Same-page branch targets resolve to direct
+    /// rel32 jumps (their labels bind within this page); cross-page
+    /// targets, and a fall-through off the page end, dispatch indirectly
+    /// through the table, so the target page need not be compiled yet
+    /// (the foundation for lazy compilation). `bb`/`is_basic_block_start`
+    /// is the whole-blob precomputed set, so targets validate regardless
+    /// of which pages exist.
+    fn compile_page(&mut self, code: &[u8], start: usize, end: usize) {
+        let mut pending_gas: Option<(Label, u32, usize)> = None;
+        let mut pc = start;
+        // Whether the last instruction compiled terminates the block. An
+        // empty range trivially "terminates" (nothing falls through).
+        let mut last_terminates = true;
+
+        while pc < end {
+            self.asm.ensure_capacity(512);
+
+            // Length encoding lives in bits [1:0] of byte 0: `xx11` is
+            // 4-byte, anything else 2-byte (RVC).
+            if pc + 2 > code.len() {
+                self.rv_emit_panic_at(pc as u32);
+                last_terminates = true;
+                break;
+            }
+            let is_4byte = code[pc] & 0b11 == 0b11;
+            let base_len = if is_4byte { 4 } else { 2 };
+            if pc + base_len > code.len() {
+                self.rv_emit_panic_at(pc as u32);
+                last_terminates = true;
+                break;
+            }
+
+            let inst_pc = pc as u32;
+
+            // Bind a gas block at every block start in the precomputed set
+            // ({0} ∪ post-terminator ∪ page starts) — same partition as
+            // predecode, so per-block gas matches.
+            if self.is_basic_block_start(inst_pc) {
+                self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
+            }
+
+            // Suppress fusion across a block boundary (incl. the page end,
+            // which is a block start): fusing a trailer that starts a new
+            // block would diverge the recompiler's partition (and per-block
+            // gas) from predecode's. `rest` is lookahead-only — an empty
+            // slice defers the trailer to its own block.
+            let next_inst_pc = inst_pc + base_len as u32;
+            let rest: &[u8] = if self.is_basic_block_start(next_inst_pc) {
+                &[]
+            } else {
+                &code[pc + base_len..]
+            };
+            let (term, preserve_cf, extra) = if is_4byte {
+                let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
+                self.compile_rv4(w, inst_pc, 4, rest)
+            } else {
+                let h = u16::from_le_bytes([code[pc], code[pc + 1]]);
+                self.compile_rvc(h, inst_pc, rest)
+            };
+
+            if !preserve_cf {
+                self.last_add_cf = None;
+            }
+            last_terminates = term;
+            pc += base_len + extra;
+        }
+
+        // Flush the page's last gas block cost.
+        if let Some((stub_label, block_pc, patch_offset)) = pending_gas.take() {
+            let cost = self.gas_sim.flush_and_get_cost();
+            self.asm.patch_i32(patch_offset, cost as i32);
+            self.oog_stubs.push((stub_label, block_pc, cost));
+        }
+
+        // If the page's last block falls through, dispatch to the next
+        // page start (a block start). Under lazy compilation that page may
+        // not be compiled yet → the dispatch lands on the compile-page
+        // stub. `end` is the next page's start offset (instructions never
+        // straddle a page, invariant 10).
+        if !last_terminates {
+            let next = end as u32;
+            if (next as usize) < code.len() {
+                self.emit_dispatch_static(next);
+            } else {
+                // Fall-through past the end of the blob — malformed.
+                self.rv_emit_panic_at(next.saturating_sub(1));
+            }
+        }
+
+        // Emit this page's OOG stubs (they reference the shared handler).
+        self.emit_page_oog_stubs();
     }
 
     /// Streaming gas-block-start hook: bind label, flush prior block's

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -88,8 +88,6 @@ pub const CTX_EXIT_REASON: u64 = CTX_VA + offset_of!(JitContext, exit_reason) as
 pub const CTX_EXIT_ARG: u64 = CTX_VA + offset_of!(JitContext, exit_arg) as u64;
 pub const CTX_HEAP_BASE: u64 = CTX_VA + offset_of!(JitContext, heap_base) as u64;
 pub const CTX_HEAP_TOP: u64 = CTX_VA + offset_of!(JitContext, heap_top) as u64;
-pub const CTX_JT_PTR: u64 = CTX_VA + offset_of!(JitContext, jt_ptr) as u64;
-pub const CTX_JT_LEN: u64 = CTX_VA + offset_of!(JitContext, jt_len) as u64;
 pub const CTX_BB_STARTS: u64 = CTX_VA + offset_of!(JitContext, bb_starts) as u64;
 pub const CTX_BB_LEN: u64 = CTX_VA + offset_of!(JitContext, bb_len) as u64;
 pub const CTX_ENTRY_PC: u64 = CTX_VA + offset_of!(JitContext, entry_pc) as u64;
@@ -199,11 +197,13 @@ pub struct Compiler {
     /// block boundaries. The PVM `compile()` path uses its own local
     /// simulator and leaves this one untouched.
     pub(crate) gas_sim: GasSimulator,
-    /// PVM2: per-function `br_table` sub-table CSR offsets. Each
-    /// `BrTable { table_id, .. }` instruction dispatches through
-    /// entries `jt_ptr[rv_jt_offsets[table_id] ..
-    /// rv_jt_offsets[table_id + 1]]`. Empty for PVM legacy.
-    pub(crate) rv_jt_offsets: Vec<u32>,
+    /// Guest VA the code region is mapped at. `jalr`/`auipc` produce
+    /// and consume code addresses as `code_base + offset`; the
+    /// dispatch/bb tables are offset-indexed (offset = VA - code_base).
+    pub(crate) code_base: u32,
+    /// Code region length in bytes — the upper bound for jalr target
+    /// offsets (== `bb_starts` / dispatch-table length).
+    pub(crate) code_len: u32,
     /// True during RV streaming compile (`compile`). When set, branch
     /// emit helpers defer forward-target validation (`target > pc`) to a
     /// post-pass instead of consulting `bitmask_ptr`. Off for PVM, whose
@@ -222,7 +222,13 @@ pub struct Compiler {
 }
 
 impl Compiler {
-    pub fn new(helpers: HelperFns, code_len: usize, jit_va_base: u64, mem_cycles: u8) -> Self {
+    pub fn new(
+        helpers: HelperFns,
+        code_len: usize,
+        jit_va_base: u64,
+        mem_cycles: u8,
+        code_base: u32,
+    ) -> Self {
         // Estimate native code size: ~3x PVM code provides safety margin for
         // direct-write emission (no per-byte capacity checks in hot loop).
         let estimated_native = code_len * 3 + 8192;
@@ -265,7 +271,8 @@ impl Compiler {
             trap_entries: Vec::with_capacity(2048),
             mem_cycles,
             gas_sim: GasSimulator::new(),
-            rv_jt_offsets: Vec::new(),
+            code_base,
+            code_len: code_len as u32,
             rv_streaming: false,
             rv_pending_fwd_branches: Vec::new(),
             rv_valid_pc: Vec::new(),
@@ -709,9 +716,11 @@ const OP_OP_IMM_32: u32 = 0b00_110;
 const OP_STORE: u32 = 0b01_000;
 const OP_OP: u32 = 0b01_100;
 const OP_LUI: u32 = 0b01_101;
+const OP_AUIPC: u32 = 0b00_101;
 const OP_OP_32: u32 = 0b01_110;
 const OP_BRANCH: u32 = 0b11_000;
 const OP_JAL: u32 = 0b11_011;
+const OP_JALR: u32 = 0b11_001;
 const OP_CUSTOM_0: u32 = 0b00_010;
 
 // Sign-extended immediates straight off a 4-byte RV word. Mirrors the
@@ -1145,22 +1154,12 @@ impl Compiler {
     /// intermediary — that was 57% of the old cold-path compile time
     /// on the large guests (ed25519, ecrecover).
     ///
-    /// `jump_table_offsets` is the Image's CSR-style sub-table boundary
-    /// array — see `javm_cap::image::Image::jump_table_offsets`.
-    /// Empty implies no br_table dispatch is used. Each
-    /// `BrTable { table_id, .. }` instruction dispatches through sub-
-    /// table `table_id`, whose entries live at
-    /// `jt_ptr[jump_table_offsets[table_id] ..
-    /// jump_table_offsets[table_id+1]]`.
-    ///
     /// The returned `CompileResult.valid_pc` is the byte-indexed
     /// "valid branch target" bitmap the runtime BB region needs. A bit
     /// is set iff the PC is a gas-block start (= dispatchable entry in
     /// the gas-block dispatch table). Built incrementally during the
     /// streaming pass — no separate length-only pre-pass.
-    pub fn compile(mut self, code: &[u8], jump_table_offsets: &[u32]) -> CompileResult {
-        self.rv_jt_offsets = jump_table_offsets.to_vec();
-
+    pub fn compile(mut self, code: &[u8]) -> CompileResult {
         // valid_pc is populated incrementally as the streaming pass
         // binds gas-block starts. The pointer is stable across mutation
         // (Vec doesn't reallocate from `vec![false; n]` with in-place
@@ -1353,7 +1352,9 @@ impl Compiler {
             OP_OP => self.compile_op(rd, rs1, rs2, f3, f7, w, pc, rest),
             OP_OP_32 => self.compile_op_32(rd, rs1, rs2, f3, f7, w, pc),
             OP_LUI => self.compile_lui(rd, w, pc, rest),
+            OP_AUIPC => self.compile_auipc(rd, w, pc),
             OP_JAL => self.compile_jal(rd, w, pc),
+            OP_JALR if f3 == 0 => self.compile_jalr(rd, rs1, w, pc),
             OP_BRANCH => self.compile_branch(rs1, rs2, f3, w, pc),
             OP_CUSTOM_0 => self.compile_custom_0(rd, rs1, f3, w, pc),
             OP_MISC_MEM => {
@@ -1361,7 +1362,7 @@ impl Compiler {
                 self.feed_gas_rv(RV_KIND_FENCE, 0, 0, 0);
                 (false, false, 0)
             }
-            // OP_AUIPC, OP_JALR, OP_SYSTEM, OP_CUSTOM_1 etc. — all
+            // OP_SYSTEM, OP_CUSTOM_1, jalr-with-funct3≠0, etc. — all
             // forbidden in PVM2 and rejected by the linker's validator.
             // Defence in depth: emit a runtime panic if we ever see one.
             _ => {
@@ -2119,6 +2120,26 @@ impl Compiler {
         (term, false, 0)
     }
 
+    fn compile_auipc(&mut self, rd: u8, w: u32, pc: u32) -> (bool, bool, usize) {
+        use javm_exec::gas_cost::*;
+        // auipc result is a compile-time constant: code_base + pc + imm.
+        let imm = imm_u(w);
+        self.rv_auipc(rd, imm, pc);
+        // Gas: same kind/cost as LUI (a constant materialise).
+        let term = self.feed_gas_rv(RV_KIND_LUI, 0, 0, rd);
+        (term, false, 0)
+    }
+
+    fn compile_jalr(&mut self, rd: u8, rs1: u8, w: u32, pc: u32) -> (bool, bool, usize) {
+        use javm_exec::gas_cost::*;
+        let imm = imm_i(w);
+        let next_pc = pc + 4;
+        self.rv_jalr(rd, rs1, imm, pc, next_pc);
+        // src = rs1 (target); rd not tracked (terminator).
+        let term = self.feed_gas_rv(RV_KIND_JALR, rs1, 0, 0);
+        (term, false, 0)
+    }
+
     fn compile_branch(&mut self, rs1: u8, rs2: u8, f3: u8, w: u32, pc: u32) -> (bool, bool, usize) {
         use javm_exec::gas_cost::*;
         let imm = imm_b(w);
@@ -2143,8 +2164,8 @@ impl Compiler {
 
     fn compile_custom_0(
         &mut self,
-        rd: u8,
-        rs1: u8,
+        _rd: u8,
+        _rs1: u8,
         f3: u8,
         w: u32,
         pc: u32,
@@ -2154,8 +2175,8 @@ impl Compiler {
         //   f3=000 → trap     (other fields ignored)
         //   f3=001 → ecall.jar
         //   f3=010 → ecalli imm
-        //   f3=011 → br_table table_id, rs1 (rd must be 0)
         //   f3=100 → fallthrough (terminator no-op)
+        //   f3=011 (was br_table) → reserved; PVM2 uses plain jalr.
         let next_pc = pc + 4;
         match f3 {
             0b000 => {
@@ -2172,17 +2193,6 @@ impl Compiler {
                 let imm = imm_i(w);
                 self.rv_ecalli(imm, next_pc);
                 let term = self.feed_gas_rv(RV_KIND_ECALLI, 0, 0, 0);
-                (term, false, 0)
-            }
-            0b011 => {
-                if rd != 0 {
-                    self.rv_emit_panic_at(pc);
-                    self.feed_gas_rv(RV_KIND_RESERVED, 0, 0, 0);
-                    return (true, false, 0);
-                }
-                let table_id = ((w >> 20) & 0xFFF) as u16;
-                self.rv_br_table(table_id, rs1, pc, next_pc);
-                let term = self.feed_gas_rv(RV_KIND_BR_TABLE, rs1, 0, 0);
                 (term, false, 0)
             }
             0b100 => {
@@ -2335,6 +2345,21 @@ impl Compiler {
         if let Some(d) = self.rv_dst(rd, pc) {
             // imm has bits in [31:12]; sign-extend to 64.
             self.asm.mov_ri64(d, imm as i64 as u64);
+            self.invalidate_reg(rv_slot(rd).unwrap());
+        }
+    }
+
+    /// `auipc rd, imm` — `rd = (code_base + pc) + imm`. Both addends
+    /// are compile-time constants, so this materialises a single
+    /// constant (mirrors the interpreter's `Auipc` arm exactly). The
+    /// value is a guest VA, sign-extended 32→64 like `lui`.
+    fn rv_auipc(&mut self, rd: u8, imm: i32, pc: u32) {
+        if let Some(d) = self.rv_dst(rd, pc) {
+            let va = self
+                .code_base
+                .wrapping_add(pc)
+                .wrapping_add(imm as u32);
+            self.asm.mov_ri64(d, va as i32 as i64 as u64);
             self.invalidate_reg(rv_slot(rd).unwrap());
         }
     }
@@ -3386,111 +3411,73 @@ impl Compiler {
         self.emit_static_branch(target, true, next_pc, pc);
     }
 
-    /// Emit a PVM2 `br_table table_id, rs1` — indirect-jump terminator
-    /// dispatching through `Image.jump_table[table_id]`.
-    ///
-    /// The `rs1` register carries the index encoded as `2*idx + 1`.
-    /// Decode:
-    ///   1. If `rs1 == 0` → fall through (uninitialised register is a
-    ///      sentinel for "no valid target").
-    ///   2. `idx = (rs1 - 1) >> 1`. If the LSB of `rs1` was 0 (raw PC
-    ///      shape), `idx` underflows to a huge value and the bounds
-    ///      check fails → fall through.
-    ///   3. If `idx >= table_len[table_id]` → fall through.
-    ///   4. `target_pc = jt[jt_offsets[table_id] + idx]`.
-    ///   5. `native_addr = code_base + dispatch_table[target_pc]`.
-    ///   6. `jmp native_addr`.
-    ///
-    /// `table_base_byte_offset` and `table_len` are baked in as
-    /// immediates at JIT time; they come from `self.rv_jt_offsets`
-    /// (the Image's `jump_table_offsets`).
-    fn rv_br_table(&mut self, table_id: u16, rs1: u8, pc: u32, next_pc: u32) {
+    /// Emit `jalr rd, rs1, imm` — indirect jump (return / indirect
+    /// call). Strictly simpler than the former br_table (no jump-table
+    /// indirection):
+    ///   1. `target_va = (rs1 + imm) & 0xFFFFFFFF`   (2³² wrap)
+    ///   2. write `rd = code_base + next_pc` if `rd != 0` (return addr)
+    ///   3. `offset = target_va - code_base`
+    ///   4. bounds: `offset < code_len`  else PANIC
+    ///   5. `bb_starts[offset] == 1`?     else PANIC  (security-critical:
+    ///      rejects mid-block / mid-instruction targets — gas is
+    ///      precharged at block entry)
+    ///   6. `native = code_base_native + dispatch_table[offset]; jmp`
+    fn rv_jalr(&mut self, rd: u8, rs1: u8, imm: i32, pc: u32, next_pc: u32) {
         use super::asm::Cc;
-
-        // Validate table_id against the compiled jump_table_offsets.
-        // (linker_rv guarantees this; this is defence-in-depth.)
-        let nt = self.rv_jt_offsets.len().saturating_sub(1);
-        if (table_id as usize) >= nt {
-            self.rv_emit_panic_at(pc);
-            return;
-        }
-        let table_start_entries = self.rv_jt_offsets[table_id as usize];
-        let table_end_entries = self.rv_jt_offsets[(table_id as usize) + 1];
-        if table_end_entries < table_start_entries {
-            self.rv_emit_panic_at(pc);
-            return;
-        }
-        let table_len = table_end_entries - table_start_entries;
-        let table_byte_offset = (table_start_entries as i32)
-            .checked_mul(4)
-            .unwrap_or(i32::MAX);
 
         if rv_is_reserved(rs1) {
             self.rv_emit_panic_at(pc);
             return;
         }
 
-        // OOB / sentinel handling: per spec the default behavior is
-        // to fall through to the next instruction (LLVM-friendly
-        // default-case shape). For PVM2 function returns this should
-        // never fire — caller always passes a valid encoded idx. We
-        // route to panic during bring-up to surface bugs; once stable
-        // this can be relaxed to `let fallthrough = label_for_pc(next_pc);`
-        // and bind a real fallthrough.
-        let oob_target = self.panic_label;
-
-        if rs1 == 0 {
-            // rs1 = x0: never dispatch.
-            self.asm.jmp_label(oob_target);
-            let _ = next_pc;
-            return;
-        }
-        // Load the encoded idx from rs1 into SCRATCH.
+        // SCRATCH = rs1 (x0 → 0).
         self.rv_read(rs1, SCRATCH, pc);
+        if imm != 0 {
+            self.asm.add_ri(SCRATCH, imm);
+        }
+        // 2³² wrap: zero-extend the low 32 bits (shl 32 ; shr 32).
+        self.asm.shl_ri64(SCRATCH, 32);
+        self.asm.shr_ri64(SCRATCH, 32);
 
-        // Check rs1 == 0 → OOB.
-        self.asm.test_rr(SCRATCH, SCRATCH);
-        self.asm.jcc_label(Cc::E, oob_target);
-
-        // idx = (rs1 - 1) >> 1.
-        self.asm.sub_ri(SCRATCH, 1);
-        self.asm.shr_ri64(SCRATCH, 1);
-
-        // Bounds check: idx < table_len.
-        if table_len == 0 {
-            self.asm.jmp_label(oob_target);
-        } else {
-            self.asm.cmp_ri32(SCRATCH, table_len as i32);
-            self.asm.jcc_label(Cc::AE, oob_target);
+        // Write the return address (a guest VA) — target already in
+        // SCRATCH, so this can't clobber it (rd never maps to RDX).
+        if rd != 0 {
+            let slot = rv_slot(rd).unwrap();
+            self.asm
+                .mov_ri64(REG_MAP[slot], self.code_base.wrapping_add(next_pc) as u64);
+            self.invalidate_reg(slot);
         }
 
-        // target_pc = jt_ptr[table_byte_offset + idx*4]
-        //           = *((u32*) (jt_ptr + table_byte_offset + idx*4))
-        self.asm.push(Reg::RAX); // save RAX (= x14)
-        self.asm.shl_ri64(SCRATCH, 2); // idx *= 4
-        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_JT_PTR);
-        if table_byte_offset != 0 {
-            self.asm.add_ri(Reg::RAX, table_byte_offset);
+        // offset = target_va - code_base.
+        if self.code_base != 0 {
+            self.asm.sub_ri(SCRATCH, self.code_base as i32);
         }
-        // Load the u32 PVM2 PC from [RAX + SCRATCH].
-        self.asm.add_rr(Reg::RAX, SCRATCH);
-        self.asm.mov_load32(SCRATCH, Reg::RAX, 0); // SCRATCH = target_pc
 
-        // native_addr = code_base + dispatch_table[target_pc]
+        // Record the offset as the paused PC for fault attribution.
+        self.asm.mov_store32_rip_rel(CTX_PC, SCRATCH);
+
+        // Bounds: offset < code_len (unsigned) — underflow from a
+        // target below code_base wraps huge and fails here.
+        self.asm.cmp_ri32(SCRATCH, self.code_len as i32);
+        self.asm.jcc_label(Cc::AE, self.panic_label);
+
+        // Validate bb_starts[offset] == 1 (basic-block start).
+        self.asm.push(Reg::RAX); // save x14
+        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_BB_STARTS);
+        // RAX = byte bb_starts[offset] (zero-extended).
+        self.asm.movzx_load8_sib(Reg::RAX, Reg::RAX, SCRATCH);
+        self.asm.test_rr(Reg::RAX, Reg::RAX);
+        self.asm.pop(Reg::RAX); // restore x14 before the conditional branch
+        self.asm.jcc_label(Cc::E, self.panic_label);
+
+        // native = code_base_native + dispatch_table[offset]; jmp.
+        self.asm.push(Reg::RAX);
         self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
         self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
         self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
-        // Record the target PC for gas-block tracking / pause attribution.
-        self.asm.mov_store32_rip_rel(CTX_PC, SCRATCH);
-        // RAX holds native addr; restore the saved RAX (= x14) value.
-        // Use SCRATCH as the parking lot for the native addr while we pop.
         self.asm.mov_rr(SCRATCH, Reg::RAX);
         self.asm.pop(Reg::RAX);
         self.asm.jmp_reg(SCRATCH);
-
-        // OOB targets `panic_label` directly (see oob_target above);
-        // no per-instruction bind needed here.
-        let _ = next_pc;
     }
 
     fn rv_branch(&mut self, rs1: u8, rs2: u8, imm: i32, cc: Cc, pc: u32, next_pc: u32) {

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -49,18 +49,29 @@ pub(crate) const REG_MAP: [Reg; 13] = [
 /// Scratch register (not mapped to any PVM register).
 pub(crate) const SCRATCH: Reg = Reg::RDX;
 
-/// RV register number → PVM2 slot (0..12), or `0xFF` for "no slot"
-/// (x0, reserved x3/x4, or any out-of-range value). Mirrors the
-/// slot encoding used by `rv_op_metadata` so that gas accounting
-/// agrees bit-for-bit with the predecode-cached path.
+/// RV register (5-bit, 0..31) → PVM2 slot (0..12), or `0xFF` for "no
+/// slot" (x0, reserved x3/x4, x16..x31). A 32-byte const lookup table:
+/// one load replaces the range-match, which the profiler showed at
+/// ~8.8% of compile (called ~6×/instruction across codegen + gas feed).
+/// Values mirror the original match exactly, so gas stays bit-identical.
+pub(crate) const RV_SLOT_LUT: [u8; 32] = {
+    let mut t = [0xFFu8; 32];
+    t[1] = 0;
+    t[2] = 1;
+    let mut x = 5usize;
+    while x <= 15 {
+        t[x] = (x - 3) as u8;
+        x += 1;
+    }
+    t
+};
+
+/// RV register number → PVM2 slot (0..12), or `0xFF` for "no slot".
+/// Mirrors the slot encoding used by `rv_op_metadata` so that gas
+/// accounting agrees bit-for-bit with the predecode-cached path.
 #[inline(always)]
 pub(crate) fn rv_slot_or_ff(x: u8) -> u8 {
-    match x {
-        1 => 0,
-        2 => 1,
-        5..=15 => x - 3,
-        _ => 0xFF,
-    }
+    RV_SLOT_LUT[(x & 31) as usize]
 }
 /// R15 = gas meter. Loaded from `ctx.gas` at the prologue, decremented
 /// once per basic block, flushed back to `ctx.gas` at every exit.
@@ -1135,11 +1146,9 @@ fn expand_rvc_q2(h: u16, f3: u16) -> Option<u32> {
 /// deblob, so this is just defence-in-depth).
 #[inline]
 fn rv_slot(x: u8) -> Option<usize> {
-    match x {
-        1 => Some(0),
-        2 => Some(1),
-        5..=15 => Some((x as usize) - 3),
-        _ => None,
+    match RV_SLOT_LUT[(x & 31) as usize] {
+        0xFF => None,
+        s => Some(s as usize),
     }
 }
 

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -21,7 +21,6 @@
 //!
 //! Reserved: R15 = gas meter, RDX = scratch, RSP = native stack.
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 use super::asm::{Assembler, Cc, Label, Reg};
@@ -204,20 +203,11 @@ pub struct Compiler {
     /// Code region length in bytes — the upper bound for jalr target
     /// offsets (== `bb_starts` / dispatch-table length).
     pub(crate) code_len: u32,
-    /// True during RV streaming compile (`compile`). When set, branch
-    /// emit helpers defer forward-target validation (`target > pc`) to a
-    /// post-pass instead of consulting `bitmask_ptr`. Off for PVM, whose
-    /// caller-supplied bitmask is fully populated at emit time.
-    pub(crate) rv_streaming: bool,
-    /// Forward branches whose target validity could not be determined at
-    /// emit time. Resolved post-pass: each entry is
-    /// `(target_pc, branch_pc, fixup_idx)`. If `valid_pc[target]` is
-    /// false after the streaming pass, the fixup is redirected to a
-    /// per-branch panic stub.
-    pub(crate) rv_pending_fwd_branches: Vec<(u32, u32, usize)>,
-    /// Backing storage for `bitmask_ptr` during RV streaming compile.
-    /// Built incrementally in `bind_rv_gas_block_start_streaming`. Empty
-    /// for the PVM path (uses the caller-supplied bitmask).
+    /// Backing storage for `bitmask_ptr`: the whole-blob gas-block-start
+    /// set, computed up front by `predecode::bb_start_bitmap` (shared
+    /// with the interp). Every branch / jalr target is validated against
+    /// it, and it is returned as `CompileResult::valid_pc` for the
+    /// runtime's `jalr` bb-check.
     pub(crate) rv_valid_pc: Vec<bool>,
 }
 
@@ -273,8 +263,6 @@ impl Compiler {
             gas_sim: GasSimulator::new(),
             code_base,
             code_len: code_len as u32,
-            rv_streaming: false,
-            rv_pending_fwd_branches: Vec::new(),
             rv_valid_pc: Vec::new(),
         }
     }
@@ -426,13 +414,9 @@ impl Compiler {
         if !condition {
             return;
         }
-        if self.rv_streaming && target > pc {
-            let label = self.label_for_pc(target);
-            let fixup_idx = self.asm.fixups_len();
-            self.asm.jmp_label(label);
-            self.rv_pending_fwd_branches.push((target, pc, fixup_idx));
-            return;
-        }
+        // Target validity is known up front (whole-blob bb set). A
+        // forward target's label binds later in this pass; `jmp_label`
+        // records a fixup the assembler resolves at finalize.
         if !self.is_basic_block_start(target) {
             self.asm.mov_store32_rip_rel_imm(CTX_PC, pc as i32);
             self.emit_exit(EXIT_PANIC, 0);
@@ -452,14 +436,6 @@ impl Compiler {
         _fallthrough: u32,
         pc: u32,
     ) {
-        if self.rv_streaming && target > pc {
-            self.asm.cmp_rr(a, b);
-            let label = self.label_for_pc(target);
-            let fixup_idx = self.asm.fixups_len();
-            self.asm.jcc_label(cc, label);
-            self.rv_pending_fwd_branches.push((target, pc, fixup_idx));
-            return;
-        }
         if !self.is_basic_block_start(target) {
             self.asm.mov_store32_rip_rel_imm(CTX_PC, pc as i32);
             self.asm.cmp_rr(a, b);
@@ -1165,20 +1141,21 @@ impl Compiler {
     /// the gas-block dispatch table). Built incrementally during the
     /// streaming pass — no separate length-only pre-pass.
     pub fn compile(mut self, code: &[u8]) -> CompileResult {
-        // valid_pc is populated incrementally as the streaming pass
-        // binds gas-block starts. The pointer is stable across mutation
-        // (Vec doesn't reallocate from `vec![false; n]` with in-place
-        // index assignment), so `is_basic_block_start` reads through
-        // the raw pointer remain coherent.
-        self.rv_valid_pc = vec![false; code.len()];
+        // Whole-blob gas-block-start set, computed up front and shared
+        // with the interp (`predecode::bb_start_bitmap`) so both engines
+        // partition gas blocks identically. The compile loop binds a gas
+        // block at each set member and validates every branch / jalr
+        // target against it. The buffer is stable for the pass (no
+        // reallocation), so `is_basic_block_start` reads through
+        // `bitmask_ptr` stay coherent.
+        let (bb, _decode_err) = javm_exec::predecode::bb_start_bitmap(code);
+        self.rv_valid_pc = bb.into_iter().map(|b| b == 1).collect();
         self.bitmask_ptr = self.rv_valid_pc.as_ptr() as *const u8;
         self.bitmask_len = self.rv_valid_pc.len();
-        self.rv_streaming = true;
 
         self.emit_prologue();
 
         let mut pending_gas: Option<(Label, u32, usize)> = None;
-        let mut next_is_gas_start = true;
         let mut pc: usize = 0;
 
         while pc < code.len() {
@@ -1200,41 +1177,36 @@ impl Compiler {
 
             let inst_pc = pc as u32;
 
-            // Page starts are gas-block starts (PVM2 invariant 11),
-            // mirroring `predecode` so the interp and recompiler agree on
-            // the block partition and so lazy per-page compilation can
-            // enter each page at a dispatchable block. Trustless: derived
-            // from PC, not linker metadata.
-            if inst_pc.is_multiple_of(javm_exec::PAGE_SIZE) {
-                next_is_gas_start = true;
-            }
-
-            if next_is_gas_start {
+            // Bind a gas block at every block start in the precomputed
+            // set ({0} ∪ post-terminator ∪ page starts). Same partition
+            // as predecode → identical per-block gas.
+            if self.is_basic_block_start(inst_pc) {
                 self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
-                next_is_gas_start = false;
             }
 
             // Byte-based dispatch. Each path returns
             // `(is_terminator, preserve_cf, extra_bytes)`. `extra_bytes`
             // counts the *additional* bytes consumed beyond `base_len`
             // for lookahead fusion (e.g., Ld→Add fuses an extra 4-byte
-            // Add). `preserve_cf` tells us whether to keep
-            // `last_add_cf` alive for a following Sltu fusion.
-            // Suppress instruction fusion across a page boundary: the
-            // next instruction starts a 4 KiB page, which is a gas-block
-            // start (invariant 11) that predecode always splits on.
-            // Fusing the trailer into this block would diverge the
-            // recompiler's block partition (and thus its per-block gas)
-            // from the interp's. `rest` is lookahead-only — an empty
-            // slice forces the trailer to compile as its own
-            // page-starting block next iteration.
+            // Add). `preserve_cf` tells us whether to keep `last_add_cf`
+            // alive for a following Sltu fusion.
+            //
+            // Suppress fusion across a block boundary: if the trailer
+            // starts a new gas block, fusing it into this block would
+            // diverge the recompiler's partition (and per-block gas) from
+            // predecode's. `rest` is lookahead-only — an empty slice
+            // defers the trailer to its own block next iteration. (Only
+            // page-boundary starts can fall between two fusable
+            // non-terminators; post-terminator starts follow a
+            // non-fusable terminator. Gating on the block-start set covers
+            // both uniformly.)
             let next_inst_pc = inst_pc + base_len as u32;
-            let rest: &[u8] = if next_inst_pc.is_multiple_of(javm_exec::PAGE_SIZE) {
+            let rest: &[u8] = if self.is_basic_block_start(next_inst_pc) {
                 &[]
             } else {
                 &code[pc + base_len..]
             };
-            let (term, preserve_cf, extra) = if is_4byte {
+            let (_term, preserve_cf, extra) = if is_4byte {
                 let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
                 self.compile_rv4(w, inst_pc, 4, rest)
             } else {
@@ -1246,10 +1218,6 @@ impl Compiler {
                 self.last_add_cf = None;
             }
 
-            if term {
-                next_is_gas_start = true;
-            }
-
             pc += base_len + extra;
         }
 
@@ -1258,28 +1226,6 @@ impl Compiler {
             let cost = self.gas_sim.flush_and_get_cost();
             self.asm.patch_i32(patch_offset, cost as i32);
             self.oog_stubs.push((stub_label, block_pc, cost));
-        }
-
-        // Resolve deferred forward branches now that valid_pc is fully
-        // populated. For each forward branch recorded with target > pc
-        // at emit time:
-        //   - valid target: label_for_pc(target) was bound during the
-        //     streaming pass; the existing fixup resolves naturally.
-        //   - invalid target: append a per-branch panic stub and
-        //     redirect the fixup to it. Keeps the source PC of the
-        //     branch in the exit report.
-        // We disable rv_streaming first so emit_branch_* / panic helpers
-        // called below take their non-deferred path.
-        self.rv_streaming = false;
-        let pending = core::mem::take(&mut self.rv_pending_fwd_branches);
-        for (target, branch_pc, fixup_idx) in pending {
-            if !self.is_basic_block_start(target) {
-                let stub = self.asm.new_label();
-                self.asm.bind_label(stub);
-                self.asm.mov_store32_rip_rel_imm(CTX_PC, branch_pc as i32);
-                self.asm.jmp_label(self.panic_label);
-                self.asm.redirect_fixup(fixup_idx, stub);
-            }
         }
 
         self.emit_exit_sequences();
@@ -1322,16 +1268,9 @@ impl Compiler {
         let label = Label(self.label_base + pc);
         self.asm.bind_label(label);
         self.gas_block_pcs.push(pc);
-        // valid_pc is the gas-block-start bitmap consulted by both the
-        // codegen-time `is_basic_block_start` check and the runtime's
-        // djump validation. Set it here so backward branches emit time
-        // see the bit (we walk PCs in order, so any T < cur_pc has
-        // already passed through here if it's a gas-block start).
-        // bitmask_ptr points to rv_valid_pc's heap buffer, so this
-        // mutation is visible to subsequent is_basic_block_start reads.
-        if (pc as usize) < self.rv_valid_pc.len() {
-            self.rv_valid_pc[pc as usize] = true;
-        }
+        // `rv_valid_pc` (the gas-block-start bitmap) is precomputed in
+        // `compile`, so there's nothing to mark here — the loop already
+        // gated this call on `is_basic_block_start(pc)`.
 
         // Peephole state must not leak across gas-block boundaries: the
         // dispatch table can enter this block from any predecessor.

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -1090,15 +1090,20 @@ fn expand_rvc_q2(h: u16, f3: u16) -> Option<u32> {
         }
         0b100 => {
             // (bit12, rdrs1, rs2):
-            //   (0, r, 0)  r!=0 -> c.jr     (FORBIDDEN in PVM2)
+            //   (0, r, 0)  r!=0 -> c.jr     -> jalr x0, r, 0  (return)
             //   (0, r, s)  both!=0 -> c.mv  -> add rd, x0, rs2
             //   (1, 0, 0)         -> c.ebreak (FORBIDDEN)
-            //   (1, r, 0)  r!=0 -> c.jalr   (FORBIDDEN)
+            //   (1, r, 0)  r!=0 -> c.jalr   -> jalr x1, r, 0  (indirect call)
             //   (1, r, s)  both!=0 -> c.add -> add rd, rd, rs2
             let bit12 = (h >> 12) & 1;
             if rs2 == 0 {
-                // c.jr / c.jalr / c.ebreak — all forbidden.
-                None
+                // c.jr (bit12=0) / c.jalr (bit12=1): native jalr. rdrs1=0
+                // is c.ebreak (bit12=1) or reserved (bit12=0) — forbidden.
+                if rdrs1 == 0 {
+                    return None;
+                }
+                let rd = if bit12 == 0 { 0 } else { 1 };
+                Some(enc_i(OP_JALR, 0b000, rd, rdrs1, 0))
             } else {
                 // c.mv (bit12=0, rs1=x0) or c.add (bit12=1, rs1=rdrs1)
                 if rdrs1 == 0 {
@@ -1209,7 +1214,7 @@ impl Compiler {
             let rest = &code[pc + base_len..];
             let (term, preserve_cf, extra) = if is_4byte {
                 let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
-                self.compile_rv4(w, inst_pc, rest)
+                self.compile_rv4(w, inst_pc, 4, rest)
             } else {
                 let h = u16::from_le_bytes([code[pc], code[pc + 1]]);
                 self.compile_rvc(h, inst_pc, rest)
@@ -1335,7 +1340,12 @@ impl Compiler {
     /// Hot path: walks the opcode-major tree directly on raw bits, no
     /// `Inst` enum constructed. Fusion sites (Ld→Add, Mul-pair) are
     /// inline at their dispatchers.
-    fn compile_rv4(&mut self, w: u32, pc: u32, rest: &[u8]) -> (bool, bool, usize) {
+    /// `inst_len` is the encoded length of the instruction being
+    /// compiled (4 for the 4-byte path, 2 for an RVC instruction
+    /// expanded by [`compile_rvc`]). It is what jal/jalr use to compute
+    /// the return-address `next_pc = pc + inst_len`; a hardcoded `pc + 4`
+    /// would mis-set `ra` for `c.jalr` (a 2-byte indirect call).
+    fn compile_rv4(&mut self, w: u32, pc: u32, inst_len: u32, rest: &[u8]) -> (bool, bool, usize) {
         use javm_exec::gas_cost::*;
         let opcode = (w >> 2) & 0x1F;
         let rd = ((w >> 7) & 0x1F) as u8;
@@ -1353,8 +1363,8 @@ impl Compiler {
             OP_OP_32 => self.compile_op_32(rd, rs1, rs2, f3, f7, w, pc),
             OP_LUI => self.compile_lui(rd, w, pc, rest),
             OP_AUIPC => self.compile_auipc(rd, w, pc),
-            OP_JAL => self.compile_jal(rd, w, pc),
-            OP_JALR if f3 == 0 => self.compile_jalr(rd, rs1, w, pc),
+            OP_JAL => self.compile_jal(rd, w, pc, inst_len),
+            OP_JALR if f3 == 0 => self.compile_jalr(rd, rs1, w, pc, inst_len),
             OP_BRANCH => self.compile_branch(rs1, rs2, f3, w, pc),
             OP_CUSTOM_0 => self.compile_custom_0(rd, rs1, f3, w, pc),
             OP_MISC_MEM => {
@@ -1390,7 +1400,9 @@ impl Compiler {
     fn compile_rvc(&mut self, h: u16, pc: u32, rest: &[u8]) -> (bool, bool, usize) {
         use javm_exec::gas_cost::*;
         match expand_rvc(h) {
-            Some(w) => self.compile_rv4(w, pc, rest),
+            // RVC instructions are 2 bytes — pass inst_len = 2 so a
+            // `c.jalr` writes the correct return address (`pc + 2`).
+            Some(w) => self.compile_rv4(w, pc, 2, rest),
             None => {
                 self.rv_emit_panic_at(pc);
                 self.feed_gas_rv(RV_KIND_RESERVED, 0, 0, 0);
@@ -2111,10 +2123,10 @@ impl Compiler {
         (term, false, 0)
     }
 
-    fn compile_jal(&mut self, rd: u8, w: u32, pc: u32) -> (bool, bool, usize) {
+    fn compile_jal(&mut self, rd: u8, w: u32, pc: u32, inst_len: u32) -> (bool, bool, usize) {
         use javm_exec::gas_cost::*;
         let imm = imm_j(w);
-        let next_pc = pc + 4;
+        let next_pc = pc + inst_len;
         self.rv_jal(rd, imm, pc, next_pc);
         let term = self.feed_gas_rv(RV_KIND_JAL, 0, 0, rd);
         (term, false, 0)
@@ -2130,10 +2142,17 @@ impl Compiler {
         (term, false, 0)
     }
 
-    fn compile_jalr(&mut self, rd: u8, rs1: u8, w: u32, pc: u32) -> (bool, bool, usize) {
+    fn compile_jalr(
+        &mut self,
+        rd: u8,
+        rs1: u8,
+        w: u32,
+        pc: u32,
+        inst_len: u32,
+    ) -> (bool, bool, usize) {
         use javm_exec::gas_cost::*;
         let imm = imm_i(w);
-        let next_pc = pc + 4;
+        let next_pc = pc + inst_len;
         self.rv_jalr(rd, rs1, imm, pc, next_pc);
         // src = rs1 (target); rd not tracked (terminator).
         let term = self.feed_gas_rv(RV_KIND_JALR, rs1, 0, 0);
@@ -2355,10 +2374,7 @@ impl Compiler {
     /// value is a guest VA, sign-extended 32→64 like `lui`.
     fn rv_auipc(&mut self, rd: u8, imm: i32, pc: u32) {
         if let Some(d) = self.rv_dst(rd, pc) {
-            let va = self
-                .code_base
-                .wrapping_add(pc)
-                .wrapping_add(imm as u32);
+            let va = self.code_base.wrapping_add(pc).wrapping_add(imm as u32);
             self.asm.mov_ri64(d, va as i32 as i64 as u64);
             self.invalidate_reg(rv_slot(rd).unwrap());
         }
@@ -3403,8 +3419,11 @@ impl Compiler {
             return;
         }
         if rd != 0 {
+            // The link register holds a guest VA (code_base + offset),
+            // matching jalr's return-address contract and the interp.
             let slot = rv_slot(rd).unwrap();
-            self.asm.mov_ri64(REG_MAP[slot], next_pc as u64);
+            self.asm
+                .mov_ri64(REG_MAP[slot], self.code_base.wrapping_add(next_pc) as u64);
             self.invalidate_reg(slot);
         }
         let target = (pc as i64).wrapping_add(imm as i64) as u32;

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -21,6 +21,7 @@
 //!
 //! Reserved: R15 = gas meter, RDX = scratch, RSP = native stack.
 
+use alloc::vec;
 use alloc::vec::Vec;
 
 use super::asm::{Assembler, Cc, Label, Reg};
@@ -104,12 +105,6 @@ pub const EXIT_PAGE_FAULT: u32 = 3;
 pub const EXIT_HOST_CALL: u32 = 4;
 pub const EXIT_ECALL: u32 = 6;
 pub const EXIT_TRAP: u32 = 7;
-/// Lazy compilation: a dispatch landed on a block whose 4 KiB page is
-/// not compiled yet. The compile-page stub sets this reason and exits;
-/// the runtime reads `ctx.pc` (the target offset, set by whichever
-/// dispatcher jumped here), compiles that page, patches its dispatch
-/// entries, and re-enters the same frame.
-pub const EXIT_COMPILE_PAGE: u32 = 8;
 
 /// Result of compilation.
 pub struct CompileResult {
@@ -122,11 +117,6 @@ pub struct CompileResult {
     pub dispatch_entries: Vec<(u32, i32)>,
     pub trap_table: Vec<(u32, u32)>,
     pub exit_label_offset: u32,
-    /// Native offset of the compile-page stub (lazy path). Uncompiled
-    /// blocks' dispatch entries point here until their page is compiled.
-    /// On the eager path nothing references it, but it's emitted anyway
-    /// (one tiny stub) so eager and lazy share `emit_stub_handlers`.
-    pub compile_stub_offset: u32,
     /// Byte-indexed validity map (RV path only): true at every PC where
     /// an instruction begins. Empty for the PVM path — `compile()`
     /// consumes its own bitmask argument, no need to surface it.
@@ -179,9 +169,6 @@ pub struct Compiler {
     pub(crate) panic_label: Label,
     /// Label for OOG handler that reads PC from SCRATCH: stores PC, then falls through to oog_label.
     oog_pc_label: Label,
-    /// Label for the lazy compile-page stub (sets EXIT_COMPILE_PAGE,
-    /// jumps to the exit sequence). Emitted once in `emit_stub_handlers`.
-    compile_stub_label: Label,
     /// Per-gas-block OOG stubs: (label, pvm_pc) — emitted as cold code after main body.
     pub(crate) oog_stubs: Vec<(Label, u32, u32)>, // (label, pvm_pc, block_cost)
     /// Helper function addresses.
@@ -217,11 +204,20 @@ pub struct Compiler {
     /// Code region length in bytes — the upper bound for jalr target
     /// offsets (== `bb_starts` / dispatch-table length).
     pub(crate) code_len: u32,
-    /// Backing storage for `bitmask_ptr`: the whole-blob gas-block-start
-    /// set, computed up front by `predecode::bb_start_bitmap` (shared
-    /// with the interp). Every branch / jalr target is validated against
-    /// it, and it is returned as `CompileResult::valid_pc` for the
-    /// runtime's `jalr` bb-check.
+    /// True during RV streaming compile (`compile`). When set, branch
+    /// emit helpers defer forward-target validation (`target > pc`) to a
+    /// post-pass instead of consulting `bitmask_ptr`. Off for PVM, whose
+    /// caller-supplied bitmask is fully populated at emit time.
+    pub(crate) rv_streaming: bool,
+    /// Forward branches whose target validity could not be determined at
+    /// emit time. Resolved post-pass: each entry is
+    /// `(target_pc, branch_pc, fixup_idx)`. If `valid_pc[target]` is
+    /// false after the streaming pass, the fixup is redirected to a
+    /// per-branch panic stub.
+    pub(crate) rv_pending_fwd_branches: Vec<(u32, u32, usize)>,
+    /// Backing storage for `bitmask_ptr` during RV streaming compile.
+    /// Built incrementally in `bind_rv_gas_block_start_streaming`. Empty
+    /// for the PVM path (uses the caller-supplied bitmask).
     pub(crate) rv_valid_pc: Vec<bool>,
 }
 
@@ -251,7 +247,6 @@ impl Compiler {
         let oog_label = asm.new_label();
         let panic_label = asm.new_label();
         let oog_pc_label = asm.new_label();
-        let compile_stub_label = asm.new_label();
         // Pre-create one label per PC for O(1) lookup in label_for_pc.
         // With LABEL_UNBOUND=0, bulk allocation uses zeroed pages (calloc/COW).
         // Only the ~640 labels that get bound trigger page faults — the other
@@ -266,7 +261,6 @@ impl Compiler {
             oog_label,
             panic_label,
             oog_pc_label,
-            compile_stub_label,
             oog_stubs: Vec::with_capacity(1024),
             reg_defs: [RegDef::Unknown; 13],
             reg_defs_active: 0,
@@ -279,6 +273,8 @@ impl Compiler {
             gas_sim: GasSimulator::new(),
             code_base,
             code_len: code_len as u32,
+            rv_streaming: false,
+            rv_pending_fwd_branches: Vec::new(),
             rv_valid_pc: Vec::new(),
         }
     }
@@ -430,29 +426,23 @@ impl Compiler {
         if !condition {
             return;
         }
-        // Target validity is known up front (whole-blob bb set). A
-        // forward target's label binds later in this pass; `jmp_label`
-        // records a fixup the assembler resolves at finalize.
+        if self.rv_streaming && target > pc {
+            let label = self.label_for_pc(target);
+            let fixup_idx = self.asm.fixups_len();
+            self.asm.jmp_label(label);
+            self.rv_pending_fwd_branches.push((target, pc, fixup_idx));
+            return;
+        }
         if !self.is_basic_block_start(target) {
             self.asm.mov_store32_rip_rel_imm(CTX_PC, pc as i32);
             self.emit_exit(EXIT_PANIC, 0);
-            return;
-        }
-        // Cross-page target → indirect dispatch through the table: its
-        // native code lives in a different page-window, and under lazy
-        // compilation the page may not be compiled yet. Same-page →
-        // direct rel32 jump to the bound label.
-        if !same_page(target, pc) {
-            self.emit_dispatch_static(target);
             return;
         }
         let label = self.label_for_pc(target);
         self.asm.jmp_label(label);
     }
 
-    /// Emit a conditional branch. Same-page target → direct `jcc` to the
-    /// bound label. Cross-page target → indirect dispatch on the taken
-    /// path (lowered as `jcc.invert() skip; <dispatch>; skip:`).
+    /// Emit a dynamic jump (through jump table).
     pub(crate) fn emit_branch_reg(
         &mut self,
         a: Reg,
@@ -462,6 +452,14 @@ impl Compiler {
         _fallthrough: u32,
         pc: u32,
     ) {
+        if self.rv_streaming && target > pc {
+            self.asm.cmp_rr(a, b);
+            let label = self.label_for_pc(target);
+            let fixup_idx = self.asm.fixups_len();
+            self.asm.jcc_label(cc, label);
+            self.rv_pending_fwd_branches.push((target, pc, fixup_idx));
+            return;
+        }
         if !self.is_basic_block_start(target) {
             self.asm.mov_store32_rip_rel_imm(CTX_PC, pc as i32);
             self.asm.cmp_rr(a, b);
@@ -469,42 +467,8 @@ impl Compiler {
             return;
         }
         self.asm.cmp_rr(a, b);
-        if !same_page(target, pc) {
-            // Not taken → skip the dispatch; taken → fall into it.
-            let skip = self.asm.new_label();
-            self.asm.jcc_label(cc.invert(), skip);
-            self.emit_dispatch_static(target);
-            self.asm.bind_label(skip);
-            return;
-        }
         let label = self.label_for_pc(target);
         self.asm.jcc_label(cc, label);
-    }
-
-    /// Indirect-dispatch tail: with `SCRATCH` holding a validated
-    /// code-region byte offset (a gas-block start), jump to its native
-    /// code at `ctx.code_base + dispatch_table[offset]`. Shared by `jalr`
-    /// and the static cross-page dispatch.
-    pub(crate) fn emit_dispatch_indirect_tail(&mut self) {
-        self.asm.push(Reg::RAX);
-        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
-        self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
-        self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
-        self.asm.mov_rr(SCRATCH, Reg::RAX);
-        self.asm.pop(Reg::RAX);
-        self.asm.jmp_reg(SCRATCH);
-    }
-
-    /// Dispatch to a compile-time-known, already-validated block-start
-    /// `offset` (a cross-page branch / jal target, or a page-boundary
-    /// fall-through). Needs no bounds or bb-start check — unlike `jalr`,
-    /// the target is a static block start by construction. Records the
-    /// offset as the paused PC (fault attribution + the lazy compile-page
-    /// stub reads it to know which page to compile), then dispatches.
-    pub(crate) fn emit_dispatch_static(&mut self, offset: u32) {
-        self.asm.mov_store32_rip_rel_imm(CTX_PC, offset as i32);
-        self.asm.mov_ri32(SCRATCH, offset);
-        self.emit_dispatch_indirect_tail();
     }
 
     /// Emit a shift by register value using CL.
@@ -615,14 +579,14 @@ impl Compiler {
         self.asm.jmp_reg(SCRATCH);
     }
 
-    /// Emit the shared exit / OOG / panic handlers (the runtime "stub").
-    /// Emitted once, up front (right after the prologue), so per-page
-    /// bodies — which under lazy compilation are compiled later and in
-    /// arbitrary order — can backward-reference them. The per-block OOG
-    /// stubs are emitted per page by `emit_page_oog_stubs`.
-    pub(crate) fn emit_stub_handlers(&mut self) {
-        self.asm.ensure_capacity(512);
-        // Shared OOG handler: PC already in SCRATCH.
+    /// Emit exit sequences and epilogue.
+    pub(crate) fn emit_exit_sequences(&mut self) {
+        // Reserve capacity for exit sequences + all OOG stubs.
+        // Each OOG stub is ~12 bytes.
+        let needed = 512 + self.oog_stubs.len() * 16;
+        self.asm.ensure_capacity(needed);
+        // Shared OOG handler that reads PC from SCRATCH — emitted BEFORE OOG
+        // stubs so backward jumps from stubs can use jmp rel8 (2 bytes).
         self.asm.bind_label(self.oog_pc_label);
         self.asm.mov_store32_rip_rel(CTX_PC, SCRATCH);
         // fall through to oog_label:
@@ -631,20 +595,16 @@ impl Compiler {
             .mov_store32_rip_rel_imm(CTX_EXIT_REASON, EXIT_OOG as i32);
         self.asm.jmp_label(self.exit_label);
 
-        // Page faults are handled by the SIGSEGV handler (signal.rs).
+        // Per-gas-block OOG stubs: compact format — load PC into SCRATCH,
+        // jump to shared handler. Saves ~6 bytes per stub vs inline PC store.
+        let stubs = core::mem::take(&mut self.oog_stubs);
+        for (label, pvm_pc, _cost) in &stubs {
+            self.asm.bind_label(*label);
+            self.asm.mov_ri32(SCRATCH, *pvm_pc);
+            self.asm.jmp_label(self.oog_pc_label);
+        }
 
-        // Lazy compile-page stub. A dispatch (prologue / jalr /
-        // cross-page branch / page-boundary fall-through) lands here
-        // when the target block's page is not compiled yet. `ctx.pc`
-        // already holds the target offset (set by the dispatcher); we
-        // just signal the runtime, which compiles that page, patches
-        // its dispatch entries, and re-enters. Reuses the exit sequence
-        // so gas (R15) and the live regs are flushed to ctx and
-        // restored verbatim on re-entry — the bounce is gas-neutral.
-        self.asm.bind_label(self.compile_stub_label);
-        self.asm
-            .mov_store32_rip_rel_imm(CTX_EXIT_REASON, EXIT_COMPILE_PAGE as i32);
-        self.asm.jmp_label(self.exit_label);
+        // Page faults are handled by the SIGSEGV handler (signal.rs).
 
         // Panic exit
         self.asm.bind_label(self.panic_label);
@@ -677,20 +637,6 @@ impl Compiler {
         self.asm.pop(Reg::RBP);
         self.asm.pop(Reg::RBX);
         self.asm.ret();
-    }
-
-    /// Emit the OOG stubs gathered while compiling the current page:
-    /// `mov SCRATCH, pvm_pc; jmp oog_pc_handler`. Each block's gas check
-    /// (`js stub`) targets one of these. Drains `self.oog_stubs` so the
-    /// next page starts clean.
-    pub(crate) fn emit_page_oog_stubs(&mut self) {
-        let stubs = core::mem::take(&mut self.oog_stubs);
-        self.asm.ensure_capacity(512 + stubs.len() * 16);
-        for (label, pvm_pc, _cost) in &stubs {
-            self.asm.bind_label(*label);
-            self.asm.mov_ri32(SCRATCH, *pvm_pc);
-            self.asm.jmp_label(self.oog_pc_label);
-        }
     }
 }
 
@@ -1197,15 +1143,6 @@ fn rv_slot(x: u8) -> Option<usize> {
     }
 }
 
-/// Two code-region byte offsets lie in the same 4 KiB page. A
-/// cross-page control transfer can't use a direct rel32 to a label in
-/// another page-window (under lazy compilation that page may not be
-/// compiled yet) — it dispatches indirectly through the table instead.
-#[inline]
-fn same_page(a: u32, b: u32) -> bool {
-    a / javm_exec::PAGE_SIZE == b / javm_exec::PAGE_SIZE
-}
-
 /// True for x3 and x4 — registers that PVM2 reserves and the transpiler
 /// must reject. If we ever see them at codegen time, we trap.
 #[inline]
@@ -1213,108 +1150,7 @@ fn rv_is_reserved(x: u8) -> bool {
     x == 3 || x == 4
 }
 
-/// Initial artifacts of a lazy compile: the prologue + shared stub
-/// handlers (incl. the compile-page stub), emitted once up front. Page
-/// bodies are compiled on demand by [`Compiler::compile_lazy_page`].
-pub struct LazyInit {
-    /// Whole-blob basic-block-start set (one byte per code offset). The
-    /// runtime copies this into the arena BB region (for `jalr`
-    /// validation) and uses it to point every block start's dispatch
-    /// entry at the compile-page stub.
-    pub valid_pc: Vec<bool>,
-    /// Native offset of the shared exit label (#PF redirect target).
-    pub exit_label_offset: u32,
-    /// Native offset of the compile-page stub.
-    pub compile_stub_offset: u32,
-    /// Bytes emitted so far (prologue + stubs): the caller copies
-    /// `asm.written()[0..len]` into the arena JIT region.
-    pub len: usize,
-}
-
-/// One page's lazily-emitted native code plus its dispatch / trap
-/// deltas. The newly-emitted bytes are `asm.written()[start..end]`.
-pub struct LazyPage {
-    pub start: usize,
-    pub end: usize,
-    /// `(code_offset, native_offset)` for each block start in this page.
-    pub dispatch_entries: Vec<(u32, i32)>,
-    /// `(native_offset, pvm_pc)` trap entries for this page, ascending by
-    /// native offset (the page occupies the next contiguous native range,
-    /// so appending these to the image's trap table keeps it sorted).
-    pub trap_entries: Vec<(u32, u32)>,
-}
-
 impl Compiler {
-    /// Compute the whole-blob gas-block-start set and publish it through
-    /// `bitmask_ptr`/`bitmask_len` for `is_basic_block_start`. Shared by
-    /// the eager `compile` and lazy `compile_lazy_init` entry points. The
-    /// backing `rv_valid_pc` is never mutated again, so `bitmask_ptr`
-    /// stays valid across Compiler moves (into the JIT cache) and grows.
-    fn prepare_bb(&mut self, code: &[u8]) {
-        let (bb, _decode_err) = javm_exec::predecode::bb_start_bitmap(code);
-        self.rv_valid_pc = bb.into_iter().map(|b| b == 1).collect();
-        self.bitmask_ptr = self.rv_valid_pc.as_ptr() as *const u8;
-        self.bitmask_len = self.rv_valid_pc.len();
-    }
-
-    /// Begin a lazy compile: compute the block-start set and emit the
-    /// prologue + shared stub handlers. No page bodies — every block
-    /// dispatches through the table, which the runtime initialises to the
-    /// compile-page stub, so the first entry to any page bounces out via
-    /// `EXIT_COMPILE_PAGE`. Takes `&mut self` (not `self`): the Compiler
-    /// persists in the JIT cache for later `compile_lazy_page` calls.
-    pub fn compile_lazy_init(&mut self, code: &[u8]) -> LazyInit {
-        self.prepare_bb(code);
-        self.emit_prologue();
-        self.emit_stub_handlers();
-        // Resolve the stubs' internal forward refs (panic/compile → exit).
-        self.asm.resolve_fixups();
-        LazyInit {
-            valid_pc: self.rv_valid_pc.clone(),
-            exit_label_offset: self.asm.label_offset(self.exit_label).unwrap_or(0) as u32,
-            compile_stub_offset: self.asm.label_offset(self.compile_stub_label).unwrap_or(0) as u32,
-            len: self.asm.offset(),
-        }
-    }
-
-    /// Compile one 4 KiB page's body, appended to the growing JIT buffer.
-    /// Returns the newly-emitted byte range plus this page's dispatch and
-    /// trap deltas. The caller must not compile the same page twice (the
-    /// JIT cache guards this with a per-page "compiled" bitmap).
-    ///
-    /// Produces byte-for-byte the same per-block gas accounting as the
-    /// eager path's `compile_page` for this page: `compile_page` is
-    /// self-contained (its gas/reg/CF state resets at the page-start
-    /// block), so compile *order* across pages doesn't change any page's
-    /// gas. Every branch fixup is intra-page (cross-page targets go via
-    /// the dispatch table), so `resolve_fixups` fully resolves the page.
-    pub fn compile_lazy_page(&mut self, code: &[u8], page: usize) -> LazyPage {
-        let page_bytes = javm_exec::PAGE_SIZE as usize;
-        let start_off = page * page_bytes;
-        let end_off = ((page + 1) * page_bytes).min(code.len());
-
-        let gas_old = self.gas_block_pcs.len();
-        self.trap_entries.clear();
-        let start = self.asm.offset();
-        self.compile_page(code, start_off, end_off);
-        self.asm.resolve_fixups();
-        let end = self.asm.offset();
-
-        let mut dispatch_entries = Vec::with_capacity(self.gas_block_pcs.len() - gas_old);
-        for &pc in &self.gas_block_pcs[gas_old..] {
-            if let Some(off) = self.asm.label_offset(Label(self.label_base + pc)) {
-                dispatch_entries.push((pc, off as i32));
-            }
-        }
-        let trap_entries = core::mem::take(&mut self.trap_entries);
-        LazyPage {
-            start,
-            end,
-            dispatch_entries,
-            trap_entries,
-        }
-    }
-
     /// Compile an RV+C+custom-0 byte stream into x86-64 in a single
     /// streaming pass.
     ///
@@ -1329,30 +1165,102 @@ impl Compiler {
     /// the gas-block dispatch table). Built incrementally during the
     /// streaming pass — no separate length-only pre-pass.
     pub fn compile(mut self, code: &[u8]) -> CompileResult {
-        // Whole-blob gas-block-start set, computed up front and shared
-        // with the interp (`predecode::bb_start_bitmap`) so both engines
-        // partition gas blocks identically. The compile loop binds a gas
-        // block at each set member and validates every branch / jalr
-        // target against it. The buffer is stable for the pass (no
-        // reallocation), so `is_basic_block_start` reads through
-        // `bitmask_ptr` stay coherent.
-        self.prepare_bb(code);
+        // valid_pc is populated incrementally as the streaming pass
+        // binds gas-block starts. The pointer is stable across mutation
+        // (Vec doesn't reallocate from `vec![false; n]` with in-place
+        // index assignment), so `is_basic_block_start` reads through
+        // the raw pointer remain coherent.
+        self.rv_valid_pc = vec![false; code.len()];
+        self.bitmask_ptr = self.rv_valid_pc.as_ptr() as *const u8;
+        self.bitmask_len = self.rv_valid_pc.len();
+        self.rv_streaming = true;
 
         self.emit_prologue();
-        // Shared exit/OOG/panic handlers up front, before any page body.
-        self.emit_stub_handlers();
 
-        // Compile each 4 KiB page's body in order. The per-page structure
-        // (with the page-boundary fall-through dispatching through the
-        // table) is exactly what lazy compilation needs; here we drive it
-        // eagerly so every page is compiled up front.
-        let page = javm_exec::PAGE_SIZE as usize;
-        let n_pages = code.len().div_ceil(page);
-        for p in 0..n_pages {
-            let start = p * page;
-            let end = ((p + 1) * page).min(code.len());
-            self.compile_page(code, start, end);
+        let mut pending_gas: Option<(Label, u32, usize)> = None;
+        let mut next_is_gas_start = true;
+        let mut pc: usize = 0;
+
+        while pc < code.len() {
+            self.asm.ensure_capacity(512);
+
+            // Length encoding lives in bits [1:0] of byte 0: `xx11` is
+            // 4-byte, anything else is 2-byte (RVC). Decode no further
+            // than that — the dispatcher inspects raw bits directly.
+            if pc + 2 > code.len() {
+                self.rv_emit_panic_at(pc as u32);
+                break;
+            }
+            let is_4byte = code[pc] & 0b11 == 0b11;
+            let base_len = if is_4byte { 4 } else { 2 };
+            if pc + base_len > code.len() {
+                self.rv_emit_panic_at(pc as u32);
+                break;
+            }
+
+            let inst_pc = pc as u32;
+
+            if next_is_gas_start {
+                self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
+                next_is_gas_start = false;
+            }
+
+            // Byte-based dispatch. Each path returns
+            // `(is_terminator, preserve_cf, extra_bytes)`. `extra_bytes`
+            // counts the *additional* bytes consumed beyond `base_len`
+            // for lookahead fusion (e.g., Ld→Add fuses an extra 4-byte
+            // Add). `preserve_cf` tells us whether to keep
+            // `last_add_cf` alive for a following Sltu fusion.
+            let rest = &code[pc + base_len..];
+            let (term, preserve_cf, extra) = if is_4byte {
+                let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
+                self.compile_rv4(w, inst_pc, 4, rest)
+            } else {
+                let h = u16::from_le_bytes([code[pc], code[pc + 1]]);
+                self.compile_rvc(h, inst_pc, rest)
+            };
+
+            if !preserve_cf {
+                self.last_add_cf = None;
+            }
+
+            if term {
+                next_is_gas_start = true;
+            }
+
+            pc += base_len + extra;
         }
+
+        // Finalize the last gas block — patch its cost in.
+        if let Some((stub_label, block_pc, patch_offset)) = pending_gas.take() {
+            let cost = self.gas_sim.flush_and_get_cost();
+            self.asm.patch_i32(patch_offset, cost as i32);
+            self.oog_stubs.push((stub_label, block_pc, cost));
+        }
+
+        // Resolve deferred forward branches now that valid_pc is fully
+        // populated. For each forward branch recorded with target > pc
+        // at emit time:
+        //   - valid target: label_for_pc(target) was bound during the
+        //     streaming pass; the existing fixup resolves naturally.
+        //   - invalid target: append a per-branch panic stub and
+        //     redirect the fixup to it. Keeps the source PC of the
+        //     branch in the exit report.
+        // We disable rv_streaming first so emit_branch_* / panic helpers
+        // called below take their non-deferred path.
+        self.rv_streaming = false;
+        let pending = core::mem::take(&mut self.rv_pending_fwd_branches);
+        for (target, branch_pc, fixup_idx) in pending {
+            if !self.is_basic_block_start(target) {
+                let stub = self.asm.new_label();
+                self.asm.bind_label(stub);
+                self.asm.mov_store32_rip_rel_imm(CTX_PC, branch_pc as i32);
+                self.asm.jmp_label(self.panic_label);
+                self.asm.redirect_fixup(fixup_idx, stub);
+            }
+        }
+
+        self.emit_exit_sequences();
 
         // Sparse dispatch entries — caller writes only these into the
         // (page-zero-filled) arena dispatch region. No code.len() + 1
@@ -1366,8 +1274,6 @@ impl Compiler {
         }
 
         let exit_label_offset = self.asm.label_offset(self.exit_label).unwrap_or(0) as u32;
-        let compile_stub_offset =
-            self.asm.label_offset(self.compile_stub_label).unwrap_or(0) as u32;
         let trap_table = core::mem::take(&mut self.trap_entries);
         let valid_pc = core::mem::take(&mut self.rv_valid_pc);
 
@@ -1376,104 +1282,8 @@ impl Compiler {
             dispatch_entries,
             trap_table,
             exit_label_offset,
-            compile_stub_offset,
             valid_pc,
         }
-    }
-
-    /// Compile the blocks in code byte range `[start, end)` — one 4 KiB
-    /// page — into the JIT buffer at the current cursor, then emit this
-    /// page's OOG stubs. Same-page branch targets resolve to direct
-    /// rel32 jumps (their labels bind within this page); cross-page
-    /// targets, and a fall-through off the page end, dispatch indirectly
-    /// through the table, so the target page need not be compiled yet
-    /// (the foundation for lazy compilation). `bb`/`is_basic_block_start`
-    /// is the whole-blob precomputed set, so targets validate regardless
-    /// of which pages exist.
-    fn compile_page(&mut self, code: &[u8], start: usize, end: usize) {
-        let mut pending_gas: Option<(Label, u32, usize)> = None;
-        let mut pc = start;
-        // Whether the last instruction compiled terminates the block. An
-        // empty range trivially "terminates" (nothing falls through).
-        let mut last_terminates = true;
-
-        while pc < end {
-            self.asm.ensure_capacity(512);
-
-            // Length encoding lives in bits [1:0] of byte 0: `xx11` is
-            // 4-byte, anything else 2-byte (RVC).
-            if pc + 2 > code.len() {
-                self.rv_emit_panic_at(pc as u32);
-                last_terminates = true;
-                break;
-            }
-            let is_4byte = code[pc] & 0b11 == 0b11;
-            let base_len = if is_4byte { 4 } else { 2 };
-            if pc + base_len > code.len() {
-                self.rv_emit_panic_at(pc as u32);
-                last_terminates = true;
-                break;
-            }
-
-            let inst_pc = pc as u32;
-
-            // Bind a gas block at every block start in the precomputed set
-            // ({0} ∪ post-terminator ∪ page starts) — same partition as
-            // predecode, so per-block gas matches.
-            if self.is_basic_block_start(inst_pc) {
-                self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
-            }
-
-            // Suppress fusion across a block boundary (incl. the page end,
-            // which is a block start): fusing a trailer that starts a new
-            // block would diverge the recompiler's partition (and per-block
-            // gas) from predecode's. `rest` is lookahead-only — an empty
-            // slice defers the trailer to its own block.
-            let next_inst_pc = inst_pc + base_len as u32;
-            let rest: &[u8] = if self.is_basic_block_start(next_inst_pc) {
-                &[]
-            } else {
-                &code[pc + base_len..]
-            };
-            let (term, preserve_cf, extra) = if is_4byte {
-                let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
-                self.compile_rv4(w, inst_pc, 4, rest)
-            } else {
-                let h = u16::from_le_bytes([code[pc], code[pc + 1]]);
-                self.compile_rvc(h, inst_pc, rest)
-            };
-
-            if !preserve_cf {
-                self.last_add_cf = None;
-            }
-            last_terminates = term;
-            pc += base_len + extra;
-        }
-
-        // Flush the page's last gas block cost.
-        if let Some((stub_label, block_pc, patch_offset)) = pending_gas.take() {
-            let cost = self.gas_sim.flush_and_get_cost();
-            self.asm.patch_i32(patch_offset, cost as i32);
-            self.oog_stubs.push((stub_label, block_pc, cost));
-        }
-
-        // If the page's last block falls through, dispatch to the next
-        // page start (a block start). Under lazy compilation that page may
-        // not be compiled yet → the dispatch lands on the compile-page
-        // stub. `end` is the next page's start offset (instructions never
-        // straddle a page, invariant 10).
-        if !last_terminates {
-            let next = end as u32;
-            if (next as usize) < code.len() {
-                self.emit_dispatch_static(next);
-            } else {
-                // Fall-through past the end of the blob — malformed.
-                self.rv_emit_panic_at(next.saturating_sub(1));
-            }
-        }
-
-        // Emit this page's OOG stubs (they reference the shared handler).
-        self.emit_page_oog_stubs();
     }
 
     /// Streaming gas-block-start hook: bind label, flush prior block's
@@ -1490,9 +1300,16 @@ impl Compiler {
         let label = Label(self.label_base + pc);
         self.asm.bind_label(label);
         self.gas_block_pcs.push(pc);
-        // `rv_valid_pc` (the gas-block-start bitmap) is precomputed in
-        // `compile`, so there's nothing to mark here — the loop already
-        // gated this call on `is_basic_block_start(pc)`.
+        // valid_pc is the gas-block-start bitmap consulted by both the
+        // codegen-time `is_basic_block_start` check and the runtime's
+        // djump validation. Set it here so backward branches emit time
+        // see the bit (we walk PCs in order, so any T < cur_pc has
+        // already passed through here if it's a gas-block start).
+        // bitmask_ptr points to rv_valid_pc's heap buffer, so this
+        // mutation is visible to subsequent is_basic_block_start reads.
+        if (pc as usize) < self.rv_valid_pc.len() {
+            self.rv_valid_pc[pc as usize] = true;
+        }
 
         // Peephole state must not leak across gas-block boundaries: the
         // dispatch table can enter this block from any predecessor.
@@ -3673,7 +3490,13 @@ impl Compiler {
         self.asm.jcc_label(Cc::E, self.panic_label);
 
         // native = code_base_native + dispatch_table[offset]; jmp.
-        self.emit_dispatch_indirect_tail();
+        self.asm.push(Reg::RAX);
+        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
+        self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
+        self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
+        self.asm.mov_rr(SCRATCH, Reg::RAX);
+        self.asm.pop(Reg::RAX);
+        self.asm.jmp_reg(SCRATCH);
     }
 
     fn rv_branch(&mut self, rs1: u8, rs2: u8, imm: i32, cc: Cc, pc: u32, next_pc: u32) {

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -99,8 +99,6 @@ pub const CTX_EXIT_REASON: u64 = CTX_VA + offset_of!(JitContext, exit_reason) as
 pub const CTX_EXIT_ARG: u64 = CTX_VA + offset_of!(JitContext, exit_arg) as u64;
 pub const CTX_HEAP_BASE: u64 = CTX_VA + offset_of!(JitContext, heap_base) as u64;
 pub const CTX_HEAP_TOP: u64 = CTX_VA + offset_of!(JitContext, heap_top) as u64;
-pub const CTX_BB_STARTS: u64 = CTX_VA + offset_of!(JitContext, bb_starts) as u64;
-pub const CTX_BB_LEN: u64 = CTX_VA + offset_of!(JitContext, bb_len) as u64;
 pub const CTX_ENTRY_PC: u64 = CTX_VA + offset_of!(JitContext, entry_pc) as u64;
 pub const CTX_PC: u64 = CTX_VA + offset_of!(JitContext, pc) as u64;
 pub const CTX_DISPATCH_TABLE: u64 = CTX_VA + offset_of!(JitContext, dispatch_table) as u64;
@@ -128,10 +126,12 @@ pub struct CompileResult {
     pub dispatch_entries: Vec<(u32, i32)>,
     pub trap_table: Vec<(u32, u32)>,
     pub exit_label_offset: u32,
-    /// Byte-indexed validity map (RV path only): true at every PC where
-    /// an instruction begins. Empty for the PVM path — `compile()`
-    /// consumes its own bitmask argument, no need to surface it.
-    pub valid_pc: Vec<bool>,
+    /// Native offset of the panic stub. The runtime dense-fills the
+    /// dispatch table with this so a `jalr` to any non-block-start
+    /// offset lands on the panic stub *via the table* — folding the
+    /// block-start validation into the dispatch lookup (no separate
+    /// `bb_starts` set). 0 for the PVM path.
+    pub panic_offset: u32,
 }
 
 /// Helper function pointers passed to compiled code.
@@ -209,11 +209,11 @@ pub struct Compiler {
     /// simulator and leaves this one untouched.
     pub(crate) gas_sim: GasSimulator,
     /// Guest VA the code region is mapped at. `jalr`/`auipc` produce
-    /// and consume code addresses as `code_base + offset`; the
-    /// dispatch/bb tables are offset-indexed (offset = VA - code_base).
+    /// and consume code addresses as `code_base + offset`; the dispatch
+    /// table is offset-indexed (offset = VA - code_base).
     pub(crate) code_base: u32,
     /// Code region length in bytes — the upper bound for jalr target
-    /// offsets (== `bb_starts` / dispatch-table length).
+    /// offsets (== dispatch-table length in entries).
     pub(crate) code_len: u32,
     /// True during RV streaming compile (`compile`). When set, branch
     /// emit helpers defer forward-target validation (`target > pc`) to a
@@ -1168,11 +1168,12 @@ impl Compiler {
     /// intermediary — that was 57% of the old cold-path compile time
     /// on the large guests (ed25519, ecrecover).
     ///
-    /// The returned `CompileResult.valid_pc` is the byte-indexed
-    /// "valid branch target" bitmap the runtime BB region needs. A bit
-    /// is set iff the PC is a gas-block start (= dispatchable entry in
-    /// the gas-block dispatch table). Built incrementally during the
-    /// streaming pass — no separate length-only pre-pass.
+    /// The internal `rv_valid_pc` bitmap (a bit set iff the PC is a
+    /// gas-block start) drives compile-time forward-branch validation
+    /// via `is_basic_block_start`. It is *not* surfaced: the runtime
+    /// validates `jalr` targets through the dense dispatch table
+    /// instead. Built incrementally during the streaming pass — no
+    /// separate length-only pre-pass.
     pub fn compile(mut self, code: &[u8]) -> CompileResult {
         // valid_pc is populated incrementally as the streaming pass
         // binds gas-block starts. The pointer is stable across mutation
@@ -1283,15 +1284,23 @@ impl Compiler {
         }
 
         let exit_label_offset = self.asm.label_offset(self.exit_label).unwrap_or(0) as u32;
+        // Security-critical: the runtime dense-fills the dispatch table
+        // with this, so it must resolve to the real panic stub (a 0 here
+        // would route bad `jalr` targets to native offset 0 instead of
+        // faulting). The panic stub is always emitted by
+        // `emit_exit_sequences` above.
+        let panic_offset = self
+            .asm
+            .label_offset(self.panic_label)
+            .expect("panic stub label must resolve") as u32;
         let trap_table = core::mem::take(&mut self.trap_entries);
-        let valid_pc = core::mem::take(&mut self.rv_valid_pc);
 
         CompileResult {
             native_code: self.asm.finalize(),
             dispatch_entries,
             trap_table,
             exit_label_offset,
-            valid_pc,
+            panic_offset,
         }
     }
 
@@ -3446,10 +3455,12 @@ impl Compiler {
     ///   2. write `rd = code_base + next_pc` if `rd != 0` (return addr)
     ///   3. `offset = target_va - code_base`
     ///   4. bounds: `offset < code_len`  else PANIC
-    ///   5. `bb_starts[offset] == 1`?     else PANIC  (security-critical:
-    ///      rejects mid-block / mid-instruction targets — gas is
-    ///      precharged at block entry)
-    ///   6. `native = code_base_native + dispatch_table[offset]; jmp`
+    ///   5. `native = code_base_native + dispatch_table[offset]; jmp`
+    ///      — the dispatch table is *dense*: every non-block-start offset
+    ///      holds the panic-stub offset, so a mid-block / mid-instruction
+    ///      target jumps to the panic stub (gas is precharged at block
+    ///      entry). Folds the former `bb_starts` check into the lookup.
+    ///      SECURITY-CRITICAL: the runtime MUST dense-fill the table.
     fn rv_jalr(&mut self, rd: u8, rs1: u8, imm: i32, pc: u32, next_pc: u32) {
         use super::asm::Cc;
 
@@ -3489,16 +3500,12 @@ impl Compiler {
         self.asm.cmp_ri32(SCRATCH, self.code_len as i32);
         self.asm.jcc_label(Cc::AE, self.panic_label);
 
-        // Validate bb_starts[offset] == 1 (basic-block start).
-        self.asm.push(Reg::RAX); // save x14
-        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_BB_STARTS);
-        // RAX = byte bb_starts[offset] (zero-extended).
-        self.asm.movzx_load8_sib(Reg::RAX, Reg::RAX, SCRATCH);
-        self.asm.test_rr(Reg::RAX, Reg::RAX);
-        self.asm.pop(Reg::RAX); // restore x14 before the conditional branch
-        self.asm.jcc_label(Cc::E, self.panic_label);
-
         // native = code_base_native + dispatch_table[offset]; jmp.
+        // The dispatch table is dense: a non-block-start offset holds the
+        // panic-stub offset, so a mid-block / mid-instruction target
+        // lands on the panic stub here instead of valid native code.
+        // This folds the former `bb_starts[offset] == 1` validation into
+        // the lookup (one fewer load + branch per jalr).
         self.asm.push(Reg::RAX);
         self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
         self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -422,11 +422,21 @@ impl Compiler {
             self.emit_exit(EXIT_PANIC, 0);
             return;
         }
+        // Cross-page target → indirect dispatch through the table: its
+        // native code lives in a different page-window, and under lazy
+        // compilation the page may not be compiled yet. Same-page →
+        // direct rel32 jump to the bound label.
+        if !same_page(target, pc) {
+            self.emit_dispatch_static(target);
+            return;
+        }
         let label = self.label_for_pc(target);
         self.asm.jmp_label(label);
     }
 
-    /// Emit a dynamic jump (through jump table).
+    /// Emit a conditional branch. Same-page target → direct `jcc` to the
+    /// bound label. Cross-page target → indirect dispatch on the taken
+    /// path (lowered as `jcc.invert() skip; <dispatch>; skip:`).
     pub(crate) fn emit_branch_reg(
         &mut self,
         a: Reg,
@@ -443,8 +453,42 @@ impl Compiler {
             return;
         }
         self.asm.cmp_rr(a, b);
+        if !same_page(target, pc) {
+            // Not taken → skip the dispatch; taken → fall into it.
+            let skip = self.asm.new_label();
+            self.asm.jcc_label(cc.invert(), skip);
+            self.emit_dispatch_static(target);
+            self.asm.bind_label(skip);
+            return;
+        }
         let label = self.label_for_pc(target);
         self.asm.jcc_label(cc, label);
+    }
+
+    /// Indirect-dispatch tail: with `SCRATCH` holding a validated
+    /// code-region byte offset (a gas-block start), jump to its native
+    /// code at `ctx.code_base + dispatch_table[offset]`. Shared by `jalr`
+    /// and the static cross-page dispatch.
+    pub(crate) fn emit_dispatch_indirect_tail(&mut self) {
+        self.asm.push(Reg::RAX);
+        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
+        self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
+        self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
+        self.asm.mov_rr(SCRATCH, Reg::RAX);
+        self.asm.pop(Reg::RAX);
+        self.asm.jmp_reg(SCRATCH);
+    }
+
+    /// Dispatch to a compile-time-known, already-validated block-start
+    /// `offset` (a cross-page branch / jal target, or a page-boundary
+    /// fall-through). Needs no bounds or bb-start check — unlike `jalr`,
+    /// the target is a static block start by construction. Records the
+    /// offset as the paused PC (fault attribution + the lazy compile-page
+    /// stub reads it to know which page to compile), then dispatches.
+    pub(crate) fn emit_dispatch_static(&mut self, offset: u32) {
+        self.asm.mov_store32_rip_rel_imm(CTX_PC, offset as i32);
+        self.asm.mov_ri32(SCRATCH, offset);
+        self.emit_dispatch_indirect_tail();
     }
 
     /// Emit a shift by register value using CL.
@@ -1117,6 +1161,15 @@ fn rv_slot(x: u8) -> Option<usize> {
         5..=15 => Some((x as usize) - 3),
         _ => None,
     }
+}
+
+/// Two code-region byte offsets lie in the same 4 KiB page. A
+/// cross-page control transfer can't use a direct rel32 to a label in
+/// another page-window (under lazy compilation that page may not be
+/// compiled yet) — it dispatches indirectly through the table instead.
+#[inline]
+fn same_page(a: u32, b: u32) -> bool {
+    a / javm_exec::PAGE_SIZE == b / javm_exec::PAGE_SIZE
 }
 
 /// True for x3 and x4 — registers that PVM2 reserves and the transpiler
@@ -3451,13 +3504,7 @@ impl Compiler {
         self.asm.jcc_label(Cc::E, self.panic_label);
 
         // native = code_base_native + dispatch_table[offset]; jmp.
-        self.asm.push(Reg::RAX);
-        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
-        self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
-        self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
-        self.asm.mov_rr(SCRATCH, Reg::RAX);
-        self.asm.pop(Reg::RAX);
-        self.asm.jmp_reg(SCRATCH);
+        self.emit_dispatch_indirect_tail();
     }
 
     fn rv_branch(&mut self, rs1: u8, rs2: u8, imm: i32, cc: Cc, pc: u32, next_pc: u32) {

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -1200,6 +1200,15 @@ impl Compiler {
 
             let inst_pc = pc as u32;
 
+            // Page starts are gas-block starts (PVM2 invariant 11),
+            // mirroring `predecode` so the interp and recompiler agree on
+            // the block partition and so lazy per-page compilation can
+            // enter each page at a dispatchable block. Trustless: derived
+            // from PC, not linker metadata.
+            if inst_pc.is_multiple_of(javm_exec::PAGE_SIZE) {
+                next_is_gas_start = true;
+            }
+
             if next_is_gas_start {
                 self.bind_rv_gas_block_start_streaming(inst_pc, &mut pending_gas);
                 next_is_gas_start = false;
@@ -1211,7 +1220,20 @@ impl Compiler {
             // for lookahead fusion (e.g., Ld→Add fuses an extra 4-byte
             // Add). `preserve_cf` tells us whether to keep
             // `last_add_cf` alive for a following Sltu fusion.
-            let rest = &code[pc + base_len..];
+            // Suppress instruction fusion across a page boundary: the
+            // next instruction starts a 4 KiB page, which is a gas-block
+            // start (invariant 11) that predecode always splits on.
+            // Fusing the trailer into this block would diverge the
+            // recompiler's block partition (and thus its per-block gas)
+            // from the interp's. `rest` is lookahead-only — an empty
+            // slice forces the trailer to compile as its own
+            // page-starting block next iteration.
+            let next_inst_pc = inst_pc + base_len as u32;
+            let rest: &[u8] = if next_inst_pc.is_multiple_of(javm_exec::PAGE_SIZE) {
+                &[]
+            } else {
+                &code[pc + base_len..]
+            };
             let (term, preserve_cf, extra) = if is_4byte {
                 let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
                 self.compile_rv4(w, inst_pc, 4, rest)

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -104,6 +104,12 @@ pub const EXIT_PAGE_FAULT: u32 = 3;
 pub const EXIT_HOST_CALL: u32 = 4;
 pub const EXIT_ECALL: u32 = 6;
 pub const EXIT_TRAP: u32 = 7;
+/// Lazy compilation: a dispatch landed on a block whose 4 KiB page is
+/// not compiled yet. The compile-page stub sets this reason and exits;
+/// the runtime reads `ctx.pc` (the target offset, set by whichever
+/// dispatcher jumped here), compiles that page, patches its dispatch
+/// entries, and re-enters the same frame.
+pub const EXIT_COMPILE_PAGE: u32 = 8;
 
 /// Result of compilation.
 pub struct CompileResult {
@@ -116,6 +122,11 @@ pub struct CompileResult {
     pub dispatch_entries: Vec<(u32, i32)>,
     pub trap_table: Vec<(u32, u32)>,
     pub exit_label_offset: u32,
+    /// Native offset of the compile-page stub (lazy path). Uncompiled
+    /// blocks' dispatch entries point here until their page is compiled.
+    /// On the eager path nothing references it, but it's emitted anyway
+    /// (one tiny stub) so eager and lazy share `emit_stub_handlers`.
+    pub compile_stub_offset: u32,
     /// Byte-indexed validity map (RV path only): true at every PC where
     /// an instruction begins. Empty for the PVM path — `compile()`
     /// consumes its own bitmask argument, no need to surface it.
@@ -168,6 +179,9 @@ pub struct Compiler {
     pub(crate) panic_label: Label,
     /// Label for OOG handler that reads PC from SCRATCH: stores PC, then falls through to oog_label.
     oog_pc_label: Label,
+    /// Label for the lazy compile-page stub (sets EXIT_COMPILE_PAGE,
+    /// jumps to the exit sequence). Emitted once in `emit_stub_handlers`.
+    compile_stub_label: Label,
     /// Per-gas-block OOG stubs: (label, pvm_pc) — emitted as cold code after main body.
     pub(crate) oog_stubs: Vec<(Label, u32, u32)>, // (label, pvm_pc, block_cost)
     /// Helper function addresses.
@@ -237,6 +251,7 @@ impl Compiler {
         let oog_label = asm.new_label();
         let panic_label = asm.new_label();
         let oog_pc_label = asm.new_label();
+        let compile_stub_label = asm.new_label();
         // Pre-create one label per PC for O(1) lookup in label_for_pc.
         // With LABEL_UNBOUND=0, bulk allocation uses zeroed pages (calloc/COW).
         // Only the ~640 labels that get bound trigger page faults — the other
@@ -251,6 +266,7 @@ impl Compiler {
             oog_label,
             panic_label,
             oog_pc_label,
+            compile_stub_label,
             oog_stubs: Vec::with_capacity(1024),
             reg_defs: [RegDef::Unknown; 13],
             reg_defs_active: 0,
@@ -616,6 +632,19 @@ impl Compiler {
         self.asm.jmp_label(self.exit_label);
 
         // Page faults are handled by the SIGSEGV handler (signal.rs).
+
+        // Lazy compile-page stub. A dispatch (prologue / jalr /
+        // cross-page branch / page-boundary fall-through) lands here
+        // when the target block's page is not compiled yet. `ctx.pc`
+        // already holds the target offset (set by the dispatcher); we
+        // just signal the runtime, which compiles that page, patches
+        // its dispatch entries, and re-enters. Reuses the exit sequence
+        // so gas (R15) and the live regs are flushed to ctx and
+        // restored verbatim on re-entry — the bounce is gas-neutral.
+        self.asm.bind_label(self.compile_stub_label);
+        self.asm
+            .mov_store32_rip_rel_imm(CTX_EXIT_REASON, EXIT_COMPILE_PAGE as i32);
+        self.asm.jmp_label(self.exit_label);
 
         // Panic exit
         self.asm.bind_label(self.panic_label);
@@ -1184,7 +1213,108 @@ fn rv_is_reserved(x: u8) -> bool {
     x == 3 || x == 4
 }
 
+/// Initial artifacts of a lazy compile: the prologue + shared stub
+/// handlers (incl. the compile-page stub), emitted once up front. Page
+/// bodies are compiled on demand by [`Compiler::compile_lazy_page`].
+pub struct LazyInit {
+    /// Whole-blob basic-block-start set (one byte per code offset). The
+    /// runtime copies this into the arena BB region (for `jalr`
+    /// validation) and uses it to point every block start's dispatch
+    /// entry at the compile-page stub.
+    pub valid_pc: Vec<bool>,
+    /// Native offset of the shared exit label (#PF redirect target).
+    pub exit_label_offset: u32,
+    /// Native offset of the compile-page stub.
+    pub compile_stub_offset: u32,
+    /// Bytes emitted so far (prologue + stubs): the caller copies
+    /// `asm.written()[0..len]` into the arena JIT region.
+    pub len: usize,
+}
+
+/// One page's lazily-emitted native code plus its dispatch / trap
+/// deltas. The newly-emitted bytes are `asm.written()[start..end]`.
+pub struct LazyPage {
+    pub start: usize,
+    pub end: usize,
+    /// `(code_offset, native_offset)` for each block start in this page.
+    pub dispatch_entries: Vec<(u32, i32)>,
+    /// `(native_offset, pvm_pc)` trap entries for this page, ascending by
+    /// native offset (the page occupies the next contiguous native range,
+    /// so appending these to the image's trap table keeps it sorted).
+    pub trap_entries: Vec<(u32, u32)>,
+}
+
 impl Compiler {
+    /// Compute the whole-blob gas-block-start set and publish it through
+    /// `bitmask_ptr`/`bitmask_len` for `is_basic_block_start`. Shared by
+    /// the eager `compile` and lazy `compile_lazy_init` entry points. The
+    /// backing `rv_valid_pc` is never mutated again, so `bitmask_ptr`
+    /// stays valid across Compiler moves (into the JIT cache) and grows.
+    fn prepare_bb(&mut self, code: &[u8]) {
+        let (bb, _decode_err) = javm_exec::predecode::bb_start_bitmap(code);
+        self.rv_valid_pc = bb.into_iter().map(|b| b == 1).collect();
+        self.bitmask_ptr = self.rv_valid_pc.as_ptr() as *const u8;
+        self.bitmask_len = self.rv_valid_pc.len();
+    }
+
+    /// Begin a lazy compile: compute the block-start set and emit the
+    /// prologue + shared stub handlers. No page bodies — every block
+    /// dispatches through the table, which the runtime initialises to the
+    /// compile-page stub, so the first entry to any page bounces out via
+    /// `EXIT_COMPILE_PAGE`. Takes `&mut self` (not `self`): the Compiler
+    /// persists in the JIT cache for later `compile_lazy_page` calls.
+    pub fn compile_lazy_init(&mut self, code: &[u8]) -> LazyInit {
+        self.prepare_bb(code);
+        self.emit_prologue();
+        self.emit_stub_handlers();
+        // Resolve the stubs' internal forward refs (panic/compile → exit).
+        self.asm.resolve_fixups();
+        LazyInit {
+            valid_pc: self.rv_valid_pc.clone(),
+            exit_label_offset: self.asm.label_offset(self.exit_label).unwrap_or(0) as u32,
+            compile_stub_offset: self.asm.label_offset(self.compile_stub_label).unwrap_or(0) as u32,
+            len: self.asm.offset(),
+        }
+    }
+
+    /// Compile one 4 KiB page's body, appended to the growing JIT buffer.
+    /// Returns the newly-emitted byte range plus this page's dispatch and
+    /// trap deltas. The caller must not compile the same page twice (the
+    /// JIT cache guards this with a per-page "compiled" bitmap).
+    ///
+    /// Produces byte-for-byte the same per-block gas accounting as the
+    /// eager path's `compile_page` for this page: `compile_page` is
+    /// self-contained (its gas/reg/CF state resets at the page-start
+    /// block), so compile *order* across pages doesn't change any page's
+    /// gas. Every branch fixup is intra-page (cross-page targets go via
+    /// the dispatch table), so `resolve_fixups` fully resolves the page.
+    pub fn compile_lazy_page(&mut self, code: &[u8], page: usize) -> LazyPage {
+        let page_bytes = javm_exec::PAGE_SIZE as usize;
+        let start_off = page * page_bytes;
+        let end_off = ((page + 1) * page_bytes).min(code.len());
+
+        let gas_old = self.gas_block_pcs.len();
+        self.trap_entries.clear();
+        let start = self.asm.offset();
+        self.compile_page(code, start_off, end_off);
+        self.asm.resolve_fixups();
+        let end = self.asm.offset();
+
+        let mut dispatch_entries = Vec::with_capacity(self.gas_block_pcs.len() - gas_old);
+        for &pc in &self.gas_block_pcs[gas_old..] {
+            if let Some(off) = self.asm.label_offset(Label(self.label_base + pc)) {
+                dispatch_entries.push((pc, off as i32));
+            }
+        }
+        let trap_entries = core::mem::take(&mut self.trap_entries);
+        LazyPage {
+            start,
+            end,
+            dispatch_entries,
+            trap_entries,
+        }
+    }
+
     /// Compile an RV+C+custom-0 byte stream into x86-64 in a single
     /// streaming pass.
     ///
@@ -1206,10 +1336,7 @@ impl Compiler {
         // target against it. The buffer is stable for the pass (no
         // reallocation), so `is_basic_block_start` reads through
         // `bitmask_ptr` stay coherent.
-        let (bb, _decode_err) = javm_exec::predecode::bb_start_bitmap(code);
-        self.rv_valid_pc = bb.into_iter().map(|b| b == 1).collect();
-        self.bitmask_ptr = self.rv_valid_pc.as_ptr() as *const u8;
-        self.bitmask_len = self.rv_valid_pc.len();
+        self.prepare_bb(code);
 
         self.emit_prologue();
         // Shared exit/OOG/panic handlers up front, before any page body.
@@ -1239,6 +1366,8 @@ impl Compiler {
         }
 
         let exit_label_offset = self.asm.label_offset(self.exit_label).unwrap_or(0) as u32;
+        let compile_stub_offset =
+            self.asm.label_offset(self.compile_stub_label).unwrap_or(0) as u32;
         let trap_table = core::mem::take(&mut self.trap_entries);
         let valid_pc = core::mem::take(&mut self.rv_valid_pc);
 
@@ -1247,6 +1376,7 @@ impl Compiler {
             dispatch_entries,
             trap_table,
             exit_label_offset,
+            compile_stub_offset,
             valid_pc,
         }
     }

--- a/rust/javm-recompiler-x86/src/lib.rs
+++ b/rust/javm-recompiler-x86/src/lib.rs
@@ -39,14 +39,10 @@ pub struct JitContext {
     pub heap_base: u32,
     /// Current heap top (offset 124).
     pub heap_top: u32,
-    /// Jump table pointer (offset 128).
-    pub jt_ptr: *const u32,
-    /// Jump table length (offset 136).
-    pub jt_len: u32,
-    pub _pad0: u32,
-    /// Basic block starts pointer (offset 144).
+    /// Basic block starts pointer (byte array, 1 = block start).
+    /// jalr validates its target offset against this set.
     pub bb_starts: *const u8,
-    /// Basic block starts length (offset 152).
+    /// Basic block starts length (== code region length in bytes).
     pub bb_len: u32,
     pub _pad1: u32,
     /// Entry PC for re-entry after host calls (offset 160).

--- a/rust/javm-recompiler-x86/src/lib.rs
+++ b/rust/javm-recompiler-x86/src/lib.rs
@@ -39,13 +39,7 @@ pub struct JitContext {
     pub heap_base: u32,
     /// Current heap top (offset 124).
     pub heap_top: u32,
-    /// Basic block starts pointer (byte array, 1 = block start).
-    /// jalr validates its target offset against this set.
-    pub bb_starts: *const u8,
-    /// Basic block starts length (== code region length in bytes).
-    pub bb_len: u32,
-    pub _pad1: u32,
-    /// Entry PC for re-entry after host calls (offset 160).
+    /// Entry PC for re-entry after host calls.
     pub entry_pc: u32,
     /// Current PC when execution stopped (offset 164).
     pub pc: u32,

--- a/rust/javm-transpiler/src/elf.rs
+++ b/rust/javm-transpiler/src/elf.rs
@@ -58,8 +58,13 @@ pub(crate) struct LinkedElf {
     pub(crate) heap_pages: u32,
     /// PCREL_HI20: AUIPC instruction vaddr → resolved data address.
     pub(crate) hi20_targets: HashMap<u64, u64>,
-    /// PCREL_LO12: instruction vaddr → resolved data address (looked up from paired HI20).
+    /// PCREL_LO12: instruction vaddr → resolved target address (looked up from paired HI20).
     pub(crate) lo12_targets: HashMap<u64, u64>,
+    /// PCREL_LO12: instruction vaddr → its anchor AUIPC (HI20) instruction
+    /// vaddr. The LO12's immediate is relative to the *AUIPC's* PC (RISC-V
+    /// ABI), so re-encoding a kept code-relative pair after fallthrough
+    /// injection needs the anchor's post-injection offset, not the LO12's.
+    pub(crate) lo12_to_hi20: HashMap<u64, u64>,
     /// CALL_PLT: AUIPC instruction vaddr → target function RISC-V vaddr.
     pub(crate) call_targets: HashMap<u64, u64>,
     /// Absolute code pointers in data sections: (data_vaddr, target_code_vaddr, entry_size).
@@ -329,6 +334,7 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
 
     let mut hi20_targets: HashMap<u64, u64> = HashMap::new();
     let mut lo12_targets: HashMap<u64, u64> = HashMap::new();
+    let mut lo12_to_hi20: HashMap<u64, u64> = HashMap::new();
     let mut call_targets: HashMap<u64, u64> = HashMap::new();
 
     let mut lo12_entries: Vec<(u64, u64)> = Vec::new();
@@ -410,6 +416,7 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
     for (lo12_addr, hi20_addr) in lo12_entries {
         if let Some(&data_addr) = hi20_targets.get(&hi20_addr) {
             lo12_targets.insert(lo12_addr, data_addr);
+            lo12_to_hi20.insert(lo12_addr, hi20_addr);
         }
     }
 
@@ -424,6 +431,7 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
         heap_pages,
         hi20_targets,
         lo12_targets,
+        lo12_to_hi20,
         call_targets,
         abs_code_ptrs: abs64_relocs,
         sub32_relocs,

--- a/rust/javm-transpiler/src/elf.rs
+++ b/rust/javm-transpiler/src/elf.rs
@@ -69,8 +69,16 @@ pub(crate) struct LinkedElf {
     pub(crate) call_targets: HashMap<u64, u64>,
     /// Absolute code pointers in data sections: (data_vaddr, target_code_vaddr, entry_size).
     pub(crate) abs_code_ptrs: Vec<(u64, u64, u8)>,
+    /// Absolute *data* pointers in data sections: (data_vaddr,
+    /// target_data_vaddr, entry_size). The stored value is an ELF data
+    /// vaddr (the `[0, extent)` layout); the linker shifts it to the
+    /// runtime `[DATA_BASE, …)` mapping.
+    pub(crate) abs_data_ptrs: Vec<(u64, u64, u8)>,
     /// SUB32 relocations: (data_vaddr, subtracted_addr).
     pub(crate) sub32_relocs: Vec<(u64, u64)>,
+    /// Base RV vaddr that `rw_data[0]` maps to (for relocating absolute
+    /// data pointers stored in `.data`).
+    pub(crate) rw_base: u64,
     /// Code section address ranges for detecting code pointers.
     pub(crate) code_ranges: Vec<(u64, u64)>,
 }
@@ -313,6 +321,9 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
     let ro_pages = ro_data.len().div_ceil(page_size as usize);
     let rw_pvm_base = stack_size + (ro_pages as u64 * page_size);
     let mut rw_data = Vec::new();
+    // Base RV vaddr that `rw_data[0]` corresponds to (for relocating
+    // absolute data pointers stored in `.data`).
+    let mut rw_base = rw_pvm_base;
     if !rw_sections.is_empty() {
         let rw_min = rw_sections.iter().map(|(a, _, _)| *a).min().unwrap();
         let rw_max = rw_sections
@@ -320,10 +331,11 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
             .map(|(a, sz, _)| *a + *sz as u64)
             .max()
             .unwrap();
-        let rw_blob_size = (rw_max - rw_pvm_base.min(rw_min)) as usize;
+        rw_base = rw_pvm_base.min(rw_min);
+        let rw_blob_size = (rw_max - rw_base) as usize;
         rw_data = vec![0u8; rw_blob_size];
         for (addr, sz, d) in &rw_sections {
-            let off = (*addr - rw_pvm_base.min(rw_min)) as usize;
+            let off = (*addr - rw_base) as usize;
             if let Some(d) = d
                 && off + sz <= rw_data.len()
             {
@@ -339,6 +351,7 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
 
     let mut lo12_entries: Vec<(u64, u64)> = Vec::new();
     let mut abs64_relocs: Vec<(u64, u64, u8)> = Vec::new();
+    let mut abs_data_relocs: Vec<(u64, u64, u8)> = Vec::new();
     let mut sub32_relocs: Vec<(u64, u64)> = Vec::new();
     let code_ranges: Vec<(u64, u64)> = code_sections
         .iter()
@@ -379,6 +392,8 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
                         .any(|(lo, hi)| target_addr >= *lo && target_addr < *hi);
                     if is_code_ptr {
                         abs64_relocs.push((r_offset, target_addr, 4));
+                    } else {
+                        abs_data_relocs.push((r_offset, target_addr, 4));
                     }
                 }
                 RelocType::Abs64 => {
@@ -387,6 +402,8 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
                         .any(|(lo, hi)| target_addr >= *lo && target_addr < *hi);
                     if is_code_ptr {
                         abs64_relocs.push((r_offset, target_addr, 8));
+                    } else {
+                        abs_data_relocs.push((r_offset, target_addr, 8));
                     }
                 }
                 RelocType::Add32 => {
@@ -421,7 +438,6 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
     }
 
     let heap_pages = 16u32; // 64KB heap
-    let _ = rw_pvm_base;
 
     Ok(LinkedElf {
         code_sections,
@@ -434,7 +450,9 @@ pub(crate) fn parse_linked_elf(data: &[u8]) -> Result<LinkedElf, TranspileError>
         lo12_to_hi20,
         call_targets,
         abs_code_ptrs: abs64_relocs,
+        abs_data_ptrs: abs_data_relocs,
         sub32_relocs,
+        rw_base,
         code_ranges,
     })
 }

--- a/rust/javm-transpiler/src/layout.rs
+++ b/rust/javm-transpiler/src/layout.rs
@@ -9,9 +9,10 @@
 //! base-page metadata also feed declarative `Image.memory_mappings`.
 //!
 //! Cap-index convention: 64 = CODE, 65 = stack, 66 = ro, 67 = rw,
-//! 68 = heap. Address layout starts at page 0 and stacks linearly:
-//! stack lives at `[0, stack_pages)`, ro at `[stack_pages,
-//! stack_pages + ro_pages)`, etc.
+//! 68 = heap. Data is laid out from [`javm_cap::layout::DATA_BASE`]
+//! (256 MiB) upward and stacks linearly: stack lives at `[DATA_BASE,
+//! DATA_BASE + stack_pages)`, ro at `[DATA_BASE + stack_pages, …)`,
+//! etc. Code maps separately at [`CODE_BASE`].
 
 /// Cap index of the CODE cap in transpiler-emitted blobs. Matches the
 /// JAR `init_cap` field.
@@ -31,11 +32,13 @@ pub const PVM_PAGE_SIZE: u32 = 4096;
 ///
 /// The canonical definition is the PVM2 ABI constant
 /// [`javm_cap::layout::CODE_BASE`] (re-exported here for transpiler
-/// call sites). Data regions (stack/ro/rw/heap) occupy the low address
-/// space from page 0 upward (see [`ProgramLayout`]); the linker asserts
-/// the data layout stays below `CODE_BASE` and `CODE_BASE + code_len`
-/// stays within the 4 GiB guest range.
+/// call sites). Code occupies `[CODE_BASE, DATA_BASE)`; data regions
+/// (stack/ro/rw/heap) occupy `[DATA_BASE, 4 GiB)` (see [`ProgramLayout`]).
+/// The linker asserts code stays below [`DATA_BASE`] and the data
+/// layout stays within the 4 GiB guest range.
 pub use javm_cap::layout::CODE_BASE;
+/// Re-exported PVM2 ABI layout constants (see [`javm_cap::layout`]).
+pub use javm_cap::layout::{DATA_BASE, MAX_CODE_SIZE};
 
 /// One DATA cap's layout: where it lives in the manifest and where it
 /// maps in guest memory.
@@ -65,7 +68,8 @@ impl ProgramLayout {
     /// that. `ro_pages`, `rw_pages`, `heap_pages` of zero omit those
     /// caps entirely.
     pub fn compute(stack_pages: u32, ro_pages: u32, rw_pages: u32, heap_pages: u32) -> Self {
-        let mut next_page = 0u32;
+        // Data starts at DATA_BASE (256 MiB), above the code region.
+        let mut next_page = javm_cap::layout::DATA_BASE / PVM_PAGE_SIZE;
 
         let stack = DataCapEntry {
             cap_index: STACK_CAP_INDEX,

--- a/rust/javm-transpiler/src/layout.rs
+++ b/rust/javm-transpiler/src/layout.rs
@@ -29,17 +29,13 @@ pub const PVM_PAGE_SIZE: u32 = 4096;
 
 /// Guest virtual address where the code region is mapped read-only.
 ///
-/// Data regions (stack/ro/rw/heap) occupy the low address space from
-/// page 0 upward (see [`ProgramLayout`]). Code lives at a separate,
-/// high base so that `PC = CODE_BASE + byte_offset` is a real low-4 GiB
-/// virtual address — `auipc`/`jalr` resolve natively against it, and a
-/// guest can read its own bytes (PIC AUIPC+load). 1 GiB sits far above
-/// any plausible data extent (keeping the high bit clear so a 32-bit
-/// `ra` spill round-trips identically under `lw`/`lwu`) while leaving
-/// 3 GiB of headroom below CTX (mapped at 4 GiB). The linker asserts
+/// The canonical definition is the PVM2 ABI constant
+/// [`javm_cap::layout::CODE_BASE`] (re-exported here for transpiler
+/// call sites). Data regions (stack/ro/rw/heap) occupy the low address
+/// space from page 0 upward (see [`ProgramLayout`]); the linker asserts
 /// the data layout stays below `CODE_BASE` and `CODE_BASE + code_len`
 /// stays within the 4 GiB guest range.
-pub const CODE_BASE: u32 = 0x4000_0000;
+pub use javm_cap::layout::CODE_BASE;
 
 /// One DATA cap's layout: where it lives in the manifest and where it
 /// maps in guest memory.

--- a/rust/javm-transpiler/src/layout.rs
+++ b/rust/javm-transpiler/src/layout.rs
@@ -27,6 +27,20 @@ pub const HEAP_CAP_INDEX: u8 = 68;
 /// PVM page size in bytes.
 pub const PVM_PAGE_SIZE: u32 = 4096;
 
+/// Guest virtual address where the code region is mapped read-only.
+///
+/// Data regions (stack/ro/rw/heap) occupy the low address space from
+/// page 0 upward (see [`ProgramLayout`]). Code lives at a separate,
+/// high base so that `PC = CODE_BASE + byte_offset` is a real low-4 GiB
+/// virtual address — `auipc`/`jalr` resolve natively against it, and a
+/// guest can read its own bytes (PIC AUIPC+load). 1 GiB sits far above
+/// any plausible data extent (keeping the high bit clear so a 32-bit
+/// `ra` spill round-trips identically under `lw`/`lwu`) while leaving
+/// 3 GiB of headroom below CTX (mapped at 4 GiB). The linker asserts
+/// the data layout stays below `CODE_BASE` and `CODE_BASE + code_len`
+/// stays within the 4 GiB guest range.
+pub const CODE_BASE: u32 = 0x4000_0000;
+
 /// One DATA cap's layout: where it lives in the manifest and where it
 /// maps in guest memory.
 #[derive(Debug, Clone, Copy)]

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -955,31 +955,6 @@ fn encode_custom0_fallthrough() -> u32 {
     (0b100 << 12) | OP_CUSTOM_0
 }
 
-/// Pad `new_code` with `c.nop` (2 bytes) so emitting the next `len`-byte
-/// instruction won't straddle a 4 KiB page boundary (PVM2 invariant 10:
-/// no instruction crosses a page boundary, so lazy per-page compilation
-/// can split the blob at page boundaries without splitting an
-/// instruction).
-///
-/// Only 4-byte instructions can straddle: RV+C is 2-byte aligned and a
-/// page is even, so a 2-byte instruction always fits within its page,
-/// and the only straddling offset for a 4-byte instruction is
-/// `PAGE - 2` — fixed by a single `c.nop` that pushes the instruction
-/// onto the boundary. Padding only ever lands an instruction *on* a
-/// page boundary, so it never demotes a branch target out of the
-/// block-start set (page starts are block starts; see the predecode
-/// pass).
-#[inline]
-fn pad_page_straddle(new_code: &mut Vec<u8>, len: usize) {
-    let page = PVM_PAGE_SIZE as usize;
-    if len == 4 && new_code.len() % page + len > page {
-        // c.nop = addi x0, x0, 0 = 0x0001.
-        while !new_code.len().is_multiple_of(page) {
-            new_code.extend_from_slice(&0x0001u16.to_le_bytes());
-        }
-    }
-}
-
 /// Decode J-type immediate (sign-extended 21-bit).
 fn imm_j(w: u32) -> i32 {
     let b20 = (w >> 31) & 1;
@@ -1016,11 +991,6 @@ fn encode_b_imm(opcode_and_regs: u32, imm: i32) -> u32 {
 /// JAL / branch target that isn't already preceded by a terminator
 /// instruction. After injection, all reachable static targets are
 /// guaranteed to be in the strict bb_starts set the predecode computes.
-///
-/// Also pads with `c.nop` so no instruction straddles a 4 KiB page
-/// boundary (PVM2 invariant 10), a precondition for lazy per-page
-/// compilation. Injection and padding both shift offsets; both are
-/// captured in the returned map.
 ///
 /// Mutates `code` in place. Returns `old_pc → new_pc` map so the
 /// caller can remap PC values stored elsewhere (endpoint entries,
@@ -1172,15 +1142,14 @@ fn align_branch_targets(
         }
     }
 
-    // ---- Pass 3: build new code with fallthrough injected + page pad ----
-    //
-    // We always rebuild (rather than fast-pathing the no-injection case
-    // to identity) because page-straddle padding may shift offsets even
-    // when no fallthrough injection is required. Both shifts compose
-    // into the single `offset_map`, which Pass 4 (immediate re-encode)
-    // and `fixup_code_pcrel` (kept AUIPC pairs) consume downstream.
-    // Over-reserve for injections + one straddle pad per page.
-    let new_len = n + needs_inject.len() * 4 + (n / PVM_PAGE_SIZE as usize + 1) * 2;
+    if needs_inject.is_empty() {
+        // No injections needed — old offsets are identity.
+        let identity: BTreeMap<usize, usize> = inst_starts.into_iter().map(|p| (p, p)).collect();
+        return Ok(identity);
+    }
+
+    // ---- Pass 3: build new code with fallthrough injected ----
+    let new_len = n + needs_inject.len() * 4;
     let mut new_code: Vec<u8> = Vec::with_capacity(new_len);
     // old_pc → new_pc (only for old instruction-start positions; mid-
     // instruction bytes don't get mapped).
@@ -1195,17 +1164,15 @@ fn align_branch_targets(
         // If any injection is scheduled at this old_pc, emit fallthrough first.
         while let Some(&&inject_pc) = next_inject_iter.peek() {
             if inject_pc == old_pc {
-                pad_page_straddle(&mut new_code, 4); // fallthrough is 4 bytes
                 new_code.extend_from_slice(&fallthrough_bytes);
                 next_inject_iter.next();
             } else {
                 break;
             }
         }
+        offset_map.insert(old_pc, new_code.len());
         let next_pc = inst_starts.get(old_idx + 1).copied().unwrap_or(n);
         let inst_len = next_pc - old_pc;
-        pad_page_straddle(&mut new_code, inst_len);
-        offset_map.insert(old_pc, new_code.len());
         new_code.extend_from_slice(&code[old_pc..old_pc + inst_len]);
         old_idx += 1;
     }

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -8,7 +8,7 @@
 //!    `lui`+lo12 — data lives at its page-0 layout address, unrelated to
 //!    where code maps. *Code* references (`R_RISCV_CALL_PLT` and
 //!    code-targeting `PCREL_HI20`) stay native `auipc`+`jalr`/`addi`:
-//!    code is mapped at [`CODE_BASE`](crate::layout::CODE_BASE), so the
+//!    code is mapped at [`CODE_BASE`], so the
 //!    PC-relative computation lands on the right code VA. Kept pairs are
 //!    re-encoded after step 4 if fallthrough injection shifts the layout
 //!    (LUI is absolute, so injection-stable, and needs no fixup).

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -1,32 +1,45 @@
 //! ELF → PVM2 (raw RV+C+custom-0 bytes) linker.
 //!
 //! Pipeline:
-//! 1. **Parse ELF + relocs** via `crate::elf::parse_linked_elf`.
-//! 2. **Concatenate code sections**. Require a single contiguous
-//!    code section for now — typical for LLD PIE output.
-//! 3. **Rewrite AUIPC pairs** to LUI with absolute targets. PVM2's
-//!    32-bit memory cap guarantees the absolute target fits in 32
-//!    bits, so each `auipc + X` collapses to `lui + X` with no
-//!    further range adjustment needed.
-//! 4. **Replace standard ECALL markers**. The PVM guest convention
-//!    is `csrrw x0, 0x800/0x801, x0` followed by `ecall`. Rewrite
-//!    the marker slot to a canonical NOP and the `ecall` slot to a
-//!    custom-0 `ecall.jar` or `ecalli`.
-//! 5. **Validate**: no AUIPC remaining, no x3/x4 use, no remaining
-//!    standard `ecall` / `ebreak`, no CSR / atomic / FP / privileged
-//!    encodings (see `~/docs/pvm-isa/05-pvm2-rv-diff.md` §"Forbidden
-//!    encodings").
-//! 6. **Emit Image** with `code = raw RV bytes`. The recompiler-side
-//!    `compile` consumes these directly.
+//! 1. **Concatenate code sections** at their ELF vaddr offsets (typical
+//!    LLD PIE output places each function in its own `.text.<sym>`).
+//! 2. **Resolve AUIPC pairs.** *Data* references (an `auipc` paired with
+//!    a load/store/addi of a low-memory address) fold to absolute
+//!    `lui`+lo12 — data lives at its page-0 layout address, unrelated to
+//!    where code maps. *Code* references (`R_RISCV_CALL_PLT` and
+//!    code-targeting `PCREL_HI20`) stay native `auipc`+`jalr`/`addi`:
+//!    code is mapped at [`CODE_BASE`](crate::layout::CODE_BASE), so the
+//!    PC-relative computation lands on the right code VA. Kept pairs are
+//!    re-encoded after step 4 if fallthrough injection shifts the layout
+//!    (LUI is absolute, so injection-stable, and needs no fixup).
+//! 3. **Replace standard ECALL markers**. The guest convention is
+//!    `csrrw x0, 0x800/0x801, x0` followed by `ecall`; the marker slot
+//!    becomes a NOP and the `ecall` a custom-0 `ecall.jar` / `ecalli`.
+//! 4. **Inject fallthrough markers** before branch/jal/endpoint targets
+//!    that aren't already post-terminator, so the predecoder's strict
+//!    basic-block-start set — derived purely from the instruction stream
+//!    — covers every reachable jump target. `jalr` targets are validated
+//!    against that set at *runtime*; the linker never emits a trusted
+//!    target table (the recompiler runs untrusted code).
+//! 5. **Validate**: no x3/x4 use, no remaining standard `ecall` /
+//!    `ebreak`, no CSR / atomic / FP / custom-1 / privileged encodings
+//!    (see `~/docs/pvm-isa/05-pvm2-rv-diff.md`). `auipc`/`jalr` are
+//!    standard PVM2 instructions and are accepted.
+//! 6. **Emit Image** with one [`CodeRegion`] mapped read-only at
+//!    `CODE_BASE` via a [`MappingSource::Code`] mapping. The recompiler
+//!    consumes the raw bytes directly.
 
 use crate::TranspileError;
 use crate::elf::parse_linked_elf;
 use crate::layout::{
-    HEAP_CAP_INDEX, PVM_PAGE_SIZE, ProgramLayout, RO_CAP_INDEX, RW_CAP_INDEX, STACK_CAP_INDEX,
+    CODE_BASE, HEAP_CAP_INDEX, PVM_PAGE_SIZE, ProgramLayout, RO_CAP_INDEX, RW_CAP_INDEX,
+    STACK_CAP_INDEX,
 };
 use javm_cap::SlotIdx;
 use javm_cap::abi::{BARE_GAS_SLOT, BARE_QUOTA_SLOT, BARE_YIELD_CATCHER_SLOT};
-use javm_cap::image::{EndpointDef, Image, InitialDataCap, MemoryMapping, PinnedCap};
+use javm_cap::image::{
+    CodeRegion, EndpointDef, Image, InitialDataCap, MappingSource, MemoryMapping, PinnedCap,
+};
 use javm_cap::slot::SlotPath;
 use std::collections::BTreeMap;
 
@@ -58,8 +71,8 @@ const NOP_BYTES: [u8; 4] = [0x13, 0x00, 0x00, 0x00];
 const CSR_ECALL_JAR: u32 = 0x800;
 const CSR_ECALLI: u32 = 0x801;
 
-/// Link an RV ELF into a PVM2 [`Image`] whose `code` field is raw
-/// RV+C+custom-0 bytes.
+/// Link an RV ELF into a PVM2 [`Image`]. The single [`CodeRegion`] holds
+/// raw RV+C+custom-0 bytes, mapped read-only at [`CODE_BASE`].
 pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     let elf = parse_linked_elf(elf_data)?;
 
@@ -105,98 +118,75 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         if o >= code_len { None } else { Some(o) }
     };
 
-    // ---- 2. AUIPC → LUI rewrite ------------------------------------
-    //
-    // lld emits each `auipc rd, hi20` with `hi20` chosen so that
-    //   anchor := auipc_pc + sext(hi20 << 12)
-    // sits within ±2 KiB of the symbol. The paired LO12 instruction
-    // (load/store/addi/jalr) carries `lo12 = target - anchor`. The
-    // anchor's low 12 bits inherit `auipc_pc`'s low 12 bits, so the
-    // anchor is *not* 4 KiB-aligned in general.
-    //
-    // LUI can only load 4-KiB-aligned values, so the rewrite must
-    // patch **both** the LUI immediate and the paired LO12's imm
-    // field. We compute:
-    //
-    //   effective_target = `target` for data refs,
-    //                    = `target − base_vaddr` for code refs
-    //                      (so JALR/branch validation against
-    //                      `valid_pc` indexes into our code buffer).
-    //   new_lui  = (effective_target + 0x800) & 0xFFFFF000
-    //   new_lo12 = effective_target & 0xFFF (12-bit signed)
-    //
-    // The +0x800 carry compensates for lo12's sign extension when
-    // its top bit is set.
     let is_code_addr = |addr: u64| -> bool {
         elf.code_ranges
             .iter()
             .any(|(start, end)| addr >= *start && addr < *end)
     };
 
-    // Compute effective_target per AUIPC reloc.
-    let mut auipc_effective: BTreeMap<u64, u32> = BTreeMap::new();
-    for (&v, &t) in &elf.call_targets {
-        // CALL_PLT — always code.
-        auipc_effective.insert(v, t.wrapping_sub(base_vaddr) as u32);
-    }
-    for (&v, &t) in &elf.hi20_targets {
-        let eff = if is_code_addr(t) {
-            t.wrapping_sub(base_vaddr) as u32
-        } else {
-            (t & 0xFFFFFFFF) as u32
-        };
-        auipc_effective.insert(v, eff);
-    }
+    // ---- 2. Resolve AUIPC pairs ------------------------------------
+    //
+    // lld emits each `auipc rd, hi20` with `hi20` chosen so that
+    //   anchor := auipc_pc + sext(hi20 << 12)
+    // sits within ±2 KiB of the symbol; the paired LO12 instruction
+    // (load/store/addi/jalr) carries `lo12 = target - anchor`.
+    //
+    // *Data* references address the page-0 layout absolutely, so we
+    // fold them to `lui rd, hi; <op> rd, lo12` (the +0x800 carry
+    // compensates lo12's sign extension). LUI is absolute — unaffected
+    // by later fallthrough injection.
+    //
+    // *Code* references stay native `auipc`/`jalr`/`addi`: code maps at
+    // `CODE_BASE`, so `auipc`'s PC-relative result is already the right
+    // code VA. We only record them here; their displacement is
+    // re-encoded in step 4b after injection settles the final offsets.
+    //
+    // `code_auipc`: auipc byte-offset → target byte-offset.
+    // `code_lo12`:  (lo12 offset, anchor-auipc offset, target offset).
+    let mut code_auipc: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut code_lo12: Vec<(usize, usize, usize)> = Vec::new();
 
-    // Rewrite AUIPC bytes → LUI.
-    for (&v, &eff) in &auipc_effective {
-        let off = vaddr_to_offset(v).ok_or_else(|| {
+    // CALL_PLT — always a code target: `auipc` + `jalr` at +4.
+    for (&call_v, &target) in &elf.call_targets {
+        let auipc_off = vaddr_to_offset(call_v).ok_or_else(|| {
             TranspileError::InvalidSection(format!(
-                "link_elf: AUIPC reloc at vaddr {:#x} outside code section",
-                v
+                "link_elf: CALL_PLT AUIPC at vaddr {call_v:#x} outside code section"
             ))
         })?;
-        if off + 4 > code.len() {
-            return Err(TranspileError::InvalidSection(format!(
-                "link_elf: AUIPC reloc at vaddr {:#x} truncated by section end",
-                v
-            )));
+        let target_off = vaddr_to_offset(target).ok_or_else(|| {
+            TranspileError::InvalidSection(format!(
+                "link_elf: CALL_PLT target {target:#x} (from {call_v:#x}) outside code section"
+            ))
+        })?;
+        expect_auipc(&code, auipc_off, call_v)?;
+        code_auipc.insert(auipc_off, target_off);
+        if let Some(jalr_off) = vaddr_to_offset(call_v + 4) {
+            code_lo12.push((jalr_off, auipc_off, target_off));
         }
-        let word = u32::from_le_bytes([code[off], code[off + 1], code[off + 2], code[off + 3]]);
-        if word & 0x7F != OP_AUIPC {
-            return Err(TranspileError::InvalidSection(format!(
-                "link_elf: reloc at vaddr {:#x} not an AUIPC (opcode {:#x})",
-                v,
-                word & 0x7F
-            )));
-        }
-        let rd = (word >> 7) & 0x1F;
-        let new_hi = eff.wrapping_add(0x800) & 0xFFFFF000;
-        let new_word = new_hi | (rd << 7) | OP_LUI;
-        code[off..off + 4].copy_from_slice(&new_word.to_le_bytes());
     }
 
-    // ---- 2b. Patch paired LO12 / JALR lo12 fields ------------------
-    //
-    // For CALL_PLT entries the paired JALR is the 4-byte slot
-    // immediately after the AUIPC at vaddr `v+4`. For PCREL_LO12
-    // entries each `lo_v → target` pair names a specific instruction
-    // whose lo12 needs the same `effective_target & 0xFFF`.
-    let lo12_from_eff = |eff: u32| -> i32 {
-        // Sign-extend the low 12 bits.
-        (eff as i32) << 20 >> 20
-    };
-    for (&call_v, &call_target) in &elf.call_targets {
-        let eff = call_target.wrapping_sub(base_vaddr) as u32;
-        let new_lo12 = lo12_from_eff(eff);
-        let jalr_v = call_v + 4;
-        if let Some(jalr_off) = vaddr_to_offset(jalr_v) {
-            if jalr_off + 4 > code.len() {
-                continue;
-            }
-            patch_imm_i(&mut code[jalr_off..jalr_off + 4], new_lo12);
+    // PCREL_HI20 — code target stays native `auipc`; data folds to LUI.
+    for (&hi20_v, &target) in &elf.hi20_targets {
+        let auipc_off = vaddr_to_offset(hi20_v).ok_or_else(|| {
+            TranspileError::InvalidSection(format!(
+                "link_elf: PCREL_HI20 AUIPC at vaddr {hi20_v:#x} outside code section"
+            ))
+        })?;
+        if is_code_addr(target) {
+            let target_off = vaddr_to_offset(target).ok_or_else(|| {
+                TranspileError::InvalidSection(format!(
+                    "link_elf: PCREL_HI20 code target {target:#x} (from {hi20_v:#x}) out of range"
+                ))
+            })?;
+            expect_auipc(&code, auipc_off, hi20_v)?;
+            code_auipc.insert(auipc_off, target_off);
+        } else {
+            fold_auipc_to_lui(&mut code, auipc_off, hi20_v, (target & 0xFFFF_FFFF) as u32)?;
         }
     }
+
+    // PCREL_LO12 — code lo12 re-encoded in step 4b; data lo12 patched
+    // to the absolute target's low 12 bits now.
     for (&lo_v, &target) in &elf.lo12_targets {
         let Some(lo_off) = vaddr_to_offset(lo_v) else {
             continue;
@@ -204,23 +194,15 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         if lo_off + 4 > code.len() {
             continue;
         }
-        let eff = if is_code_addr(target) {
-            target.wrapping_sub(base_vaddr) as u32
+        if is_code_addr(target) {
+            if let Some(&hi20_v) = elf.lo12_to_hi20.get(&lo_v)
+                && let (Some(auipc_off), Some(target_off)) =
+                    (vaddr_to_offset(hi20_v), vaddr_to_offset(target))
+            {
+                code_lo12.push((lo_off, auipc_off, target_off));
+            }
         } else {
-            (target & 0xFFFFFFFF) as u32
-        };
-        let new_lo12 = lo12_from_eff(eff);
-        let opcode = code[lo_off] & 0x7F;
-        match opcode {
-            // I-type (load, addi, jalr) — imm in [31:20].
-            0b0000011 | 0b0010011 | 0b1100111 => {
-                patch_imm_i(&mut code[lo_off..lo_off + 4], new_lo12);
-            }
-            // S-type (store) — imm[11:5] in [31:25], imm[4:0] in [11:7].
-            0b0100011 => {
-                patch_imm_s(&mut code[lo_off..lo_off + 4], new_lo12);
-            }
-            _ => {}
+            patch_lo12_abs(&mut code, lo_off, (target & 0xFFFF_FFFF) as u32);
         }
     }
 
@@ -238,25 +220,26 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     // through x5 at runtime — matching today's PVM ecalli behaviour).
     rewrite_ecall_markers(&mut code)?;
 
-    // ---- 3b. CFG analysis + br_table-based call/return rewrite ------
+    // ---- 4. Fallthrough injection ----------------------------------
     //
-    // PVM2 forbids JALR entirely. We rewrite the canonical call /
-    // return / tail-call patterns to:
-    //   - direct call:   `addi ra, x0, 2*idx+1; jal x0, callee_entry`
-    //   - tail call:     `nop;                  jal x0, callee_entry`
-    //                    (ra is passed through unchanged so the callee's
-    //                     br_table dispatches the upstream caller's idx)
-    //   - function ret:  `br_table table_id, ra` (custom-0 funct3=011)
+    // Branch / jal / endpoint / rodata-code-pointer targets aren't
+    // necessarily post-terminator. Inject `fallthrough` (4 bytes,
+    // custom-0, terminator no-op) before each such target so the
+    // predecode's strict basic-block-start set — derived purely from
+    // the instruction stream, never trusted from linker metadata —
+    // covers everything reachable. `jalr` targets are validated against
+    // that set at runtime.
     //
-    // Each function gets a per-SCC return table; functions whose
-    // tail-call relationships form a SCC share a table. Tail-call
-    // predecessors transitively inject their callers' resume PCs
-    // into the callee SCC's table so the same ra-idx works at any
-    // br_table reached via a tail-call chain.
-    //
-    // Read endpoint entries first since they're required function
-    // entries (the host trampoline jumps directly to these PCs).
-    let endpoint_entries_pre: Vec<u32> = {
+    // A statically-known jalr target must be a block start too. Resume
+    // PCs (the instruction after a call's jalr) already are — jalr is a
+    // terminator, so its successor is post-terminator. But the *call
+    // targets* (CALL_PLT and code-`hi20` function entries reached via
+    // `auipc`+`jalr`) are not static jal edges, so they're fed as
+    // `extra_targets` alongside endpoint entries and `.rodata`
+    // code-pointer targets. `align_branch_targets` only injects where a
+    // target isn't already post-terminator, so entries that already
+    // follow a `ret`/`j` cost nothing.
+    let endpoint_entries_pre: Vec<usize> = {
         match crate::elf::find_all_section_bytes(elf_data, ".subsoil.endpoints") {
             Ok(sections) => sections
                 .iter()
@@ -269,115 +252,56 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
                     if fn_ptr < base_vaddr {
                         return None;
                     }
-                    Some((fn_ptr - base_vaddr) as u32)
+                    Some((fn_ptr - base_vaddr) as usize)
                 })
                 .collect(),
             Err(_) => Vec::new(),
         }
     };
-
-    let cfg_pvm2 = analyze_pvm2_cfg(&code, &auipc_effective, base_vaddr, &endpoint_entries_pre)?;
-    let return_tables_pre = build_return_tables(&cfg_pvm2)?;
-    let (new_code, offset_map_pre, mut tables_new_pcs) =
-        rewrite_pvm2_calls_returns(&code, &cfg_pvm2, &return_tables_pre)?;
-    let mut code = new_code;
-
-    // ---- 3c. Branch-target alignment (fallthrough injection) -------
-    //
-    // After the call/return rewrites, branch / jal targets aren't
-    // necessarily post-terminator yet. Inject `fallthrough` (4 bytes,
-    // custom-0, terminator no-op) before each such target so the
-    // predecode's strict bb_start set covers everything reachable.
-    //
-    // Targets that must be bb_starts:
-    //   - branch / jal targets (handled by align_branch_targets internally)
-    //   - endpoint entries (host trampoline entry — must remap via
-    //     offset_map_pre first)
-    //   - .rodata code-pointer targets (also via offset_map_pre)
-    //   - every entry in tables_new_pcs (br_table dispatches into these)
-    let pre_align_endpoint_offsets: Vec<usize> = endpoint_entries_pre
-        .iter()
-        .map(|&e| {
-            offset_map_pre
-                .get(&(e as usize))
-                .copied()
-                .unwrap_or(e as usize)
-        })
-        .collect();
-    let pre_align_rodata_targets: Vec<usize> = elf
+    let rodata_targets_pre: Vec<usize> = elf
         .abs_code_ptrs
         .iter()
         .filter_map(|&(_, rv_target, _)| {
-            if !is_code_addr(rv_target) {
-                None
+            if is_code_addr(rv_target) {
+                Some(rv_target.wrapping_sub(base_vaddr) as usize)
             } else {
-                let pre = rv_target.wrapping_sub(base_vaddr) as usize;
-                Some(offset_map_pre.get(&pre).copied().unwrap_or(pre))
+                None
             }
         })
         .collect();
-    let mut extra_targets: Vec<usize> = pre_align_endpoint_offsets;
-    extra_targets.extend_from_slice(&pre_align_rodata_targets);
-    for table in &tables_new_pcs {
-        for &pc in table {
-            extra_targets.push(pc as usize);
-        }
-    }
-    let offset_map_align = align_branch_targets(&mut code, &extra_targets)?;
+    let mut extra_targets: Vec<usize> = endpoint_entries_pre;
+    extra_targets.extend_from_slice(&rodata_targets_pre);
+    extra_targets.extend(code_auipc.values().copied());
+    let offset_map = align_branch_targets(&mut code, &extra_targets)?;
 
-    // Apply the alignment-pass offset_map to the return tables in place.
-    for table in tables_new_pcs.iter_mut() {
-        for entry in table.iter_mut() {
-            let new_pc = offset_map_align
-                .get(&(*entry as usize))
-                .copied()
-                .ok_or_else(|| {
-                    TranspileError::InvalidSection(format!(
-                        "link_elf: br_table resume pc {:#x} not in align offset_map",
-                        *entry
-                    ))
-                })?;
-            *entry = new_pc as u32;
-        }
-    }
+    // ---- 4b. Re-encode kept code-relative pairs --------------------
+    //
+    // Injection may have shifted offsets between an `auipc` and its
+    // target, invalidating the original displacement. Recompute each
+    // kept pair's PC-relative split against the post-injection layout.
+    fixup_code_pcrel(&mut code, &offset_map, &code_auipc, &code_lo12)?;
 
-    // Compose offset_map_pre with offset_map_align so the existing
-    // `.rodata` + endpoint translation logic below (which uses OLD-pre-
-    // rewrite PCs as input) keeps working uniformly.
-    let offset_map: BTreeMap<usize, usize> = offset_map_pre
-        .iter()
-        .filter_map(|(&old_pre, &new_pre)| {
-            offset_map_align
-                .get(&new_pre)
-                .copied()
-                .map(|new_post| (old_pre, new_post))
-        })
-        .collect();
-
-    // ---- 4. Validation pass ----------------------------------------
+    // ---- 5. Validation pass ----------------------------------------
     //
     // Walk every 2- or 4-byte instruction boundary (RV+C self-describes
     // length via op[1:0]) and reject anything that PVM2 forbids.
     validate_pvm2(&code)?;
 
-    // ---- 4b. Rewrite code pointers in .rodata -----------------------
+    // ---- 5b. Rewrite code pointers in .rodata -----------------------
     //
     // Function pointer tables (e.g. LLVM jump tables, vtables) store
     // code addresses as raw u32/u64 values in .rodata. The original
-    // values are ELF vaddrs; the runtime JALR validates against
-    // `valid_pc` indexed by RV byte offset (0..code.len()), so we
-    // must translate each pointer.
+    // values are ELF vaddrs; at runtime a `jalr` through such a pointer
+    // validates the target VA against the basic-block-start set, so each
+    // pointer must become `CODE_BASE + post-injection byte offset`.
     //
-    // Sources of code pointers we recognise:
-    //  - `elf.abs_code_ptrs` — explicit R_RISCV_32/64/ADD32 relocs
-    //    naming code addresses. Already classified by size (4 or 8).
-    //  - 8-byte values in .rodata that happen to be in code_ranges
-    //    (heuristic — function pointers without an explicit reloc
-    //    show up this way).
-    //
-    // SUB32-based relative jump tables (entries of the form
-    // `target - base`) don't need rewriting: the linear shift of
-    // `-base_vaddr` cancels in the differential.
+    // SUB32-based relative jump tables (entries `target - base`) are
+    // left as-is: their base register is loaded from a *data* address
+    // (the table lives in `.rodata`), so `base + delta` reconstructs the
+    // ELF vaddr, not `CODE_BASE + offset`. Such a `jalr` target fails the
+    // runtime block-start check and faults loudly rather than corrupting
+    // state — relocating relative tables into the CODE_BASE model is a
+    // follow-up (TODO). The absolute-pointer path below is correct.
     let mut ro_data_rewritten = elf.ro_data.clone();
     let ro_base = elf.stack_size as u64;
     {
@@ -386,12 +310,12 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         let sub32_data_vaddrs: std::collections::HashSet<u64> =
             elf.sub32_relocs.iter().map(|(v, _)| *v).collect();
 
-        // Translate a code address (RV vaddr) to a post-alignment byte
-        // offset within `code`. Applies offset_map to remap shifts
-        // introduced by fallthrough injection.
+        // Translate a code address (RV vaddr) to its guest VA:
+        // `CODE_BASE + post-injection byte offset within the region`.
         let translate_code_addr = |rv_target: u64| -> u32 {
             let pre = rv_target.wrapping_sub(base_vaddr) as usize;
-            offset_map.get(&pre).copied().unwrap_or(pre) as u32
+            let off = offset_map.get(&pre).copied().unwrap_or(pre);
+            CODE_BASE.wrapping_add(off as u32)
         };
 
         for &(data_vaddr, rv_target, size) in &elf.abs_code_ptrs {
@@ -438,13 +362,11 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         }
     }
 
-    // ---- 5. Endpoints -----------------------------------------------
+    // ---- 6. Endpoints -----------------------------------------------
     //
-    // `parse_linked_elf` doesn't read `.subsoil.endpoints` itself —
-    // the PVM path's `read_subsoil_endpoints` resolves fn_ptrs via
-    // `TranslationContext.address_map`. For the RV path the address
-    // map is `vaddr → vaddr - base_vaddr → offset_map[…]`, where
-    // `offset_map` accounts for any fallthrough injection.
+    // `entry_pc` stays a code-region byte offset; the runtime adds
+    // `CODE_BASE` when it seeds the PC. Remap through `offset_map` to
+    // account for any fallthrough injection.
     let mut endpoints = read_subsoil_endpoints_rv(elf_data, base_vaddr, code.len())?;
     for def in endpoints.values_mut() {
         let pre = def.entry_pc as usize;
@@ -453,7 +375,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         }
     }
 
-    // ---- 6. Memory layout + Image construction ----------------------
+    // ---- 7. Memory layout + Image construction ----------------------
     let ro_data = ro_data_rewritten;
     let rw_data = elf.rw_data.clone();
 
@@ -477,7 +399,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     memory_mappings.push(MemoryMapping {
         start: u64::from(layout.stack.base_page) * page_bytes,
         size: stack_size,
-        source: SlotPath::root(stack_slot),
+        source: MappingSource::Slot(SlotPath::root(stack_slot)),
     });
     initial_slots.insert(
         stack_slot,
@@ -493,7 +415,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(ro.base_page) * page_bytes,
             size,
-            source: SlotPath::root(ro_slot),
+            source: MappingSource::Slot(SlotPath::root(ro_slot)),
         });
         pinned_slots.insert(
             ro_slot,
@@ -510,7 +432,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(rw.base_page) * page_bytes,
             size,
-            source: SlotPath::root(rw_slot),
+            source: MappingSource::Slot(SlotPath::root(rw_slot)),
         });
         initial_slots.insert(
             rw_slot,
@@ -527,7 +449,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(heap.base_page) * page_bytes,
             size,
-            source: SlotPath::root(heap_slot),
+            source: MappingSource::Slot(SlotPath::root(heap_slot)),
         });
         initial_slots.insert(
             heap_slot,
@@ -538,25 +460,29 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         );
     }
 
-    // Flatten per-table br_table targets into the Image's CSR
-    // layout: a single `jump_table` Vec<u32> with `jump_table_offsets`
-    // recording each sub-table's start. The final offsets entry is
-    // jump_table.len() so consumers can compute the last table's
-    // length uniformly.
-    let mut jump_table: Vec<u32> = Vec::new();
-    let mut jump_table_offsets: Vec<u32> = Vec::with_capacity(tables_new_pcs.len() + 1);
-    if !tables_new_pcs.is_empty() {
-        jump_table_offsets.push(0);
-        for table in &tables_new_pcs {
-            jump_table.extend_from_slice(table);
-            jump_table_offsets.push(jump_table.len() as u32);
-        }
+    // Code region: mapped read-only at CODE_BASE, clear of the page-0
+    // data layout and within the 4 GiB guest range (CTX sits at 4 GiB).
+    let data_end = u64::from(layout.total_data_pages()) * page_bytes;
+    let code_base = u64::from(CODE_BASE);
+    if code_base < data_end {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: CODE_BASE {code_base:#x} overlaps data end {data_end:#x}"
+        )));
     }
+    let code_size = (code.len() as u64).div_ceil(page_bytes) * page_bytes;
+    if code_base + code_size > (1u64 << 32) {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: code at {code_base:#x}+{code_size:#x} exceeds the 4 GiB guest range"
+        )));
+    }
+    memory_mappings.push(MemoryMapping {
+        start: code_base,
+        size: code_size,
+        source: MappingSource::Code(0),
+    });
 
     Ok(Image {
-        code,
-        jump_table,
-        jump_table_offsets,
+        codes: vec![CodeRegion { code }],
         endpoints,
         memory_mappings,
         gas_slots: vec![BARE_GAS_SLOT],
@@ -565,6 +491,117 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         initial_slots,
         yield_marker_slot: Some(BARE_YIELD_CATCHER_SLOT),
     })
+}
+
+/// Verify the 4 bytes at `off` decode to an `auipc`; error otherwise.
+/// Used before recording a code reference whose AUIPC we keep native.
+fn expect_auipc(code: &[u8], off: usize, v: u64) -> Result<(), TranspileError> {
+    if off + 4 > code.len() {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: AUIPC reloc at vaddr {v:#x} truncated by section end"
+        )));
+    }
+    let word = u32::from_le_bytes([code[off], code[off + 1], code[off + 2], code[off + 3]]);
+    if word & 0x7F != OP_AUIPC {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: reloc at vaddr {v:#x} not an AUIPC (opcode {:#x})",
+            word & 0x7F
+        )));
+    }
+    Ok(())
+}
+
+/// Fold a *data* `auipc rd, hi20` at `off` into `lui rd, hi` loading the
+/// absolute 4 KiB-aligned base of `eff` (the paired lo12 supplies the
+/// rest). The +0x800 carry compensates the lo12's sign extension.
+fn fold_auipc_to_lui(
+    code: &mut [u8],
+    off: usize,
+    v: u64,
+    eff: u32,
+) -> Result<(), TranspileError> {
+    if off + 4 > code.len() {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: AUIPC reloc at vaddr {v:#x} truncated by section end"
+        )));
+    }
+    let word = u32::from_le_bytes([code[off], code[off + 1], code[off + 2], code[off + 3]]);
+    if word & 0x7F != OP_AUIPC {
+        return Err(TranspileError::InvalidSection(format!(
+            "link_elf: reloc at vaddr {v:#x} not an AUIPC (opcode {:#x})",
+            word & 0x7F
+        )));
+    }
+    let rd = (word >> 7) & 0x1F;
+    let new_word = (eff.wrapping_add(0x800) & 0xFFFF_F000) | (rd << 7) | OP_LUI;
+    code[off..off + 4].copy_from_slice(&new_word.to_le_bytes());
+    Ok(())
+}
+
+/// Patch a *data* LO12 instruction (I- or S-type) with the absolute
+/// low 12 bits of `eff` (sign-extended).
+fn patch_lo12_abs(code: &mut [u8], off: usize, eff: u32) {
+    let new_lo12 = ((eff as i32) << 20) >> 20;
+    match code[off] & 0x7F {
+        // I-type (load, addi, jalr) — imm in [31:20].
+        0b0000011 | 0b0010011 | 0b1100111 => patch_imm_i(&mut code[off..off + 4], new_lo12),
+        // S-type (store) — imm[11:5] in [31:25], imm[4:0] in [11:7].
+        0b0100011 => patch_imm_s(&mut code[off..off + 4], new_lo12),
+        _ => {}
+    }
+}
+
+/// Re-encode the displacement of every kept code-relative `auipc` pair
+/// against the post-injection layout. The `auipc` carries the high 20
+/// bits (with the +0x800 carry) and the paired `jalr`/`addi`/load/store
+/// the low 12 (sign-extended), both relative to the *AUIPC's* PC.
+fn fixup_code_pcrel(
+    code: &mut [u8],
+    offset_map: &BTreeMap<usize, usize>,
+    code_auipc: &BTreeMap<usize, usize>,
+    code_lo12: &[(usize, usize, usize)],
+) -> Result<(), TranspileError> {
+    let remap = |o: usize| -> Result<usize, TranspileError> {
+        offset_map.get(&o).copied().ok_or_else(|| {
+            TranspileError::InvalidSection(format!(
+                "fixup_code_pcrel: offset {o:#x} not in offset_map"
+            ))
+        })
+    };
+    for (&auipc_off, &target_off) in code_auipc {
+        let na = remap(auipc_off)?;
+        let nt = remap(target_off)?;
+        if na + 4 > code.len() {
+            continue;
+        }
+        let word = u32::from_le_bytes([code[na], code[na + 1], code[na + 2], code[na + 3]]);
+        if word & 0x7F != OP_AUIPC {
+            return Err(TranspileError::InvalidSection(format!(
+                "fixup_code_pcrel: expected AUIPC at offset {na:#x} (opcode {:#x})",
+                word & 0x7F
+            )));
+        }
+        let disp = nt as i64 - na as i64;
+        let rd = (word >> 7) & 0x1F;
+        let new_word = ((disp as u32).wrapping_add(0x800) & 0xFFFF_F000) | (rd << 7) | OP_AUIPC;
+        code[na..na + 4].copy_from_slice(&new_word.to_le_bytes());
+    }
+    for &(lo12_off, auipc_off, target_off) in code_lo12 {
+        let nl = remap(lo12_off)?;
+        let na = remap(auipc_off)?;
+        let nt = remap(target_off)?;
+        if nl + 4 > code.len() {
+            continue;
+        }
+        let disp = nt as i64 - na as i64;
+        let new_lo12 = ((disp as i32) << 20) >> 20;
+        match code[nl] & 0x7F {
+            0b0000011 | 0b0010011 | 0b1100111 => patch_imm_i(&mut code[nl..nl + 4], new_lo12),
+            0b0100011 => patch_imm_s(&mut code[nl..nl + 4], new_lo12),
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Walk `code` and rewrite ECALL-related sequences:
@@ -658,10 +695,9 @@ fn reg_fields_for(opcode: u32) -> RegFields {
             rs1: true,
             rs2: false,
         },
-        // I-type ALU (OP-IMM, OP-IMM-32). JALR is rejected earlier by
-        // the dedicated OP_JALR arm in `validate_pvm2` so we don't
-        // include it here.
-        0b001_0011 | 0b001_1011 => RegFields {
+        // I-type ALU (OP-IMM, OP-IMM-32) and JALR — rd + rs1 are
+        // registers; the I-type slot holds the immediate.
+        0b001_0011 | 0b001_1011 | 0b110_0111 => RegFields {
             rd: true,
             rs1: true,
             rs2: false,
@@ -738,24 +774,9 @@ fn validate_pvm2(code: &[u8]) -> Result<(), TranspileError> {
         let w = u32::from_le_bytes([code[i], code[i + 1], code[i + 2], code[i + 3]]);
         let opcode = w & 0x7F;
         match opcode {
-            OP_AUIPC => {
-                return Err(TranspileError::InvalidSection(format!(
-                    "link_elf: AUIPC still present at offset {:#x} (rewrite incomplete)",
-                    i
-                )));
-            }
-            OP_JALR => {
-                return Err(TranspileError::InvalidSection(format!(
-                    "link_elf: JALR still present at offset {:#x} (rewrite incomplete) — \
-                     PVM2 has no JALR; calls/tail-calls/returns must use \
-                     addi+jal-x0 / br_table",
-                    i
-                )));
-            }
             OP_CUSTOM_1 => {
                 return Err(TranspileError::InvalidSection(format!(
-                    "link_elf: custom-1 opcode at offset {:#x} is reserved in PVM2 \
-                     (callf is gone; br_table lives in custom-0)",
+                    "link_elf: custom-1 opcode at offset {:#x} is reserved in PVM2",
                     i
                 )));
             }
@@ -932,51 +953,11 @@ fn encode_custom0_ecalli(imm: i32) -> u32 {
     (imm12 << 20) | (0b010 << 12) | OP_CUSTOM_0
 }
 
-/// Encode custom-0 `br_table table_id, rs1` — I-type indirect-jump
-/// terminator. funct3 = 011, rd = 0, imm[11:0] = table_id (unsigned
-/// 12-bit), rs1 = idx-carrier reg.
-#[inline]
-fn encode_custom0_br_table(table_id: u16, rs1: u8) -> u32 {
-    debug_assert!(
-        table_id < (1 << 12),
-        "br_table table_id must fit in 12 bits"
-    );
-    debug_assert!(rs1 < 32, "rs1 must be 5-bit");
-    let imm12 = (table_id as u32) & 0xFFF;
-    (imm12 << 20) | ((rs1 as u32) << 15) | (0b011 << 12) | OP_CUSTOM_0
-}
-
 /// Encode custom-0 `fallthrough` (funct3 = 100; all other fields zero).
 /// A 4-byte terminator no-op that creates a bb_start at the next byte.
 #[inline]
 fn encode_custom0_fallthrough() -> u32 {
     (0b100 << 12) | OP_CUSTOM_0
-}
-
-/// Encode I-type `addi rd, rs1, imm` (RV `OP-IMM`, funct3=000).
-/// `imm` is signed 12-bit (range −2048..=2047).
-#[inline]
-fn encode_addi(rd: u8, rs1: u8, imm: i32) -> u32 {
-    debug_assert!(rd < 32 && rs1 < 32, "register field must fit 5 bits");
-    debug_assert!(
-        (-2048..=2047).contains(&imm),
-        "addi imm must fit signed 12-bit, got {imm}"
-    );
-    let imm12 = (imm as u32) & 0xFFF;
-    ((imm12 << 20) | ((rs1 as u32) << 15)) | ((rd as u32) << 7) | 0b001_0011
-}
-
-/// Encode JAL with rd=0 and J-type immediate (= the static-jump form,
-/// same encoding as `c.j` once decompressed).
-#[inline]
-fn encode_jal_x0(imm: i32) -> u32 {
-    let v = imm as u32;
-    let b20 = (v >> 20) & 0x1;
-    let b10_1 = (v >> 1) & 0x3FF;
-    let b11 = (v >> 11) & 0x1;
-    let b19_12 = (v >> 12) & 0xFF;
-    let imm_field = (b20 << 31) | (b10_1 << 21) | (b11 << 20) | (b19_12 << 12);
-    imm_field | OP_JAL
 }
 
 /// Decode J-type immediate (sign-extended 21-bit).
@@ -1011,734 +992,10 @@ fn encode_b_imm(opcode_and_regs: u32, imm: i32) -> u32 {
     cleared | (b12 << 31) | (b10_5 << 25) | (b4_1 << 8) | (b11 << 7)
 }
 
-// ============================================================================
-// PVM2 call / return rewrite (br_table-based static dispatch)
-// ============================================================================
-
-/// Direct call site identified in the OLD (pre-rewrite) code.
-#[derive(Debug, Clone)]
-struct DirectCall {
-    /// Byte offset of the start of the OLD call sequence:
-    ///   - JAL rd != x0:        offset of the JAL (4 bytes long)
-    ///   - AUIPC + JALR rd!=x0: offset of the AUIPC (8 bytes long)
-    seq_start: u32,
-    /// Length of the OLD call sequence in bytes (4 or 8).
-    seq_len: u32,
-    /// Target callee entry PC in OLD code.
-    target: u32,
-}
-
-/// Tail-call site (same shape as DirectCall but represents an
-/// `auipc + jalr x0` pair — no link register written).
-#[derive(Debug, Clone)]
-struct TailCall {
-    seq_start: u32,
-    seq_len: u32,
-    target: u32,
-}
-
-/// Function return site (`c.jr ra` or uncompressed `jalr x0, x1, 0`).
-#[derive(Debug, Clone, Copy)]
-struct ReturnSite {
-    /// Byte offset of the return instruction.
-    pc: u32,
-    /// 2 for `c.jr ra`, 4 for uncompressed `jalr x0, x1, 0`.
-    len: u32,
-}
-
-/// Control-flow graph extracted from OLD code.
-#[derive(Debug)]
-struct Pvm2Cfg {
-    /// Function entry PCs (OLD code coordinates), sorted.
-    function_entries: Vec<u32>,
-    direct_calls: Vec<DirectCall>,
-    tail_calls: Vec<TailCall>,
-    returns: Vec<ReturnSite>,
-}
-
-/// Walk the (pre-rewrite) code and extract call / tail-call / return
-/// sites and the set of function entry PCs.
-///
-/// Patterns recognised (all anchored at instruction boundaries):
-///   - `jal rd != x0, imm`           → DirectCall (4-byte sequence)
-///   - `auipc + jalr rd != x0, imm`  → DirectCall (8-byte sequence)
-///   - `auipc + jalr x0, imm`        → TailCall (8-byte sequence)
-///   - `jalr x0, x1, 0` (uncomp.)    → ReturnSite (4 bytes)
-///   - `c.jr ra` (= 0x8082)          → ReturnSite (2 bytes)
-///   - `c.j imm` / `c.beqz` / etc.   → no edge added (static jump or branch)
-///   - any other JALR pattern        → error (forbidden in PVM2)
-///
-/// Function entries are derived from call/tail-call targets and from
-/// the caller-supplied endpoint entries.
-fn analyze_pvm2_cfg(
-    code: &[u8],
-    auipc_effective: &BTreeMap<u64, u32>,
-    base_vaddr: u64,
-    endpoint_entries: &[u32],
-) -> Result<Pvm2Cfg, TranspileError> {
-    let n = code.len();
-    let mut direct_calls: Vec<DirectCall> = Vec::new();
-    let mut tail_calls: Vec<TailCall> = Vec::new();
-    let mut returns: Vec<ReturnSite> = Vec::new();
-    let mut entries: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
-
-    for &e in endpoint_entries {
-        if (e as usize) < n {
-            entries.insert(e);
-        }
-    }
-
-    let mut pc: usize = 0;
-    while pc < n {
-        if pc + 2 > n {
-            break;
-        }
-        let lo = u16::from_le_bytes([code[pc], code[pc + 1]]);
-        if lo & 0b11 != 0b11 {
-            // Compressed (2 bytes).
-            // Only c.jr ra matters here — it's a return site.
-            // c.jr ra has wire encoding 0x8082:
-            //   bits[15:13]=100  bit12=0  bits[11:7]=rdrs1=1  bits[6:2]=0  bits[1:0]=10
-            if lo == 0x8082 {
-                returns.push(ReturnSite {
-                    pc: pc as u32,
-                    len: 2,
-                });
-            }
-            pc += 2;
-            continue;
-        }
-        if pc + 4 > n {
-            break;
-        }
-        let w = u32::from_le_bytes([code[pc], code[pc + 1], code[pc + 2], code[pc + 3]]);
-        let opcode = w & 0x7F;
-
-        if opcode == OP_JAL {
-            let rd = ((w >> 7) & 0x1F) as u8;
-            let imm = imm_j(w);
-            if rd != 0 {
-                // jal rd, imm — direct call.
-                let target_i = (pc as i64) + (imm as i64);
-                if target_i < 0 || (target_i as usize) >= n {
-                    return Err(TranspileError::InvalidSection(format!(
-                        "analyze_pvm2_cfg: JAL at {:#x} target {} out of code range",
-                        pc, target_i
-                    )));
-                }
-                let target = target_i as u32;
-                direct_calls.push(DirectCall {
-                    seq_start: pc as u32,
-                    seq_len: 4,
-                    target,
-                });
-                entries.insert(target);
-            }
-            // rd == 0 (= static jump / c.j-like): not a call edge.
-            pc += 4;
-            continue;
-        }
-
-        if opcode == OP_JALR {
-            let rd = ((w >> 7) & 0x1F) as u8;
-            let rs1 = ((w >> 15) & 0x1F) as u8;
-            let funct3 = (w >> 12) & 0x7;
-            let imm12_signed = (w as i32) >> 20;
-
-            if funct3 != 0 {
-                return Err(TranspileError::InvalidSection(format!(
-                    "analyze_pvm2_cfg: JALR with funct3={} at {:#x} (reserved encoding)",
-                    funct3, pc
-                )));
-            }
-
-            // Check AUIPC pairing.
-            let jalr_vaddr = base_vaddr + pc as u64;
-            let auipc_vaddr = jalr_vaddr.checked_sub(4);
-            let paired_target = auipc_vaddr.and_then(|v| auipc_effective.get(&v).copied());
-
-            if let Some(target_off) = paired_target {
-                if pc < 4 {
-                    return Err(TranspileError::InvalidSection(format!(
-                        "analyze_pvm2_cfg: AUIPC+JALR pair at {:#x} has no AUIPC slot",
-                        pc
-                    )));
-                }
-                let target = target_off;
-                if (target as usize) >= n {
-                    return Err(TranspileError::InvalidSection(format!(
-                        "analyze_pvm2_cfg: AUIPC+JALR target {:#x} out of code range (pc {:#x})",
-                        target, pc
-                    )));
-                }
-                let seq_start = (pc - 4) as u32;
-                if rd == 0 {
-                    tail_calls.push(TailCall {
-                        seq_start,
-                        seq_len: 8,
-                        target,
-                    });
-                } else {
-                    direct_calls.push(DirectCall {
-                        seq_start,
-                        seq_len: 8,
-                        target,
-                    });
-                }
-                entries.insert(target);
-                pc += 4;
-                continue;
-            }
-
-            // Standalone JALR. Only the canonical uncompressed return form
-            // (`jalr x0, x1, 0`) is allowed; everything else is reserved.
-            if rd == 0 && rs1 == 1 && imm12_signed == 0 {
-                returns.push(ReturnSite {
-                    pc: pc as u32,
-                    len: 4,
-                });
-                pc += 4;
-                continue;
-            }
-            return Err(TranspileError::InvalidSection(format!(
-                "analyze_pvm2_cfg: unhandled JALR at {:#x} (rd={}, rs1={}, imm={}) — \
-                 PVM2 forbids indirect dispatch; rewrite to call/tail/return \
-                 or refactor to remove indirect jumps",
-                pc, rd, rs1, imm12_signed
-            )));
-        }
-
-        pc += 4;
-    }
-
-    let mut function_entries: Vec<u32> = entries.into_iter().collect();
-    function_entries.sort();
-    Ok(Pvm2Cfg {
-        function_entries,
-        direct_calls,
-        tail_calls,
-        returns,
-    })
-}
-
-/// Result of return-table construction.
-#[derive(Debug)]
-struct ReturnTables {
-    /// `function_entry_old_pc → table_id`. Every function in the
-    /// function_entries set has an entry here (table_id may be shared
-    /// among functions in the same tail-call SCC + transitive
-    /// inheritance chain).
-    function_to_table: BTreeMap<u32, u16>,
-    /// `table_id → ordered list of OLD resume PCs`. Each entry is
-    /// `call_site.seq_start + call_site.seq_len`, the byte AFTER the
-    /// caller's call sequence in OLD code. After offset_map is
-    /// applied (in a separate pass) these become the NEW resume PCs
-    /// stored in `Image.jump_table`.
-    tables_old_pcs: Vec<Vec<u32>>,
-    /// Per-direct-call-site index assignment. `idx_of_call[i]` is the
-    /// idx within the callee's table for `cfg.direct_calls[i]`.
-    /// `0..table_size`; the encoded value passed in `ra` is
-    /// `2*idx + 1`.
-    idx_of_call: Vec<u32>,
-}
-
-/// Build per-WCC return tables with tail-call propagation.
-///
-/// Algorithm:
-/// 1. Group functions into tail-call **weakly-connected components**
-///    (union-find over tail-call edges, treated as undirected).
-///    Every pair of functions related by a chain of tail-calls — in
-///    either direction — must share one table so that an `ra` value
-///    set at any caller in the chain decodes to the same resume PC
-///    at any br_table along the chain.
-/// 2. For each WCC, the table is the union of direct-caller resume
-///    PCs of every function in the WCC, sorted.
-/// 3. Each direct call site `C → callee F` gets `idx = position of
-///    (C + len(C)) in WCC(F)'s sorted table`. The encoded value
-///    passed in `ra` is `2*idx + 1`.
-fn build_return_tables(cfg: &Pvm2Cfg) -> Result<ReturnTables, TranspileError> {
-    let entries = &cfg.function_entries;
-    let n = entries.len();
-    if n == 0 {
-        return Ok(ReturnTables {
-            function_to_table: BTreeMap::new(),
-            tables_old_pcs: Vec::new(),
-            idx_of_call: vec![0; cfg.direct_calls.len()],
-        });
-    }
-
-    // Function-entry PC → dense index 0..n.
-    let entry_idx: BTreeMap<u32, usize> =
-        entries.iter().enumerate().map(|(i, &e)| (e, i)).collect();
-
-    // Union-find over function indices. Every tail-call edge unions
-    // its endpoints — direction doesn't matter for the
-    // share-a-table constraint.
-    let mut uf_parent: Vec<usize> = (0..n).collect();
-    fn uf_find(parent: &mut [usize], mut x: usize) -> usize {
-        while parent[x] != x {
-            parent[x] = parent[parent[x]];
-            x = parent[x];
-        }
-        x
-    }
-    fn uf_union(parent: &mut [usize], a: usize, b: usize) {
-        let ra = uf_find(parent, a);
-        let rb = uf_find(parent, b);
-        if ra != rb {
-            parent[ra] = rb;
-        }
-    }
-    for tc in &cfg.tail_calls {
-        let caller_entry = entries
-            .partition_point(|&e| e <= tc.seq_start)
-            .checked_sub(1)
-            .and_then(|i| entries.get(i).copied())
-            .ok_or_else(|| {
-                TranspileError::InvalidSection(format!(
-                    "build_return_tables: tail-call at {:#x} has no enclosing function",
-                    tc.seq_start
-                ))
-            })?;
-        let caller_idx = entry_idx[&caller_entry];
-        let callee_idx = entry_idx[&tc.target];
-        uf_union(&mut uf_parent, caller_idx, callee_idx);
-    }
-
-    // Group functions by WCC root. Resolve every function's root
-    // once and stash a dense WCC id for it.
-    let mut wcc_id: Vec<u32> = vec![u32::MAX; n];
-    let mut next_wcc: u32 = 0;
-    let mut root_to_wcc: BTreeMap<usize, u32> = BTreeMap::new();
-    for (i, w) in wcc_id.iter_mut().enumerate().take(n) {
-        let r = uf_find(&mut uf_parent, i);
-        let id = *root_to_wcc.entry(r).or_insert_with(|| {
-            let id = next_wcc;
-            next_wcc += 1;
-            id
-        });
-        *w = id;
-    }
-
-    // Per-WCC union of direct-caller resume PCs.
-    let num_wccs = next_wcc as usize;
-    let mut returns_by_wcc: Vec<std::collections::BTreeSet<u32>> =
-        vec![std::collections::BTreeSet::new(); num_wccs];
-    for dc in &cfg.direct_calls {
-        let callee_fn_idx = entry_idx[&dc.target];
-        let w = wcc_id[callee_fn_idx];
-        let resume = dc.seq_start + dc.seq_len;
-        returns_by_wcc[w as usize].insert(resume);
-    }
-
-    // Materialize tables. Empty WCCs (functions that are never called
-    // and don't tail-call into a called function) don't get a
-    // table_id; their c.jr ra is unreachable in practice.
-    let mut tables_old_pcs: Vec<Vec<u32>> = Vec::new();
-    let mut wcc_to_table: Vec<Option<u16>> = vec![None; num_wccs];
-    for (wid, set) in returns_by_wcc.iter().enumerate() {
-        if set.is_empty() {
-            continue;
-        }
-        let table_id = u16::try_from(tables_old_pcs.len()).map_err(|_| {
-            TranspileError::InvalidSection(
-                "build_return_tables: too many tables (>= 4096)".to_string(),
-            )
-        })?;
-        if (table_id as u32) >= (1 << 12) {
-            return Err(TranspileError::InvalidSection(format!(
-                "build_return_tables: table_id {} exceeds 12-bit limit",
-                table_id
-            )));
-        }
-        wcc_to_table[wid] = Some(table_id);
-        let mut v: Vec<u32> = set.iter().copied().collect();
-        v.sort();
-        tables_old_pcs.push(v);
-    }
-
-    // function_to_table: each function's br_table dispatches through
-    // its WCC's shared table.
-    let mut function_to_table: BTreeMap<u32, u16> = BTreeMap::new();
-    for (i, &entry) in entries.iter().enumerate() {
-        if let Some(tid) = wcc_to_table[wcc_id[i] as usize] {
-            function_to_table.insert(entry, tid);
-        }
-    }
-
-    // idx_of_call: for each direct call, find its resume PC's position
-    // within the callee's WCC table.
-    let mut idx_of_call: Vec<u32> = Vec::with_capacity(cfg.direct_calls.len());
-    for dc in &cfg.direct_calls {
-        let table_id = *function_to_table.get(&dc.target).ok_or_else(|| {
-            TranspileError::InvalidSection(format!(
-                "build_return_tables: direct call to {:#x} has no return table",
-                dc.target
-            ))
-        })?;
-        let table = &tables_old_pcs[table_id as usize];
-        let resume = dc.seq_start + dc.seq_len;
-        let idx = table.iter().position(|&p| p == resume).ok_or_else(|| {
-            TranspileError::InvalidSection(format!(
-                "build_return_tables: direct call resume {:#x} missing from \
-                     callee {:#x} table",
-                resume, dc.target
-            ))
-        })? as u32;
-        idx_of_call.push(idx);
-    }
-
-    Ok(ReturnTables {
-        function_to_table,
-        tables_old_pcs,
-        idx_of_call,
-    })
-}
-
-/// Rewrite OLD code into the new PVM2 call/return layout:
-///   - JAL rd ≠ x0           →  addi ra, x0, encoded_idx; jal x0, off  (4B→8B grow)
-///   - AUIPC+JALR rd ≠ x0    →  addi ra, x0, encoded_idx; jal x0, off  (8B→8B)
-///   - AUIPC+JALR rd == x0   →  addi x0, x0, 0;          jal x0, off  (8B→8B; ra passed through)
-///   - c.jr ra (2B)          →  br_table table_id, ra                  (2B→4B grow)
-///   - jalr x0, x1, 0 (4B)   →  br_table table_id, ra                  (4B→4B)
-///   - everything else copied verbatim.
-///
-/// Returns:
-///   - new code bytes
-///   - `offset_map_pre`: old_pc → new_pc for every OLD instruction start
-///   - `tables_new_pcs`: per-table list of NEW resume PCs (= offset_map_pre[old_resume_pc]).
-type RewriteResult = (Vec<u8>, BTreeMap<usize, usize>, Vec<Vec<u32>>);
-
-fn rewrite_pvm2_calls_returns(
-    code: &[u8],
-    cfg: &Pvm2Cfg,
-    tables: &ReturnTables,
-) -> Result<RewriteResult, TranspileError> {
-    let n = code.len();
-
-    // Index direct/tail calls by their `seq_start` (so we can recognise
-    // them when we visit the AUIPC / JAL position).
-    let mut direct_by_seq_start: BTreeMap<u32, &DirectCall> = BTreeMap::new();
-    for dc in &cfg.direct_calls {
-        direct_by_seq_start.insert(dc.seq_start, dc);
-    }
-    let direct_idx_by_seq_start: BTreeMap<u32, usize> = cfg
-        .direct_calls
-        .iter()
-        .enumerate()
-        .map(|(i, dc)| (dc.seq_start, i))
-        .collect();
-    let mut tail_by_seq_start: BTreeMap<u32, &TailCall> = BTreeMap::new();
-    for tc in &cfg.tail_calls {
-        tail_by_seq_start.insert(tc.seq_start, tc);
-    }
-    let return_pcs: std::collections::BTreeSet<u32> = cfg.returns.iter().map(|r| r.pc).collect();
-    // Return site PC → enclosing function entry.
-    let return_to_function: BTreeMap<u32, u32> = {
-        let entries = &cfg.function_entries;
-        let mut m = BTreeMap::new();
-        for r in &cfg.returns {
-            let enc = entries
-                .partition_point(|&e| e <= r.pc)
-                .checked_sub(1)
-                .and_then(|i| entries.get(i).copied())
-                .ok_or_else(|| {
-                    TranspileError::InvalidSection(format!(
-                        "rewrite_pvm2_calls_returns: return at {:#x} has no enclosing function",
-                        r.pc
-                    ))
-                })?;
-            m.insert(r.pc, enc);
-        }
-        m
-    };
-
-    let mut new_code: Vec<u8> = Vec::with_capacity(n + 1024);
-    let mut offset_map_pre: BTreeMap<usize, usize> = BTreeMap::new();
-
-    // (new_jal_pc, target_old_pc) pairs to patch up after we know
-    // every old_pc → new_pc mapping.
-    let mut jal_fixups: Vec<(usize, u32)> = Vec::new();
-
-    let mut pc: usize = 0;
-    while pc < n {
-        offset_map_pre.insert(pc, new_code.len());
-
-        // Direct call (JAL rd!=0 OR AUIPC+JALR rd!=0): seq_start = pc.
-        if let Some(dc) = direct_by_seq_start.get(&(pc as u32)).copied() {
-            let dc_idx = direct_idx_by_seq_start[&dc.seq_start];
-            let idx = tables.idx_of_call[dc_idx];
-            let encoded_idx: i32 = 2 * (idx as i32) + 1;
-            if !(-2048..=2047).contains(&encoded_idx) {
-                return Err(TranspileError::InvalidSection(format!(
-                    "rewrite_pvm2_calls_returns: encoded idx {} (idx={}) at call \
-                     site {:#x} does not fit signed 12-bit (table size too large)",
-                    encoded_idx, idx, pc
-                )));
-            }
-            // ra = x1. Emit `addi ra, x0, encoded_idx` then a placeholder
-            // `jal x0, 0` whose imm we'll patch in pass 2.
-            let addi_word = encode_addi(/*rd=*/ 1, /*rs1=*/ 0, encoded_idx);
-            new_code.extend_from_slice(&addi_word.to_le_bytes());
-            let jal_pc_new = new_code.len();
-            new_code.extend_from_slice(&encode_jal_x0(0).to_le_bytes());
-            jal_fixups.push((jal_pc_new, dc.target));
-            pc += dc.seq_len as usize;
-            continue;
-        }
-
-        // Tail-call (AUIPC+JALR rd=0): seq_start = pc.
-        if let Some(tc) = tail_by_seq_start.get(&(pc as u32)).copied() {
-            // Emit `addi x0, x0, 0` (4-byte NOP) so the slot the AUIPC
-            // occupied stays a benign instruction. ra is preserved
-            // intact — the callee's br_table dispatches on the
-            // upstream caller's idx.
-            new_code.extend_from_slice(&NOP_BYTES);
-            let jal_pc_new = new_code.len();
-            new_code.extend_from_slice(&encode_jal_x0(0).to_le_bytes());
-            jal_fixups.push((jal_pc_new, tc.target));
-            pc += tc.seq_len as usize;
-            continue;
-        }
-
-        // Return site (c.jr ra: 2 bytes; or jalr x0,x1,0: 4 bytes).
-        if return_pcs.contains(&(pc as u32)) {
-            let func_entry = return_to_function[&(pc as u32)];
-            let table_id = *tables.function_to_table.get(&func_entry).ok_or_else(|| {
-                TranspileError::InvalidSection(format!(
-                    "rewrite_pvm2_calls_returns: function {:#x} has no return table \
-                     (no callers — orphan function?)",
-                    func_entry
-                ))
-            })?;
-            let br_word = encode_custom0_br_table(table_id, /*rs1=ra*/ 1);
-            new_code.extend_from_slice(&br_word.to_le_bytes());
-            // Determine OLD length: c.jr ra is 2 bytes; uncompressed
-            // jalr x0,x1,0 is 4 bytes.
-            let len = cfg
-                .returns
-                .iter()
-                .find(|r| r.pc as usize == pc)
-                .map(|r| r.len)
-                .unwrap_or(2);
-            pc += len as usize;
-            continue;
-        }
-
-        // Default: copy this old instruction verbatim.
-        if pc + 2 > n {
-            break;
-        }
-        let lo = u16::from_le_bytes([code[pc], code[pc + 1]]);
-        let inst_len = if lo & 0b11 == 0b11 { 4 } else { 2 };
-        if pc + inst_len > n {
-            // Truncated trailing bytes — copy what's there.
-            new_code.extend_from_slice(&code[pc..n]);
-            pc = n;
-            continue;
-        }
-        new_code.extend_from_slice(&code[pc..pc + inst_len]);
-        pc += inst_len;
-    }
-    // Sentinel: map end-of-code so we can compute offsets uniformly.
-    offset_map_pre.insert(n, new_code.len());
-
-    // Pass 2: patch jal x0 offsets now that offset_map_pre is final.
-    for (new_jal_pc, target_old) in jal_fixups {
-        let new_target = *offset_map_pre.get(&(target_old as usize)).ok_or_else(|| {
-            TranspileError::InvalidSection(format!(
-                "rewrite_pvm2_calls_returns: jal target {:#x} not in offset_map",
-                target_old
-            ))
-        })?;
-        let off = new_target as i64 - new_jal_pc as i64;
-        if !(-(1 << 20)..(1 << 20)).contains(&off) {
-            return Err(TranspileError::InvalidSection(format!(
-                "rewrite_pvm2_calls_returns: jal at new_pc {:#x} offset {} out of \
-                 ±1 MiB range",
-                new_jal_pc, off
-            )));
-        }
-        let w = encode_jal_x0(off as i32);
-        new_code[new_jal_pc..new_jal_pc + 4].copy_from_slice(&w.to_le_bytes());
-    }
-
-    // Pass 3: re-encode branch / JAL immediates copied verbatim from
-    // OLD code so they point to the correct NEW target after any
-    // growth (JAL rd≠0: 4B→8B, c.jr ra: 2B→4B). We walk the OLD
-    // instruction stream (which we recompute by iterating the
-    // offset_map_pre keys in order) and patch the matching instruction
-    // in new_code. The instructions emitted by this pass itself
-    // (addi+jal, NOP+jal, br_table) already have correct imms.
-    //
-    // Sites we patch here:
-    //   - c.j imm   (RVC: 2B, op=01, f3=101)
-    //   - c.beqz/c.bnez (RVC: 2B, op=01, f3=110/111)
-    //   - B-type branch (4B, opcode=0b110_0011)
-    //   - JAL rd=0 static jump that we DID NOT rewrite (those we did
-    //     rewrite are addi+jal pairs whose jal we already patched).
-    //
-    // We use the fact that offset_map_pre keys are exactly the old
-    // instruction-start byte offsets. For each old_pc whose
-    // instruction was NOT rewritten in pass 1, fix up the imm.
-    let direct_seq_starts: std::collections::BTreeSet<u32> =
-        cfg.direct_calls.iter().map(|d| d.seq_start).collect();
-    let tail_seq_starts: std::collections::BTreeSet<u32> =
-        cfg.tail_calls.iter().map(|t| t.seq_start).collect();
-    let return_pcs_set: std::collections::BTreeSet<u32> =
-        cfg.returns.iter().map(|r| r.pc).collect();
-    for (&old_pc, &new_pc) in &offset_map_pre {
-        if old_pc == n {
-            continue; // end-of-code sentinel
-        }
-        // Skip instructions we ourselves emitted (their imms are
-        // either correct already or patched in pass 2).
-        if direct_seq_starts.contains(&(old_pc as u32))
-            || tail_seq_starts.contains(&(old_pc as u32))
-            || return_pcs_set.contains(&(old_pc as u32))
-        {
-            continue;
-        }
-        if old_pc + 2 > code.len() {
-            continue;
-        }
-        let lo = u16::from_le_bytes([code[old_pc], code[old_pc + 1]]);
-        if lo & 0b11 != 0b11 {
-            // RVC. Patch c.j and c.beqz/c.bnez.
-            let op = lo & 0b11;
-            let f3 = (lo >> 13) & 0b111;
-            let (is_jump, is_branch) = (
-                op == 0b01 && f3 == 0b101,
-                op == 0b01 && (f3 == 0b110 || f3 == 0b111),
-            );
-            if !is_jump && !is_branch {
-                continue;
-            }
-            let old_imm = if is_jump {
-                decompress_cj_imm(lo)
-            } else {
-                decompress_cb_imm(lo)
-            };
-            let old_target = old_pc as i64 + old_imm as i64;
-            if old_target < 0 || (old_target as usize) >= code.len() {
-                continue;
-            }
-            let new_target = *offset_map_pre.get(&(old_target as usize)).ok_or_else(|| {
-                TranspileError::InvalidSection(format!(
-                    "rewrite_pvm2_calls_returns: RVC branch target {:#x} not in offset_map",
-                    old_target
-                ))
-            })?;
-            let new_imm = new_target as i64 - new_pc as i64;
-            let new_h = if is_jump {
-                encode_cj_imm(lo, new_imm as i32)
-            } else {
-                encode_cb_imm(lo, new_imm as i32)
-            };
-            let new_h = new_h.ok_or_else(|| {
-                TranspileError::InvalidSection(format!(
-                    "rewrite_pvm2_calls_returns: RVC branch new_imm {} at {:#x} out of range",
-                    new_imm, new_pc
-                ))
-            })?;
-            new_code[new_pc..new_pc + 2].copy_from_slice(&new_h.to_le_bytes());
-            continue;
-        }
-        if old_pc + 4 > code.len() {
-            continue;
-        }
-        let w = u32::from_le_bytes([
-            code[old_pc],
-            code[old_pc + 1],
-            code[old_pc + 2],
-            code[old_pc + 3],
-        ]);
-        let opcode = w & 0x7F;
-        match opcode {
-            0b110_0011 => {
-                // B-type branch.
-                let old_imm = imm_b(w);
-                let old_target = old_pc as i64 + old_imm as i64;
-                if old_target < 0 || (old_target as usize) >= code.len() {
-                    continue;
-                }
-                let new_target = *offset_map_pre.get(&(old_target as usize)).ok_or_else(|| {
-                    TranspileError::InvalidSection(format!(
-                        "rewrite_pvm2_calls_returns: B-branch target {:#x} not in offset_map",
-                        old_target
-                    ))
-                })?;
-                let new_imm = new_target as i64 - new_pc as i64;
-                if !(-(1 << 12)..(1 << 12)).contains(&new_imm) {
-                    return Err(TranspileError::InvalidSection(format!(
-                        "rewrite_pvm2_calls_returns: B-branch at {:#x} new_imm {} out of \
-                         ±4 KiB range",
-                        new_pc, new_imm
-                    )));
-                }
-                let new_w = encode_b_imm(w, new_imm as i32);
-                new_code[new_pc..new_pc + 4].copy_from_slice(&new_w.to_le_bytes());
-            }
-            OP_JAL => {
-                // JAL with any rd. Direct calls are handled in pass 2;
-                // this path covers `jal x0, imm` (static jump) and any
-                // other JAL we didn't rewrite.
-                let old_imm = imm_j(w);
-                let old_target = old_pc as i64 + old_imm as i64;
-                if old_target < 0 || (old_target as usize) >= code.len() {
-                    continue;
-                }
-                let new_target = *offset_map_pre.get(&(old_target as usize)).ok_or_else(|| {
-                    TranspileError::InvalidSection(format!(
-                        "rewrite_pvm2_calls_returns: JAL target {:#x} not in offset_map",
-                        old_target
-                    ))
-                })?;
-                let new_imm = new_target as i64 - new_pc as i64;
-                if !(-(1 << 20)..(1 << 20)).contains(&new_imm) {
-                    return Err(TranspileError::InvalidSection(format!(
-                        "rewrite_pvm2_calls_returns: JAL at {:#x} new_imm {} out of ±1 MiB",
-                        new_pc, new_imm
-                    )));
-                }
-                let rd = (w >> 7) & 0x1F;
-                let v = new_imm as u32;
-                let b20 = (v >> 20) & 0x1;
-                let b10_1 = (v >> 1) & 0x3FF;
-                let b11 = (v >> 11) & 0x1;
-                let b19_12 = (v >> 12) & 0xFF;
-                let imm_field = (b20 << 31) | (b10_1 << 21) | (b11 << 20) | (b19_12 << 12);
-                let new_w = imm_field | (rd << 7) | OP_JAL;
-                new_code[new_pc..new_pc + 4].copy_from_slice(&new_w.to_le_bytes());
-            }
-            _ => {}
-        }
-    }
-
-    // Translate per-table OLD resume PCs to NEW resume PCs.
-    let mut tables_new_pcs: Vec<Vec<u32>> = Vec::with_capacity(tables.tables_old_pcs.len());
-    for old_table in &tables.tables_old_pcs {
-        let mut new_table = Vec::with_capacity(old_table.len());
-        for &old_resume in old_table {
-            let new_resume = *offset_map_pre.get(&(old_resume as usize)).ok_or_else(|| {
-                TranspileError::InvalidSection(format!(
-                    "rewrite_pvm2_calls_returns: resume {:#x} not in offset_map",
-                    old_resume
-                ))
-            })?;
-            new_table.push(new_resume as u32);
-        }
-        tables_new_pcs.push(new_table);
-    }
-
-    Ok((new_code, offset_map_pre, tables_new_pcs))
-}
-
-/// Walk the rewritten code and inject a `fallthrough` (4 bytes) before
-/// every JAL / Callf / branch target that isn't already preceded by a
-/// terminator instruction. After injection, all reachable static
-/// targets are guaranteed to be in the strict bb_starts set the
-/// predecode computes.
+/// Walk the code and inject a `fallthrough` (4 bytes) before every
+/// JAL / branch target that isn't already preceded by a terminator
+/// instruction. After injection, all reachable static targets are
+/// guaranteed to be in the strict bb_starts set the predecode computes.
 ///
 /// Mutates `code` in place. Returns `old_pc → new_pc` map so the
 /// caller can remap PC values stored elsewhere (endpoint entries,
@@ -1758,7 +1015,7 @@ fn align_branch_targets(
     // Decode each instruction at its byte offset; record:
     //  - The set of all instruction-start byte offsets (`inst_starts`).
     //  - The set of terminator instruction END offsets (their next_pc).
-    //  - The list of (callf_or_branch_pc, target_pc) edges.
+    //  - The list of (branch_or_jal_pc, target_pc) static edges.
     let n = code.len();
     let mut inst_starts: Vec<usize> = Vec::with_capacity(n / 4);
     let mut post_terminator: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -1778,11 +1035,9 @@ fn align_branch_targets(
             // RVC encodings that are terminators in PVM2:
             //   c.j imm    (op=01, f3=101)        — static jump
             //   c.beqz / c.bnez (op=01, f3=110/111) — conditional branches
-            //   c.jr / c.jalr / c.ebreak (op=10, f3=100) — all Reserved
-            //     in PVM2; treated as terminators because reaching them
-            //     panics. (The linker rewrites the c.jr-ra return idiom
-            //     to a 4-byte br_table before reaching this pass, so any
-            //     leftover c.jr is a true error.)
+            //   c.jr (op=10, f3=100) — `jalr x0, rs1, 0` (return /
+            //     indirect jump): a terminator. c.jalr is a call (also a
+            //     terminator); c.ebreak is Reserved (panics, terminator).
             //   c.illegal  (= 0x0000)             — reserved (terminator)
             // Other RVC ops are non-terminators.
             let op = lo & 0b11;
@@ -1836,6 +1091,13 @@ fn align_branch_targets(
                     is_terminator = true;
                     target = Some(pc as i64 + imm as i64);
                 }
+                OP_JALR => {
+                    // jalr — return / indirect call. A terminator; its
+                    // successor comes via the runtime dispatch table, not
+                    // a static immediate.
+                    is_terminator = true;
+                    target = None;
+                }
                 0b110_0011 => {
                     // B-type branch (BEQ/BNE/etc.).
                     let imm = imm_b(w);
@@ -1843,10 +1105,8 @@ fn align_branch_targets(
                     target = Some(pc as i64 + imm as i64);
                 }
                 OP_CUSTOM_0 => {
-                    // trap / ecalli / ecall.jar / br_table / fallthrough —
-                    // all terminators. br_table successors come from the
-                    // Image jump_table at runtime, not from an
-                    // instruction-embedded immediate, so no static target.
+                    // trap / ecalli / ecall.jar / fallthrough — all
+                    // terminators with no statically-embedded successor.
                     is_terminator = true;
                     target = None;
                     let _ = funct3;
@@ -2151,49 +1411,10 @@ mod tests {
     }
 
     #[test]
-    fn custom0_br_table_decodes() {
-        // br_table table_id=7, rs1=x1 (ra).
-        let w = encode_custom0_br_table(7, 1);
-        assert_eq!(w & 0x7F, OP_CUSTOM_0);
-        assert_eq!((w >> 7) & 0x1F, 0, "rd must be zero");
-        assert_eq!((w >> 12) & 0x7, 0b011, "funct3 = 011");
-        assert_eq!((w >> 15) & 0x1F, 1, "rs1 = ra");
-        assert_eq!((w >> 20) & 0xFFF, 7, "imm12 = table_id");
-    }
-
-    #[test]
     fn custom0_fallthrough_decodes() {
         let w = encode_custom0_fallthrough();
         assert_eq!(w & 0x7F, OP_CUSTOM_0);
         assert_eq!((w >> 12) & 0x7, 0b100);
-    }
-
-    #[test]
-    fn addi_encodes() {
-        // addi ra, x0, 5
-        let w = encode_addi(1, 0, 5);
-        assert_eq!(w & 0x7F, 0b001_0011, "opcode = OP-IMM");
-        assert_eq!((w >> 12) & 0x7, 0b000, "funct3 = addi");
-        assert_eq!((w >> 7) & 0x1F, 1, "rd = ra");
-        assert_eq!((w >> 15) & 0x1F, 0, "rs1 = x0");
-        assert_eq!((w >> 20) & 0xFFF, 5, "imm = 5");
-    }
-
-    #[test]
-    fn addi_negative_encoding() {
-        // addi ra, x0, -1 — imm12 sign-extends to 0xFFF.
-        let w = encode_addi(1, 0, -1);
-        assert_eq!((w >> 20) & 0xFFF, 0xFFF);
-    }
-
-    #[test]
-    fn jal_x0_round_trips_through_imm_j() {
-        for &imm in &[0, 4, 8, -4, -8, 100, -100, 0x7_FFFE, -0x8_0000] {
-            let w = encode_jal_x0(imm);
-            assert_eq!(w & 0x7F, OP_JAL);
-            assert_eq!((w >> 7) & 0x1F, 0);
-            assert_eq!(imm_j(w), imm);
-        }
     }
 
     #[test]
@@ -2258,14 +1479,17 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_auipc() {
+    fn validate_accepts_auipc_and_jalr() {
+        // PVM2 now uses native RISC-V control flow: AUIPC computes a
+        // code VA, JALR jumps to it (validated against bb_starts at
+        // runtime). Both are accepted by the linker.
         let auipc = (0x1000u32 << 12) | (1 << 7) | OP_AUIPC; // auipc x1, 0x1000
-        let code = auipc.to_le_bytes().to_vec();
-        let err = validate_pvm2(&code).unwrap_err();
-        let TranspileError::InvalidSection(msg) = err else {
-            panic!("expected InvalidSection, got {:?}", err);
-        };
-        assert!(msg.contains("AUIPC"));
+        validate_pvm2(&auipc.to_le_bytes()).unwrap();
+        let jalr = (1u32 << 15) | (1 << 7) | OP_JALR; // jalr x1, x1, 0
+        validate_pvm2(&jalr.to_le_bytes()).unwrap();
+        // jalr to x3/x4 is still forbidden (reserved registers).
+        let jalr_x3 = (3u32 << 15) | (1 << 7) | OP_JALR; // jalr x1, x3, 0
+        assert!(validate_pvm2(&jalr_x3.to_le_bytes()).is_err());
     }
 
     #[test]

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -514,12 +514,7 @@ fn expect_auipc(code: &[u8], off: usize, v: u64) -> Result<(), TranspileError> {
 /// Fold a *data* `auipc rd, hi20` at `off` into `lui rd, hi` loading the
 /// absolute 4 KiB-aligned base of `eff` (the paired lo12 supplies the
 /// rest). The +0x800 carry compensates the lo12's sign extension.
-fn fold_auipc_to_lui(
-    code: &mut [u8],
-    off: usize,
-    v: u64,
-    eff: u32,
-) -> Result<(), TranspileError> {
+fn fold_auipc_to_lui(code: &mut [u8], off: usize, v: u64, eff: u32) -> Result<(), TranspileError> {
     if off + 4 > code.len() {
         return Err(TranspileError::InvalidSection(format!(
             "link_elf: AUIPC reloc at vaddr {v:#x} truncated by section end"

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -955,6 +955,31 @@ fn encode_custom0_fallthrough() -> u32 {
     (0b100 << 12) | OP_CUSTOM_0
 }
 
+/// Pad `new_code` with `c.nop` (2 bytes) so emitting the next `len`-byte
+/// instruction won't straddle a 4 KiB page boundary (PVM2 invariant 10:
+/// no instruction crosses a page boundary, so lazy per-page compilation
+/// can split the blob at page boundaries without splitting an
+/// instruction).
+///
+/// Only 4-byte instructions can straddle: RV+C is 2-byte aligned and a
+/// page is even, so a 2-byte instruction always fits within its page,
+/// and the only straddling offset for a 4-byte instruction is
+/// `PAGE - 2` — fixed by a single `c.nop` that pushes the instruction
+/// onto the boundary. Padding only ever lands an instruction *on* a
+/// page boundary, so it never demotes a branch target out of the
+/// block-start set (page starts are block starts; see the predecode
+/// pass).
+#[inline]
+fn pad_page_straddle(new_code: &mut Vec<u8>, len: usize) {
+    let page = PVM_PAGE_SIZE as usize;
+    if len == 4 && new_code.len() % page + len > page {
+        // c.nop = addi x0, x0, 0 = 0x0001.
+        while !new_code.len().is_multiple_of(page) {
+            new_code.extend_from_slice(&0x0001u16.to_le_bytes());
+        }
+    }
+}
+
 /// Decode J-type immediate (sign-extended 21-bit).
 fn imm_j(w: u32) -> i32 {
     let b20 = (w >> 31) & 1;
@@ -991,6 +1016,11 @@ fn encode_b_imm(opcode_and_regs: u32, imm: i32) -> u32 {
 /// JAL / branch target that isn't already preceded by a terminator
 /// instruction. After injection, all reachable static targets are
 /// guaranteed to be in the strict bb_starts set the predecode computes.
+///
+/// Also pads with `c.nop` so no instruction straddles a 4 KiB page
+/// boundary (PVM2 invariant 10), a precondition for lazy per-page
+/// compilation. Injection and padding both shift offsets; both are
+/// captured in the returned map.
 ///
 /// Mutates `code` in place. Returns `old_pc → new_pc` map so the
 /// caller can remap PC values stored elsewhere (endpoint entries,
@@ -1142,14 +1172,15 @@ fn align_branch_targets(
         }
     }
 
-    if needs_inject.is_empty() {
-        // No injections needed — old offsets are identity.
-        let identity: BTreeMap<usize, usize> = inst_starts.into_iter().map(|p| (p, p)).collect();
-        return Ok(identity);
-    }
-
-    // ---- Pass 3: build new code with fallthrough injected ----
-    let new_len = n + needs_inject.len() * 4;
+    // ---- Pass 3: build new code with fallthrough injected + page pad ----
+    //
+    // We always rebuild (rather than fast-pathing the no-injection case
+    // to identity) because page-straddle padding may shift offsets even
+    // when no fallthrough injection is required. Both shifts compose
+    // into the single `offset_map`, which Pass 4 (immediate re-encode)
+    // and `fixup_code_pcrel` (kept AUIPC pairs) consume downstream.
+    // Over-reserve for injections + one straddle pad per page.
+    let new_len = n + needs_inject.len() * 4 + (n / PVM_PAGE_SIZE as usize + 1) * 2;
     let mut new_code: Vec<u8> = Vec::with_capacity(new_len);
     // old_pc → new_pc (only for old instruction-start positions; mid-
     // instruction bytes don't get mapped).
@@ -1164,15 +1195,17 @@ fn align_branch_targets(
         // If any injection is scheduled at this old_pc, emit fallthrough first.
         while let Some(&&inject_pc) = next_inject_iter.peek() {
             if inject_pc == old_pc {
+                pad_page_straddle(&mut new_code, 4); // fallthrough is 4 bytes
                 new_code.extend_from_slice(&fallthrough_bytes);
                 next_inject_iter.next();
             } else {
                 break;
             }
         }
-        offset_map.insert(old_pc, new_code.len());
         let next_pc = inst_starts.get(old_idx + 1).copied().unwrap_or(n);
         let inst_len = next_pc - old_pc;
+        pad_page_straddle(&mut new_code, inst_len);
+        offset_map.insert(old_pc, new_code.len());
         new_code.extend_from_slice(&code[old_pc..old_pc + inst_len]);
         old_idx += 1;
     }

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -32,8 +32,8 @@
 use crate::TranspileError;
 use crate::elf::parse_linked_elf;
 use crate::layout::{
-    CODE_BASE, HEAP_CAP_INDEX, PVM_PAGE_SIZE, ProgramLayout, RO_CAP_INDEX, RW_CAP_INDEX,
-    STACK_CAP_INDEX,
+    CODE_BASE, DATA_BASE, HEAP_CAP_INDEX, MAX_CODE_SIZE, PVM_PAGE_SIZE, ProgramLayout,
+    RO_CAP_INDEX, RW_CAP_INDEX, STACK_CAP_INDEX,
 };
 use javm_cap::SlotIdx;
 use javm_cap::abi::{BARE_GAS_SLOT, BARE_QUOTA_SLOT, BARE_YIELD_CATCHER_SLOT};
@@ -179,7 +179,15 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
             expect_auipc(&code, auipc_off, hi20_v)?;
             code_auipc.insert(auipc_off, target_off);
         } else {
-            fold_auipc_to_lui(&mut code, auipc_off, hi20_v, (target & 0xFFFF_FFFF) as u32)?;
+            // Data target: relocate from the ELF's `[0, extent)` data
+            // layout to the runtime `[DATA_BASE, …)` mapping.
+            let data_target = target.wrapping_add(u64::from(DATA_BASE));
+            fold_auipc_to_lui(
+                &mut code,
+                auipc_off,
+                hi20_v,
+                (data_target & 0xFFFF_FFFF) as u32,
+            )?;
         }
     }
 
@@ -200,7 +208,11 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
                 code_lo12.push((lo_off, auipc_off, target_off));
             }
         } else {
-            patch_lo12_abs(&mut code, lo_off, (target & 0xFFFF_FFFF) as u32);
+            // Data target: relocate to the runtime `[DATA_BASE, …)`
+            // mapping (DATA_BASE is page-aligned, so the low 12 bits the
+            // LO12 carries are unchanged — kept explicit for clarity).
+            let data_target = target.wrapping_add(u64::from(DATA_BASE));
+            patch_lo12_abs(&mut code, lo_off, (data_target & 0xFFFF_FFFF) as u32);
         }
     }
 
@@ -360,6 +372,42 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         }
     }
 
+    // ---- 5c. Relocate absolute data pointers ------------------------
+    //
+    // Pointers stored in data that point *into data* (e.g. `&'static`
+    // constants in `.data.rel.ro`) hold ELF data vaddrs (the `[0,
+    // extent)` layout). The runtime maps data at `[DATA_BASE, …)`, so
+    // shift each by `+DATA_BASE`. Data-targeting abs relocs the parser
+    // captured but the code-pointer pass above ignored. A pointer that
+    // lands in neither the RO nor RW blob is unrelocatable — error
+    // loudly rather than emit a silently-wrong pointer.
+    let mut rw_data_rewritten = elf.rw_data.clone();
+    {
+        let ro_base = elf.stack_size as u64;
+        let rw_base = elf.rw_base;
+        for &(data_vaddr, target, size) in &elf.abs_data_ptrs {
+            let new_val = target.wrapping_add(u64::from(DATA_BASE));
+            let n = size as usize;
+            let bytes = new_val.to_le_bytes();
+            if data_vaddr >= ro_base
+                && (data_vaddr - ro_base) as usize + n <= ro_data_rewritten.len()
+            {
+                let off = (data_vaddr - ro_base) as usize;
+                ro_data_rewritten[off..off + n].copy_from_slice(&bytes[..n]);
+            } else if data_vaddr >= rw_base
+                && (data_vaddr - rw_base) as usize + n <= rw_data_rewritten.len()
+            {
+                let off = (data_vaddr - rw_base) as usize;
+                rw_data_rewritten[off..off + n].copy_from_slice(&bytes[..n]);
+            } else {
+                return Err(TranspileError::InvalidSection(format!(
+                    "link_elf: absolute data pointer at vaddr {data_vaddr:#x} (→ {target:#x}) \
+                     falls outside the RO/RW data blobs; cannot relocate to DATA_BASE"
+                )));
+            }
+        }
+    }
+
     // ---- 6. Endpoints -----------------------------------------------
     //
     // `entry_pc` stays a code-region byte offset; the runtime adds
@@ -375,7 +423,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
 
     // ---- 7. Memory layout + Image construction ----------------------
     let ro_data = ro_data_rewritten;
-    let rw_data = elf.rw_data.clone();
+    let rw_data = rw_data_rewritten;
 
     let stack_pages = elf.stack_size / PVM_PAGE_SIZE;
     let ro_pages = (ro_data.len() as u32).div_ceil(PVM_PAGE_SIZE);
@@ -458,19 +506,22 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         );
     }
 
-    // Code region: mapped read-only at CODE_BASE, clear of the page-0
-    // data layout and within the 4 GiB guest range (CTX sits at 4 GiB).
-    let data_end = u64::from(layout.total_data_pages()) * page_bytes;
+    // Layout geometry: code occupies `[CODE_BASE, CODE_BASE +
+    // code_size)` and must stay below DATA_BASE (i.e. `code_size ≤
+    // MAX_CODE_SIZE`); data occupies `[DATA_BASE, DATA_BASE +
+    // data_extent)` and must stay within the 4 GiB guest range.
     let code_base = u64::from(CODE_BASE);
-    if code_base < data_end {
+    let code_size = (code.len() as u64).div_ceil(page_bytes) * page_bytes;
+    if code_base + code_size > u64::from(DATA_BASE) {
         return Err(TranspileError::InvalidSection(format!(
-            "link_elf: CODE_BASE {code_base:#x} overlaps data end {data_end:#x}"
+            "link_elf: code size {code_size:#x} exceeds MAX_CODE_SIZE {:#x} (would overlap DATA_BASE {:#x})",
+            MAX_CODE_SIZE, DATA_BASE,
         )));
     }
-    let code_size = (code.len() as u64).div_ceil(page_bytes) * page_bytes;
-    if code_base + code_size > (1u64 << 32) {
+    let data_end = u64::from(DATA_BASE) + u64::from(layout.total_data_pages()) * page_bytes;
+    if data_end > (1u64 << 32) {
         return Err(TranspileError::InvalidSection(format!(
-            "link_elf: code at {code_base:#x}+{code_size:#x} exceeds the 4 GiB guest range"
+            "link_elf: data end {data_end:#x} exceeds the 4 GiB guest range"
         )));
     }
     // Code is mapped RO at the fixed `CODE_BASE` by the runtime — not

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -25,8 +25,8 @@
 //!    `ebreak`, no CSR / atomic / FP / custom-1 / privileged encodings
 //!    (see `~/docs/pvm-isa/05-pvm2-rv-diff.md`). `auipc`/`jalr` are
 //!    standard PVM2 instructions and are accepted.
-//! 6. **Emit Image** with one [`CodeRegion`] mapped read-only at
-//!    `CODE_BASE` via a [`MappingSource::Code`] mapping. The recompiler
+//! 6. **Emit Image** with the raw code bytes in [`Image::code`], mapped
+//!    read-only at the fixed `CODE_BASE` by the runtime. The recompiler
 //!    consumes the raw bytes directly.
 
 use crate::TranspileError;
@@ -37,9 +37,7 @@ use crate::layout::{
 };
 use javm_cap::SlotIdx;
 use javm_cap::abi::{BARE_GAS_SLOT, BARE_QUOTA_SLOT, BARE_YIELD_CATCHER_SLOT};
-use javm_cap::image::{
-    CodeRegion, EndpointDef, Image, InitialDataCap, MappingSource, MemoryMapping, PinnedCap,
-};
+use javm_cap::image::{EndpointDef, Image, InitialDataCap, MemoryMapping, PinnedCap};
 use javm_cap::slot::SlotPath;
 use std::collections::BTreeMap;
 
@@ -71,8 +69,8 @@ const NOP_BYTES: [u8; 4] = [0x13, 0x00, 0x00, 0x00];
 const CSR_ECALL_JAR: u32 = 0x800;
 const CSR_ECALLI: u32 = 0x801;
 
-/// Link an RV ELF into a PVM2 [`Image`]. The single [`CodeRegion`] holds
-/// raw RV+C+custom-0 bytes, mapped read-only at [`CODE_BASE`].
+/// Link an RV ELF into a PVM2 [`Image`]. [`Image::code`] holds the raw
+/// RV+C+custom-0 bytes, mapped read-only at [`CODE_BASE`] by the runtime.
 pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     let elf = parse_linked_elf(elf_data)?;
 
@@ -399,7 +397,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     memory_mappings.push(MemoryMapping {
         start: u64::from(layout.stack.base_page) * page_bytes,
         size: stack_size,
-        source: MappingSource::Slot(SlotPath::root(stack_slot)),
+        source: SlotPath::root(stack_slot),
     });
     initial_slots.insert(
         stack_slot,
@@ -415,7 +413,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(ro.base_page) * page_bytes,
             size,
-            source: MappingSource::Slot(SlotPath::root(ro_slot)),
+            source: SlotPath::root(ro_slot),
         });
         pinned_slots.insert(
             ro_slot,
@@ -432,7 +430,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(rw.base_page) * page_bytes,
             size,
-            source: MappingSource::Slot(SlotPath::root(rw_slot)),
+            source: SlotPath::root(rw_slot),
         });
         initial_slots.insert(
             rw_slot,
@@ -449,7 +447,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings.push(MemoryMapping {
             start: u64::from(heap.base_page) * page_bytes,
             size,
-            source: MappingSource::Slot(SlotPath::root(heap_slot)),
+            source: SlotPath::root(heap_slot),
         });
         initial_slots.insert(
             heap_slot,
@@ -475,14 +473,12 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
             "link_elf: code at {code_base:#x}+{code_size:#x} exceeds the 4 GiB guest range"
         )));
     }
-    memory_mappings.push(MemoryMapping {
-        start: code_base,
-        size: code_size,
-        source: MappingSource::Code(0),
-    });
+    // Code is mapped RO at the fixed `CODE_BASE` by the runtime — not
+    // via a declarative mapping, so an untrusted Image cannot relocate
+    // it. `memory_mappings` describes data/slot regions only.
 
     Ok(Image {
-        codes: vec![CodeRegion { code }],
+        code,
         endpoints,
         memory_mappings,
         gas_slots: vec![BARE_GAS_SLOT],

--- a/rust/javm-transpiler/tests/layout.rs
+++ b/rust/javm-transpiler/tests/layout.rs
@@ -2,24 +2,27 @@ use javm_transpiler::layout::*;
 
 #[test]
 fn layout_minimal_stack_only() {
+    // Data is laid out from DATA_BASE upward.
+    let base = DATA_BASE / PVM_PAGE_SIZE;
     let l = ProgramLayout::compute(1, 0, 0, 0);
     assert_eq!(l.stack.cap_index, STACK_CAP_INDEX);
-    assert_eq!(l.stack.base_page, 0);
+    assert_eq!(l.stack.base_page, base);
     assert_eq!(l.stack.page_count, 1);
     assert!(l.ro.is_none());
     assert!(l.rw.is_none());
     assert!(l.heap.is_none());
-    assert_eq!(l.stack_top(), 4096);
+    assert_eq!(l.stack_top(), u64::from(DATA_BASE) + 4096);
     assert_eq!(l.total_data_pages(), 1);
 }
 
 #[test]
 fn layout_full_stack_ro_rw_heap() {
+    let base = DATA_BASE / PVM_PAGE_SIZE;
     let l = ProgramLayout::compute(2, 1, 1, 4);
-    assert_eq!(l.stack.base_page, 0);
-    assert_eq!(l.ro.as_ref().unwrap().base_page, 2);
-    assert_eq!(l.rw.as_ref().unwrap().base_page, 3);
-    assert_eq!(l.heap.as_ref().unwrap().base_page, 4);
-    assert_eq!(l.stack_top(), 2 * 4096);
+    assert_eq!(l.stack.base_page, base);
+    assert_eq!(l.ro.as_ref().unwrap().base_page, base + 2);
+    assert_eq!(l.rw.as_ref().unwrap().base_page, base + 3);
+    assert_eq!(l.heap.as_ref().unwrap().base_page, base + 4);
+    assert_eq!(l.stack_top(), u64::from(DATA_BASE) + 2 * 4096);
     assert_eq!(l.total_data_pages(), 2 + 1 + 1 + 4);
 }

--- a/rust/javm/src/callstack.rs
+++ b/rust/javm/src/callstack.rs
@@ -327,7 +327,7 @@ mod tests {
     use super::*;
 
     fn make_entry(tag: u8) -> InstanceEntry {
-        let prog = Arc::new(Program::new(vec![0x0B, 0x00, 0x00, 0x00], vec![], vec![0]));
+        let prog = Arc::new(Program::new(vec![0x0B, 0x00, 0x00, 0x00], 0));
         let cnode = CNodeCap::new(8).unwrap();
         InstanceEntry {
             instance_ref: CapHashOrRef::Hash([tag; 32]),

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -1023,24 +1023,17 @@ mod tests {
     use super::*;
     use crate::callstack::{EntryStatus, InstanceEntry};
     use crate::kernel_assist::InProcessKernelAssist;
-    use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
+    use javm_cap::image::Image;
     use javm_cap::{CNodeCap, NUM_REGS};
     use javm_exec::{Access, GasCounter, Mem, PAGE_SIZE, Regs, interp::Program};
     use std::sync::Arc;
 
-    /// Minimal PVM2 test image: one code region mapped read-only at a
-    /// code base, no slots. Mirrors what the linker emits (a
-    /// `MappingSource::Code` mapping) so `ImageCap::code_mapping`
-    /// resolves it.
+    /// Minimal PVM2 test image: code bytes (mapped read-only at the
+    /// fixed `CODE_BASE` by the runtime), no slots. Mirrors what the
+    /// linker emits so `ImageCap::code_mapping` resolves it.
     fn pvm2_image(code: Vec<u8>) -> Image {
-        let size = (code.len() as u64).next_multiple_of(4096).max(4096);
         let mut img = Image::empty();
-        img.codes = vec![CodeRegion { code }];
-        img.memory_mappings.push(MemoryMapping {
-            start: 0x4000_0000,
-            size,
-            source: MappingSource::Code(0),
-        });
+        img.code = code;
         img
     }
 

--- a/rust/javm/src/ecall.rs
+++ b/rust/javm/src/ecall.rs
@@ -372,12 +372,12 @@ impl<K: KernelAssist> Vm<K> {
             Cap::Image(i) => i.clone(),
             _ => return Err(VmError::ImageNotFound),
         };
-        let program = self.image_cache.get_or_decode(
-            new_image_hash,
-            img.code.as_slice().to_vec(),
-            img.jump_table.as_slice().to_vec(),
-            img.jump_table_offsets.as_slice().to_vec(),
-        );
+        let (code_base, code_bytes) = img
+            .code_mapping()
+            .ok_or(VmError::Invariant("image has no executable code mapping"))?;
+        let program =
+            self.image_cache
+                .get_or_decode(new_image_hash, code_bytes.to_vec(), code_base);
         let pinned_slots: Vec<SlotIdx> = img.pinned.iter().map(|e| e.slot).collect();
 
         let running = self
@@ -1023,10 +1023,26 @@ mod tests {
     use super::*;
     use crate::callstack::{EntryStatus, InstanceEntry};
     use crate::kernel_assist::InProcessKernelAssist;
-    use javm_cap::image::Image;
+    use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
     use javm_cap::{CNodeCap, NUM_REGS};
     use javm_exec::{Access, GasCounter, Mem, PAGE_SIZE, Regs, interp::Program};
     use std::sync::Arc;
+
+    /// Minimal PVM2 test image: one code region mapped read-only at a
+    /// code base, no slots. Mirrors what the linker emits (a
+    /// `MappingSource::Code` mapping) so `ImageCap::code_mapping`
+    /// resolves it.
+    fn pvm2_image(code: Vec<u8>) -> Image {
+        let size = (code.len() as u64).next_multiple_of(4096).max(4096);
+        let mut img = Image::empty();
+        img.codes = vec![CodeRegion { code }];
+        img.memory_mappings.push(MemoryMapping {
+            start: 0x4000_0000,
+            size,
+            source: MappingSource::Code(0),
+        });
+        img
+    }
 
     fn fixture_vm() -> Vm<InProcessKernelAssist> {
         let mut vm = Vm::new(InProcessKernelAssist::new());
@@ -1036,7 +1052,7 @@ mod tests {
             .set(SlotIdx(2), Some(CapHashOrRef::Hash([0xAA; 32])))
             .unwrap();
         // Trivial PVM2 blob: single `trap` (custom-0 funct3=000).
-        let prog = Arc::new(Program::new(vec![0x0B, 0x00, 0x00, 0x00], vec![], vec![0]));
+        let prog = Arc::new(Program::new(vec![0x0B, 0x00, 0x00, 0x00], 0));
         let entry = InstanceEntry {
             instance_ref: CapHashOrRef::Hash([1u8; 32]),
             image_hash_chain: [1u8; 32],
@@ -1228,10 +1244,8 @@ mod tests {
     fn set_image_reloads_program_from_cache() {
         let mut vm = fixture_vm();
         let mut cache = CacheDirectory::new();
-        let mut img = Image::empty();
         // PVM2 `ecalli 0` — 32-bit custom-0 word at PC 0.
-        img.code = 0x0000_200Bu32.to_le_bytes().to_vec();
-        img.jump_table_offsets = vec![0, 0];
+        let img = pvm2_image(0x0000_200Bu32.to_le_bytes().to_vec());
         let image_hash = cache
             .put_cap(&Cap::image_with_slots(&img, &[], &[]).unwrap())
             .unwrap();
@@ -1251,7 +1265,9 @@ mod tests {
         );
         let running = vm.stack.running_instance().unwrap();
         assert_eq!(running.image_hash, image_hash);
-        assert_eq!(running.program.code, 0x0000_200Bu32.to_le_bytes().to_vec());
+        // The code region is page-aligned (zero-padded) by `image_cap`
+        // so it can be direct-mapped; only the prefix is the real code.
+        assert_eq!(&running.program.code[..4], &0x0000_200Bu32.to_le_bytes());
     }
 
     #[test]
@@ -1553,10 +1569,8 @@ mod tests {
         let mut cache = CacheDirectory::new();
 
         // Publish a tiny child image with no pinned/initial slots.
-        let mut child_img = javm_cap::image::Image::empty();
         // PVM2 `ecalli 0` — 32-bit custom-0 word at PC 0.
-        child_img.code = 0x0000_200Bu32.to_le_bytes().to_vec();
-        child_img.jump_table_offsets = vec![0, 0];
+        let child_img = pvm2_image(0x0000_200Bu32.to_le_bytes().to_vec());
         let image_hash = cache
             .put_cap(&Cap::image_with_slots(&child_img, &[], &[]).unwrap())
             .unwrap();
@@ -1644,9 +1658,7 @@ mod tests {
 
         // Publish a no-op image (one Halt instruction) + empty cnode
         // + Cap::Instance referencing them.
-        let mut child_img = javm_cap::image::Image::empty();
-        child_img.code = 0x0000_200Bu32.to_le_bytes().to_vec();
-        child_img.jump_table_offsets = vec![0, 0];
+        let child_img = pvm2_image(0x0000_200Bu32.to_le_bytes().to_vec());
         let image_hash = cache
             .put_cap(&Cap::image_with_slots(&child_img, &[], &[]).unwrap())
             .unwrap();

--- a/rust/javm/src/image_cache.rs
+++ b/rust/javm/src/image_cache.rs
@@ -46,18 +46,19 @@ impl ImageCache {
         self.entries.insert(content_hash, program);
     }
 
-    /// Look up or compute the predecoded program for an image.
+    /// Look up or compute the predecoded program for an image. `code` is
+    /// the executable region's raw bytes; `code_base` is the guest VA it
+    /// maps at (PC = `code_base` + byte offset).
     pub fn get_or_decode(
         &mut self,
         content_hash: CapHash,
         code: Vec<u8>,
-        jump_table: Vec<u32>,
-        jump_table_offsets: Vec<u32>,
+        code_base: u32,
     ) -> Arc<Program> {
         if let Some(prog) = self.entries.get(&content_hash) {
             return prog.clone();
         }
-        let prog = Arc::new(Program::new(code, jump_table, jump_table_offsets));
+        let prog = Arc::new(Program::new(code, code_base));
         self.entries.insert(content_hash, prog.clone());
         prog
     }
@@ -73,9 +74,9 @@ impl ImageCache {
 mod tests {
     use super::*;
 
-    fn trivial_blob() -> (Vec<u8>, Vec<u32>, Vec<u32>) {
+    fn trivial_blob() -> Vec<u8> {
         // Single `trap` instruction (custom-0 funct3=000, opcode 0x0B).
-        (vec![0x0B, 0x00, 0x00, 0x00], vec![], vec![0])
+        vec![0x0B, 0x00, 0x00, 0x00]
     }
 
     #[test]
@@ -84,8 +85,7 @@ mod tests {
         let h = [1u8; 32];
         assert!(cache.get(&h).is_none());
 
-        let (code, jt, jto) = trivial_blob();
-        let p = cache.get_or_decode(h, code, jt, jto);
+        let p = cache.get_or_decode(h, trivial_blob(), 0);
         assert_eq!(cache.len(), 1);
         assert!(Arc::ptr_eq(&p, &cache.get(&h).unwrap()));
     }
@@ -94,10 +94,8 @@ mod tests {
     fn get_or_decode_reuses_existing_entry() {
         let mut cache = ImageCache::new();
         let h = [2u8; 32];
-        let (c1, jt1, jto1) = trivial_blob();
-        let (c2, jt2, jto2) = trivial_blob();
-        let p1 = cache.get_or_decode(h, c1, jt1, jto1);
-        let p2 = cache.get_or_decode(h, c2, jt2, jto2);
+        let p1 = cache.get_or_decode(h, trivial_blob(), 0);
+        let p2 = cache.get_or_decode(h, trivial_blob(), 0);
         assert!(Arc::ptr_eq(&p1, &p2));
         assert_eq!(cache.len(), 1);
     }
@@ -105,8 +103,7 @@ mod tests {
     #[test]
     fn clear_drops_entries() {
         let mut cache = ImageCache::new();
-        let (code, jt, jto) = trivial_blob();
-        cache.get_or_decode([3u8; 32], code, jt, jto);
+        cache.get_or_decode([3u8; 32], trivial_blob(), 0);
         assert_eq!(cache.len(), 1);
         cache.clear();
         assert!(cache.is_empty());

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -667,20 +667,16 @@ impl<K: KernelAssist + std::fmt::Debug> std::fmt::Debug for Vm<K> {
 mod tests {
     use super::*;
     use crate::kernel_assist::InProcessKernelAssist;
-    use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
+    use javm_cap::image::Image;
     use javm_cap::{CacheDirectory, Cap, NUM_REGS};
     use std::collections::BTreeMap;
 
     fn empty_image_with_code(code: Vec<u8>) -> Image {
-        let size = (code.len() as u64).next_multiple_of(4096).max(4096);
         Image {
-            codes: vec![CodeRegion { code }],
+            code,
             endpoints: BTreeMap::new(),
-            memory_mappings: vec![MemoryMapping {
-                start: 0x4000_0000,
-                size,
-                source: MappingSource::Code(0),
-            }],
+            // Code is mapped at the fixed CODE_BASE; no data mappings.
+            memory_mappings: Vec::new(),
             gas_slots: Vec::new(),
             quota_slots: Vec::new(),
             pinned_slots: BTreeMap::new(),

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -173,13 +173,24 @@ impl<K: KernelAssist> Vm<K> {
             .get(endpoint_idx as usize)
             .ok_or(VmError::Invariant("endpoint index out of range"))?;
 
-        // Memory layout: base RW region sized to instance.mem_size,
-        // plus per-overlay regions.
+        // Memory layout: the data region lives at [DATA_BASE, mem_size);
+        // the flat buffer is based at DATA_BASE so [0, DATA_BASE) (null
+        // guard + code) is out of range and faults — matching the
+        // recompiler's page table. `inst.mem_size` is the absolute max
+        // data VA; the RW extent above DATA_BASE is what we map.
         let mut mem = CopyingMemory::new();
-        let mem_size_pages = page_round_up_u64(inst.mem_size as u64);
-        if mem_size_pages > 0 {
-            mem.map_region(0, mem_size_pages, Access::ReadWrite, None)
-                .map_err(VmError::MapRegion)?;
+        mem.base = javm_cap::layout::DATA_BASE;
+        let data_extent = page_round_up_u64(
+            (inst.mem_size as u64).saturating_sub(javm_cap::layout::DATA_BASE as u64),
+        );
+        if data_extent > 0 {
+            mem.map_region(
+                javm_cap::layout::DATA_BASE as u64,
+                data_extent,
+                Access::ReadWrite,
+                None,
+            )
+            .map_err(VmError::MapRegion)?;
         }
         for overlay_entry in inst.rw_overlays.iter() {
             overlay_into(

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -159,12 +159,12 @@ impl<K: KernelAssist> Vm<K> {
         };
 
         // Predecode the image bytecode (cache hit when seen before).
-        let program = self.image_cache.get_or_decode(
-            inst.image_hash,
-            img.code.as_slice().to_vec(),
-            img.jump_table.as_slice().to_vec(),
-            img.jump_table_offsets.as_slice().to_vec(),
-        );
+        let (code_base, code_bytes) = img
+            .code_mapping()
+            .ok_or(VmError::Invariant("image has no executable code mapping"))?;
+        let program =
+            self.image_cache
+                .get_or_decode(inst.image_hash, code_bytes.to_vec(), code_base);
 
         // Locate the endpoint definition (dense array, sentinel =
         // entry_pc == 0).
@@ -667,17 +667,20 @@ impl<K: KernelAssist + std::fmt::Debug> std::fmt::Debug for Vm<K> {
 mod tests {
     use super::*;
     use crate::kernel_assist::InProcessKernelAssist;
-    use javm_cap::image::Image;
+    use javm_cap::image::{CodeRegion, Image, MappingSource, MemoryMapping};
     use javm_cap::{CacheDirectory, Cap, NUM_REGS};
     use std::collections::BTreeMap;
 
     fn empty_image_with_code(code: Vec<u8>) -> Image {
+        let size = (code.len() as u64).next_multiple_of(4096).max(4096);
         Image {
-            code,
-            jump_table: Vec::new(),
-            jump_table_offsets: vec![0, 0],
+            codes: vec![CodeRegion { code }],
             endpoints: BTreeMap::new(),
-            memory_mappings: Vec::new(),
+            memory_mappings: vec![MemoryMapping {
+                start: 0x4000_0000,
+                size,
+                source: MappingSource::Code(0),
+            }],
             gas_slots: Vec::new(),
             quota_slots: Vec::new(),
             pinned_slots: BTreeMap::new(),
@@ -865,18 +868,7 @@ mod tests {
         // iteration is a 1-instruction basic block) until the gas
         // budget runs out.
         let code = 0x0000_006Fu32.to_le_bytes().to_vec();
-        let img = Image {
-            code,
-            jump_table: Vec::new(),
-            jump_table_offsets: vec![0, 0],
-            endpoints: BTreeMap::new(),
-            memory_mappings: Vec::new(),
-            gas_slots: Vec::new(),
-            quota_slots: Vec::new(),
-            pinned_slots: BTreeMap::new(),
-            initial_slots: BTreeMap::new(),
-            yield_marker_slot: None,
-        };
+        let img = empty_image_with_code(code);
         let mut cache = CacheDirectory::new();
         let inst_hash = publish_simple_instance(&mut cache, img);
         let mut vm = Vm::new(InProcessKernelAssist::new());

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -118,7 +118,12 @@ pub fn run_instance(
         .mappings
         .iter()
         .find(|m| m.source_kind == MAP_SRC_CODE)
-        .map(|m| (m.start as u32, image.codes[m.code_index as usize].code.as_slice()))
+        .map(|m| {
+            (
+                m.start as u32,
+                image.codes[m.code_index as usize].code.as_slice(),
+            )
+        })
         .expect("image has no executable code mapping");
 
     let predecode = predecode(code_bytes);

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`javm_exec::interp::Interpreter::run`], and produces an
 //! [`InvocationResult`].
 
-use javm_cap::cap::image::ImageCap;
+use javm_cap::cap::image::{ImageCap, MAP_SRC_CODE};
 use javm_cap::cap::instance::InstanceCap;
 use javm_exec::{
     Access, CopyingMemory, EcallHandler, EcallKind, EcallResult, ExitReason, GasCounter, PAGE_SIZE,
@@ -111,11 +111,20 @@ pub fn run_instance(
     let mut gas = GasCounter::new(initial_gas);
     let mut handler = LocalEcallHandler;
 
-    let predecode = predecode(image.code.as_slice());
+    // Locate the executable code region: the first mapping with a
+    // `Code` source. `start` is the region's CODE_BASE (PC = base +
+    // offset); the bytes live in `image.codes[code_index]`.
+    let (code_base, code_bytes) = image
+        .mappings
+        .iter()
+        .find(|m| m.source_kind == MAP_SRC_CODE)
+        .map(|m| (m.start as u32, image.codes[m.code_index as usize].code.as_slice()))
+        .expect("image has no executable code mapping");
+
+    let predecode = predecode(code_bytes);
     let exit = Interpreter::run(
         &predecode,
-        image.jump_table.as_slice(),
-        image.jump_table_offsets.as_slice(),
+        code_base,
         &mut regs,
         &mut mem,
         &mut gas,

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`javm_exec::interp::Interpreter::run`], and produces an
 //! [`InvocationResult`].
 
-use javm_cap::cap::image::{ImageCap, MAP_SRC_CODE};
+use javm_cap::cap::image::ImageCap;
 use javm_cap::cap::instance::InstanceCap;
 use javm_exec::{
     Access, CopyingMemory, EcallHandler, EcallKind, EcallResult, ExitReason, GasCounter, PAGE_SIZE,
@@ -111,19 +111,10 @@ pub fn run_instance(
     let mut gas = GasCounter::new(initial_gas);
     let mut handler = LocalEcallHandler;
 
-    // Locate the executable code region: the first mapping with a
-    // `Code` source. `start` is the region's CODE_BASE (PC = base +
-    // offset); the bytes live in `image.codes[code_index]`.
+    // The executable code region, mapped RO at the fixed CODE_BASE
+    // (PC = CODE_BASE + byte_offset).
     let (code_base, code_bytes) = image
-        .mappings
-        .iter()
-        .find(|m| m.source_kind == MAP_SRC_CODE)
-        .map(|m| {
-            (
-                m.start as u32,
-                image.codes[m.code_index as usize].code.as_slice(),
-            )
-        })
+        .code_mapping()
         .expect("image has no executable code mapping");
 
     let predecode = predecode(code_bytes);

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -75,10 +75,23 @@ pub fn run_instance(
     args: [u64; 4],
     initial_gas: u64,
 ) -> InvocationResult {
+    // Data lives at [DATA_BASE, mem_size); base the flat buffer at
+    // DATA_BASE so [0, DATA_BASE) (null guard + code) faults, matching
+    // the recompiler's page table.
     let mut mem = CopyingMemory::new();
-    let mem_size_pages = page_round_up_u64(instance.mem_size as u64);
-    mem.map_region(0, mem_size_pages, Access::ReadWrite, None)
+    mem.base = javm_cap::layout::DATA_BASE;
+    let data_extent = page_round_up_u64(
+        (instance.mem_size as u64).saturating_sub(javm_cap::layout::DATA_BASE as u64),
+    );
+    if data_extent > 0 {
+        mem.map_region(
+            javm_cap::layout::DATA_BASE as u64,
+            data_extent,
+            Access::ReadWrite,
+            None,
+        )
         .expect("map base RW region");
+    }
     for overlay_entry in instance.rw_overlays.iter() {
         overlay(
             &mut mem,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -96,6 +96,7 @@ use alloc::vec::Vec;
 
 use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::Cap;
+use javm_cap::cap::image::MAP_SRC_CODE;
 use javm_cap::hash::{Blake2b256, Hash};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CapHash, NUM_REGS};
@@ -423,12 +424,33 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
         }
     }
 
-    let mut direct_maps: Vec<DirectMap> = Vec::with_capacity(img.mappings.len());
+    let mut direct_maps: Vec<DirectMap> = Vec::with_capacity(img.mappings.len() + 1);
     let mut mem_size: u32 = 0;
+
+    // Executable code region: RO direct-map at its code base. The code
+    // lives in the Image's page-aligned `CodeRegionCap`, so it maps
+    // straight in like a pinned data cap — and is *excluded* from
+    // mem_size (the flat RW buffer): code sits high (CODE_BASE), well
+    // above the data layout, and must not inflate the per-call alloc.
+    let (code_base, code_bytes) = img.code_mapping().ok_or(ERR_IMAGE_KIND)?;
+    {
+        let pa = paging::va_to_pa(code_bytes.as_ptr() as u64).ok_or(ERR_MAP_BAD_KIND)?;
+        direct_maps.push(DirectMap {
+            start: code_base,
+            pa,
+            size: code_bytes.len() as u32,
+        });
+    }
+
     // Keep Arcs alive for the data-cap lookups so the slice references
     // we feed to direct_maps stay valid until function return.
     let mut data_arcs: Vec<alloc::sync::Arc<Cap>> = Vec::new();
     for m in img.mappings.iter() {
+        // Code mappings are handled above and never extend the flat
+        // RW buffer.
+        if m.source_kind == MAP_SRC_CODE {
+            continue;
+        }
         let end = (m.start + m.size) as u32;
         if end > mem_size {
             mem_size = end;
@@ -523,9 +545,8 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     unsafe {
         jit_run::build_frame_runtime(
             &frame.image_hash,
-            img.code.as_slice(),
-            img.jump_table.as_slice(),
-            img.jump_table_offsets.as_slice(),
+            code_bytes,
+            code_base,
             frame.pc,
             mem_size,
             MemRegion {

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -434,10 +434,15 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     let (code_base, code_bytes) = img.code_mapping().ok_or(ERR_IMAGE_KIND)?;
     {
         let pa = paging::va_to_pa(code_bytes.as_ptr() as u64).ok_or(ERR_MAP_BAD_KIND)?;
+        // `code_bytes.len()` is the real code length; the backing
+        // allocation is page-aligned and page-size-rounded (zeroed
+        // tail). Map the page-rounded extent so the PT mapping covers
+        // whole pages — the trailing zero bytes are RO and unreachable.
+        let map_size = (code_bytes.len() as u32).next_multiple_of(paging::PAGE_SIZE as u32);
         direct_maps.push(DirectMap {
             start: code_base,
             pa,
-            size: code_bytes.len() as u32,
+            size: map_size,
         });
     }
 

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -109,9 +109,6 @@ use crate::state_cache::{CACHE, publish_transient_instance};
 const EXIT_HALT: u32 = 0;
 const EXIT_HOST_CALL: u32 = 4;
 const EXIT_ECALL: u32 = 6;
-/// Lazy compilation: a dispatch hit a block whose 4 KiB page isn't
-/// compiled yet (see `javm_recompiler_x86::codegen::EXIT_COMPILE_PAGE`).
-const EXIT_COMPILE_PAGE: u32 = 8;
 
 const OP_REPLY: u32 = 0;
 const OP_DERIVE_SPAWN: u32 = 18;
@@ -343,24 +340,6 @@ pub fn run_top(
                             gas_remaining: gas,
                         };
                     }
-                }
-            }
-            EXIT_COMPILE_PAGE => {
-                // A dispatch hit an uncompiled page. `info.pc` (already
-                // mirrored into `frame.pc` above) is the target code
-                // offset; compile its 4 KiB page, refresh the #PF trap
-                // view, and re-enter the SAME frame — no pop. The next
-                // loop iteration runs `run_one_entry` at `frame.pc`,
-                // whose prologue now dispatches to real compiled code.
-                // Gas + regs were flushed to ctx by the stub's exit and
-                // are restored verbatim on re-entry, so the bounce is
-                // transparent to the guest.
-                let frame = stack.last_mut().expect("non-empty");
-                let page = frame.pc as usize / paging::PAGE_SIZE;
-                let (tt_ptr, tt_len) =
-                    crate::jit_cache::compile_page_into_arena(&frame.image_hash, page)?;
-                if let Some(rt) = frame.runtime.as_mut() {
-                    rt.set_trap_table(tt_ptr, tt_len);
                 }
             }
             _ => {

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -109,6 +109,9 @@ use crate::state_cache::{CACHE, publish_transient_instance};
 const EXIT_HALT: u32 = 0;
 const EXIT_HOST_CALL: u32 = 4;
 const EXIT_ECALL: u32 = 6;
+/// Lazy compilation: a dispatch hit a block whose 4 KiB page isn't
+/// compiled yet (see `javm_recompiler_x86::codegen::EXIT_COMPILE_PAGE`).
+const EXIT_COMPILE_PAGE: u32 = 8;
 
 const OP_REPLY: u32 = 0;
 const OP_DERIVE_SPAWN: u32 = 18;
@@ -340,6 +343,24 @@ pub fn run_top(
                             gas_remaining: gas,
                         };
                     }
+                }
+            }
+            EXIT_COMPILE_PAGE => {
+                // A dispatch hit an uncompiled page. `info.pc` (already
+                // mirrored into `frame.pc` above) is the target code
+                // offset; compile its 4 KiB page, refresh the #PF trap
+                // view, and re-enter the SAME frame — no pop. The next
+                // loop iteration runs `run_one_entry` at `frame.pc`,
+                // whose prologue now dispatches to real compiled code.
+                // Gas + regs were flushed to ctx by the stub's exit and
+                // are restored verbatim on re-entry, so the bounce is
+                // transparent to the guest.
+                let frame = stack.last_mut().expect("non-empty");
+                let page = frame.pc as usize / paging::PAGE_SIZE;
+                let (tt_ptr, tt_len) =
+                    crate::jit_cache::compile_page_into_arena(&frame.image_hash, page)?;
+                if let Some(rt) = frame.runtime.as_mut() {
+                    rt.set_trap_table(tt_ptr, tt_len);
                 }
             }
             _ => {

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -96,7 +96,6 @@ use alloc::vec::Vec;
 
 use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::Cap;
-use javm_cap::cap::image::MAP_SRC_CODE;
 use javm_cap::hash::{Blake2b256, Hash};
 use javm_cap::slot::SlotIdx;
 use javm_cap::{CapHash, NUM_REGS};
@@ -427,11 +426,11 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     let mut direct_maps: Vec<DirectMap> = Vec::with_capacity(img.mappings.len() + 1);
     let mut mem_size: u32 = 0;
 
-    // Executable code region: RO direct-map at its code base. The code
-    // lives in the Image's page-aligned `CodeRegionCap`, so it maps
+    // Executable code region: RO direct-map at the fixed CODE_BASE. The
+    // code lives in the Image's page-aligned `ImageCap.code`, so it maps
     // straight in like a pinned data cap — and is *excluded* from
-    // mem_size (the flat RW buffer): code sits high (CODE_BASE), well
-    // above the data layout, and must not inflate the per-call alloc.
+    // mem_size (the flat RW buffer): code sits at CODE_BASE, clear of
+    // the data layout, and must not inflate the per-call alloc.
     let (code_base, code_bytes) = img.code_mapping().ok_or(ERR_IMAGE_KIND)?;
     {
         let pa = paging::va_to_pa(code_bytes.as_ptr() as u64).ok_or(ERR_MAP_BAD_KIND)?;
@@ -446,11 +445,9 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // we feed to direct_maps stay valid until function return.
     let mut data_arcs: Vec<alloc::sync::Arc<Cap>> = Vec::new();
     for m in img.mappings.iter() {
-        // Code mappings are handled above and never extend the flat
+        // `img.mappings` describes data/slot regions only; code is
+        // direct-mapped above at CODE_BASE and never extends the flat
         // RW buffer.
-        if m.source_kind == MAP_SRC_CODE {
-            continue;
-        }
         let end = (m.start + m.size) as u32;
         if end > mem_size {
             mem_size = end;

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -33,7 +33,7 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 
-use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
+use javm_recompiler_x86::codegen::{Compiler, HelperFns, LazyInit};
 
 use javm_cap::CapHash;
 
@@ -72,7 +72,11 @@ pub struct CompiledImage {
     /// — `jit_pf_handler` redirects the saved RIP here on page fault.
     pub exit_label_offset: u32,
     /// (native_offset, pvm_pc) pairs the #PF handler binary-searches
-    /// to recover the PVM PC from a faulting RIP.
+    /// to recover the PVM PC from a faulting RIP. Grows as pages are
+    /// lazily compiled; pre-reserved to its worst case so the backing
+    /// allocation (and hence the pointer the #PF handler caches) never
+    /// moves. Stays sorted by native offset because each newly-compiled
+    /// page occupies the next contiguous native range.
     pub trap_table: Vec<(u32, u32)>,
     /// Template PD subtree mapping the arena pages at per-call VAs.
     /// Per-call PTs install [`template_pd_pa`] into PDPT[1] of the
@@ -83,6 +87,25 @@ pub struct CompiledImage {
     /// Physical address of `template`'s PD page, cached for fast
     /// install on the per-call hot path.
     pub template_pd_pa: u64,
+
+    // === Lazy per-page compilation state ============================
+    /// Persistent compiler: owns the assembler (prologue, shared stubs,
+    /// and every page body compiled so far) plus the whole-blob
+    /// block-start set. `compile_page_into_arena` appends a page body on
+    /// first entry.
+    ///
+    /// Self-referential (`asm.buf` → its own Vec heap; `bitmask_ptr` →
+    /// `rv_valid_pc` heap). Both target heap allocations that survive a
+    /// move of this struct (BTreeMap rebalance), so caching it is sound.
+    pub compiler: Compiler,
+    /// Guest code bytes — `compile_lazy_page` decodes a page from these.
+    pub code: Vec<u8>,
+    /// Per-4 KiB-page "already compiled" flag (len = number of code
+    /// pages). Guards against compiling a page twice.
+    pub compiled: Vec<bool>,
+    /// Byte size of one JIT region (== `tramp_offset - jit_offset`),
+    /// the upper bound a lazily-appended page must not exceed.
+    pub jit_region_size: usize,
 }
 
 /// Process-wide compile cache.
@@ -148,28 +171,43 @@ pub fn get_or_compile(
     // SAFETY: single-threaded guest.
     let map = unsafe { &mut *CACHE.inner.get() };
     if !map.contains_key(image_hash) {
-        // Region sizing. valid_pc is `code.len()` bytes; the streaming
-        // compile produces it inline so we don't allocate it twice.
-        // Layout: BB | DISPATCH | JIT | TRAMP (no jump table — jalr
-        // targets are validated against BB directly).
+        // Region sizing. Layout: BB | DISPATCH | JIT | TRAMP (no jump
+        // table — jalr targets are validated against BB directly).
+        //
+        // BB / DISPATCH scale exactly with code length. The JIT region,
+        // under lazy compilation, must be sized to its *worst case* up
+        // front: pages compile in on first entry (in execution order),
+        // appending to a fixed arena that's mapped RX once and never
+        // moves.
+        //
+        // 32× code length + 16 KiB is the per-byte worst case. The
+        // recompiler runs untrusted code, so the bound must hold for any
+        // input, not just typical guests (~3× expansion): a page of
+        // 0x0000 halfwords — the zero-padding `CodeRegionCap` appends to
+        // round code up to a page — compiles to ~22.5× (each illegal
+        // halfword is a terminating panic stub, so the next halfword is a
+        // fresh gas block too), and a worst-case cross-page conditional
+        // branch is ~27×. `compile_page_into_arena` hard-checks against
+        // the bound, so even an under-estimate fails cleanly (a
+        // pathological guest just won't run) rather than corrupting.
         let bb_size = page_round_up_min1(code.len());
         let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
+        let jit_region_size = page_round_up_min1(code.len() * 32 + 16384);
 
         let bb_offset = 0usize;
         let dispatch_offset = bb_offset + bb_size;
         let jit_offset = dispatch_offset + dispatch_size;
         let jit_va = arena_base_va + jit_offset as u64;
 
-        let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
-        let CompileResult {
-            native_code,
-            dispatch_entries,
-            trap_table,
-            exit_label_offset,
-            valid_pc,
-        } = compiler.compile(code);
+        let mut compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
+        // Emit prologue + shared stubs only (incl. the compile-page
+        // stub). Page bodies compile lazily on first entry.
+        let init: LazyInit = compiler.compile_lazy_init(code);
 
-        let jit_size = page_round_up_min1(native_code.len());
+        // #PF window covers the whole (worst-case) JIT region: a fault's
+        // RIP is always inside already-compiled code, which lives within
+        // this window.
+        let jit_size = jit_region_size;
         let tramp_offset = jit_offset + jit_size;
         let tramp_size = PAGE_SIZE;
         let total = tramp_offset + tramp_size;
@@ -179,19 +217,27 @@ pub fn get_or_compile(
 
         // BB region: valid_pc as bytes (Vec<bool> is 0/1 single-byte
         // representation, so a raw-pointer reinterpret is sound).
-        let bb_ptr = valid_pc.as_ptr() as *const u8;
+        let bb_ptr = init.valid_pc.as_ptr() as *const u8;
         // SAFETY: bb_ptr valid for valid_pc.len() bytes.
-        let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, valid_pc.len()) };
-        buf[bb_offset..bb_offset + valid_pc.len()].copy_from_slice(bb_bytes);
+        let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, init.valid_pc.len()) };
+        buf[bb_offset..bb_offset + init.valid_pc.len()].copy_from_slice(bb_bytes);
 
-        // DISPATCH region — sparse write (arena is page-zero).
-        for &(pvm_pc, off) in &dispatch_entries {
-            let slot_off = dispatch_offset + (pvm_pc as usize) * core::mem::size_of::<i32>();
-            buf[slot_off..slot_off + 4].copy_from_slice(&off.to_le_bytes());
+        // DISPATCH region — point every block start at the compile-page
+        // stub (sparse write; arena is page-zero, so non-block-start
+        // slots stay 0 and are never used as dispatch targets). As pages
+        // compile, `compile_page_into_arena` patches their block starts
+        // to the real native offsets.
+        let stub_bytes = (init.compile_stub_offset as i32).to_le_bytes();
+        for off in 0..init.valid_pc.len() {
+            if init.valid_pc[off] {
+                let slot_off = dispatch_offset + off * core::mem::size_of::<i32>();
+                buf[slot_off..slot_off + 4].copy_from_slice(&stub_bytes);
+            }
         }
 
-        // JIT region.
-        buf[jit_offset..jit_offset + native_code.len()].copy_from_slice(&native_code);
+        // JIT region — prologue + shared stubs (offsets 0..init.len).
+        let init_bytes = compiler.asm.written();
+        buf[jit_offset..jit_offset + init.len].copy_from_slice(&init_bytes[..init.len]);
 
         // TRAMP region (same 26-byte sequence as PVM).
         let tramp_start = tramp_offset;
@@ -228,6 +274,15 @@ pub fn get_or_compile(
             .pd_pa()
             .expect("template PD must be in kernel half");
 
+        // Trap table: empty after init (prologue + stubs have no memory
+        // ops). Pre-reserve to the worst case — at most one entry per
+        // instruction, and instructions are ≥ 2 bytes — so lazily
+        // appending page trap entries never reallocates, keeping the
+        // backing pointer (cached by the #PF handler) stable.
+        let trap_table: Vec<(u32, u32)> = Vec::with_capacity(code.len() / 2 + 64);
+
+        let n_pages = code.len().div_ceil(PAGE_SIZE);
+
         map.insert(
             *image_hash,
             CompiledImage {
@@ -237,12 +292,103 @@ pub fn get_or_compile(
                 jit_offset,
                 tramp_offset,
                 jit_size,
-                exit_label_offset,
+                exit_label_offset: init.exit_label_offset,
                 trap_table,
                 template,
                 template_pd_pa,
+                compiler,
+                code: code.to_vec(),
+                compiled: alloc::vec![false; n_pages],
+                jit_region_size,
             },
         );
     }
     map.get(image_hash).expect("inserted above")
+}
+
+/// Image not present in the cache (must be inserted by `get_or_compile`
+/// before a page is compiled).
+pub const ERR_LAZY_NO_IMAGE: u32 = 70;
+/// Requested page index is past the end of the code.
+pub const ERR_LAZY_PAGE_OOB: u32 = 71;
+/// Compiled page would overrun the worst-case JIT region — only a
+/// pathological guest can hit this (see the 32× bound in `get_or_compile`).
+pub const ERR_LAZY_ARENA_FULL: u32 = 72;
+
+/// Lazily compile one 4 KiB code page into the cached Image's arena.
+///
+/// Called from the `EXIT_COMPILE_PAGE` runtime path when a dispatch
+/// landed on a block whose page is not compiled yet. Compiles the page
+/// body (appending to the persistent compiler's JIT buffer), copies the
+/// new native bytes into the arena's JIT region, patches the page's
+/// block-start dispatch entries to their real native offsets, and
+/// appends the page's trap entries.
+///
+/// Returns the `(ptr, len)` of the (possibly-grown) trap table so the
+/// caller can refresh the live frame's #PF-handler view before
+/// re-entering ring 3. Idempotent: a page already compiled is a no-op
+/// that returns the current trap view.
+///
+/// `Err(())` on a bad page index or if the worst-case JIT region bound
+/// is exceeded (never expected for real guests — a clean failure rather
+/// than an arena overwrite).
+///
+/// # Safety
+/// Single-threaded guest; the runtime sequences this between ring-3
+/// entries, so no live `&CompiledImage` borrow overlaps the `&mut` here.
+pub fn compile_page_into_arena(
+    image_hash: &CapHash,
+    page: usize,
+) -> Result<(*const (u32, u32), u64), u32> {
+    // SAFETY: single-threaded guest.
+    let map = unsafe { &mut *CACHE.inner.get() };
+    let image = map.get_mut(image_hash).ok_or(ERR_LAZY_NO_IMAGE)?;
+
+    if page >= image.compiled.len() {
+        return Err(ERR_LAZY_PAGE_OOB);
+    }
+    if image.compiled[page] {
+        // Already compiled — dispatch entries already point at real
+        // code; this re-entry just needs the current trap view.
+        return Ok((image.trap_table.as_ptr(), image.trap_table.len() as u64));
+    }
+
+    // Compile the page body (appends to the compiler's JIT buffer).
+    // Disjoint field borrows: `compiler` (&mut) vs `code` (&).
+    let lazy = image.compiler.compile_lazy_page(&image.code, page);
+
+    // Worst-case JIT region bound — refuse to overrun the arena (would
+    // only fire for a pathological/adversarial guest; the 32× sizing
+    // covers every real workload). Clean failure, never a corrupting
+    // write past the arena.
+    if lazy.end > image.jit_region_size {
+        return Err(ERR_LAZY_ARENA_FULL);
+    }
+
+    // Copy the newly-emitted bytes into the arena JIT region. `compiler`
+    // and `arena` are disjoint fields, so the two borrows don't alias.
+    {
+        let src = image.compiler.asm.written();
+        let bytes = &src[lazy.start..lazy.end];
+        let buf = image.arena.as_mut_slice();
+        let dst = image.jit_offset + lazy.start;
+        buf[dst..dst + bytes.len()].copy_from_slice(bytes);
+    }
+
+    // Patch this page's block-start dispatch entries to real offsets.
+    {
+        let dispatch_offset = image.dispatch_offset;
+        let buf = image.arena.as_mut_slice();
+        for &(pc, noff) in &lazy.dispatch_entries {
+            let slot = dispatch_offset + (pc as usize) * core::mem::size_of::<i32>();
+            buf[slot..slot + 4].copy_from_slice(&noff.to_le_bytes());
+        }
+    }
+
+    // Append trap entries — pre-reserved, so no realloc; stays sorted by
+    // native offset because this page occupies the next native range.
+    image.trap_table.extend_from_slice(&lazy.trap_entries);
+    image.compiled[page] = true;
+
+    Ok((image.trap_table.as_ptr(), image.trap_table.len() as u64))
 }

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -1,16 +1,18 @@
 //! Per-Image JIT code cache + page-aligned arena.
 //!
-//! Each Image gets one [`PageBuf`] arena containing five regions
+//! Each Image gets one [`PageBuf`] arena containing four regions
 //! laid out contiguously, each starting on a page boundary:
 //!
 //! ```text
 //!   arena base (page-aligned)
 //!     + bb_offset       : BB (bitmask)      RO
-//!     + jt_offset       : JT (jump table)   RO
 //!     + dispatch_offset : DISPATCH table    RO
 //!     + jit_offset      : JIT native code   RX
 //!     + tramp_offset    : trampoline (26B)  RX
 //! ```
+//!
+//! `jalr` targets are validated against the BB (basic-block-start) set
+//! directly — there is no separate jump table.
 //!
 //! The arena lives for the cache entry's lifetime and is mapped into
 //! every Instance's page table that runs this Image — so we only pay
@@ -51,7 +53,8 @@ use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
 /// The `trap_table` is kept outside the arena — `jit_pf_handler` reads
 /// it via static atomics and never needs it mapped into ring-3.
 pub struct CompiledImage {
-    /// Page-aligned buffer holding the five regions.
+    /// Page-aligned buffer holding the four regions
+    /// (BB | DISPATCH | JIT | TRAMP).
     ///
     /// Kept solely to own the backing pages — referenced by the
     /// template's leaf PTEs and freed when the cache entry is evicted.
@@ -59,7 +62,6 @@ pub struct CompiledImage {
     pub arena: PageBuf,
     /// Offsets into `arena` for each region (in bytes from arena base).
     pub bb_offset: usize,
-    pub jt_offset: usize,
     pub dispatch_offset: usize,
     pub jit_offset: usize,
     pub tramp_offset: usize,
@@ -137,8 +139,7 @@ pub fn evict_all() {
 pub fn get_or_compile(
     image_hash: &CapHash,
     code: &[u8],
-    jump_table: &[u32],
-    jump_table_offsets: &[u32],
+    code_base: u32,
     arena_base_va: u64,
     ctx_va: u64,
     mem_cycles: u8,
@@ -149,25 +150,24 @@ pub fn get_or_compile(
     if !map.contains_key(image_hash) {
         // Region sizing. valid_pc is `code.len()` bytes; the streaming
         // compile produces it inline so we don't allocate it twice.
+        // Layout: BB | DISPATCH | JIT | TRAMP (no jump table — jalr
+        // targets are validated against BB directly).
         let bb_size = page_round_up_min1(code.len());
-        let jt_bytes_used = core::mem::size_of_val(jump_table);
-        let jt_size = page_round_up_min1(jt_bytes_used);
         let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
 
         let bb_offset = 0usize;
-        let jt_offset = bb_offset + bb_size;
-        let dispatch_offset = jt_offset + jt_size;
+        let dispatch_offset = bb_offset + bb_size;
         let jit_offset = dispatch_offset + dispatch_size;
         let jit_va = arena_base_va + jit_offset as u64;
 
-        let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles);
+        let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
         let CompileResult {
             native_code,
             dispatch_entries,
             trap_table,
             exit_label_offset,
             valid_pc,
-        } = compiler.compile(code, jump_table_offsets);
+        } = compiler.compile(code);
 
         let jit_size = page_round_up_min1(native_code.len());
         let tramp_offset = jit_offset + jit_size;
@@ -183,15 +183,6 @@ pub fn get_or_compile(
         // SAFETY: bb_ptr valid for valid_pc.len() bytes.
         let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, valid_pc.len()) };
         buf[bb_offset..bb_offset + valid_pc.len()].copy_from_slice(bb_bytes);
-
-        // JT region: copy per-function br_table sub-tables (concatenated
-        // PVM2 PCs, sub-table boundaries in `jump_table_offsets`).
-        if !jump_table.is_empty() {
-            let jt_ptr = jump_table.as_ptr() as *const u8;
-            // SAFETY: jt_ptr valid for jt_bytes_used bytes.
-            let jt_slice = unsafe { core::slice::from_raw_parts(jt_ptr, jt_bytes_used) };
-            buf[jt_offset..jt_offset + jt_bytes_used].copy_from_slice(jt_slice);
-        }
 
         // DISPATCH region — sparse write (arena is page-zero).
         for &(pvm_pc, off) in &dispatch_entries {
@@ -242,7 +233,6 @@ pub fn get_or_compile(
             CompiledImage {
                 arena,
                 bb_offset,
-                jt_offset,
                 dispatch_offset,
                 jit_offset,
                 tramp_offset,

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -33,7 +33,7 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 
-use javm_recompiler_x86::codegen::{Compiler, HelperFns, LazyInit};
+use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 
 use javm_cap::CapHash;
 
@@ -72,11 +72,7 @@ pub struct CompiledImage {
     /// — `jit_pf_handler` redirects the saved RIP here on page fault.
     pub exit_label_offset: u32,
     /// (native_offset, pvm_pc) pairs the #PF handler binary-searches
-    /// to recover the PVM PC from a faulting RIP. Grows as pages are
-    /// lazily compiled; pre-reserved to its worst case so the backing
-    /// allocation (and hence the pointer the #PF handler caches) never
-    /// moves. Stays sorted by native offset because each newly-compiled
-    /// page occupies the next contiguous native range.
+    /// to recover the PVM PC from a faulting RIP.
     pub trap_table: Vec<(u32, u32)>,
     /// Template PD subtree mapping the arena pages at per-call VAs.
     /// Per-call PTs install [`template_pd_pa`] into PDPT[1] of the
@@ -87,25 +83,6 @@ pub struct CompiledImage {
     /// Physical address of `template`'s PD page, cached for fast
     /// install on the per-call hot path.
     pub template_pd_pa: u64,
-
-    // === Lazy per-page compilation state ============================
-    /// Persistent compiler: owns the assembler (prologue, shared stubs,
-    /// and every page body compiled so far) plus the whole-blob
-    /// block-start set. `compile_page_into_arena` appends a page body on
-    /// first entry.
-    ///
-    /// Self-referential (`asm.buf` → its own Vec heap; `bitmask_ptr` →
-    /// `rv_valid_pc` heap). Both target heap allocations that survive a
-    /// move of this struct (BTreeMap rebalance), so caching it is sound.
-    pub compiler: Compiler,
-    /// Guest code bytes — `compile_lazy_page` decodes a page from these.
-    pub code: Vec<u8>,
-    /// Per-4 KiB-page "already compiled" flag (len = number of code
-    /// pages). Guards against compiling a page twice.
-    pub compiled: Vec<bool>,
-    /// Byte size of one JIT region (== `tramp_offset - jit_offset`),
-    /// the upper bound a lazily-appended page must not exceed.
-    pub jit_region_size: usize,
 }
 
 /// Process-wide compile cache.
@@ -171,43 +148,28 @@ pub fn get_or_compile(
     // SAFETY: single-threaded guest.
     let map = unsafe { &mut *CACHE.inner.get() };
     if !map.contains_key(image_hash) {
-        // Region sizing. Layout: BB | DISPATCH | JIT | TRAMP (no jump
-        // table — jalr targets are validated against BB directly).
-        //
-        // BB / DISPATCH scale exactly with code length. The JIT region,
-        // under lazy compilation, must be sized to its *worst case* up
-        // front: pages compile in on first entry (in execution order),
-        // appending to a fixed arena that's mapped RX once and never
-        // moves.
-        //
-        // 32× code length + 16 KiB is the per-byte worst case. The
-        // recompiler runs untrusted code, so the bound must hold for any
-        // input, not just typical guests (~3× expansion): a page of
-        // 0x0000 halfwords — the zero-padding `CodeRegionCap` appends to
-        // round code up to a page — compiles to ~22.5× (each illegal
-        // halfword is a terminating panic stub, so the next halfword is a
-        // fresh gas block too), and a worst-case cross-page conditional
-        // branch is ~27×. `compile_page_into_arena` hard-checks against
-        // the bound, so even an under-estimate fails cleanly (a
-        // pathological guest just won't run) rather than corrupting.
+        // Region sizing. valid_pc is `code.len()` bytes; the streaming
+        // compile produces it inline so we don't allocate it twice.
+        // Layout: BB | DISPATCH | JIT | TRAMP (no jump table — jalr
+        // targets are validated against BB directly).
         let bb_size = page_round_up_min1(code.len());
         let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
-        let jit_region_size = page_round_up_min1(code.len() * 32 + 16384);
 
         let bb_offset = 0usize;
         let dispatch_offset = bb_offset + bb_size;
         let jit_offset = dispatch_offset + dispatch_size;
         let jit_va = arena_base_va + jit_offset as u64;
 
-        let mut compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
-        // Emit prologue + shared stubs only (incl. the compile-page
-        // stub). Page bodies compile lazily on first entry.
-        let init: LazyInit = compiler.compile_lazy_init(code);
+        let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
+        let CompileResult {
+            native_code,
+            dispatch_entries,
+            trap_table,
+            exit_label_offset,
+            valid_pc,
+        } = compiler.compile(code);
 
-        // #PF window covers the whole (worst-case) JIT region: a fault's
-        // RIP is always inside already-compiled code, which lives within
-        // this window.
-        let jit_size = jit_region_size;
+        let jit_size = page_round_up_min1(native_code.len());
         let tramp_offset = jit_offset + jit_size;
         let tramp_size = PAGE_SIZE;
         let total = tramp_offset + tramp_size;
@@ -217,27 +179,19 @@ pub fn get_or_compile(
 
         // BB region: valid_pc as bytes (Vec<bool> is 0/1 single-byte
         // representation, so a raw-pointer reinterpret is sound).
-        let bb_ptr = init.valid_pc.as_ptr() as *const u8;
+        let bb_ptr = valid_pc.as_ptr() as *const u8;
         // SAFETY: bb_ptr valid for valid_pc.len() bytes.
-        let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, init.valid_pc.len()) };
-        buf[bb_offset..bb_offset + init.valid_pc.len()].copy_from_slice(bb_bytes);
+        let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, valid_pc.len()) };
+        buf[bb_offset..bb_offset + valid_pc.len()].copy_from_slice(bb_bytes);
 
-        // DISPATCH region — point every block start at the compile-page
-        // stub (sparse write; arena is page-zero, so non-block-start
-        // slots stay 0 and are never used as dispatch targets). As pages
-        // compile, `compile_page_into_arena` patches their block starts
-        // to the real native offsets.
-        let stub_bytes = (init.compile_stub_offset as i32).to_le_bytes();
-        for off in 0..init.valid_pc.len() {
-            if init.valid_pc[off] {
-                let slot_off = dispatch_offset + off * core::mem::size_of::<i32>();
-                buf[slot_off..slot_off + 4].copy_from_slice(&stub_bytes);
-            }
+        // DISPATCH region — sparse write (arena is page-zero).
+        for &(pvm_pc, off) in &dispatch_entries {
+            let slot_off = dispatch_offset + (pvm_pc as usize) * core::mem::size_of::<i32>();
+            buf[slot_off..slot_off + 4].copy_from_slice(&off.to_le_bytes());
         }
 
-        // JIT region — prologue + shared stubs (offsets 0..init.len).
-        let init_bytes = compiler.asm.written();
-        buf[jit_offset..jit_offset + init.len].copy_from_slice(&init_bytes[..init.len]);
+        // JIT region.
+        buf[jit_offset..jit_offset + native_code.len()].copy_from_slice(&native_code);
 
         // TRAMP region (same 26-byte sequence as PVM).
         let tramp_start = tramp_offset;
@@ -274,15 +228,6 @@ pub fn get_or_compile(
             .pd_pa()
             .expect("template PD must be in kernel half");
 
-        // Trap table: empty after init (prologue + stubs have no memory
-        // ops). Pre-reserve to the worst case — at most one entry per
-        // instruction, and instructions are ≥ 2 bytes — so lazily
-        // appending page trap entries never reallocates, keeping the
-        // backing pointer (cached by the #PF handler) stable.
-        let trap_table: Vec<(u32, u32)> = Vec::with_capacity(code.len() / 2 + 64);
-
-        let n_pages = code.len().div_ceil(PAGE_SIZE);
-
         map.insert(
             *image_hash,
             CompiledImage {
@@ -292,103 +237,12 @@ pub fn get_or_compile(
                 jit_offset,
                 tramp_offset,
                 jit_size,
-                exit_label_offset: init.exit_label_offset,
+                exit_label_offset,
                 trap_table,
                 template,
                 template_pd_pa,
-                compiler,
-                code: code.to_vec(),
-                compiled: alloc::vec![false; n_pages],
-                jit_region_size,
             },
         );
     }
     map.get(image_hash).expect("inserted above")
-}
-
-/// Image not present in the cache (must be inserted by `get_or_compile`
-/// before a page is compiled).
-pub const ERR_LAZY_NO_IMAGE: u32 = 70;
-/// Requested page index is past the end of the code.
-pub const ERR_LAZY_PAGE_OOB: u32 = 71;
-/// Compiled page would overrun the worst-case JIT region — only a
-/// pathological guest can hit this (see the 32× bound in `get_or_compile`).
-pub const ERR_LAZY_ARENA_FULL: u32 = 72;
-
-/// Lazily compile one 4 KiB code page into the cached Image's arena.
-///
-/// Called from the `EXIT_COMPILE_PAGE` runtime path when a dispatch
-/// landed on a block whose page is not compiled yet. Compiles the page
-/// body (appending to the persistent compiler's JIT buffer), copies the
-/// new native bytes into the arena's JIT region, patches the page's
-/// block-start dispatch entries to their real native offsets, and
-/// appends the page's trap entries.
-///
-/// Returns the `(ptr, len)` of the (possibly-grown) trap table so the
-/// caller can refresh the live frame's #PF-handler view before
-/// re-entering ring 3. Idempotent: a page already compiled is a no-op
-/// that returns the current trap view.
-///
-/// `Err(())` on a bad page index or if the worst-case JIT region bound
-/// is exceeded (never expected for real guests — a clean failure rather
-/// than an arena overwrite).
-///
-/// # Safety
-/// Single-threaded guest; the runtime sequences this between ring-3
-/// entries, so no live `&CompiledImage` borrow overlaps the `&mut` here.
-pub fn compile_page_into_arena(
-    image_hash: &CapHash,
-    page: usize,
-) -> Result<(*const (u32, u32), u64), u32> {
-    // SAFETY: single-threaded guest.
-    let map = unsafe { &mut *CACHE.inner.get() };
-    let image = map.get_mut(image_hash).ok_or(ERR_LAZY_NO_IMAGE)?;
-
-    if page >= image.compiled.len() {
-        return Err(ERR_LAZY_PAGE_OOB);
-    }
-    if image.compiled[page] {
-        // Already compiled — dispatch entries already point at real
-        // code; this re-entry just needs the current trap view.
-        return Ok((image.trap_table.as_ptr(), image.trap_table.len() as u64));
-    }
-
-    // Compile the page body (appends to the compiler's JIT buffer).
-    // Disjoint field borrows: `compiler` (&mut) vs `code` (&).
-    let lazy = image.compiler.compile_lazy_page(&image.code, page);
-
-    // Worst-case JIT region bound — refuse to overrun the arena (would
-    // only fire for a pathological/adversarial guest; the 32× sizing
-    // covers every real workload). Clean failure, never a corrupting
-    // write past the arena.
-    if lazy.end > image.jit_region_size {
-        return Err(ERR_LAZY_ARENA_FULL);
-    }
-
-    // Copy the newly-emitted bytes into the arena JIT region. `compiler`
-    // and `arena` are disjoint fields, so the two borrows don't alias.
-    {
-        let src = image.compiler.asm.written();
-        let bytes = &src[lazy.start..lazy.end];
-        let buf = image.arena.as_mut_slice();
-        let dst = image.jit_offset + lazy.start;
-        buf[dst..dst + bytes.len()].copy_from_slice(bytes);
-    }
-
-    // Patch this page's block-start dispatch entries to real offsets.
-    {
-        let dispatch_offset = image.dispatch_offset;
-        let buf = image.arena.as_mut_slice();
-        for &(pc, noff) in &lazy.dispatch_entries {
-            let slot = dispatch_offset + (pc as usize) * core::mem::size_of::<i32>();
-            buf[slot..slot + 4].copy_from_slice(&noff.to_le_bytes());
-        }
-    }
-
-    // Append trap entries — pre-reserved, so no realloc; stays sorted by
-    // native offset because this page occupies the next native range.
-    image.trap_table.extend_from_slice(&lazy.trap_entries);
-    image.compiled[page] = true;
-
-    Ok((image.trap_table.as_ptr(), image.trap_table.len() as u64))
 }

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -5,14 +5,16 @@
 //!
 //! ```text
 //!   arena base (page-aligned)
-//!     + bb_offset       : BB (bitmask)      RO
 //!     + dispatch_offset : DISPATCH table    RO
 //!     + jit_offset      : JIT native code   RX
 //!     + tramp_offset    : trampoline (26B)  RX
 //! ```
 //!
-//! `jalr` targets are validated against the BB (basic-block-start) set
-//! directly — there is no separate jump table.
+//! `jalr` targets are validated by the dispatch table itself: it is
+//! *dense* (one `i32` native offset per code byte), and every
+//! non-block-start offset holds the panic-stub offset, so an invalid
+//! target jumps to the panic stub. There is no separate basic-block-
+//! start set or jump table.
 //!
 //! The arena lives for the cache entry's lifetime and is mapped into
 //! every Instance's page table that runs this Image — so we only pay
@@ -42,8 +44,8 @@ use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
 
 /// One cached Image's worth of compiled artifacts.
 ///
-/// The arena holds BB / JT / DISPATCH / JIT / TRAMP regions
-/// contiguously, page-aligned. The `template` is a pre-built PD
+/// The arena holds DISPATCH / JIT / TRAMP regions contiguously,
+/// page-aligned. The `template` is a pre-built PD
 /// subtree (one PD + up to a handful of PT pages) whose leaf PTEs
 /// already point at the arena's pages with the right permissions —
 /// per-call page tables install the PD via
@@ -53,15 +55,14 @@ use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
 /// The `trap_table` is kept outside the arena — `jit_pf_handler` reads
 /// it via static atomics and never needs it mapped into ring-3.
 pub struct CompiledImage {
-    /// Page-aligned buffer holding the four regions
-    /// (BB | DISPATCH | JIT | TRAMP).
+    /// Page-aligned buffer holding the three regions
+    /// (DISPATCH | JIT | TRAMP).
     ///
     /// Kept solely to own the backing pages — referenced by the
     /// template's leaf PTEs and freed when the cache entry is evicted.
     #[allow(dead_code)]
     pub arena: PageBuf,
     /// Offsets into `arena` for each region (in bytes from arena base).
-    pub bb_offset: usize,
     pub dispatch_offset: usize,
     pub jit_offset: usize,
     pub tramp_offset: usize,
@@ -148,15 +149,12 @@ pub fn get_or_compile(
     // SAFETY: single-threaded guest.
     let map = unsafe { &mut *CACHE.inner.get() };
     if !map.contains_key(image_hash) {
-        // Region sizing. valid_pc is `code.len()` bytes; the streaming
-        // compile produces it inline so we don't allocate it twice.
-        // Layout: BB | DISPATCH | JIT | TRAMP (no jump table — jalr
-        // targets are validated against BB directly).
-        let bb_size = page_round_up_min1(code.len());
+        // Region sizing. Layout: DISPATCH | JIT | TRAMP. The dispatch
+        // table is dense — one i32 native offset per code byte — and
+        // doubles as the jalr-target validator (no separate BB set).
         let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
 
-        let bb_offset = 0usize;
-        let dispatch_offset = bb_offset + bb_size;
+        let dispatch_offset = 0usize;
         let jit_offset = dispatch_offset + dispatch_size;
         let jit_va = arena_base_va + jit_offset as u64;
 
@@ -166,7 +164,7 @@ pub fn get_or_compile(
             dispatch_entries,
             trap_table,
             exit_label_offset,
-            valid_pc,
+            panic_offset,
         } = compiler.compile(code);
 
         let jit_size = page_round_up_min1(native_code.len());
@@ -177,17 +175,37 @@ pub fn get_or_compile(
         let mut arena = PageBuf::new(total).expect("PageBuf alloc for Image arena");
         let buf = arena.as_mut_slice();
 
-        // BB region: valid_pc as bytes (Vec<bool> is 0/1 single-byte
-        // representation, so a raw-pointer reinterpret is sound).
-        let bb_ptr = valid_pc.as_ptr() as *const u8;
-        // SAFETY: bb_ptr valid for valid_pc.len() bytes.
-        let bb_bytes = unsafe { core::slice::from_raw_parts(bb_ptr, valid_pc.len()) };
-        buf[bb_offset..bb_offset + valid_pc.len()].copy_from_slice(bb_bytes);
-
-        // DISPATCH region — sparse write (arena is page-zero).
+        // DISPATCH region — dense fill. First set *every* code-byte slot
+        // to the panic-stub offset, so a jalr to any non-block-start
+        // offset lands on the panic stub; then overwrite the block-start
+        // offsets with their real native targets. This folds the
+        // block-start validation into the dispatch lookup.
+        //
+        // SECURITY-CRITICAL: the panic-fill must cover all `code.len()`
+        // slots — a slot left zero (the arena is page-zeroed) would route
+        // a bad jalr target to native offset 0 instead of faulting.
+        //
+        // The panic-fill is the per-recompile (cold-path) cost of the
+        // dense table, so do it at memset speed via a u32 view rather
+        // than a per-slot byte copy. `dispatch_offset` is 0 in the
+        // page-aligned arena, so the region is 4-aligned and holds
+        // exactly `code.len()` i32 slots. The host is little-endian
+        // (x86-64), so a native u32 store matches the LE bytes the JIT
+        // reads back as i32.
+        let dispatch_slots = code.len();
+        debug_assert_eq!(dispatch_offset, 0);
+        // SAFETY: 4-aligned (page-aligned arena base), in-bounds
+        // (dispatch_size ≥ dispatch_slots * 4), no aliasing (exclusive
+        // `buf`).
+        let dispatch_u32: &mut [u32] = unsafe {
+            core::slice::from_raw_parts_mut(
+                buf.as_mut_ptr().add(dispatch_offset) as *mut u32,
+                dispatch_slots,
+            )
+        };
+        dispatch_u32.fill(panic_offset);
         for &(pvm_pc, off) in &dispatch_entries {
-            let slot_off = dispatch_offset + (pvm_pc as usize) * core::mem::size_of::<i32>();
-            buf[slot_off..slot_off + 4].copy_from_slice(&off.to_le_bytes());
+            dispatch_u32[pvm_pc as usize] = off as u32;
         }
 
         // JIT region.
@@ -232,7 +250,6 @@ pub fn get_or_compile(
             *image_hash,
             CompiledImage {
                 arena,
-                bb_offset,
                 dispatch_offset,
                 jit_offset,
                 tramp_offset,

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -343,6 +343,19 @@ pub struct FrameRuntime {
     ctx_kva: u64,
 }
 
+impl FrameRuntime {
+    /// Refresh the cached trap-table view after a lazy page compile grew
+    /// the Image's trap table. [`enter_frame`] republishes these to the
+    /// #PF handler atomics on the next ring-3 entry, so the handler can
+    /// resolve a faulting RIP in the just-compiled page. The backing
+    /// allocation is pre-reserved (never moves), so in practice only the
+    /// length changes — but we refresh both for robustness.
+    pub fn set_trap_table(&mut self, ptr: *const (u32, u32), len: u64) {
+        self.trap_table_ptr = ptr;
+        self.trap_table_len = len;
+    }
+}
+
 /// Build a per-frame runtime: compile the Image (cached), allocate
 /// per-call mem/ctx/stack pages, populate mem from `arg`/`ro`/`rw`,
 /// initialise the frame-constant `JitContext` fields, and build the

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -1,6 +1,6 @@
 //! In-kernel JIT execution at ring 3.
 //!
-//! Takes a PVM program (code + bitmask + jump_table) and runs it
+//! Takes a PVM program (code + basic-block-start set) and runs it
 //! inside a per-invocation page table at ring 3. The PVM exits
 //! through `int 0x81` (a hand-rolled trampoline placed after the
 //! JIT'd code at a user-RX VA); the kernel handler longjmps back to
@@ -27,12 +27,16 @@
 //!   CTX_VA   = 4 GiB              4 KiB JitContext                (user-RW)
 //!
 //!   META_BASE= 4 GiB + 16 MiB     per-Image arena base
-//!                                 (BB | JT | DISPATCH | JIT | TRAMP)
-//!     BB / JT / DISPATCH                                          (user-RO)
+//!                                 (BB | DISPATCH | JIT | TRAMP)
+//!     BB / DISPATCH                                               (user-RO)
 //!     JIT / TRAMP                                                 (user-RX)
 //!
 //!   STACK    = META + 1 GiB       ring-3 x86 stack, 4 KiB         (user-RW)
 //! ```
+//!
+//! Guest code is mapped read-only into the low-4 GiB guest range at its
+//! `CODE_BASE` (a `DirectMap`, like a pinned data cap), so PVM PCs are
+//! real VAs and the guest can read its own bytes (PIC AUIPC+load).
 //!
 //! The Image arena lives in [`jit_cache::CompiledImage`] (one per
 //! Image, allocated once and mapped read-only into every Instance's
@@ -284,7 +288,7 @@ const META_PML4_BASE: u64 = 1u64 << 39; // 512 GiB
 /// CTX sits at the slot base. CTX_VA_M must match
 /// `javm_recompiler_x86::codegen::CTX_VA`.
 const CTX_VA_M: u64 = META_PML4_BASE;
-/// Base of the per-Image arena (BB | JT | DISPATCH | JIT | TRAMP).
+/// Base of the per-Image arena (BB | DISPATCH | JIT | TRAMP).
 /// 1 GiB past CTX so the arena occupies its own PDPT slot, enabling
 /// template-PT sharing of the entire PD subtree.
 const META_BASE_M: u64 = META_PML4_BASE + (1u64 << 30);
@@ -319,9 +323,9 @@ pub struct DirectMap {
 /// first [`enter_frame`]); reused across re-entries on the same frame
 /// — saves N PageTable + 3 PageBuf allocations in a depth-N recursion.
 ///
-/// Frame-constant `JitContext` fields (jt_ptr, bb_starts,
-/// dispatch_table, code_base, flat_buf, …) are written once when the
-/// runtime is built. [`enter_frame`] only updates regs/pc/gas/exit_*.
+/// Frame-constant `JitContext` fields (bb_starts, dispatch_table,
+/// code_base, flat_buf, …) are written once when the runtime is built.
+/// [`enter_frame`] only updates regs/pc/gas/exit_*.
 pub struct FrameRuntime {
     pt: PageTable,
     #[allow(dead_code)] // kept solely to own the backing page (referenced by `pt`).
@@ -347,14 +351,15 @@ pub struct FrameRuntime {
 /// Per-entry mutable state (regs, pc, gas, exit_*) is written by
 /// [`enter_frame`]; this function only touches frame-constant fields.
 ///
-/// PVM2 variant of [`build_frame_runtime`]. The `code` is raw
-/// RV+C+custom-0 bytes; the JIT cache's RV path predecodes it once
-/// and reuses the result on subsequent calls.
+/// The `code` is raw RV+C+custom-0 bytes; the JIT cache predecodes it
+/// once and reuses the result on subsequent calls. `code_base` is the
+/// guest VA the region maps at — it's threaded into the compiler (so
+/// `auipc`/`jalr` resolve correctly) and into the cache key.
 ///
-/// Signature differs from the PVM path: no `bitmask` (the BB region
-/// holds the valid-PC set, sized to `code.len()`, populated by
-/// `jit_cache::get_or_compile`); no `jump_table` (RV jalr targets
-/// are raw PCs, validated against valid_pc directly).
+/// The BB region holds the basic-block-start set (sized to `code.len()`,
+/// populated by `jit_cache::get_or_compile`); `jalr` targets are
+/// validated against it directly (no jump table). The code itself is
+/// RO-mapped into the guest range at `code_base` via `direct_maps`.
 ///
 /// # Safety
 /// Same constraints as [`build_frame_runtime`].
@@ -362,8 +367,7 @@ pub struct FrameRuntime {
 pub unsafe fn build_frame_runtime(
     image_hash: &javm_cap::CapHash,
     code: &[u8],
-    jump_table: &[u32],
-    jump_table_offsets: &[u32],
+    code_base: u32,
     entry_pc: u32,
     mem_size: u32,
     arg: MemRegion,
@@ -385,8 +389,7 @@ pub unsafe fn build_frame_runtime(
     let cached = jit_cache::get_or_compile(
         image_hash,
         code,
-        jump_table,
-        jump_table_offsets,
+        code_base,
         META_BASE_M,
         CTX_VA_M,
         javm_exec::gas_cost::DEFAULT_MEM_CYCLES,
@@ -397,7 +400,6 @@ pub unsafe fn build_frame_runtime(
     }
 
     let bb_va = META_BASE_M + cached.bb_offset as u64;
-    let jt_va = META_BASE_M + cached.jt_offset as u64;
     let dispatch_va = META_BASE_M + cached.dispatch_offset as u64;
     let jit_va = META_BASE_M + cached.jit_offset as u64;
     let tramp_va = META_BASE_M + cached.tramp_offset as u64;
@@ -433,10 +435,8 @@ pub unsafe fn build_frame_runtime(
     unsafe {
         (*ctx).heap_base = 0;
         (*ctx).heap_top = 0;
-        // RV path: no jump table; jalr validation uses BB (valid_pc).
-        (*ctx).jt_ptr = jt_va as *const u32;
-        (*ctx).jt_len = 0;
-        (*ctx)._pad0 = 0;
+        // jalr validation uses the BB (basic-block-start) set directly —
+        // no separate jump table.
         (*ctx).bb_starts = bb_va as *const u8;
         (*ctx).bb_len = code.len() as u32;
         (*ctx)._pad1 = 0;

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -261,12 +261,14 @@ pub struct ExitInfo {
 //
 // Lives in PML4 slot 0 (low VA 0..512 GiB) — now empty after the
 // Stage F kernel relocation moved the kernel to PML4 slot 511. User
-// VA `[0, mem_size)` mirrors PVM's u32 address space directly so
-// mem accesses can use `[rdx]` baseless. CTX sits at exactly 4 GiB
-// — the first page above the PVM u32 range. The recompiler does no
-// bounds-checking on guest mem (the PT does, via faults outside
-// `[0, mem_size)`) so PVM addresses can reach anywhere in the low
-// 4 GiB; CTX must be outside that range to avoid spoofing.
+// VA mirrors PVM's u32 address space directly (native VA == guest
+// addr) so mem accesses can use `[rdx]` baseless. The PVM layout is
+// `[0, CODE_BASE)` unmapped (null guard), `[CODE_BASE, …)` code (RO
+// direct-map), `[DATA_BASE, mem_size)` the flat RW data buffer; the
+// recompiler does no bounds-checking on guest mem (the PT does, via
+// faults outside the mapped ranges) so PVM addresses can reach
+// anywhere in the low 4 GiB. CTX sits in PML4 slot 1 (512 GiB),
+// outside the PVM u32 range, so guest addresses can't spoof it.
 
 const MEM_VA_M: u64 = 0;
 /// PML4 slot 1 (base 512 GiB) hosts CTX + the per-Image arena + STACK.
@@ -404,7 +406,14 @@ pub unsafe fn build_frame_runtime(
     let jit_va = META_BASE_M + cached.jit_offset as u64;
     let tramp_va = META_BASE_M + cached.tramp_offset as u64;
 
-    let mem_bytes = (mem_size as usize).next_multiple_of(PAGE_SIZE);
+    // Data lives at [DATA_BASE, mem_size). The flat RW buffer covers
+    // only that extent and is mapped at native VA DATA_BASE, leaving
+    // [0, DATA_BASE) unmapped — a null guard, save for the code
+    // direct-map at CODE_BASE. `mem_size` is the absolute max data VA.
+    let data_base = javm_cap::layout::DATA_BASE as usize;
+    let mem_bytes = (mem_size as usize)
+        .saturating_sub(data_base)
+        .next_multiple_of(PAGE_SIZE);
 
     let mem_buf = PageBuf::new(mem_bytes.max(PAGE_SIZE))?;
     let ctx_buf = PageBuf::new(PAGE_SIZE)?;
@@ -414,7 +423,9 @@ pub unsafe fn build_frame_runtime(
         if region.data.is_empty() {
             continue;
         }
-        let off = region.start as usize;
+        // Overlay starts are absolute guest VAs (≥ DATA_BASE); rebase
+        // into the buffer.
+        let off = (region.start as usize).checked_sub(data_base)?;
         let end = off.checked_add(region.data.len())?;
         if end > mem_bytes {
             return None;
@@ -443,7 +454,9 @@ pub unsafe fn build_frame_runtime(
         (*ctx).entry_pc = entry_pc;
         (*ctx).dispatch_table = dispatch_va as *const i32;
         (*ctx).code_base = jit_va;
-        (*ctx).flat_buf = MEM_VA_M as *mut u8;
+        // Vestigial (codegen addresses mem baseless as `[reg]`); set to
+        // the data buffer's native base for documentation.
+        (*ctx).flat_buf = (MEM_VA_M + data_base as u64) as *mut u8;
         (*ctx).fast_reentry = 0;
         (*ctx)._pad2 = 0;
         (*ctx).max_heap_pages = 0;
@@ -453,7 +466,12 @@ pub unsafe fn build_frame_runtime(
     let mut pt = PageTable::new()?;
     pt.map(CTX_VA_M, ctx_buf.pa(), ctx_buf.size(), Perm::user_rw())?;
     if mem_bytes > 0 {
-        pt.map(MEM_VA_M, mem_buf.pa(), mem_buf.size(), Perm::user_rw())?;
+        pt.map(
+            MEM_VA_M + data_base as u64,
+            mem_buf.pa(),
+            mem_buf.size(),
+            Perm::user_rw(),
+        )?;
     }
     for dm in direct_maps {
         if dm.size == 0 {

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -343,19 +343,6 @@ pub struct FrameRuntime {
     ctx_kva: u64,
 }
 
-impl FrameRuntime {
-    /// Refresh the cached trap-table view after a lazy page compile grew
-    /// the Image's trap table. [`enter_frame`] republishes these to the
-    /// #PF handler atomics on the next ring-3 entry, so the handler can
-    /// resolve a faulting RIP in the just-compiled page. The backing
-    /// allocation is pre-reserved (never moves), so in practice only the
-    /// length changes — but we refresh both for robustness.
-    pub fn set_trap_table(&mut self, ptr: *const (u32, u32), len: u64) {
-        self.trap_table_ptr = ptr;
-        self.trap_table_len = len;
-    }
-}
-
 /// Build a per-frame runtime: compile the Image (cached), allocate
 /// per-call mem/ctx/stack pages, populate mem from `arg`/`ro`/`rw`,
 /// initialise the frame-constant `JitContext` fields, and build the

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -325,8 +325,8 @@ pub struct DirectMap {
 /// first [`enter_frame`]); reused across re-entries on the same frame
 /// — saves N PageTable + 3 PageBuf allocations in a depth-N recursion.
 ///
-/// Frame-constant `JitContext` fields (bb_starts, dispatch_table,
-/// code_base, flat_buf, …) are written once when the runtime is built.
+/// Frame-constant `JitContext` fields (dispatch_table, code_base,
+/// flat_buf, …) are written once when the runtime is built.
 /// [`enter_frame`] only updates regs/pc/gas/exit_*.
 pub struct FrameRuntime {
     pt: PageTable,
@@ -401,7 +401,6 @@ pub unsafe fn build_frame_runtime(
         return None;
     }
 
-    let bb_va = META_BASE_M + cached.bb_offset as u64;
     let dispatch_va = META_BASE_M + cached.dispatch_offset as u64;
     let jit_va = META_BASE_M + cached.jit_offset as u64;
     let tramp_va = META_BASE_M + cached.tramp_offset as u64;
@@ -446,11 +445,9 @@ pub unsafe fn build_frame_runtime(
     unsafe {
         (*ctx).heap_base = 0;
         (*ctx).heap_top = 0;
-        // jalr validation uses the BB (basic-block-start) set directly —
-        // no separate jump table.
-        (*ctx).bb_starts = bb_va as *const u8;
-        (*ctx).bb_len = code.len() as u32;
-        (*ctx)._pad1 = 0;
+        // jalr targets are validated by the dense dispatch table (a
+        // non-block-start offset holds the panic-stub offset) — no
+        // separate bb_starts set.
         (*ctx).entry_pc = entry_pc;
         (*ctx).dispatch_table = dispatch_va as *const i32;
         (*ctx).code_base = jit_va;

--- a/rust/nub/build.rs
+++ b/rust/nub/build.rs
@@ -38,14 +38,17 @@ fn main() {
     println!("cargo:rerun-if-changed=../nub-arch-x86/src");
     println!("cargo:rerun-if-changed=../nub-arch-x86/Cargo.toml");
     println!("cargo:rerun-if-changed=../nub-arch-x86/link.x");
-    // nub-arch-x86 embeds javm-recompiler-x86 and javm-exec; its build
-    // script doesn't know about path-deps via cargo metadata, so register
-    // their src trees here explicitly. Without this, changes to the
-    // recompiler or exec layer don't trigger a guest blob rebuild and the
-    // cached blob goes stale (e.g. gas-cost tweaks in javm-exec wouldn't
-    // appear in bench numbers).
+    // nub-arch-x86 embeds javm-recompiler-x86, javm-exec, and javm-cap;
+    // its build script doesn't know about path-deps via cargo metadata,
+    // so register their src trees here explicitly. Without this, changes
+    // to those layers don't trigger a guest blob rebuild and the cached
+    // blob goes stale (e.g. gas-cost tweaks in javm-exec, or the
+    // page-aligned `CodeRegionCap`/`DataContent` clone in javm-cap that
+    // the kernel direct-maps, wouldn't appear in the blob).
     println!("cargo:rerun-if-changed=../javm-recompiler-x86/src");
     println!("cargo:rerun-if-changed=../javm-recompiler-x86/Cargo.toml");
     println!("cargo:rerun-if-changed=../javm-exec/src");
     println!("cargo:rerun-if-changed=../javm-exec/Cargo.toml");
+    println!("cargo:rerun-if-changed=../javm-cap/src");
+    println!("cargo:rerun-if-changed=../javm-cap/Cargo.toml");
 }

--- a/rust/nub/build.rs
+++ b/rust/nub/build.rs
@@ -43,7 +43,7 @@ fn main() {
     // so register their src trees here explicitly. Without this, changes
     // to those layers don't trigger a guest blob rebuild and the cached
     // blob goes stale (e.g. gas-cost tweaks in javm-exec, or the
-    // page-aligned `CodeRegionCap`/`DataContent` clone in javm-cap that
+    // page-aligned `ImageCap.code`/`DataContent` clone in javm-cap that
     // the kernel direct-maps, wouldn't appear in the blob).
     println!("cargo:rerun-if-changed=../javm-recompiler-x86/src");
     println!("cargo:rerun-if-changed=../javm-recompiler-x86/Cargo.toml");

--- a/rust/nub/tests/smoke.rs
+++ b/rust/nub/tests/smoke.rs
@@ -3,7 +3,7 @@
 //! typed API and check that `invoke_cached` returns the expected
 //! `HostCall(42)` result.
 
-use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
+use javm_cap::image::{EndpointDef, Image};
 use javm_cap::{Cap, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
@@ -14,14 +14,8 @@ fn ecalli_42_image() -> Image {
     // PVM2 `ecalli 42` — custom-0 (opcode bits[6:2] = 0b00010), funct3 =
     // 0b010, rd = 0, rs1 = 0, imm = 42. As an I-type 32-bit word:
     //   (42 << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11 = 0x02A0_200B
-    img.codes = vec![CodeRegion {
-        code: 0x02A0_200Bu32.to_le_bytes().to_vec(),
-    }];
-    img.memory_mappings.push(MemoryMapping {
-        start: 0x4000_0000,
-        size: 4096,
-        source: MappingSource::Code(0),
-    });
+    img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
+    // Code is mapped at the fixed CODE_BASE; no data mappings.
 
     let mut endpoints: BTreeMap<u8, EndpointDef> = BTreeMap::new();
     endpoints.insert(

--- a/rust/nub/tests/smoke.rs
+++ b/rust/nub/tests/smoke.rs
@@ -3,7 +3,7 @@
 //! typed API and check that `invoke_cached` returns the expected
 //! `HostCall(42)` result.
 
-use javm_cap::image::{EndpointDef, Image};
+use javm_cap::image::{CodeRegion, EndpointDef, Image, MappingSource, MemoryMapping};
 use javm_cap::{Cap, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
@@ -14,9 +14,14 @@ fn ecalli_42_image() -> Image {
     // PVM2 `ecalli 42` — custom-0 (opcode bits[6:2] = 0b00010), funct3 =
     // 0b010, rd = 0, rs1 = 0, imm = 42. As an I-type 32-bit word:
     //   (42 << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11 = 0x02A0_200B
-    img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
-    // PVM2 marker: a single empty sub-table.
-    img.jump_table_offsets = vec![0, 0];
+    img.codes = vec![CodeRegion {
+        code: 0x02A0_200Bu32.to_le_bytes().to_vec(),
+    }];
+    img.memory_mappings.push(MemoryMapping {
+        start: 0x4000_0000,
+        size: 4096,
+        source: MappingSource::Code(0),
+    });
 
     let mut endpoints: BTreeMap<u8, EndpointDef> = BTreeMap::new();
     endpoints.insert(


### PR DESCRIPTION
## PVM2: native `jalr`/`auipc` ISA — recompiler + runtime at parity with master

This branch reworks the PVM2 guest ISA from the static **`br_table`**
dispatch design to **native RISC-V `jalr`/`auipc` control flow**,
end-to-end: data model, byte-PVM interpreter (`javm-exec`), x86-64
recompiler (`javm-recompiler-x86`), bare-metal microkernel runtime
(`nub-arch-x86`), and the transpiler/linker. The two engines stay
bit-identical (gas + results) on all 12 bench workloads.

### What changed (15 commits, oldest → newest)

- **`jalr`/`auipc` ISA core** — data model + exec + recompiler + local
  interpreter; the linker emits native `jalr`/`auipc` control flow and
  threads `code_base` through the host runtime.
- **Bare-metal runtime + recompiler** — smoke 12/12 (interp == recomp).
- **Page-aware block partition** — linker padding + both engines.
- **Cross-page control flow → indirect dispatch**, whole-blob
  block-start set precompute. (A lazy per-page compile experiment was
  explored and **reverted** — single-pass eager won on the dense bench.)
- **`rv_slot` register-mapping LUT** — closes the cold gap to master.
- **Single fixed-base code region** — collapse `Image.codes` (multi-
  region, never produced) to one `Image.code` mapped at a constant
  `CODE_BASE`.
- **Low-code / high-data guest layout** — `[0,4 MiB)` unmapped null
  guard · `[4 MiB,256 MiB)` code · `[256 MiB,4 GiB)` data.
- **Fold `jalr` block-start validation into the dispatch table** — a
  non-block-start offset routes to the panic stub via the table; one
  fewer load + branch per `jalr`.
- **Compile real code length, not the page-padded buffer** — the
  recompiler was iterating ~4 KiB of zero page-padding as bogus
  instructions on every cold compile (a fixed ~50 µs floor that
  dominated small guests). Fixed by truncating `ImageCap.code` to the
  real length while keeping the page-aligned allocation for the RO
  direct-map.

### Benchmarks — `master` (`4aa0a910`) vs this branch, same machine

Criterion median, µs. **Cold** = `evict_jit_all` + recompile + execute.

| workload | master cold | this cold | Δ cold | master warm | this warm |
|---|---:|---:|---:|---:|---:|
| sub_vm_recurse | 18.80 | 18.45 | −1.9% | 15.31 | 15.51 |
| sub_vm_data_recurse | 27.48 | 26.79 | −2.5% | 23.00 | 22.92 |
| prime_sieve | 281.5 | 288.9 | +2.6%¹ | 290.7 | 284.4 |
| goldilocks_mul | 452.96 | 452.21 | −0.2% | 448.56 | 448.09 |
| poly_eval | 1628.5 | 1591.3 | −2.3% | 1621.6 | 1575.6 |
| keccak | 47.76 | 47.21 | −1.2% | 20.11 | 20.78 |
| poseidon2_perm | 1700.4 | 1702.8 | +0.1% | 1673.7 | 1671.3 |
| mini_verifier | 728.2 | 719.9 | −1.1% | 676.1 | 677.1 |
| fri_fold_tree | 729.9 | 719.6 | −1.4% | 678.7 | 673.8 |
| blake2b | 90.80 | 86.20 | −5.1% | 17.98 | 18.25 |
| ed25519 | 622.5 | 583.5 | −6.3% | 149.44 | 153.52 |
| ecrecover | 1550.6 | 1493.6 | −3.7% | 544.40 | 552.77 |

**Cold is at parity or faster than master on all 12 workloads** (−6.3% …
+2.6%; faster on 9 of 12). Warm is parity (±3.3%, mixed).

¹ within noise — master's prime_sieve cold (281.5) measured below its own
warm (290.7).

### Verification

- `cargo run --release -p javm-bench --example smoke` → **12/12
  bit-identical** (interpreter == recompiler: exit reason, return value,
  gas).
- `cargo test --workspace` passes.
- `cargo clippy --workspace --all-targets -- -D warnings` and
  `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
