### PR TITLE
Close PVM2 interpreter↔recompiler conformance forks (B1/B2/B3/B5)

### DIFF
--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -65,6 +65,22 @@ impl ImageCap {
         }
         Some((crate::layout::CODE_BASE, self.code.as_slice()))
     }
+
+    /// True iff the memory mapping starting at guest VA `start` draws
+    /// from a pinned (read-only) slot, so it must be laid read-only — a
+    /// guest store to it faults. Mirrors the recompiler's pinned-vs-
+    /// initial slot classification (`nub-arch-x86` `build_runtime`).
+    /// Derived from [`Self::pinned`] at lay time so the per-instance
+    /// [`super::instance::RwOverlay`] wire form needs no perm field; the
+    /// interpreter drivers (`javm` `build_entry`, `nub-arch-local`) call
+    /// this so they classify identically to the recompiler.
+    pub fn mapping_is_pinned(&self, start: u32) -> bool {
+        self.mappings.iter().any(|m| {
+            m.start as u32 == start
+                && m.source_path_len > 0
+                && self.pinned.iter().any(|p| p.slot == m.source_path[0])
+        })
+    }
 }
 
 /// Endpoint definition. Dense `initial_regs` array; index `i`

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -11,6 +11,35 @@ use crate::slot::SlotIdx;
 
 use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 
+/// # Validation model: structure is eager, semantics are lazy
+///
+/// An `ImageCap` is admitted from untrusted input under a two-layer
+/// discipline:
+///
+/// - **Structure — validated eagerly** (here / in [`image_cap`], the
+///   "deblob"). The metadata that frames execution: `code` *length*
+///   (`≤ MAX_CODE_SIZE`), memory-mapping bounds, slot indices, source-path
+///   depth, endpoint indices. A malformed structural field has no clean
+///   execution point to fault on — it would diverge between engines or
+///   panic the host — so it is rejected at construction. This is cheap
+///   (`O(#endpoints + #mappings + #slots)`, it never scans the code) and
+///   therefore compatible with lazy compilation.
+///
+/// - **Semantics — validated lazily** (at execution, by both engines
+///   identically). The instruction stream itself: illegal/forbidden
+///   encodings, and `jal`/branch/`jalr`/`entry_pc` targets. These are
+///   **not** rejected at admission — any `code` bytes are accepted. A
+///   forbidden encoding decodes as illegal and an off-`bb_start` target is
+///   refused only *when reached*, as `ε = panic`. Lazy (not eager
+///   deblob) because, without an instruction bitmask, a linear validator
+///   can't tell code from data — eager rejection would reject legitimate
+///   code-as-data; lazy also keeps admission version-independent (a future
+///   ISA extension forks only at execution, never the cap set at
+///   admission) and preserves lazy compilation. The consensus requirement
+///   is that the two engines *agree* on what panics, not that the bytes
+///   are pre-screened. The producer toolchain still rejects forbidden
+///   encodings at build time as a diagnostic — that is UX, not a
+///   consensus rule.
 #[derive(Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ImageCap {
     /// The (single) code region: raw RV+C+custom-0 bytes, page-aligned
@@ -192,6 +221,16 @@ impl ssz::Decode for MemoryMapping {
             *slot = SlotIdx(u32::from_le_bytes(arr));
         }
         let source_path_len = bytes[16 + MAX_SOURCE_DEPTH * 4];
+        // Structural invariant (eager): the live path is
+        // `source_path[..source_path_len]`, so `source_path_len` must not
+        // exceed the fixed array. Reject at the decode boundary rather
+        // than letting `path()` index out of bounds later.
+        if source_path_len as usize > MAX_SOURCE_DEPTH {
+            return Err(ssz::DecodeError::BoundExceeded {
+                len: source_path_len as u64,
+                bound: MAX_SOURCE_DEPTH as u64,
+            });
+        }
         Ok(Self {
             start,
             size,
@@ -231,9 +270,12 @@ impl ssz::HashTreeRoot for MemoryMapping {
 
 impl MemoryMapping {
     /// Live slot indices (length = `source_path_len`) — the cnode path
-    /// to the `Cap::Data` backing this mapping.
+    /// to the `Cap::Data` backing this mapping. Total: the index is
+    /// clamped to the fixed array so a malformed `source_path_len` (one
+    /// that bypassed the decode/`image_cap` checks, e.g. a hand-built
+    /// value) can never panic the host.
     pub fn path(&self) -> &[SlotIdx] {
-        &self.source_path[..self.source_path_len as usize]
+        &self.source_path[..(self.source_path_len as usize).min(MAX_SOURCE_DEPTH)]
     }
 }
 
@@ -264,6 +306,8 @@ pub struct ImageSlotEntry {
 /// constraint violations.
 #[derive(Debug, thiserror::Error)]
 pub enum ImageConvertError {
+    #[error("code region {0} bytes exceeds MAX_CODE_SIZE ({1})")]
+    CodeTooLarge(usize, u32),
     #[error("memory mapping source path empty")]
     SourcePathEmpty,
     #[error("memory mapping source path too deep (steps={0} > MAX_SOURCE_DEPTH)")]
@@ -300,6 +344,19 @@ pub fn image_cap(
     pinned_hashes: &[(SlotIdx, CapHash)],
     initial_hashes: &[(SlotIdx, CapHash)],
 ) -> Result<ImageCap, ImageConvertError> {
+    // Structural invariant (eager): the code region maps RO at
+    // `[CODE_BASE, DATA_BASE)`, so it must fit under `MAX_CODE_SIZE` —
+    // otherwise a high code offset would alias the data region. The
+    // *contents* of `code` are not validated here (instruction legality
+    // is checked lazily, at execution); only its size is a structural
+    // bound. Checked before the page-aligned copy so an oversized blob
+    // is rejected without allocating it.
+    if image.code.len() > crate::layout::MAX_CODE_SIZE as usize {
+        return Err(ImageConvertError::CodeTooLarge(
+            image.code.len(),
+            crate::layout::MAX_CODE_SIZE,
+        ));
+    }
     // Code: page-aligned copy so the kernel can direct-map it RO at
     // `layout::CODE_BASE`.
     let code = alloc_page_aligned_code(&image.code);

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -38,6 +38,14 @@ use ssz_derive::{Decode, Encode};
 /// kernel installs declared pinned content into the Instance's cnode
 /// at `set_image` / `host_derive_spawn` time and treats them as
 /// read-only thereafter.
+///
+/// **Validation model.** This is the untrusted SSZ wire form; converting
+/// it to a [`crate::cap::image::ImageCap`] via
+/// [`crate::cap::image::image_cap`] is the "deblob" that validates the
+/// Image's *structure* eagerly (sizes, bounds, slot indices, path depth).
+/// The `code` *bytes* are never screened — instruction *semantics* are
+/// validated lazily, at execution. See [`crate::cap::image::ImageCap`] for
+/// the full structure-eager / semantics-lazy rationale.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub struct Image {
     /// The (single) code region: raw RV+C+custom-0 bytes. Mapped RO at

--- a/rust/javm-cap/tests/cap_image.rs
+++ b/rust/javm-cap/tests/cap_image.rs
@@ -1,0 +1,48 @@
+//! Integration tests for `javm_cap::cap::image` — the cap-level
+//! `ImageCap` / `MemoryMapping` (distinct from the SSZ wire-form
+//! `javm_cap::image::MemoryMapping` exercised in `tests/image.rs`).
+//!
+//! Focus: the eager *structural* invariants the deblob must enforce so a
+//! malformed Image can neither panic the host nor diverge between engines.
+
+use javm_cap::{MAX_SOURCE_DEPTH, MemoryMapping, SlotIdx};
+use ssz::Decode as _;
+
+/// SSZ fixed form of a cap-level `MemoryMapping`:
+/// `u64 start || u64 size || MAX_SOURCE_DEPTH×u32 || u8 source_path_len`.
+fn mapping_bytes(source_path_len: u8) -> Vec<u8> {
+    let mut bytes = vec![0u8; 8 + 8 + MAX_SOURCE_DEPTH * 4 + 1];
+    *bytes.last_mut().unwrap() = source_path_len;
+    bytes
+}
+
+#[test]
+fn decode_rejects_oversized_source_path_len() {
+    // `source_path_len > MAX_SOURCE_DEPTH` would make `path()` index past
+    // the fixed array — reject it at the decode boundary instead.
+    let bytes = mapping_bytes((MAX_SOURCE_DEPTH + 1) as u8);
+    let err = MemoryMapping::from_ssz_bytes(&bytes).unwrap_err();
+    assert!(matches!(err, ssz::DecodeError::BoundExceeded { .. }));
+
+    // The extreme (255) is rejected too, not silently truncated.
+    assert!(MemoryMapping::from_ssz_bytes(&mapping_bytes(255)).is_err());
+}
+
+#[test]
+fn decode_accepts_len_at_the_bound() {
+    let m = MemoryMapping::from_ssz_bytes(&mapping_bytes(MAX_SOURCE_DEPTH as u8)).unwrap();
+    assert_eq!(m.path().len(), MAX_SOURCE_DEPTH);
+}
+
+#[test]
+fn path_is_total_for_a_malformed_len() {
+    // A hand-built mapping (bypassing decode / `image_cap`) with a bogus
+    // length must clamp, never panic the host.
+    let m = MemoryMapping {
+        start: 0,
+        size: 0,
+        source_path: [SlotIdx(0); MAX_SOURCE_DEPTH],
+        source_path_len: 250,
+    };
+    assert_eq!(m.path().len(), MAX_SOURCE_DEPTH);
+}

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -1,7 +1,7 @@
 use javm_cap::image::{EndpointDef, MemoryMapping};
 use javm_cap::{
     Blake2b256, Image, InitialDataCap, PinnedCap, SlotIdx, SlotPath, chain_extend, chain_genesis,
-    image_content_hash,
+    image_cap, image_content_hash,
 };
 use ssz::Decode as _;
 use std::collections::BTreeMap;
@@ -188,6 +188,47 @@ fn chain_extend_is_associative_under_sequence() {
         chain_extend::<H>(&g_b, &img_c)
     };
     assert_eq!(chain_abc, chain_abc_2);
+}
+
+#[test]
+fn mapping_is_pinned_classifies_by_source_slot() {
+    // A mapping whose source slot is pinned is read-only (a guest store
+    // faults); one sourced from an initial (mutable) slot is RW. This is
+    // the shared classifier the interpreter drivers (`javm` `build_entry`,
+    // `nub-arch-local`) use so they agree with the recompiler's
+    // pinned-vs-initial slot classification.
+    let mut img = Image::empty();
+    img.memory_mappings.push(MemoryMapping {
+        start: 0x1000_0000,
+        size: 0x1000,
+        source: SlotPath::root(SlotIdx(5)),
+    });
+    img.memory_mappings.push(MemoryMapping {
+        start: 0x1000_1000,
+        size: 0x1000,
+        source: SlotPath::root(SlotIdx(6)),
+    });
+    img.pinned_slots.insert(
+        SlotIdx(5),
+        PinnedCap::Data {
+            content: vec![1, 2, 3],
+            size: 0x1000,
+        },
+    );
+    img.initial_slots.insert(
+        SlotIdx(6),
+        InitialDataCap {
+            content: vec![4, 5, 6],
+            size: 0x1000,
+        },
+    );
+
+    let dummy = [0u8; 32];
+    let cap = image_cap(&img, &[(SlotIdx(5), dummy)], &[(SlotIdx(6), dummy)]).unwrap();
+
+    assert!(cap.mapping_is_pinned(0x1000_0000)); // slot 5 pinned → RO
+    assert!(!cap.mapping_is_pinned(0x1000_1000)); // slot 6 initial → RW
+    assert!(!cap.mapping_is_pinned(0x9999_9999)); // no mapping at this VA
 }
 
 #[test]

--- a/rust/javm-exec/src/gas_cost.rs
+++ b/rust/javm-exec/src/gas_cost.rs
@@ -253,15 +253,11 @@ static RV_GAS_COST_LUT: [RvGasCostEntry; RV_LUT_LEN] = {
 
 /// PVM2 register → simulator slot (u8). 0xFF means "no register" — the
 /// simulator's `feed_direct` interprets that as "skip dep / no write".
-/// Maps x1→0, x2→1, x5..x15→2..12; x0/x3/x4 → 0xFF.
+/// Single source: [`crate::regs::reg_slot_or_ff`] (the recompiler reads
+/// the same classification via `REG_SLOT_LUT`, so gas agrees bit-for-bit).
 #[inline(always)]
 pub fn rv_slot_u8(r: u8) -> u8 {
-    match r {
-        1 => 0,
-        2 => 1,
-        5..=15 => r - 3,
-        _ => 0xFF,
-    }
+    crate::regs::reg_slot_or_ff(r)
 }
 
 /// Compute the [`crate::predecode::RvGasMeta`] for an `Inst`.

--- a/rust/javm-exec/src/gas_cost.rs
+++ b/rust/javm-exec/src/gas_cost.rs
@@ -547,3 +547,69 @@ pub fn rv_gas_cost_for_block(
     }
     sim.flush_and_get_cost()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::decode;
+    use crate::predecode::is_terminator;
+
+    /// Terminator flag as the recompiler sees it: the gas-LUT `RVF_TERM`
+    /// bit for the instruction's kind (this is the classifier
+    /// `Compiler::feed_gas_rv` consumes to mark gas-block starts).
+    fn lut_term(inst: &crate::instruction::Inst) -> bool {
+        RV_GAS_COST_LUT[rv_gas_meta(inst).kind as usize].flags & RVF_TERM != 0
+    }
+
+    /// B5: "what is a terminator" is hand-coded twice in this crate —
+    /// `predecode::is_terminator` (a `match` on `Inst`, which the
+    /// interpreter uses to mark gas-block starts) and the gas-LUT
+    /// `RVF_TERM` bit (which the recompiler uses for the same purpose).
+    /// They are independent and must classify every decodable
+    /// instruction identically, or the interpreter and recompiler would
+    /// disagree on basic-block boundaries (a consensus fork). Sweep the
+    /// whole RVC halfword space and a 4-byte opcode × funct matrix and
+    /// assert the two classifiers agree on every encoding that decodes.
+    #[test]
+    fn predecode_and_gas_lut_terminator_agree() {
+        // RVC: every 2-byte halfword whose low bits aren't the 4-byte
+        // marker.
+        for h in 0u16..=0xFFFF {
+            if h & 0b11 == 0b11 {
+                continue;
+            }
+            if let Some((inst, _len)) = decode(&h.to_le_bytes()) {
+                assert_eq!(
+                    is_terminator(&inst),
+                    lut_term(&inst),
+                    "RVC halfword {h:#06x} -> {inst:?}"
+                );
+            }
+        }
+        // 4-byte: sweep every 7-bit opcode (low bits = 0b11) across
+        // funct3 and a representative set of funct7 values, with fixed
+        // register fields. This reaches every terminator opcode (jal
+        // 0x6F, jalr 0x67, branch 0x63, custom-0 0x0B across all funct3)
+        // and every non-terminator class.
+        for major in 0u32..0x20 {
+            let opcode7 = (major << 2) | 0b11;
+            for funct3 in 0u32..8 {
+                for &funct7 in &[0u32, 0b000_0001, 0b010_0000, 0b000_0111, 0b011_0000] {
+                    let w = (funct7 << 25)
+                        | (11 << 20)
+                        | (10 << 15)
+                        | (funct3 << 12)
+                        | (10 << 7)
+                        | opcode7;
+                    if let Some((inst, _len)) = decode(&w.to_le_bytes()) {
+                        assert_eq!(
+                            is_terminator(&inst),
+                            lut_term(&inst),
+                            "word {w:#010x} -> {inst:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rust/javm-exec/src/instruction.rs
+++ b/rust/javm-exec/src/instruction.rs
@@ -601,6 +601,184 @@ pub enum Inst {
     },
 }
 
+impl Inst {
+    /// True iff this instruction names a reserved register in any of its
+    /// register fields. The valid PVM2 registers are `x0, x1, x2, x5..x15`;
+    /// reserved are `x3`/`x4` (PVM2-specific, Category 1 #4) and `x16..x31`
+    /// (they do not exist in RV64E — a 16-register base — so they are
+    /// illegal, standard RV). Either way such an instruction is a reserved
+    /// encoding: it decodes as `Reserved` and panics if executed (lazy).
+    /// Immediate bits that happen to alias a reserved register are **not**
+    /// registers and are ignored — each variant binds exactly its real
+    /// register fields. This match is the single source of truth both
+    /// consensus engines route through (the interpreter via [`decode`], the
+    /// recompiler via [`word_uses_reserved_reg`]); the lack of a wildcard
+    /// arm means a future `Inst` variant won't compile until classified.
+    pub fn uses_reserved_reg(&self) -> bool {
+        use crate::regs::reg_is_reserved as r;
+        use Inst::*;
+        match *self {
+            // Register-register (rd, rs1, rs2).
+            Add { rd, rs1, rs2 }
+            | Sub { rd, rs1, rs2 }
+            | Sll { rd, rs1, rs2 }
+            | Srl { rd, rs1, rs2 }
+            | Sra { rd, rs1, rs2 }
+            | Slt { rd, rs1, rs2 }
+            | Sltu { rd, rs1, rs2 }
+            | Xor { rd, rs1, rs2 }
+            | Or { rd, rs1, rs2 }
+            | And { rd, rs1, rs2 }
+            | Addw { rd, rs1, rs2 }
+            | Subw { rd, rs1, rs2 }
+            | Sllw { rd, rs1, rs2 }
+            | Srlw { rd, rs1, rs2 }
+            | Sraw { rd, rs1, rs2 }
+            | Mul { rd, rs1, rs2 }
+            | Mulh { rd, rs1, rs2 }
+            | Mulhsu { rd, rs1, rs2 }
+            | Mulhu { rd, rs1, rs2 }
+            | Div { rd, rs1, rs2 }
+            | Divu { rd, rs1, rs2 }
+            | Rem { rd, rs1, rs2 }
+            | Remu { rd, rs1, rs2 }
+            | Mulw { rd, rs1, rs2 }
+            | Divw { rd, rs1, rs2 }
+            | Divuw { rd, rs1, rs2 }
+            | Remw { rd, rs1, rs2 }
+            | Remuw { rd, rs1, rs2 }
+            | Min { rd, rs1, rs2 }
+            | Minu { rd, rs1, rs2 }
+            | Max { rd, rs1, rs2 }
+            | Maxu { rd, rs1, rs2 }
+            | Andn { rd, rs1, rs2 }
+            | Orn { rd, rs1, rs2 }
+            | Xnor { rd, rs1, rs2 }
+            | Rol { rd, rs1, rs2 }
+            | Ror { rd, rs1, rs2 }
+            | Rolw { rd, rs1, rs2 }
+            | Rorw { rd, rs1, rs2 }
+            | Sh1add { rd, rs1, rs2 }
+            | Sh2add { rd, rs1, rs2 }
+            | Sh3add { rd, rs1, rs2 }
+            | Sh1adduw { rd, rs1, rs2 }
+            | Sh2adduw { rd, rs1, rs2 }
+            | Sh3adduw { rd, rs1, rs2 }
+            | Adduw { rd, rs1, rs2 }
+            | Bclr { rd, rs1, rs2 }
+            | Bset { rd, rs1, rs2 }
+            | Binv { rd, rs1, rs2 }
+            | Bext { rd, rs1, rs2 }
+            | CzeroEqz { rd, rs1, rs2 }
+            | CzeroNez { rd, rs1, rs2 } => r(rd) || r(rs1) || r(rs2),
+
+            // rd + rs1 (loads, I-type ALU, shifts, unary Zbb, jalr).
+            Lb { rd, rs1, .. }
+            | Lh { rd, rs1, .. }
+            | Lw { rd, rs1, .. }
+            | Ld { rd, rs1, .. }
+            | Lbu { rd, rs1, .. }
+            | Lhu { rd, rs1, .. }
+            | Lwu { rd, rs1, .. }
+            | Addi { rd, rs1, .. }
+            | Slti { rd, rs1, .. }
+            | Sltiu { rd, rs1, .. }
+            | Andi { rd, rs1, .. }
+            | Ori { rd, rs1, .. }
+            | Xori { rd, rs1, .. }
+            | Slli { rd, rs1, .. }
+            | Srli { rd, rs1, .. }
+            | Srai { rd, rs1, .. }
+            | Addiw { rd, rs1, .. }
+            | Slliw { rd, rs1, .. }
+            | Srliw { rd, rs1, .. }
+            | Sraiw { rd, rs1, .. }
+            | Clz { rd, rs1 }
+            | Clzw { rd, rs1 }
+            | Ctz { rd, rs1 }
+            | Ctzw { rd, rs1 }
+            | Cpop { rd, rs1 }
+            | Cpopw { rd, rs1 }
+            | SextB { rd, rs1 }
+            | SextH { rd, rs1 }
+            | ZextH { rd, rs1 }
+            | Rev8 { rd, rs1 }
+            | OrcB { rd, rs1 }
+            | Rori { rd, rs1, .. }
+            | Roriw { rd, rs1, .. }
+            | Slliuw { rd, rs1, .. }
+            | Bclri { rd, rs1, .. }
+            | Bseti { rd, rs1, .. }
+            | Binvi { rd, rs1, .. }
+            | Bexti { rd, rs1, .. }
+            | Jalr { rd, rs1, .. } => r(rd) || r(rs1),
+
+            // rs1 + rs2 (stores, branches).
+            Sb { rs1, rs2, .. }
+            | Sh { rs1, rs2, .. }
+            | Sw { rs1, rs2, .. }
+            | Sd { rs1, rs2, .. }
+            | Beq { rs1, rs2, .. }
+            | Bne { rs1, rs2, .. }
+            | Blt { rs1, rs2, .. }
+            | Bge { rs1, rs2, .. }
+            | Bltu { rs1, rs2, .. }
+            | Bgeu { rs1, rs2, .. } => r(rs1) || r(rs2),
+
+            // rd only (upper-immediate, jal).
+            Lui { rd, .. } | Auipc { rd, .. } | Jal { rd, .. } => r(rd),
+
+            // No register fields.
+            Fence | FenceI | Trap | EcallJar | Ecalli { .. } | Fallthrough | Reserved { .. } => {
+                false
+            }
+        }
+    }
+}
+
+/// Reserved-register predicate on a raw 4-byte word, for the recompiler
+/// (which dispatches on raw words rather than building an [`Inst`], and
+/// runs on the cold-compile hot path — so this must not re-decode).
+///
+/// Checks `x3`/`x4` only in the positions the instruction's *format* uses
+/// as registers; immediate bits in those positions are ignored. For every
+/// **non-reserved** word this equals [`Inst::uses_reserved_reg`] (pinned by
+/// `word_predicate_matches_inst_predicate`), so the interpreter and
+/// recompiler agree on which `x3`/`x4` instructions panic. For a
+/// reserved-decoding word the two may differ, but such a word panics via
+/// the normal reserved path in both engines anyway, so the *outcome* still
+/// matches.
+///
+/// `#[inline]` so it folds into the recompiler's `compile_rv4` across the
+/// crate boundary (the field extractions then CSE against the ones
+/// `compile_rv4` already does). The residual per-instruction opcode match
+/// is a small fixed cold-compile cost (≈1–4% on the heaviest workloads,
+/// none on warm) — accepted as the price of one verifiable check that
+/// keeps the two engines from drifting; the alternative (a check spread
+/// across every register-access helper) is what made B7 possible.
+#[inline]
+pub fn word_uses_reserved_reg(w: u32) -> bool {
+    fn r(x: u32) -> bool {
+        crate::regs::reg_is_reserved(x as u8)
+    }
+    let rd = (w >> 7) & 0x1F;
+    let rs1 = (w >> 15) & 0x1F;
+    let rs2 = (w >> 20) & 0x1F;
+    match w & 0x7F {
+        // R-type (OP, OP-32): rd, rs1, rs2.
+        0b011_0011 | 0b011_1011 => r(rd) || r(rs1) || r(rs2),
+        // I-type (LOAD, OP-IMM, OP-IMM-32, JALR): rd, rs1.
+        0b000_0011 | 0b001_0011 | 0b001_1011 | 0b110_0111 => r(rd) || r(rs1),
+        // S-type (STORE), B-type (BRANCH): rs1, rs2.
+        0b010_0011 | 0b110_0011 => r(rs1) || r(rs2),
+        // U-type (LUI, AUIPC), J-type (JAL): rd.
+        0b011_0111 | 0b001_0111 | 0b110_1111 => r(rd),
+        // SYSTEM, MISC-MEM, custom-0/1, atomics, FP, … — no PVM2 register
+        // field (reserved or no-reg); they panic via the normal path.
+        _ => false,
+    }
+}
+
 /// Major opcode of a 32-bit RV instruction is bits [6:2]; bits [1:0]
 /// are always `11` for non-compressed.
 const OP_LOAD: u32 = 0b00_000;
@@ -647,13 +825,30 @@ pub fn decode(bytes: &[u8]) -> Option<(Inst, u8)> {
     //   xx11  -> 32-bit (or longer; we don't support >32)
     //   else  -> 16-bit compressed
     if lo16 & 0b11 != 0b11 {
-        return Some((decompress(lo16), 2));
+        // An instruction naming a reserved register (x3/x4, or x16..x31
+        // which don't exist in RV64E) is a reserved encoding → `Reserved`,
+        // so it panics if executed (lazy), matching the recompiler.
+        let inst = decompress(lo16);
+        let inst = reserve_if_reserved_reg(inst, lo16 as u32);
+        return Some((inst, 2));
     }
     if bytes.len() < 4 {
         return None;
     }
     let w = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-    Some((decode_32(w), 4))
+    Some((reserve_if_reserved_reg(decode_32(w), w), 4))
+}
+
+/// Map an instruction that names a reserved register (`x3`/`x4` or the
+/// nonexistent `x16..x31`) to `Reserved` so it is refused lazily, like any
+/// other reserved encoding.
+#[inline]
+fn reserve_if_reserved_reg(inst: Inst, raw: u32) -> Inst {
+    if inst.uses_reserved_reg() {
+        Inst::Reserved { raw }
+    } else {
+        inst
+    }
 }
 
 // ============================================================================
@@ -1724,5 +1919,98 @@ mod tests {
             decode(&0x9002u16.to_le_bytes()).unwrap().0,
             Inst::Reserved { .. }
         ));
+    }
+
+    // ---- B7: x3/x4 in a register field decodes as Reserved -------------
+
+    #[test]
+    fn reserved_register_field_is_reserved() {
+        // add x5, x3, x6 (rs1 = x3) → Reserved (was decoded as a live Add,
+        // which the interp executed as `0 + x6` while the recomp panicked).
+        let add_x3 = 0x0061_82B3u32; // add x5, x3, x6
+        assert!(matches!(
+            decode(&add_x3.to_le_bytes()).unwrap().0,
+            Inst::Reserved { .. }
+        ));
+        assert!(word_uses_reserved_reg(add_x3));
+
+        // addi x3, x0, 1 (rd = x3) → Reserved.
+        let addi_x3 = 0x0010_0193u32;
+        assert!(matches!(
+            decode(&addi_x3.to_le_bytes()).unwrap().0,
+            Inst::Reserved { .. }
+        ));
+
+        // add x16, x5, x6 (rd = x16) → Reserved: x16..x31 don't exist in
+        // RV64E (standard RV), so the encoding is illegal.
+        let add_x16 = 0x0062_8833u32; // add x16, x5, x6
+        assert!(matches!(
+            decode(&add_x16.to_le_bytes()).unwrap().0,
+            Inst::Reserved { .. }
+        ));
+        assert!(word_uses_reserved_reg(add_x16));
+    }
+
+    #[test]
+    fn x3_x4_free_instruction_is_unaffected() {
+        // add x5, x6, x7 — no reserved register → decodes normally.
+        let add_ok = 0x0073_02B3u32;
+        assert!(matches!(
+            decode(&add_ok.to_le_bytes()).unwrap().0,
+            Inst::Add { .. }
+        ));
+        assert!(!word_uses_reserved_reg(add_ok));
+    }
+
+    #[test]
+    fn immediate_bits_aliasing_x3_are_not_a_register() {
+        // lui x5, 0x18000 — bits [19:15] of the word are 0b00011 (= 3),
+        // but for U-type that field is *immediate*, not rs1, so the
+        // instruction is a normal Lui, never Reserved.
+        let lui = 0x0001_82B7u32;
+        assert!(matches!(
+            decode(&lui.to_le_bytes()).unwrap().0,
+            Inst::Lui { rd: 5, .. }
+        ));
+        assert!(!word_uses_reserved_reg(lui));
+    }
+
+    #[test]
+    fn word_predicate_matches_inst_predicate() {
+        // The recompiler's fast `word_uses_reserved_reg` (opcode-mask, no
+        // decode) must equal the interpreter's `Inst::uses_reserved_reg`
+        // for every *non-reserved* word — that is what makes the two
+        // engines agree on which x3/x4 instructions panic. (A
+        // reserved-decoding word panics either way, so its predicate value
+        // is unconstrained here.) Sweep every 7-bit opcode × funct3 ×
+        // representative funct7, with each register field ranging over
+        // {x0, x3, x4, x5} so both reserved and free positions are hit.
+        for major in 0u32..0x20 {
+            let opcode7 = (major << 2) | 0b11; // 7-bit opcode, 4-byte marker
+            for &rd in &[0u32, 3, 4, 5, 16, 31] {
+                for &rs1 in &[0u32, 3, 4, 5, 16, 31] {
+                    for &rs2 in &[0u32, 3, 4, 5, 16, 31] {
+                        for funct3 in 0u32..8 {
+                            for &funct7 in &[0u32, 0b000_0001, 0b010_0000, 0b000_0111] {
+                                let w = (funct7 << 25)
+                                    | (rs2 << 20)
+                                    | (rs1 << 15)
+                                    | (funct3 << 12)
+                                    | (rd << 7)
+                                    | opcode7;
+                                let inst = decode_32(w);
+                                if !matches!(inst, Inst::Reserved { .. }) {
+                                    assert_eq!(
+                                        word_uses_reserved_reg(w),
+                                        inst.uses_reserved_reg(),
+                                        "word {w:#010x} -> {inst:?}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -26,7 +26,7 @@ use crate::ecall::{EcallHandler, EcallKind, EcallResult};
 use crate::exit::ExitReason;
 use crate::gas::GasCounter;
 use crate::instruction::Inst;
-use crate::mem::Memory;
+use crate::mem::{Memory, perm};
 use crate::predecode::{Predecode, RvPreDecodedInst, predecode};
 use crate::regs::Regs;
 
@@ -73,6 +73,7 @@ impl Interpreter {
     ) -> ExitReason {
         Self::run(
             &program.predecode,
+            &program.code,
             program.code_base,
             regs,
             mem,
@@ -87,6 +88,7 @@ impl Interpreter {
     /// code addresses as `code_base + offset`.
     pub fn run<M: Memory>(
         predecode: &Predecode,
+        code: &[u8],
         code_base: u32,
         regs: &mut Regs,
         mem: &mut M,
@@ -133,49 +135,49 @@ impl Interpreter {
                 // ---- Loads ---------------------------------------------------
                 Inst::Lb { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u8(addr) {
+                    match load_u8(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as i8 as i64 as u64),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Lh { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u16_le(addr) {
+                    match load_u16(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as i16 as i64 as u64),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Lw { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u32_le(addr) {
+                    match load_u32(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as i32 as i64 as u64),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Ld { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u64_le(addr) {
+                    match load_u64(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Lbu { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u8(addr) {
+                    match load_u8(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as u64),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Lhu { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u16_le(addr) {
+                    match load_u16(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as u64),
                         None => return page_fault(regs, pc, addr),
                     }
                 }
                 Inst::Lwu { rd, rs1, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    match mem.read_u32_le(addr) {
+                    match load_u32(mem, code, code_base, addr) {
                         Some(v) => reg_write(regs, rd, v as u64),
                         None => return page_fault(regs, pc, addr),
                     }
@@ -184,25 +186,32 @@ impl Interpreter {
                 // ---- Stores --------------------------------------------------
                 Inst::Sb { rs1, rs2, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    if !mem.write_u8(addr, reg_read(regs, rs2) as u8) {
+                    if !store_writable(mem, addr, 1)
+                        || !mem.write_u8(addr, reg_read(regs, rs2) as u8)
+                    {
                         return page_fault(regs, pc, addr);
                     }
                 }
                 Inst::Sh { rs1, rs2, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    if !mem.write_u16_le(addr, reg_read(regs, rs2) as u16) {
+                    if !store_writable(mem, addr, 2)
+                        || !mem.write_u16_le(addr, reg_read(regs, rs2) as u16)
+                    {
                         return page_fault(regs, pc, addr);
                     }
                 }
                 Inst::Sw { rs1, rs2, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    if !mem.write_u32_le(addr, reg_read(regs, rs2) as u32) {
+                    if !store_writable(mem, addr, 4)
+                        || !mem.write_u32_le(addr, reg_read(regs, rs2) as u32)
+                    {
                         return page_fault(regs, pc, addr);
                     }
                 }
                 Inst::Sd { rs1, rs2, imm } => {
                     let addr = compute_addr(regs, rs1, imm);
-                    if !mem.write_u64_le(addr, reg_read(regs, rs2)) {
+                    if !store_writable(mem, addr, 8) || !mem.write_u64_le(addr, reg_read(regs, rs2))
+                    {
                         return page_fault(regs, pc, addr);
                     }
                 }
@@ -652,9 +661,14 @@ impl Interpreter {
                         reg_write(regs, rd, code_base.wrapping_add(next_pc) as u64);
                     }
                     let target = (pc as i64).wrapping_add(imm as i64) as u32;
+                    // The target must be a basic-block start (gas precharge
+                    // happens at block entry) — else Panic, matching the
+                    // recompiler's `emit_static_branch` panic stub and the
+                    // `Jalr` arm below. Accepting a mid-block target would
+                    // execute a partial block having charged zero gas.
                     next_idx_override = Some(match find_idx_for_pc(insts, target) {
-                        Some(i) => i,
-                        None => {
+                        Some(i) if insts[i].is_gas_block_start => i,
+                        _ => {
                             regs.pc = pc as u64;
                             return ExitReason::Panic;
                         }
@@ -683,8 +697,8 @@ impl Interpreter {
                     if reg_read(regs, rs1) == reg_read(regs, rs2) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -695,8 +709,8 @@ impl Interpreter {
                     if reg_read(regs, rs1) != reg_read(regs, rs2) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -707,8 +721,8 @@ impl Interpreter {
                     if (reg_read(regs, rs1) as i64) < (reg_read(regs, rs2) as i64) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -719,8 +733,8 @@ impl Interpreter {
                     if (reg_read(regs, rs1) as i64) >= (reg_read(regs, rs2) as i64) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -731,8 +745,8 @@ impl Interpreter {
                     if reg_read(regs, rs1) < reg_read(regs, rs2) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -743,8 +757,8 @@ impl Interpreter {
                     if reg_read(regs, rs1) >= reg_read(regs, rs2) {
                         let target = (pc as i64).wrapping_add(imm as i64) as u32;
                         match find_idx_for_pc(insts, target) {
-                            Some(i) => next_idx_override = Some(i),
-                            None => {
+                            Some(i) if insts[i].is_gas_block_start => next_idx_override = Some(i),
+                            _ => {
                                 regs.pc = pc as u64;
                                 return ExitReason::Panic;
                             }
@@ -848,6 +862,62 @@ fn compute_addr(regs: &Regs, rs1: u8, imm: i32) -> u32 {
     (reg_read(regs, rs1) as u32).wrapping_add(imm as u32)
 }
 
+/// Read a `width`-byte little-endian value (`width ≤ 8`, zero-extended
+/// into the `u64`) from the read-only code region if `addr` falls
+/// wholly within `[code_base, code_base + code.len())`. Returns `None`
+/// otherwise. Serves the PIC idiom (`auipc` + load) the spec blesses
+/// and the recompiler allows via its RO code direct-map: the
+/// interpreter's data buffer is based at `DATA_BASE`, so a code-region
+/// address never hits it and must be served from the code bytes here.
+#[inline]
+fn read_code(code: &[u8], code_base: u32, addr: u32, width: usize) -> Option<u64> {
+    let off = addr.checked_sub(code_base)? as usize;
+    let end = off.checked_add(width)?;
+    if end > code.len() {
+        return None;
+    }
+    let mut buf = [0u8; 8];
+    buf[..width].copy_from_slice(&code[off..end]);
+    Some(u64::from_le_bytes(buf))
+}
+
+/// Width-typed loads that fall back to the read-only code region when
+/// the data buffer misses, so `auipc`+load of the guest's own code
+/// succeeds (B2 parity with the recompiler's RO code mapping).
+#[inline]
+fn load_u8<M: Memory>(mem: &M, code: &[u8], code_base: u32, addr: u32) -> Option<u8> {
+    mem.read_u8(addr)
+        .or_else(|| read_code(code, code_base, addr, 1).map(|v| v as u8))
+}
+#[inline]
+fn load_u16<M: Memory>(mem: &M, code: &[u8], code_base: u32, addr: u32) -> Option<u16> {
+    mem.read_u16_le(addr)
+        .or_else(|| read_code(code, code_base, addr, 2).map(|v| v as u16))
+}
+#[inline]
+fn load_u32<M: Memory>(mem: &M, code: &[u8], code_base: u32, addr: u32) -> Option<u32> {
+    mem.read_u32_le(addr)
+        .or_else(|| read_code(code, code_base, addr, 4).map(|v| v as u32))
+}
+#[inline]
+fn load_u64<M: Memory>(mem: &M, code: &[u8], code_base: u32, addr: u32) -> Option<u64> {
+    mem.read_u64_le(addr)
+        .or_else(|| read_code(code, code_base, addr, 8))
+}
+
+/// True iff every page a `width`-byte guest store at `addr` touches is
+/// writable (`perm::RW`). A `width`-byte store (`width ≤ 8`) spans at
+/// most two consecutive pages, so checking the first and last byte's
+/// page covers it. Enforced only for *guest* stores so the interpreter
+/// (the in-process consensus oracle) faults a write to a read-only /
+/// pinned page exactly as the recompiler's hardware page tables do —
+/// trusted kernel/host-call writes use `mem.write_*` directly and
+/// intentionally bypass this.
+#[inline]
+fn store_writable<M: Memory>(mem: &M, addr: u32, width: u32) -> bool {
+    mem.perm_of(addr) == perm::RW && mem.perm_of(addr.wrapping_add(width - 1)) == perm::RW
+}
+
 /// Build a `PageFault` exit and record the failing PC.
 #[inline]
 fn page_fault(regs: &mut Regs, pc: u32, addr: u32) -> ExitReason {
@@ -884,7 +954,7 @@ mod tests {
         let mut mem = CopyingMemory::new();
         let mut gas = GasCounter::new(initial_gas);
         let mut h = PanickingHandler;
-        let reason = Interpreter::run(&pre, 0, &mut regs, &mut mem, &mut gas, &mut h);
+        let reason = Interpreter::run(&pre, code, 0, &mut regs, &mut mem, &mut gas, &mut h);
         let used = initial_gas.saturating_sub(gas.remaining());
         (regs, reason, used)
     }
@@ -984,7 +1054,149 @@ mod tests {
         let mut mem = CopyingMemory::new();
         let mut gas = GasCounter::new(1_000_000);
         let mut h = PanickingHandler;
-        let reason = Interpreter::run(&pre, 0, &mut regs, &mut mem, &mut gas, &mut h);
+        let reason = Interpreter::run(&pre, &code, 0, &mut regs, &mut mem, &mut gas, &mut h);
         assert_eq!(reason, ExitReason::Panic);
+    }
+
+    // ---- B1: static jal/branch to a non-block-start must Panic ----------
+    //
+    // The block-start set is {0} ∪ {pc after a terminator}. A static
+    // branch/jal whose target is a valid instruction boundary that is NOT
+    // a block start would, unguarded, run a partial block having charged
+    // zero gas. The interpreter must Panic there, matching the
+    // recompiler's `emit_static_branch` panic stub. An honest linker never
+    // emits such a target (it injects `fallthrough`), so this only bites a
+    // crafted blob.
+
+    #[test]
+    fn branch_to_non_block_start_panics() {
+        // 0:  beq x0,x0,+8   (taken; terminator → PC=4 is a block start)
+        // 4:  addi x10,x0,1  (not a terminator → PC=8 is NOT a block start)
+        // 8:  addi x11,x0,2  (the branch target — mid-block)
+        // 12: trap
+        let beq = 0x0000_0463u32; // beq x0,x0,+8
+        let addi1 = (1u32 << 20) | (10 << 7) | 0x13;
+        let addi2 = (2u32 << 20) | (11 << 7) | 0x13;
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[beq, addi1, addi2, trap]);
+        let (regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Panic);
+        assert_eq!(regs.pc, 0); // the faulting branch's PC
+    }
+
+    #[test]
+    fn jal_to_non_block_start_panics() {
+        // 0:  jal x0,+8      (terminator → PC=4 is a block start)
+        // 4:  addi x10,x0,1  (not a terminator → PC=8 is NOT a block start)
+        // 8:  addi x11,x0,2  (the jal target — mid-block)
+        // 12: trap
+        let jal = 0x0080_006Fu32; // jal x0,+8
+        let addi1 = (1u32 << 20) | (10 << 7) | 0x13;
+        let addi2 = (2u32 << 20) | (11 << 7) | 0x13;
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[jal, addi1, addi2, trap]);
+        let (regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Panic);
+        assert_eq!(regs.pc, 0);
+    }
+
+    #[test]
+    fn branch_to_real_block_start_is_allowed() {
+        // Regression guard: a branch to a genuine block start still works.
+        // 0:  beq x0,x0,+8   (terminator → PC=4 block start)
+        // 4:  trap           (terminator → PC=8 IS a block start; unreached)
+        // 8:  addi x10,x0,7  (the branch target — a valid block start)
+        // 12: trap
+        let beq = 0x0000_0463u32; // beq x0,x0,+8
+        let trap = 0x0000_000Bu32;
+        let addi = (7u32 << 20) | (10 << 7) | 0x13;
+        let code = enc4(&[beq, trap, addi, trap]);
+        let (regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Trap);
+        assert_eq!(regs.gpr[7], 7); // x10 → slot 7: the branch was taken
+    }
+
+    // ---- B2: a guest can read (but not write) its own code bytes --------
+
+    #[test]
+    fn auipc_load_reads_own_code_region() {
+        // auipc x10,0 ; lw x11,0(x10) ; trap. With the data buffer based
+        // away from the code region, the load address lands in the code
+        // region and must be served from the code bytes (the PIC idiom),
+        // not page-fault — matching the recompiler's RO code direct-map.
+        let auipc = (0u32 << 12) | (10 << 7) | 0x17; // auipc x10,0
+        let lw = (0u32 << 20) | (10 << 15) | (0b010 << 12) | (11 << 7) | 0x03; // lw x11,0(x10)
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[auipc, lw, trap]);
+        let pre = predecode(&code);
+        let mut regs = Regs::new();
+        let mut mem = CopyingMemory::new();
+        mem.base = 0x1000_0000; // data buffer elsewhere; code region unmapped here
+        let mut gas = GasCounter::new(1_000_000);
+        let mut h = PanickingHandler;
+        let code_base = 0x0040_0000u32;
+        let reason = Interpreter::run(
+            &pre, &code, code_base, &mut regs, &mut mem, &mut gas, &mut h,
+        );
+        assert_eq!(reason, ExitReason::Trap);
+        assert_eq!(regs.gpr[7], code_base as u64); // x10 = code_base + 0
+        assert_eq!(regs.gpr[8] as u32, auipc); // x11 = the first code word
+    }
+
+    #[test]
+    fn store_into_code_region_faults() {
+        // auipc x10,0 ; sw x0,0(x10) ; trap. Code is read-only: a store
+        // into the code region must PageFault in both engines.
+        let auipc = (0u32 << 12) | (10 << 7) | 0x17; // auipc x10,0
+        let sw = (0u32 << 25) | (0 << 20) | (10 << 15) | (0b010 << 12) | (0 << 7) | 0x23; // sw x0,0(x10)
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[auipc, sw, trap]);
+        let pre = predecode(&code);
+        let mut regs = Regs::new();
+        let mut mem = CopyingMemory::new();
+        mem.base = 0x1000_0000;
+        let mut gas = GasCounter::new(1_000_000);
+        let mut h = PanickingHandler;
+        let code_base = 0x0040_0000u32;
+        let reason = Interpreter::run(
+            &pre, &code, code_base, &mut regs, &mut mem, &mut gas, &mut h,
+        );
+        assert_eq!(reason, ExitReason::PageFault(code_base));
+    }
+
+    // ---- B3: a guest store to a read-only page faults -------------------
+
+    #[test]
+    fn store_writable_respects_per_page_perms() {
+        // Two RW pages, then mark the second read-only. A store wholly in
+        // an RW page passes; one touching the RO page (incl. a straddle)
+        // fails.
+        let page = crate::mem::PAGE_SIZE;
+        let mut mem = CopyingMemory::with_pages(2, perm::RW);
+        mem.perms[1] = perm::RO;
+        assert!(store_writable(&mem, 0, 4)); // wholly in RW page
+        assert!(!store_writable(&mem, page, 4)); // wholly in RO page
+        assert!(!store_writable(&mem, page - 2, 4)); // straddles RW→RO
+    }
+
+    #[test]
+    fn guest_store_to_ro_page_faults() {
+        // lui x5,1 (x5 = 0x1000) ; sw x0,0(x5) ; trap. Page 1 is RO, so
+        // the store faults; the recompiler's hardware RO mapping faults
+        // identically.
+        let lui = (1u32 << 12) | (5 << 7) | 0x37; // lui x5,1
+        let sw = (0u32 << 25) | (0 << 20) | (5 << 15) | (0b010 << 12) | (0 << 7) | 0x23; // sw x0,0(x5)
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[lui, sw, trap]);
+        let pre = predecode(&code);
+        let mut regs = Regs::new();
+        let mut mem = CopyingMemory::with_pages(2, perm::RW);
+        mem.perms[1] = perm::RO;
+        let mut gas = GasCounter::new(1_000_000);
+        let mut h = PanickingHandler;
+        let reason = Interpreter::run(&pre, &code, 0, &mut regs, &mut mem, &mut gas, &mut h);
+        assert_eq!(reason, ExitReason::PageFault(crate::mem::PAGE_SIZE));
+        // The RO page was not mutated.
+        assert_eq!(mem.read_u32_le(crate::mem::PAGE_SIZE), Some(0));
     }
 }

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -105,10 +105,18 @@ impl Interpreter {
             return ExitReason::Panic;
         }
 
-        // Resolve starting PC → instruction index.
+        // Resolve starting PC → instruction index. The entry must be a
+        // basic-block start: a fresh invocation enters at an endpoint's
+        // `entry_pc` (untrusted Image metadata) and every resume lands on
+        // a post-terminator `bb_start` (the pause invariant). A
+        // non-block-start entry would run a partial block having charged
+        // zero gas — so we Panic, exactly as the recompiler's prologue
+        // does (its dense dispatch table holds the panic stub at every
+        // non-block-start offset). Lazy: this fires at invocation, never
+        // at Image admission.
         let mut idx = match find_idx_for_pc(insts, regs.pc as u32) {
-            Some(i) => i,
-            None => return ExitReason::Panic,
+            Some(i) if insts[i].is_gas_block_start => i,
+            _ => return ExitReason::Panic,
         };
 
         loop {
@@ -829,29 +837,25 @@ impl Interpreter {
 // Helpers
 // ----------------------------------------------------------------------------
 
-/// Read PVM2 register `x`. `x0` reads as zero; `x3`/`x4` are reserved
-/// (defence-in-depth zero); `x1..x2, x5..x15` map to slots `0..12`.
+/// Read PVM2 register `x`, via the shared slot map ([`crate::regs`]).
+/// `x0` (and any reserved register, which never reaches here once decode
+/// maps it to `Reserved`) reads as zero; `x1, x2, x5..x15` map to slots
+/// `0..12`.
 #[inline]
 fn reg_read(regs: &Regs, x: u8) -> u64 {
-    match x {
-        0 => 0,
-        1 => regs.gpr[0],
-        2 => regs.gpr[1],
-        5..=15 => regs.gpr[(x as usize) - 3],
-        _ => 0,
+    match crate::regs::REG_SLOT_LUT[(x & 31) as usize] {
+        0xFF => 0,
+        s => regs.gpr[s as usize],
     }
 }
 
-/// Write PVM2 register `x`. Writes to `x0`, `x3`, `x4`, or out-of-range
-/// are no-ops.
+/// Write PVM2 register `x`, via the shared slot map. Writes to `x0` (and
+/// any reserved register) are no-ops.
 #[inline]
 fn reg_write(regs: &mut Regs, x: u8, v: u64) {
-    match x {
-        0 => {}
-        1 => regs.gpr[0] = v,
-        2 => regs.gpr[1] = v,
-        5..=15 => regs.gpr[(x as usize) - 3] = v,
-        _ => {}
+    let s = crate::regs::REG_SLOT_LUT[(x & 31) as usize];
+    if s != 0xFF {
+        regs.gpr[s as usize] = v;
     }
 }
 
@@ -1198,5 +1202,69 @@ mod tests {
         assert_eq!(reason, ExitReason::PageFault(crate::mem::PAGE_SIZE));
         // The RO page was not mutated.
         assert_eq!(mem.read_u32_le(crate::mem::PAGE_SIZE), Some(0));
+    }
+
+    // ---- B6: entry PC must be a basic-block start ----------------------
+
+    #[test]
+    fn entry_at_non_block_start_panics() {
+        // Enter at PC=4, which is mid-block: the addi at PC=0 is not a
+        // terminator, so PC=4 is not a block start. Must Panic at
+        // invocation, matching the recompiler's dispatch-table prologue
+        // (a non-block-start offset holds the panic stub).
+        let addi1 = (1u32 << 20) | (10 << 7) | 0x13;
+        let addi2 = (2u32 << 20) | (11 << 7) | 0x13;
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[addi1, addi2, trap]);
+        let pre = predecode(&code);
+        let mut regs = Regs::new();
+        regs.pc = 4; // non-block-start entry
+        let mut mem = CopyingMemory::new();
+        let mut gas = GasCounter::new(1_000_000);
+        let mut h = PanickingHandler;
+        let reason = Interpreter::run(&pre, &code, 0, &mut regs, &mut mem, &mut gas, &mut h);
+        assert_eq!(reason, ExitReason::Panic);
+    }
+
+    #[test]
+    fn entry_at_real_block_start_is_allowed() {
+        // 0: trap (terminator → PC=4 is a block start)
+        // 4: addi x10,x0,7 ; 8: trap. Entering at the PC=4 block start runs.
+        let trap = 0x0000_000Bu32;
+        let addi = (7u32 << 20) | (10 << 7) | 0x13;
+        let code = enc4(&[trap, addi, trap]);
+        let pre = predecode(&code);
+        let mut regs = Regs::new();
+        regs.pc = 4; // post-terminator block start
+        let mut mem = CopyingMemory::new();
+        let mut gas = GasCounter::new(1_000_000);
+        let mut h = PanickingHandler;
+        let reason = Interpreter::run(&pre, &code, 0, &mut regs, &mut mem, &mut gas, &mut h);
+        assert_eq!(reason, ExitReason::Trap);
+        assert_eq!(regs.gpr[7], 7); // x10 → slot 7: PC=4 block executed
+    }
+
+    // ---- B7: an x3/x4 register field panics (was: executed as zero) ----
+
+    #[test]
+    fn x3_source_register_panics() {
+        // add x5, x3, x6 ; trap. x3 is reserved, so the instruction is a
+        // reserved encoding → Panic, matching the recompiler (which used
+        // to panic here while the interp executed `0 + x6`).
+        let add_x3 = 0x0061_82B3u32; // add x5, x3, x6
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[add_x3, trap]);
+        let (_regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Panic);
+    }
+
+    #[test]
+    fn x3_free_arithmetic_still_runs() {
+        // add x5, x6, x7 ; trap — no reserved register, executes normally.
+        let add_ok = 0x0073_02B3u32; // add x5, x6, x7
+        let trap = 0x0000_000Bu32;
+        let code = enc4(&[add_ok, trap]);
+        let (_regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Trap);
     }
 }

--- a/rust/javm-exec/src/regs.rs
+++ b/rust/javm-exec/src/regs.rs
@@ -8,6 +8,76 @@
 /// Number of general-purpose registers.
 pub const REG_COUNT: usize = 13;
 
+/// Classification of a 5-bit RV register index in PVM2.
+///
+/// PVM2 is an RV64E base — a 16-register file (`x0`–`x15`) — that
+/// additionally reserves `x3`/`x4`. This is the **single source of truth**
+/// for every place that needs register classification: the gas-simulator
+/// slot map, the recompiler's codegen slot map, the interpreter's register
+/// file access, and the reserved-register check both engines use. They all
+/// derive from [`reg_class`] rather than re-encoding the valid/reserved
+/// sets (which is how `rv_is_reserved` once drifted to miss `x16..x31`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RegClass {
+    /// `x0` — hardwired zero. Valid, but has no GPR slot.
+    Zero,
+    /// `x1`, `x2`, `x5`–`x15` — general-purpose; the payload is the slot
+    /// `0..=12` into [`Regs::gpr`].
+    Gpr(u8),
+    /// `x3`, `x4` (PVM2-reserved) or `x16`–`x31` (don't exist in RV64E, so
+    /// naming one is an illegal encoding). Such an instruction is a
+    /// reserved encoding and panics if executed.
+    Reserved,
+}
+
+/// Classify a 5-bit RV register index (low 5 bits of `x`). See [`RegClass`].
+#[inline]
+pub const fn reg_class(x: u8) -> RegClass {
+    match x & 31 {
+        0 => RegClass::Zero,
+        1 => RegClass::Gpr(0),
+        2 => RegClass::Gpr(1),
+        n @ 5..=15 => RegClass::Gpr(n - 3),
+        _ => RegClass::Reserved, // x3, x4, x16..x31
+    }
+}
+
+/// PVM2 GPR slot (`0..=12`) for `x`, or `0xFF` if `x` has no slot — `x0`
+/// (hardwired zero) *or* a reserved register. The gas simulator reads
+/// `0xFF` as "no dependency / no write"; both engines' gas paths use this
+/// (the recompiler via the const-folded [`REG_SLOT_LUT`]) so gas agrees
+/// bit-for-bit. Note `0xFF` conflates `x0` with reserved — use
+/// [`reg_is_reserved`] when that distinction matters.
+#[inline]
+pub const fn reg_slot_or_ff(x: u8) -> u8 {
+    match reg_class(x) {
+        RegClass::Gpr(s) => s,
+        _ => 0xFF,
+    }
+}
+
+/// True iff `x` is a *reserved* register (`x3`/`x4`/`x16..x31`) — as
+/// opposed to `x0`, which also lacks a slot but is valid. Drives the
+/// reserved-encoding check in both engines.
+#[inline]
+pub const fn reg_is_reserved(x: u8) -> bool {
+    matches!(reg_class(x), RegClass::Reserved)
+}
+
+/// 32-entry const-folded copy of [`reg_slot_or_ff`] for the recompiler's
+/// codegen/gas hot path — a single load beats the range-match (the
+/// profiler showed the match at ~8.8% of compile). Generated from
+/// [`reg_class`], so it cannot drift from the canonical classification.
+pub const REG_SLOT_LUT: [u8; 32] = {
+    let mut t = [0u8; 32];
+    let mut x = 0u8;
+    while x < 32 {
+        t[x as usize] = reg_slot_or_ff(x);
+        x += 1;
+    }
+    t
+};
+
 /// Full register state: 13 GPRs + PC.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Regs {

--- a/rust/javm-exec/tests/regs.rs
+++ b/rust/javm-exec/tests/regs.rs
@@ -1,4 +1,42 @@
+use javm_exec::regs::{REG_SLOT_LUT, RegClass, reg_class, reg_is_reserved, reg_slot_or_ff};
 use javm_exec::{REG_COUNT, Regs};
+
+#[test]
+fn reg_classification_is_the_single_source() {
+    // Slot map: x0 and reserved → 0xFF (no slot); x1→0, x2→1, x5..x15→2..12.
+    // These exact values are the consensus gas contract — the recompiler's
+    // `REG_SLOT_LUT` and the interpreter's `rv_slot_u8` both read them, so
+    // they must stay bit-identical with the pre-unification tables.
+    assert_eq!(reg_slot_or_ff(0), 0xFF); // x0
+    assert_eq!(reg_slot_or_ff(1), 0);
+    assert_eq!(reg_slot_or_ff(2), 1);
+    assert_eq!(reg_slot_or_ff(3), 0xFF); // reserved
+    assert_eq!(reg_slot_or_ff(4), 0xFF); // reserved
+    for x in 5..=15u8 {
+        assert_eq!(reg_slot_or_ff(x), x - 3); // x5..x15 → 2..12
+    }
+    for x in 16..=31u8 {
+        assert_eq!(reg_slot_or_ff(x), 0xFF); // x16..x31 don't exist in RV64E
+    }
+
+    // Reserved set is exactly {x3, x4, x16..x31} — and crucially NOT x0.
+    for x in 0..=31u8 {
+        assert_eq!(reg_is_reserved(x), x == 3 || x == 4 || x >= 16, "x{x}");
+    }
+    assert!(!reg_is_reserved(0)); // x0 lacks a slot but is valid, not reserved
+
+    // The const-folded LUT equals the function for every index (no drift).
+    for x in 0..32u8 {
+        assert_eq!(REG_SLOT_LUT[x as usize], reg_slot_or_ff(x), "x{x}");
+    }
+
+    // The derived views agree with the classification.
+    assert_eq!(reg_class(0), RegClass::Zero);
+    assert_eq!(reg_class(1), RegClass::Gpr(0));
+    assert_eq!(reg_class(15), RegClass::Gpr(12));
+    assert_eq!(reg_class(4), RegClass::Reserved);
+    assert_eq!(reg_class(31), RegClass::Reserved);
+}
 
 #[test]
 fn new_is_zero() {

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -49,25 +49,14 @@ pub(crate) const REG_MAP: [Reg; 13] = [
 pub(crate) const SCRATCH: Reg = Reg::RDX;
 
 /// RV register (5-bit, 0..31) → PVM2 slot (0..12), or `0xFF` for "no
-/// slot" (x0, reserved x3/x4, x16..x31). A 32-byte const lookup table:
-/// one load replaces the range-match, which the profiler showed at
-/// ~8.8% of compile (called ~6×/instruction across codegen + gas feed).
-/// Values mirror the original match exactly, so gas stays bit-identical.
-pub(crate) const RV_SLOT_LUT: [u8; 32] = {
-    let mut t = [0xFFu8; 32];
-    t[1] = 0;
-    t[2] = 1;
-    let mut x = 5usize;
-    while x <= 15 {
-        t[x] = (x - 3) as u8;
-        x += 1;
-    }
-    t
-};
+/// slot" (x0, or a reserved register x3/x4/x16..x31). A 32-byte const LUT:
+/// one load replaces the range-match (~8.8% of compile, called
+/// ~6×/instruction across codegen + gas feed). The classification is the
+/// single source [`javm_exec::regs`]; this is its const-folded copy, so
+/// gas stays bit-identical with the interpreter's predecode-cached path.
+pub(crate) use javm_exec::regs::REG_SLOT_LUT as RV_SLOT_LUT;
 
 /// RV register number → PVM2 slot (0..12), or `0xFF` for "no slot".
-/// Mirrors the slot encoding used by `rv_op_metadata` so that gas
-/// accounting agrees bit-for-bit with the predecode-cached path.
 #[inline(always)]
 pub(crate) fn rv_slot_or_ff(x: u8) -> u8 {
     RV_SLOT_LUT[(x & 31) as usize]
@@ -1126,10 +1115,11 @@ fn expand_rvc_q2(h: u16, f3: u16) -> Option<u32> {
 
 /// Map an RV register index to its PVM slot (0..=12).
 ///
-/// Returns `None` for x0 (hardwired zero), x3, x4 (reserved). Callers
-/// handle x0 by loading an immediate 0; x3/x4 cause a runtime panic at
-/// the offending PC (the transpiler is expected to reject them at
-/// deblob, so this is just defence-in-depth).
+/// Returns `None` for x0 (hardwired zero) and for any reserved register
+/// (x3/x4/x16..x31). Callers handle x0 by loading an immediate 0; a
+/// reserved register causes a runtime panic at the offending PC — but it
+/// is rejected up front by `compile_rv4`'s `word_uses_reserved_reg` guard,
+/// so reaching `rv_slot(reserved)` is now unreachable defence-in-depth.
 #[inline]
 fn rv_slot(x: u8) -> Option<usize> {
     match RV_SLOT_LUT[(x & 31) as usize] {
@@ -1138,12 +1128,10 @@ fn rv_slot(x: u8) -> Option<usize> {
     }
 }
 
-/// True for x3 and x4 — registers that PVM2 reserves and the transpiler
-/// must reject. If we ever see them at codegen time, we trap.
-#[inline]
-fn rv_is_reserved(x: u8) -> bool {
-    x == 3 || x == 4
-}
+/// True for a reserved register (x3/x4/x16..x31). Single source:
+/// [`javm_exec::regs::reg_is_reserved`] (previously a local `x == 3 ||
+/// x == 4` that drifted to miss `x16..x31`).
+use javm_exec::regs::reg_is_reserved as rv_is_reserved;
 
 impl Compiler {
     /// Compile an RV+C+custom-0 byte stream into x86-64 in a single
@@ -1356,6 +1344,16 @@ impl Compiler {
         let rs2 = ((w >> 20) & 0x1F) as u8;
         let f3 = ((w >> 12) & 0x07) as u8;
         let f7 = ((w >> 25) & 0x7F) as u8;
+
+        // x3/x4 in any register field is reserved (Category 1 #4): panic,
+        // uniformly, matching the interpreter (which decodes such an
+        // instruction as `Reserved`). Shared predicate so the two engines
+        // can't drift; covers expanded RVC, which routes through here.
+        if javm_exec::instruction::word_uses_reserved_reg(w) {
+            self.rv_emit_panic_at(pc);
+            self.feed_gas_rv(RV_KIND_RESERVED, 0, 0, 0);
+            return (true, false, 0);
+        }
 
         match opcode {
             OP_LOAD => self.compile_load(rd, rs1, f3, w, pc, rest),

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -864,8 +864,13 @@ fn validate_pvm2(code: &[u8]) -> Result<(), TranspileError> {
         let rd = (w >> 7) & 0x1F;
         let rs1 = (w >> 15) & 0x1F;
         let rs2 = (w >> 20) & 0x1F;
+        // Reserved registers: x3/x4 (PVM2-specific) and x16..x31 (do not
+        // exist in RV64E — a 16-register base — so they are illegal). This
+        // producer-side check mirrors the consensus source of truth,
+        // `javm_exec::regs::reg_is_reserved`; kept local so the transpiler
+        // need not depend on the executor crate.
         let check = |name: &str, r: u32| -> Result<(), TranspileError> {
-            if r == 3 || r == 4 {
+            if r == 3 || r == 4 || r >= 16 {
                 return Err(TranspileError::InvalidSection(format!(
                     "link_elf: forbidden register x{} ({}) at offset {:#x}",
                     r, name, i

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -192,12 +192,22 @@ impl<K: KernelAssist> Vm<K> {
             )
             .map_err(VmError::MapRegion)?;
         }
+        // A mapping sourced from a pinned slot is read-only: lay it RO so
+        // a guest store faults, matching the recompiler, which RO direct-
+        // maps pinned slots and does not CoW-arm them (nub-arch-x86
+        // `build_runtime` pinned-vs-initial classification). Non-pinned
+        // (initial) overlays stay RW.
         for overlay_entry in inst.rw_overlays.iter() {
+            let access = if img.mapping_is_pinned(overlay_entry.start) {
+                Access::ReadOnly
+            } else {
+                Access::ReadWrite
+            };
             overlay_into(
                 &mut mem,
                 overlay_entry.start,
                 overlay_entry.bytes.as_slice(),
-                Access::ReadWrite,
+                access,
             )?;
         }
 

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -510,6 +510,18 @@ impl<K: KernelAssist> Vm<K> {
             },
             ExitReason::Trap
             | ExitReason::Panic
+            // TODO(oog-as-pause): uncaught OOG is treated as a hard
+            // (terminal) fault here, but unlike Trap/Panic/PageFault it is
+            // NOT semantically terminal. OOG can only fire at a per-block
+            // gas check — i.e. at a `bb_start` — so it is a *sound* resume
+            // point (see docs/pvm-isa/discussions/pause-and-bb-start.md).
+            // It should eventually become a resumable pause
+            // (Paused-persistent) so a chain can supply more gas and resume
+            // at the OOG bb_start instead of discarding the instance's
+            // work. (A *caught* OOG already yields via
+            // reconcile_and_route_oog; this arm is the uncaught case.)
+            // Open design question: data-flow "OOG-as-fault vs
+            // Paused-persistent".
             | ExitReason::OutOfGas
             | ExitReason::PageFault(_) => CallResult::Faulted {
                 reason: exit,

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -92,12 +92,21 @@ pub fn run_instance(
         )
         .expect("map base RW region");
     }
+    // A mapping sourced from a pinned slot is read-only: lay it RO so a
+    // guest store faults, matching the recompiler (which RO direct-maps
+    // pinned slots and does not CoW-arm them). Mirrors `javm` `Vm::
+    // build_entry` via the shared `ImageCap::mapping_is_pinned`.
     for overlay_entry in instance.rw_overlays.iter() {
+        let access = if image.mapping_is_pinned(overlay_entry.start) {
+            Access::ReadOnly
+        } else {
+            Access::ReadWrite
+        };
         overlay(
             &mut mem,
             overlay_entry.start,
             overlay_entry.bytes.as_slice(),
-            Access::ReadWrite,
+            access,
         );
     }
 
@@ -133,6 +142,7 @@ pub fn run_instance(
     let predecode = predecode(code_bytes);
     let exit = Interpreter::run(
         &predecode,
+        code_bytes,
         code_base,
         &mut regs,
         &mut mem,

--- a/rust/nub-build/src/lib.rs
+++ b/rust/nub-build/src/lib.rs
@@ -121,6 +121,16 @@ pub fn build(manifest_dir: &str, bin_name: &str, features: &[&str]) -> PathBuf {
         .arg(TARGET_TRIPLE)
         .arg("--bin")
         .arg(bin_name)
+        // NOTE: enabling LTO here (`--config profile.release.lto=…`) fails:
+        // the guest forces `-Ccode-model=large` (it loads at a low-half GVA,
+        // too far above 2 GiB for the default `kernel` model), but the
+        // *precompiled* `core`/`alloc` use the target-default `kernel`
+        // model, and LTO (fat *and* thin) refuses to merge modules with
+        // conflicting `Code Model` flags (`i32 4` vs `i32 2`). Making LTO
+        // work would require rebuilding std with the matching code model via
+        // `-Zbuild-std`, i.e. a nightly toolchain (or `RUSTC_BOOTSTRAP=1`) —
+        // a departure from this crate's deliberate stable / no-build-std
+        // design. Left disabled pending that decision.
         .env("CARGO_TARGET_DIR", &target_dir)
         .env("BUILD_CRATE_GUEST_BUILD", "1")
         .env("CARGO_ENCODED_RUSTFLAGS", rustflags);


### PR DESCRIPTION
## What

The PVM2 **interpreter** (the consensus oracle) under-enforced what the spec requires and the x86 **recompiler** already enforced. On a blob both engines admit, the oracle and executor could then compute different state — a consensus fork that a sandbox cannot catch. This closes four such forks and pins the classifier pair that could create a fifth. Each fix makes the interpreter match the recompiler's *observable* behavior, verified by reading both engines (interp `javm-exec` + recompiler `nub-arch-x86`/`codegen.rs`).

Re-audited each finding against current source before fixing (a prior research pass had fabricated an artifact, so nothing was taken on trust).

## Fixes

**B1 — static `jal`/branch to a non-block-start.** The `Jal` and six branch arms resolved targets with bare `find_idx_for_pc` and lacked the `is_gas_block_start` gate the `Jalr` arm already had, so a mid-block static target ran a partial block having charged **zero gas**. Added the gate to all seven arms; a non-block-start target now `Panic`s at execution, matching the recompiler's `emit_static_branch` panic stub and closing the gas hole.

**B2 — guest read of its own code.** The interpreter based its data buffer at `DATA_BASE`, so a code-region load (the `auipc`+load PIC idiom the spec blesses) page-faulted, while the recompiler RO-maps code and allows it. Threaded the code bytes into `Interpreter::run`; loads fall back to a read-only code-region read. Stores into code still fault.

**B3 — store to a pinned/read-only page wrote silently.** The interp store fast path never consulted per-page perms and `build_entry` laid every overlay `ReadWrite`. Now the store arms gate on a per-page `store_writable` check (guest stores only; trusted kernel writes bypass), and pinned-sourced mappings are laid read-only via the new shared `ImageCap::mapping_is_pinned`, used by **both** interp drivers (`Vm::build_entry` and `nub-arch-local` — the latter had the same bug). Derived from `img.pinned` at lay time, so `RwOverlay`'s cap hash is unchanged. Matches the recompiler, whose flat RW buffer is mapped *before* the RO `direct_maps`, so RO wins for pinned pages.

**B5 — drifting terminator classifiers.** The two engine-side classifiers (`predecode::is_terminator` and the gas-LUT `RVF_TERM`) are hand-coded independently and must agree or the engines disagree on basic-block starts. Added a generated test sweeping the full RVC halfword space and a 4-byte opcode×funct matrix. (The linker's third classifier is deferred — a 3-way test needs a cross-crate harness, and it is low-risk post-B1.)

**B4 — re-audited and found to be a misframing, not a missing check.** The original "PVM2 dropped PolkaVM's up-front O(n) validation" premise is PolkaVM-inherited: jar's recompiler **never rejects at load** (`compile` always returns a `CompileResult`; bad targets/reserved → runtime panic stubs), and the interpreter deliberately mirrors that. A load-time admission gate in the interpreter alone would create a *new* fork. **B1 is the real fix** — both engines now validate `target ∈ bb_starts` at execution, so `bb_start` soundness no longer rests on the linker's producer assumption even for untrusted Images. No admission gate added.

## Tests

8 directed adversarial vectors added (bench guests can't trigger these by construction):
- B1: `branch_to_non_block_start_panics`, `jal_to_non_block_start_panics`, `branch_to_real_block_start_is_allowed`
- B2: `auipc_load_reads_own_code_region`, `store_into_code_region_faults`
- B3: `store_writable_respects_per_page_perms`, `guest_store_to_ro_page_faults`, `mapping_is_pinned_classifies_by_source_slot`
- B5: `predecode_and_gas_lut_terminator_agree`

`cargo build --workspace` clean, `clippy --all-targets -D warnings` clean, `fmt` clean, **393 tests pass** (incl. `javm-guest-tests` interp↔recomp `conformance`/`sub_vm`). `javm-bench` shows no regression (changes are off the recompiler's measured path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)