### PR TITLE
Fully-conformant RISC-V: RV64E + Xjar + EEI (x3/x4 as real registers)

### DIFF
--- a/rust/javm-bench/tests/x3_x4_differential.rs
+++ b/rust/javm-bench/tests/x3_x4_differential.rs
@@ -1,0 +1,161 @@
+//! Interpreter ↔ recompiler execution differential for the host-spilled
+//! registers `x3`/`x4`.
+//!
+//! The jar toolchain never emits x3/x4, so no normal guest exercises them.
+//! This test hand-assembles small RV64E programs that *do*, builds a raw
+//! Image, and runs each one through both engines:
+//!
+//! - **Interpreter** (`Nub::new_local`) — executes x3/x4 as ordinary slot
+//!   13/14 GPRs.
+//! - **Recompiler** (in-kernel Hyperlight JIT) — routes them to the cold
+//!   spill path (donor re-dispatch for ALU, dedicated branch handler).
+//!
+//! It asserts both agree **bit-for-bit** on the return value (`φ[7]` = x10)
+//! and gas — the consensus property. This is the only test that validates
+//! the *executed* result of the spilled emit (the compile-time structural
+//! coverage lives in `javm-recompiler-x86/tests/x3_x4_spill.rs`).
+
+use javm_bench::{BuiltCaps, run_interpreter};
+use javm_cap::image::{EndpointDef, Image};
+use std::collections::BTreeMap;
+
+const HALT: u32 = 0x0000_200B; // ecalli 0 — HostCall(0); return_value = φ[7] (x10)
+
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+fn add(rd: u8, rs1: u8, rs2: u8) -> u32 {
+    ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x33
+}
+fn sub(rd: u8, rs1: u8, rs2: u8) -> u32 {
+    (0x20 << 25) | ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x33
+}
+fn beq(rs1: u8, rs2: u8, imm: i32) -> u32 {
+    let i = imm as u32;
+    ((i >> 12) & 1) << 31
+        | ((i >> 5) & 0x3F) << 25
+        | (rs2 as u32) << 20
+        | (rs1 as u32) << 15
+        | ((i >> 1) & 0xF) << 8
+        | ((i >> 11) & 1) << 7
+        | 0x63
+}
+
+fn enc(words: &[u32]) -> Vec<u8> {
+    let mut v = Vec::new();
+    for w in words {
+        v.extend_from_slice(&w.to_le_bytes());
+    }
+    v
+}
+
+fn image(code: Vec<u8>) -> Image {
+    let mut img = Image::empty();
+    img.code = code;
+    img.endpoints.insert(
+        0,
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    img
+}
+
+/// Run `code` through the interpreter; assert the return value. On
+/// linux/x86_64 also run the in-kernel recompiler and assert both engines
+/// agree bit-for-bit on return value and gas.
+fn diff(code: Vec<u8>, expected_return: u64) {
+    let built = BuiltCaps::for_image(&image(code), 0);
+    let (i_ret, _i_gas) = run_interpreter(&built);
+    assert_eq!(i_ret, expected_return, "interpreter return value");
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        let (r_ret, r_gas) = javm_bench::run_recompiler(&built);
+        assert_eq!(i_ret, r_ret, "interp vs recomp return value");
+        assert_eq!(_i_gas, r_gas, "interp vs recomp gas");
+    }
+}
+
+#[test]
+fn x3_x4_alu_and_branch_match() {
+    // The Hyperlight sandbox is a process singleton; keep all recompiler
+    // invocations in one test fn so they serialise on its lock.
+
+    // Donor ALU: add x10, x3, x4 (both sources spilled, host dest).
+    diff(
+        enc(&[addi(3, 0, 100), addi(4, 0, 23), add(10, 3, 4), HALT]),
+        123,
+    );
+
+    // Spilled destination, then read it back: x3 = x3 + x4; x10 = x3.
+    diff(
+        enc(&[
+            addi(3, 0, 40),
+            addi(4, 0, 2),
+            add(3, 3, 4),  // spilled dest + both spilled sources
+            add(10, 3, 0), // host dest ← spilled source (mv)
+            HALT,
+        ]),
+        42,
+    );
+
+    // sub with spilled operands: x10 = x3 - x4 = 70 - 28.
+    diff(
+        enc(&[addi(3, 0, 70), addi(4, 0, 28), sub(10, 3, 4), HALT]),
+        42,
+    );
+
+    // Spilled register reused in all three fields: x3 = x3 + x3 = 21*2.
+    diff(
+        enc(&[addi(3, 0, 21), add(3, 3, 3), add(10, 3, 0), HALT]),
+        42,
+    );
+
+    // Branch on spilled operands — taken path (x3 == x4).
+    //   0: addi x3,x0,5   1: addi x4,x0,5   2: beq x3,x4,+12 (→ pc 5)
+    //   3: addi x10,x0,99 4: HALT           5: addi x10,x0,42  6: HALT
+    diff(
+        enc(&[
+            addi(3, 0, 5),
+            addi(4, 0, 5),
+            beq(3, 4, 12),
+            addi(10, 0, 99),
+            HALT,
+            addi(10, 0, 42),
+            HALT,
+        ]),
+        42,
+    );
+
+    // Branch on spilled operands — not-taken path (x3 != x4).
+    diff(
+        enc(&[
+            addi(3, 0, 5),
+            addi(4, 0, 6),
+            beq(3, 4, 12),
+            addi(10, 0, 42),
+            HALT,
+            addi(10, 0, 99),
+            HALT,
+        ]),
+        42,
+    );
+
+    // Branch with one spilled operand vs a host register.
+    diff(
+        enc(&[
+            addi(3, 0, 8),
+            addi(5, 0, 8),
+            beq(3, 5, 12),
+            addi(10, 0, 99),
+            HALT,
+            addi(10, 0, 42),
+            HALT,
+        ]),
+        42,
+    );
+}

--- a/rust/javm-bench/tests/x3_x4_differential.rs
+++ b/rust/javm-bench/tests/x3_x4_differential.rs
@@ -14,6 +14,12 @@
 //! and gas — the consensus property. This is the only test that validates
 //! the *executed* result of the spilled emit (the compile-time structural
 //! coverage lives in `javm-recompiler-x86/tests/x3_x4_spill.rs`).
+//!
+//! `javm-bench` (and its `BuiltCaps` / `run_*` harness) is gated to
+//! linux/x86_64, so this whole test is too. The interpreter's x3/x4
+//! semantics are additionally covered cross-platform by the unit test in
+//! `javm-exec` (`x3_x4_execute_as_real_registers`).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use javm_bench::{BuiltCaps, run_interpreter};
 use javm_cap::image::{EndpointDef, Image};

--- a/rust/javm-exec/src/gas_cost.rs
+++ b/rust/javm-exec/src/gas_cost.rs
@@ -260,6 +260,14 @@ pub fn rv_slot_u8(r: u8) -> u8 {
     crate::regs::reg_slot_or_ff(r)
 }
 
+/// True iff a simulator slot is a *spilled* register (`x3`/`x4` → slots
+/// 13/14). Used to charge the memory-spill gas cost. `0xFF` ("no register")
+/// is `255`, so it is correctly excluded.
+#[inline(always)]
+fn is_spilled_slot(slot: u8) -> bool {
+    slot == 13 || slot == 14
+}
+
 /// Compute the [`crate::predecode::RvGasMeta`] for an `Inst`.
 /// Called once per instruction at decode time; the result is cached
 /// in [`crate::predecode::RvPreDecodedInst::gas_meta`] so the gas
@@ -452,8 +460,9 @@ fn rv_op_metadata(inst: &crate::instruction::Inst) -> (u8, u8, u8, u8) {
 /// as compile-time constants + slot lookups without going through
 /// an `RvGasMeta` struct.
 ///
-/// Slots are PVM2 register indices (0..12) or `0xFF` for "no
-/// register" (x0 / x3 / x4 / absent operand).
+/// Slots are PVM2 register indices (0..14) or `0xFF` for "no
+/// register" (x0 / absent operand). Slots 13/14 are `x3`/`x4`, which are
+/// host-spilled — see the spill-cost charge below.
 ///
 /// Returns `is_terminator` (RVF_TERM flag from the LUT entry).
 #[inline(always)]
@@ -473,6 +482,16 @@ pub fn rv_feed_gas_kind(
     } else {
         entry.cycles
     };
+
+    // x3/x4 (slots 13/14) are host-spilled: a host with exactly 13 registers
+    // materialises them from memory on each access. Charge the memory-spill
+    // cost (`mem_cycles`) per spilled operand position, on top of the base
+    // cycles — matching the load/op/store the recompiler's spill path emits,
+    // and bounding the worst-case conforming host. Conformant code never
+    // names x3/x4 (every slot is < 13), so this adds exactly nothing there.
+    let spill_ops =
+        is_spilled_slot(src1) as u8 + is_spilled_slot(src2) as u8 + is_spilled_slot(dst) as u8;
+    let cycles = cycles.saturating_add(mem_cycles.saturating_mul(spill_ops));
 
     // Overlap-dependent decode_slots.
     let decode_slots = if entry.flags & RVF_OVERLAP_DST_SRC != 0 {

--- a/rust/javm-exec/src/gas_sim.rs
+++ b/rust/javm-exec/src/gas_sim.rs
@@ -3,7 +3,7 @@
 //! O(n) single-pass model tracking per-register completion cycles.
 //! Replaces the full ROB-based pipeline simulation.
 //!
-//! Tracks `reg_done[13]` (cycle when each register is ready) and decode
+//! Tracks `reg_done[15]` (cycle when each register is ready) and decode
 //! throughput (4 slots/cycle). No ROB, no priority loop, no EU contention.
 //! See `docs/gas-metering-design.md` for detailed comparison.
 
@@ -11,7 +11,7 @@ use crate::gas_cost::FastCost;
 
 /// Single-pass pipeline gas simulator. O(1) per instruction, stack-allocated.
 pub struct GasSimulator {
-    reg_done: [u32; 13],
+    reg_done: [u32; 15],
     cycle: u32,
     decode_used: u8,
     max_done: u32,
@@ -26,7 +26,7 @@ impl Default for GasSimulator {
 impl GasSimulator {
     pub fn new() -> Self {
         Self {
-            reg_done: [0; 13],
+            reg_done: [0; 15],
             cycle: 0,
             decode_used: 0,
             max_done: 0,
@@ -36,8 +36,8 @@ impl GasSimulator {
     /// Fast path: feed an instruction using direct register indices instead of
     /// bitmasks. Avoids the shift+OR bitmask construction and trailing_zeros
     /// extraction loop. For typical 2-source, 1-dest instructions.
-    /// `src1`/`src2` are source register indices (0..12, or 0xFF for "none").
-    /// `dst` is destination register index (0..12, or 0xFF for "none").
+    /// `src1`/`src2` are source register indices (0..14, or 0xFF for "none").
+    /// `dst` is destination register index (0..14, or 0xFF for "none").
     #[inline(always)]
     pub fn feed_direct(&mut self, cycles: u8, decode_slots: u8, src1: u8, src2: u8, dst: u8) {
         // Match Lean semantics: advance cycle only if ALL 4 decode slots are
@@ -50,14 +50,14 @@ impl GasSimulator {
             self.decode_used += decode_slots;
         }
         let mut start = self.cycle;
-        if src1 < 13 {
+        if src1 < 15 {
             start = start.max(self.reg_done[src1 as usize]);
         }
-        if src2 < 13 {
+        if src2 < 15 {
             start = start.max(self.reg_done[src2 as usize]);
         }
         let done = start + cycles as u32;
-        if dst < 13 {
+        if dst < 15 {
             self.reg_done[dst as usize] = done;
         }
         self.max_done = self.max_done.max(done);
@@ -79,7 +79,7 @@ impl GasSimulator {
         if cost.is_move_reg {
             let src_reg = cost.src_mask.trailing_zeros() as usize;
             let dst_reg = cost.dst_mask.trailing_zeros() as usize;
-            if src_reg < 13 && dst_reg < 13 {
+            if src_reg < 15 && dst_reg < 15 {
                 self.reg_done[dst_reg] = self.reg_done[src_reg];
             }
             return;
@@ -91,7 +91,7 @@ impl GasSimulator {
         while src != 0 {
             let r = src.trailing_zeros() as usize;
             src &= src - 1;
-            if r < 13 {
+            if r < 15 {
                 start = start.max(self.reg_done[r]);
             }
         }
@@ -104,7 +104,7 @@ impl GasSimulator {
         while dst != 0 {
             let r = dst.trailing_zeros() as usize;
             dst &= dst - 1;
-            if r < 13 {
+            if r < 15 {
                 self.reg_done[r] = done;
             }
         }
@@ -126,7 +126,7 @@ impl GasSimulator {
     /// Reset for the next gas block.
     #[inline]
     pub fn reset(&mut self) {
-        self.reg_done = [0; 13];
+        self.reg_done = [0; 15];
         self.cycle = 0;
         self.decode_used = 0;
         self.max_done = 0;

--- a/rust/javm-exec/src/instruction.rs
+++ b/rust/javm-exec/src/instruction.rs
@@ -603,17 +603,17 @@ pub enum Inst {
 
 impl Inst {
     /// True iff this instruction names a reserved register in any of its
-    /// register fields. The valid PVM2 registers are `x0, x1, x2, x5..x15`;
-    /// reserved are `x3`/`x4` (PVM2-specific, Category 1 #4) and `x16..x31`
-    /// (they do not exist in RV64E — a 16-register base — so they are
-    /// illegal, standard RV). Either way such an instruction is a reserved
-    /// encoding: it decodes as `Reserved` and panics if executed (lazy).
-    /// Immediate bits that happen to alias a reserved register are **not**
-    /// registers and are ignored — each variant binds exactly its real
-    /// register fields. This match is the single source of truth both
-    /// consensus engines route through (the interpreter via [`decode`], the
-    /// recompiler via [`word_uses_reserved_reg`]); the lack of a wildcard
-    /// arm means a future `Inst` variant won't compile until classified.
+    /// register fields. The valid PVM2 registers are `x0, x1..x15` (RV64E's
+    /// full file, including `x3`/`x4`); reserved are only `x16..x31`, which
+    /// do not exist in RV64E — a 16-register base — so naming one is an
+    /// illegal, standard-RV encoding. Such an instruction decodes as
+    /// `Reserved` and panics if executed (lazy). Immediate bits that happen
+    /// to alias a reserved register are **not** registers and are ignored —
+    /// each variant binds exactly its real register fields. This match is
+    /// the single source of truth both consensus engines route through (the
+    /// interpreter via [`decode`], the recompiler via
+    /// [`word_uses_reserved_reg`]); the lack of a wildcard arm means a
+    /// future `Inst` variant won't compile until classified.
     pub fn uses_reserved_reg(&self) -> bool {
         use crate::regs::reg_is_reserved as r;
         use Inst::*;
@@ -736,31 +736,19 @@ impl Inst {
     }
 }
 
-/// Reserved-register predicate on a raw 4-byte word, for the recompiler
-/// (which dispatches on raw words rather than building an [`Inst`], and
-/// runs on the cold-compile hot path — so this must not re-decode).
-///
-/// Checks `x3`/`x4` only in the positions the instruction's *format* uses
-/// as registers; immediate bits in those positions are ignored. For every
-/// **non-reserved** word this equals [`Inst::uses_reserved_reg`] (pinned by
-/// `word_predicate_matches_inst_predicate`), so the interpreter and
-/// recompiler agree on which `x3`/`x4` instructions panic. For a
-/// reserved-decoding word the two may differ, but such a word panics via
-/// the normal reserved path in both engines anyway, so the *outcome* still
-/// matches.
+/// Apply a per-register-index predicate `pred` to every field a raw 4-byte
+/// word uses *as a register* (per its format), ignoring immediate bits that
+/// happen to alias a register field. The shared core behind
+/// [`word_uses_reserved_reg`] and [`word_uses_spilled_reg`] — keeping the
+/// format → register-field mapping in **one** place so the two predicates
+/// can't disagree on which positions are registers.
 ///
 /// `#[inline]` so it folds into the recompiler's `compile_rv4` across the
 /// crate boundary (the field extractions then CSE against the ones
-/// `compile_rv4` already does). The residual per-instruction opcode match
-/// is a small fixed cold-compile cost (≈1–4% on the heaviest workloads,
-/// none on warm) — accepted as the price of one verifiable check that
-/// keeps the two engines from drifting; the alternative (a check spread
-/// across every register-access helper) is what made B7 possible.
+/// `compile_rv4` already does).
 #[inline]
-pub fn word_uses_reserved_reg(w: u32) -> bool {
-    fn r(x: u32) -> bool {
-        crate::regs::reg_is_reserved(x as u8)
-    }
+fn word_reg_class_hits(w: u32, pred: fn(u8) -> bool) -> bool {
+    let r = |x: u32| pred(x as u8);
     let rd = (w >> 7) & 0x1F;
     let rs1 = (w >> 15) & 0x1F;
     let rs2 = (w >> 20) & 0x1F;
@@ -777,6 +765,33 @@ pub fn word_uses_reserved_reg(w: u32) -> bool {
         // field (reserved or no-reg); they panic via the normal path.
         _ => false,
     }
+}
+
+/// Reserved-register predicate on a raw 4-byte word, for the recompiler
+/// (which dispatches on raw words rather than building an [`Inst`], and
+/// runs on the cold-compile hot path — so this must not re-decode).
+///
+/// True iff the word names `x16..x31` (which do not exist in RV64E) in a
+/// real register field. For every word this equals
+/// [`Inst::uses_reserved_reg`] (pinned by
+/// `word_predicate_matches_inst_predicate`), so the interpreter and
+/// recompiler agree on which encodings are illegal and panic.
+#[inline]
+pub fn word_uses_reserved_reg(w: u32) -> bool {
+    word_reg_class_hits(w, crate::regs::reg_is_reserved)
+}
+
+/// Spilled-register predicate on a raw 4-byte word, for the recompiler.
+///
+/// True iff the word names `x3` or `x4` (the two host-spilled GPRs) in a
+/// real register field. The recompiler tests this *after*
+/// [`word_uses_reserved_reg`] to route an `x3`/`x4` instruction to its cold
+/// spill path; the interpreter needs no equivalent (it executes `x3`/`x4`
+/// as ordinary slot-13/14 GPRs). For every conformant word the toolchain
+/// emits this is `false`, so the recompiler's fast path is untouched.
+#[inline]
+pub fn word_uses_spilled_reg(w: u32) -> bool {
+    word_reg_class_hits(w, crate::regs::reg_is_spilled)
 }
 
 /// Major opcode of a 32-bit RV instruction is bits [6:2]; bits [1:0]
@@ -1921,58 +1936,75 @@ mod tests {
         ));
     }
 
-    // ---- B7: x3/x4 in a register field decodes as Reserved -------------
+    // ---- x3/x4 are real (spilled) registers; only x16..x31 reserved ----
 
     #[test]
-    fn reserved_register_field_is_reserved() {
-        // add x5, x3, x6 (rs1 = x3) → Reserved (was decoded as a live Add,
-        // which the interp executed as `0 + x6` while the recomp panicked).
+    fn x3_x4_decode_as_live_spilled_registers() {
+        // add x5, x3, x6 (rs1 = x3) → a live Add the interpreter executes
+        // (slot 13); the recompiler routes it to the spill path. It is NOT
+        // reserved, but IS spilled.
         let add_x3 = 0x0061_82B3u32; // add x5, x3, x6
         assert!(matches!(
             decode(&add_x3.to_le_bytes()).unwrap().0,
-            Inst::Reserved { .. }
+            Inst::Add {
+                rd: 5,
+                rs1: 3,
+                rs2: 6
+            }
         ));
-        assert!(word_uses_reserved_reg(add_x3));
+        assert!(!word_uses_reserved_reg(add_x3));
+        assert!(word_uses_spilled_reg(add_x3));
 
-        // addi x3, x0, 1 (rd = x3) → Reserved.
+        // addi x3, x0, 1 (rd = x3) → live Addi writing x3 (slot 13).
         let addi_x3 = 0x0010_0193u32;
         assert!(matches!(
             decode(&addi_x3.to_le_bytes()).unwrap().0,
-            Inst::Reserved { .. }
+            Inst::Addi {
+                rd: 3,
+                rs1: 0,
+                imm: 1
+            }
         ));
+        assert!(!word_uses_reserved_reg(addi_x3));
+        assert!(word_uses_spilled_reg(addi_x3));
 
         // add x16, x5, x6 (rd = x16) → Reserved: x16..x31 don't exist in
-        // RV64E (standard RV), so the encoding is illegal.
+        // RV64E (standard RV), so the encoding is illegal — still reserved,
+        // never spilled.
         let add_x16 = 0x0062_8833u32; // add x16, x5, x6
         assert!(matches!(
             decode(&add_x16.to_le_bytes()).unwrap().0,
             Inst::Reserved { .. }
         ));
         assert!(word_uses_reserved_reg(add_x16));
+        assert!(!word_uses_spilled_reg(add_x16));
     }
 
     #[test]
     fn x3_x4_free_instruction_is_unaffected() {
-        // add x5, x6, x7 — no reserved register → decodes normally.
+        // add x5, x6, x7 — neither reserved nor spilled → decodes normally,
+        // stays on the recompiler fast path.
         let add_ok = 0x0073_02B3u32;
         assert!(matches!(
             decode(&add_ok.to_le_bytes()).unwrap().0,
             Inst::Add { .. }
         ));
         assert!(!word_uses_reserved_reg(add_ok));
+        assert!(!word_uses_spilled_reg(add_ok));
     }
 
     #[test]
     fn immediate_bits_aliasing_x3_are_not_a_register() {
         // lui x5, 0x18000 — bits [19:15] of the word are 0b00011 (= 3),
         // but for U-type that field is *immediate*, not rs1, so the
-        // instruction is a normal Lui, never Reserved.
+        // instruction is a normal Lui — neither reserved nor spilled.
         let lui = 0x0001_82B7u32;
         assert!(matches!(
             decode(&lui.to_le_bytes()).unwrap().0,
             Inst::Lui { rd: 5, .. }
         ));
         assert!(!word_uses_reserved_reg(lui));
+        assert!(!word_uses_spilled_reg(lui));
     }
 
     #[test]
@@ -1980,9 +2012,10 @@ mod tests {
         // The recompiler's fast `word_uses_reserved_reg` (opcode-mask, no
         // decode) must equal the interpreter's `Inst::uses_reserved_reg`
         // for every *non-reserved* word — that is what makes the two
-        // engines agree on which x3/x4 instructions panic. (A
-        // reserved-decoding word panics either way, so its predicate value
-        // is unconstrained here.) Sweep every 7-bit opcode × funct3 ×
+        // engines agree on which encodings are illegal and panic (x16..x31
+        // only; x3/x4 are valid). (A reserved-decoding word panics either
+        // way, so its predicate value is unconstrained here.) Sweep every
+        // 7-bit opcode × funct3 ×
         // representative funct7, with each register field ranging over
         // {x0, x3, x4, x5} so both reserved and free positions are hit.
         for major in 0u32..0x20 {

--- a/rust/javm-exec/src/interp.rs
+++ b/rust/javm-exec/src/interp.rs
@@ -838,9 +838,9 @@ impl Interpreter {
 // ----------------------------------------------------------------------------
 
 /// Read PVM2 register `x`, via the shared slot map ([`crate::regs`]).
-/// `x0` (and any reserved register, which never reaches here once decode
-/// maps it to `Reserved`) reads as zero; `x1, x2, x5..x15` map to slots
-/// `0..12`.
+/// `x0` (and any reserved register `x16..x31`, which never reaches here once
+/// decode maps it to `Reserved`) reads as zero; `x1, x2, x5..x15` map to
+/// slots `0..12` and `x3`/`x4` to the spilled slots `13`/`14`.
 #[inline]
 fn reg_read(regs: &Regs, x: u8) -> u64 {
     match crate::regs::REG_SLOT_LUT[(x & 31) as usize] {
@@ -850,7 +850,8 @@ fn reg_read(regs: &Regs, x: u8) -> u64 {
 }
 
 /// Write PVM2 register `x`, via the shared slot map. Writes to `x0` (and
-/// any reserved register) are no-ops.
+/// any reserved register `x16..x31`) are no-ops; `x3`/`x4` write slots
+/// `13`/`14`.
 #[inline]
 fn reg_write(regs: &mut Regs, x: u8, v: u64) {
     let s = crate::regs::REG_SLOT_LUT[(x & 31) as usize];
@@ -1244,23 +1245,29 @@ mod tests {
         assert_eq!(regs.gpr[7], 7); // x10 → slot 7: PC=4 block executed
     }
 
-    // ---- B7: an x3/x4 register field panics (was: executed as zero) ----
+    // ---- x3/x4 are real (spilled) registers the interpreter executes ----
 
     #[test]
-    fn x3_source_register_panics() {
-        // add x5, x3, x6 ; trap. x3 is reserved, so the instruction is a
-        // reserved encoding → Panic, matching the recompiler (which used
-        // to panic here while the interp executed `0 + x6`).
-        let add_x3 = 0x0061_82B3u32; // add x5, x3, x6
+    fn x3_x4_execute_as_real_registers() {
+        // addi x3, x0, 7 ; addi x4, x0, 5 ; add x5, x3, x4 ; trap.
+        // x3/x4 are RV64E GPRs (high slots 13/14); the interpreter executes
+        // them, so x5 = 7 + 5 = 12.
+        let addi_x3_7 = (7u32 << 20) | (3 << 7) | 0x13; // addi x3, x0, 7
+        let addi_x4_5 = (5u32 << 20) | (4 << 7) | 0x13; // addi x4, x0, 5
+        let add_x5 = (4u32 << 20) | (3 << 15) | (5 << 7) | 0x33; // add x5, x3, x4
         let trap = 0x0000_000Bu32;
-        let code = enc4(&[add_x3, trap]);
-        let (_regs, reason, _) = run_simple(&code, 1_000_000);
-        assert_eq!(reason, ExitReason::Panic);
+        let code = enc4(&[addi_x3_7, addi_x4_5, add_x5, trap]);
+        let (regs, reason, _) = run_simple(&code, 1_000_000);
+        assert_eq!(reason, ExitReason::Trap);
+        // x5 → slot 2 (x5 - 3); x3 → slot 13; x4 → slot 14.
+        assert_eq!(regs.gpr[2], 12);
+        assert_eq!(regs.gpr[13], 7);
+        assert_eq!(regs.gpr[14], 5);
     }
 
     #[test]
     fn x3_free_arithmetic_still_runs() {
-        // add x5, x6, x7 ; trap — no reserved register, executes normally.
+        // add x5, x6, x7 ; trap — no x3/x4, executes normally.
         let add_ok = 0x0073_02B3u32; // add x5, x6, x7
         let trap = 0x0000_000Bu32;
         let code = enc4(&[add_ok, trap]);

--- a/rust/javm-exec/src/regs.rs
+++ b/rust/javm-exec/src/regs.rs
@@ -1,32 +1,37 @@
-//! Register state: 13 general-purpose 64-bit registers + PC.
+//! Register state: 15 general-purpose 64-bit registers + PC.
 //!
-//! Per JAM Gray Paper Appendix A / PVM spec: the PVM has 13 GPRs
-//! (φ₀..φ₁₂) plus an instruction pointer. PVM2 replaces the legacy PVM
-//! ISA with RISC-V (RV64EMC + Zbb/Zba/Zbs/Zicond/Zicclsm) but keeps the
-//! same 13-GPR + PC register file.
+//! PVM2 is RV64E — a 16-register integer base (`x0`–`x15`) — so it has the
+//! full **15** GPRs (`x1`, `x2`, `x5`–`x15`, plus `x3`, `x4`) with `x0`
+//! hardwired to zero, plus an instruction pointer. `x3`/`x4` map to the two
+//! *high* slots (13, 14) so the 13 commonly-used registers keep slots
+//! `0..=12`; the recompiler holds those 13 in host registers and **spills**
+//! `x3`/`x4` to memory (see [`reg_is_spilled`]). Only `x16`–`x31` (which do
+//! not exist in the E base) remain reserved.
 
 /// Number of general-purpose registers.
-pub const REG_COUNT: usize = 13;
+pub const REG_COUNT: usize = 15;
 
 /// Classification of a 5-bit RV register index in PVM2.
 ///
-/// PVM2 is an RV64E base — a 16-register file (`x0`–`x15`) — that
-/// additionally reserves `x3`/`x4`. This is the **single source of truth**
-/// for every place that needs register classification: the gas-simulator
-/// slot map, the recompiler's codegen slot map, the interpreter's register
-/// file access, and the reserved-register check both engines use. They all
+/// PVM2 is an RV64E base — a 16-register file (`x0`–`x15`). This is the
+/// **single source of truth** for every place that needs register
+/// classification: the gas-simulator slot map, the recompiler's codegen
+/// slot map, the interpreter's register file access, the spilled-register
+/// routing, and the reserved-register check both engines use. They all
 /// derive from [`reg_class`] rather than re-encoding the valid/reserved
 /// sets (which is how `rv_is_reserved` once drifted to miss `x16..x31`).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RegClass {
     /// `x0` — hardwired zero. Valid, but has no GPR slot.
     Zero,
-    /// `x1`, `x2`, `x5`–`x15` — general-purpose; the payload is the slot
-    /// `0..=12` into [`Regs::gpr`].
+    /// `x1`, `x2`, `x5`–`x15`, `x3`, `x4` — general-purpose; the payload is
+    /// the slot `0..=14` into [`Regs::gpr`]. Slots `0..=12` are the 13
+    /// commonly-used registers (`x1`, `x2`, `x5`–`x15`); slots `13`/`14` are
+    /// `x3`/`x4`, which the recompiler spills to memory ([`reg_is_spilled`]).
     Gpr(u8),
-    /// `x3`, `x4` (PVM2-reserved) or `x16`–`x31` (don't exist in RV64E, so
-    /// naming one is an illegal encoding). Such an instruction is a
-    /// reserved encoding and panics if executed.
+    /// `x16`–`x31` — do not exist in RV64E (a 16-register base), so naming
+    /// one is an illegal encoding. Such an instruction is a reserved
+    /// encoding and panics if executed.
     Reserved,
 }
 
@@ -37,16 +42,18 @@ pub const fn reg_class(x: u8) -> RegClass {
         0 => RegClass::Zero,
         1 => RegClass::Gpr(0),
         2 => RegClass::Gpr(1),
+        3 => RegClass::Gpr(13), // x3 → high spill slot
+        4 => RegClass::Gpr(14), // x4 → high spill slot
         n @ 5..=15 => RegClass::Gpr(n - 3),
-        _ => RegClass::Reserved, // x3, x4, x16..x31
+        _ => RegClass::Reserved, // x16..x31 only
     }
 }
 
-/// PVM2 GPR slot (`0..=12`) for `x`, or `0xFF` if `x` has no slot — `x0`
-/// (hardwired zero) *or* a reserved register. The gas simulator reads
-/// `0xFF` as "no dependency / no write"; both engines' gas paths use this
-/// (the recompiler via the const-folded [`REG_SLOT_LUT`]) so gas agrees
-/// bit-for-bit. Note `0xFF` conflates `x0` with reserved — use
+/// PVM2 GPR slot (`0..=14`) for `x`, or `0xFF` if `x` has no slot — `x0`
+/// (hardwired zero) *or* a reserved register (`x16..x31`). The gas
+/// simulator reads `0xFF` as "no dependency / no write"; both engines' gas
+/// paths use this (the recompiler via the const-folded [`REG_SLOT_LUT`]) so
+/// gas agrees bit-for-bit. Note `0xFF` conflates `x0` with reserved — use
 /// [`reg_is_reserved`] when that distinction matters.
 #[inline]
 pub const fn reg_slot_or_ff(x: u8) -> u8 {
@@ -56,12 +63,24 @@ pub const fn reg_slot_or_ff(x: u8) -> u8 {
     }
 }
 
-/// True iff `x` is a *reserved* register (`x3`/`x4`/`x16..x31`) — as
-/// opposed to `x0`, which also lacks a slot but is valid. Drives the
-/// reserved-encoding check in both engines.
+/// True iff `x` is a *reserved* register (`x16..x31` — they do not exist in
+/// the RV64E base) — as opposed to `x0`, which also lacks a slot but is
+/// valid. Drives the reserved-encoding (illegal) check in both engines.
 #[inline]
 pub const fn reg_is_reserved(x: u8) -> bool {
     matches!(reg_class(x), RegClass::Reserved)
+}
+
+/// True iff `x` is a *spilled* register — `x3` or `x4`, the two GPRs that
+/// map to the high slots (13, 14). They are real, fully-valid registers
+/// (the interpreter executes them as ordinary GPRs), but the x86-64
+/// recompiler's host register file is exhausted by the other 13 slots, so
+/// it holds `x3`/`x4` in memory and materialises them per access. The
+/// recompiler uses this to route an `x3`/`x4` instruction to its cold spill
+/// path; the gas model uses it to charge the memory-spill cost.
+#[inline]
+pub const fn reg_is_spilled(x: u8) -> bool {
+    matches!(reg_class(x), RegClass::Gpr(13) | RegClass::Gpr(14))
 }
 
 /// 32-entry const-folded copy of [`reg_slot_or_ff`] for the recompiler's

--- a/rust/javm-exec/tests/gas_sim.rs
+++ b/rust/javm-exec/tests/gas_sim.rs
@@ -245,3 +245,37 @@ proptest! {
         prop_assert!(sim_more.flush_and_get_cost() >= base_cost);
     }
 }
+
+// ---- x3/x4 host-spill gas cost ----------------------------------------
+
+#[test]
+fn spilled_operands_charge_memory_cost() {
+    use javm_exec::gas_cost::{DEFAULT_MEM_CYCLES, RV_KIND_ADD, rv_feed_gas_kind, rv_slot_u8};
+    use javm_exec::gas_sim::GasSimulator;
+
+    // Block cost of a single `add rd, rs1, rs2`, parameterised by the RV regs.
+    let cost = |rd: u8, rs1: u8, rs2: u8| -> u32 {
+        let mut sim = GasSimulator::new();
+        rv_feed_gas_kind(
+            RV_KIND_ADD,
+            rv_slot_u8(rs1),
+            rv_slot_u8(rs2),
+            rv_slot_u8(rd),
+            &mut sim,
+            DEFAULT_MEM_CYCLES,
+        );
+        sim.flush_and_get_cost()
+    };
+
+    let mem = DEFAULT_MEM_CYCLES as u32;
+    // Baseline: all host-mapped registers (no spill) — the cheapest block.
+    let base = cost(10, 5, 6);
+    // A spilled operand raises the cost above the no-spill baseline.
+    assert!(cost(10, 3, 6) > base, "spill must cost more than no-spill");
+    // Each *additional* spilled operand position adds exactly `mem_cycles`
+    // (the block-cost `-3` normalisation cancels between adjacent counts).
+    assert_eq!(cost(10, 3, 4) - cost(10, 3, 6), mem, "2nd spilled operand");
+    assert_eq!(cost(3, 3, 4) - cost(10, 3, 4), mem, "3rd spilled operand");
+    // Conformant code (no x3/x4) is charged exactly the baseline.
+    assert_eq!(cost(15, 14, 13), base);
+}

--- a/rust/javm-exec/tests/regs.rs
+++ b/rust/javm-exec/tests/regs.rs
@@ -1,17 +1,21 @@
-use javm_exec::regs::{REG_SLOT_LUT, RegClass, reg_class, reg_is_reserved, reg_slot_or_ff};
+use javm_exec::regs::{
+    REG_SLOT_LUT, RegClass, reg_class, reg_is_reserved, reg_is_spilled, reg_slot_or_ff,
+};
 use javm_exec::{REG_COUNT, Regs};
 
 #[test]
 fn reg_classification_is_the_single_source() {
-    // Slot map: x0 and reserved → 0xFF (no slot); x1→0, x2→1, x5..x15→2..12.
-    // These exact values are the consensus gas contract — the recompiler's
+    // Slot map: x0 and reserved (x16..x31) → 0xFF (no slot); x1→0, x2→1,
+    // x5..x15→2..12, and the two host-spilled regs x3→13, x4→14. These exact
+    // values are the consensus gas contract — the recompiler's
     // `REG_SLOT_LUT` and the interpreter's `rv_slot_u8` both read them, so
-    // they must stay bit-identical with the pre-unification tables.
+    // the 13 commonly-used slots must stay bit-identical (x3/x4 are appended
+    // in the high slots so conformant code's masks never change).
     assert_eq!(reg_slot_or_ff(0), 0xFF); // x0
     assert_eq!(reg_slot_or_ff(1), 0);
     assert_eq!(reg_slot_or_ff(2), 1);
-    assert_eq!(reg_slot_or_ff(3), 0xFF); // reserved
-    assert_eq!(reg_slot_or_ff(4), 0xFF); // reserved
+    assert_eq!(reg_slot_or_ff(3), 13); // x3 → high spill slot
+    assert_eq!(reg_slot_or_ff(4), 14); // x4 → high spill slot
     for x in 5..=15u8 {
         assert_eq!(reg_slot_or_ff(x), x - 3); // x5..x15 → 2..12
     }
@@ -19,11 +23,18 @@ fn reg_classification_is_the_single_source() {
         assert_eq!(reg_slot_or_ff(x), 0xFF); // x16..x31 don't exist in RV64E
     }
 
-    // Reserved set is exactly {x3, x4, x16..x31} — and crucially NOT x0.
+    // Reserved set is exactly {x16..x31} — NOT x0, and NOT x3/x4 (now valid).
     for x in 0..=31u8 {
-        assert_eq!(reg_is_reserved(x), x == 3 || x == 4 || x >= 16, "x{x}");
+        assert_eq!(reg_is_reserved(x), x >= 16, "x{x}");
     }
     assert!(!reg_is_reserved(0)); // x0 lacks a slot but is valid, not reserved
+    assert!(!reg_is_reserved(3)); // x3/x4 are valid registers now
+    assert!(!reg_is_reserved(4));
+
+    // Spilled set is exactly {x3, x4}.
+    for x in 0..=31u8 {
+        assert_eq!(reg_is_spilled(x), x == 3 || x == 4, "x{x}");
+    }
 
     // The const-folded LUT equals the function for every index (no drift).
     for x in 0..32u8 {
@@ -34,7 +45,9 @@ fn reg_classification_is_the_single_source() {
     assert_eq!(reg_class(0), RegClass::Zero);
     assert_eq!(reg_class(1), RegClass::Gpr(0));
     assert_eq!(reg_class(15), RegClass::Gpr(12));
-    assert_eq!(reg_class(4), RegClass::Reserved);
+    assert_eq!(reg_class(3), RegClass::Gpr(13));
+    assert_eq!(reg_class(4), RegClass::Gpr(14));
+    assert_eq!(reg_class(16), RegClass::Reserved);
     assert_eq!(reg_class(31), RegClass::Reserved);
 }
 

--- a/rust/javm-recompiler-x86/src/asm.rs
+++ b/rust/javm-recompiler-x86/src/asm.rs
@@ -865,6 +865,16 @@ impl Assembler {
         self.emit_rip_rel_disp32(target_va, 0);
     }
 
+    /// cmp r64, qword [rip+disp32] — compare a register against a memory
+    /// operand (used by the x3/x4 spill path's branch, where a spilled
+    /// source lives in `JitContext.regs[13|14]`).
+    pub fn cmp_r64_mem_rip_rel(&mut self, dst: Reg, target_va: u64) {
+        self.emit(0x48 | (dst.hi() << 2));
+        self.emit(0x3B);
+        self.modrm_rip_rel(dst.lo());
+        self.emit_rip_rel_disp32(target_va, 0);
+    }
+
     // -- In-register gas decrement (patchable) --
 
     /// sub r64, imm32 in the always-imm32 (7-byte) encoding.

--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -191,6 +191,13 @@ pub struct Compiler {
     /// `Inst`); `bind_rv_gas_block_start_streaming` flushes it at
     /// block boundaries.
     pub(crate) gas_sim: GasSimulator,
+    /// When set, [`feed_gas_rv`](Compiler::feed_gas_rv) does **not** feed the
+    /// real `gas_sim`. Used by `compile_rv_spilled`: an x3/x4 instruction is
+    /// re-dispatched through the fast path with rewritten (donor) registers,
+    /// but its gas is fed once with the *original* x3/x4 slots (so the spill
+    /// cost is charged and the interpreter is matched bit-for-bit). The
+    /// throwaway path still returns the correct terminator flag.
+    pub(crate) suppress_gas: bool,
     /// Guest VA the code region is mapped at. `jalr`/`auipc` produce
     /// and consume code addresses as `code_base + offset`; the dispatch
     /// table is offset-indexed (offset = VA - code_base).
@@ -264,6 +271,7 @@ impl Compiler {
             trap_entries: Vec::with_capacity(2048),
             mem_cycles,
             gas_sim: GasSimulator::new(),
+            suppress_gas: false,
             code_base,
             code_len: code_len as u32,
             rv_streaming: false,
@@ -279,6 +287,20 @@ impl Compiler {
     /// `is_terminator` (RVF_TERM flag from the LUT entry).
     #[inline(always)]
     pub(crate) fn feed_gas_rv(&mut self, kind: u8, rs1: u8, rs2: u8, rd: u8) -> bool {
+        // During a spilled re-dispatch, gas is fed once by `compile_rv_spilled`
+        // with the original x3/x4 slots; don't perturb the real sim here. Feed
+        // a throwaway sim only to recover the terminator flag.
+        if self.suppress_gas {
+            let mut throwaway = GasSimulator::new();
+            return javm_exec::gas_cost::rv_feed_gas_kind(
+                kind,
+                rv_slot_or_ff(rs1),
+                rv_slot_or_ff(rs2),
+                rv_slot_or_ff(rd),
+                &mut throwaway,
+                self.mem_cycles,
+            );
+        }
         javm_exec::gas_cost::rv_feed_gas_kind(
             kind,
             rv_slot_or_ff(rs1),
@@ -1113,25 +1135,37 @@ fn expand_rvc_q2(h: u16, f3: u16) -> Option<u32> {
     }
 }
 
-/// Map an RV register index to its PVM slot (0..=12).
+/// Map an RV register index to its **host-mapped** PVM slot (0..=12).
 ///
-/// Returns `None` for x0 (hardwired zero) and for any reserved register
-/// (x3/x4/x16..x31). Callers handle x0 by loading an immediate 0; a
-/// reserved register causes a runtime panic at the offending PC — but it
-/// is rejected up front by `compile_rv4`'s `word_uses_reserved_reg` guard,
-/// so reaching `rv_slot(reserved)` is now unreachable defence-in-depth.
+/// Returns `None` for x0 (hardwired zero), for the host-spilled `x3`/`x4`
+/// (slots 13/14 — no [`REG_MAP`] entry), and for any reserved register
+/// (x16..x31). Callers on the fast path never see x3/x4 (the
+/// `word_uses_spilled_reg` fork in `compile_rv4` routes them to
+/// `compile_rv_spilled` first); a reserved register is unreachable
+/// defence-in-depth (the `word_uses_reserved_reg` fork panics earlier).
 #[inline]
 fn rv_slot(x: u8) -> Option<usize> {
     match RV_SLOT_LUT[(x & 31) as usize] {
-        0xFF => None,
-        s => Some(s as usize),
+        s if s <= 12 => Some(s as usize),
+        _ => None, // 0xFF (x0 / x16..x31) or 13/14 (spilled x3/x4)
     }
 }
 
-/// True for a reserved register (x3/x4/x16..x31). Single source:
-/// [`javm_exec::regs::reg_is_reserved`] (previously a local `x == 3 ||
-/// x == 4` that drifted to miss `x16..x31`).
+/// Guest VA of a host-spilled register's home in `JitContext.regs`.
+/// Only valid for `x3`/`x4` (slots 13/14); the recompiler addresses it
+/// RIP-relatively, exactly as the prologue/epilogue address the 13
+/// host-mapped slots.
+#[inline]
+fn spill_va(x: u8) -> u64 {
+    CTX_REGS + (RV_SLOT_LUT[(x & 31) as usize] as u64) * 8
+}
+
+/// True for a reserved register (`x16..x31`, which do not exist in RV64E).
+/// Single source: [`javm_exec::regs::reg_is_reserved`].
 use javm_exec::regs::reg_is_reserved as rv_is_reserved;
+/// True for a host-spilled register (`x3`/`x4`). Single source:
+/// [`javm_exec::regs::reg_is_spilled`].
+use javm_exec::regs::reg_is_spilled;
 
 impl Compiler {
     /// Compile an RV+C+custom-0 byte stream into x86-64 in a single
@@ -1345,14 +1379,24 @@ impl Compiler {
         let f3 = ((w >> 12) & 0x07) as u8;
         let f7 = ((w >> 25) & 0x7F) as u8;
 
-        // x3/x4 in any register field is reserved (Category 1 #4): panic,
-        // uniformly, matching the interpreter (which decodes such an
+        // x16..x31 in any register field is an illegal RV64E encoding:
+        // panic, uniformly, matching the interpreter (which decodes such an
         // instruction as `Reserved`). Shared predicate so the two engines
         // can't drift; covers expanded RVC, which routes through here.
         if javm_exec::instruction::word_uses_reserved_reg(w) {
             self.rv_emit_panic_at(pc);
             self.feed_gas_rv(RV_KIND_RESERVED, 0, 0, 0);
             return (true, false, 0);
+        }
+
+        // x3/x4 in any register field: route to the cold spill path. These
+        // are valid RV64E registers the runtime must execute, but the host
+        // register file is full, so they live in `JitContext.regs[13|14]`
+        // and are materialised per access. Conformant code never names them
+        // (the toolchain rejects x3/x4), so this fork is never taken for the
+        // 12 bench guests — the fast-path dispatch below stays byte-identical.
+        if javm_exec::instruction::word_uses_spilled_reg(w) {
+            return self.compile_rv_spilled(w, pc, inst_len);
         }
 
         match opcode {
@@ -1410,6 +1454,292 @@ impl Compiler {
                 (true, false, 0)
             }
         }
+    }
+
+    // === x3/x4 spill path (cold) ==================================
+    //
+    // `x3`/`x4` are valid RV64E registers but have no host register (the
+    // file is exhausted by the 13 commonly-used slots), so they live in
+    // `JitContext.regs[13|14]` and are materialised per access. Conformant
+    // code never names them — the toolchain rejects x3/x4 — so this whole
+    // path is cold; it exists only so an untrusted RV64E blob executes
+    // bit-for-bit with the interpreter.
+    //
+    // Gas is fed once here with the *original* x3/x4 slots (so the
+    // memory-spill cost is charged, exactly as the interpreter charges it).
+    // The actual emit is then done with `suppress_gas` set so the reused
+    // fast-path helpers don't double-feed.
+
+    fn compile_rv_spilled(&mut self, w: u32, pc: u32, inst_len: u32) -> (bool, bool, usize) {
+        use javm_exec::gas_cost::{rv_feed_gas_direct, rv_gas_meta};
+        // Gas: original registers → memory-spill cost + the terminator flag,
+        // matching the interpreter's per-instruction feed exactly.
+        let inst = javm_exec::instruction::decode(&w.to_le_bytes())
+            .expect("4-byte spilled word decodes")
+            .0;
+        let term = rv_feed_gas_direct(&rv_gas_meta(&inst), &mut self.gas_sim, self.mem_cycles);
+
+        let opcode = (w >> 2) & 0x1F;
+        let f3 = (w >> 12) & 0x07;
+        let rd = ((w >> 7) & 0x1F) as u8;
+        let rs1 = ((w >> 15) & 0x1F) as u8;
+        let rs2 = ((w >> 20) & 0x1F) as u8;
+
+        self.suppress_gas = true;
+        match opcode {
+            // Terminators: sources go through the spill-aware `rv_read` /
+            // `rv_read_into` (into the clobberable SCRATCH, which the jump
+            // discards), and spilled `rd` / `rs2` are handled inline.
+            OP_JAL => self.rv_jal_spilled(rd, imm_j(w), pc, pc + inst_len),
+            OP_JALR if f3 == 0 => self.rv_jalr_spilled(rd, rs1, imm_i(w), pc, pc + inst_len),
+            OP_BRANCH => self.rv_branch_spilled(rs1, rs2, f3 as u8, imm_b(w), pc),
+            // Non-terminators: load spilled sources into collision-free donor
+            // host registers, rewrite the word, re-dispatch through the fast
+            // path, store the spilled dest back, restore donors.
+            OP_LOAD | OP_STORE | OP_IMM | OP_OP_IMM_32 | OP_OP | OP_OP_32 | OP_LUI | OP_AUIPC => {
+                self.emit_spilled_via_donors(w, pc, inst_len)
+            }
+            // No other opcode names x3/x4 in a register field
+            // (`word_uses_spilled_reg` only fires for R/I/S/B/U/J formats).
+            _ => self.rv_emit_panic_at(pc),
+        }
+        self.suppress_gas = false;
+        (term, false, 0)
+    }
+
+    /// Non-terminator spill: borrow donor host registers for x3/x4, rewrite
+    /// the instruction to name the donors, re-dispatch through the fast path
+    /// (gas suppressed, no fusion), then store a spilled dest back. Bounded:
+    /// ≤2 donor push/pops + ≤2 loads + ≤1 store around one fast-path emit.
+    fn emit_spilled_via_donors(&mut self, w: u32, pc: u32, inst_len: u32) {
+        let opcode = (w >> 2) & 0x1F;
+        let rd = ((w >> 7) & 0x1F) as u8;
+        let rs1 = ((w >> 15) & 0x1F) as u8;
+        let rs2 = ((w >> 20) & 0x1F) as u8;
+
+        // Which register fields this format actually uses, and their role.
+        let (has_rd, has_rs1, has_rs2) = match opcode {
+            OP_LOAD | OP_IMM | OP_OP_IMM_32 => (true, true, false),
+            OP_OP | OP_OP_32 => (true, true, true),
+            OP_STORE => (false, true, true),
+            OP_LUI | OP_AUIPC => (true, false, false),
+            _ => {
+                self.rv_emit_panic_at(pc);
+                return;
+            }
+        };
+
+        // Mark non-spilled, host-mapped operand regs so a donor never aliases
+        // a real operand (x0 has no host reg; x3/x4 are the ones we replace).
+        let mut blocked = [false; 16];
+        let mut block = |x: u8| {
+            if x != 0 && !reg_is_spilled(x) && !rv_is_reserved(x) {
+                blocked[x as usize] = true;
+            }
+        };
+        if has_rd {
+            block(rd);
+        }
+        if has_rs1 {
+            block(rs1);
+        }
+        if has_rs2 {
+            block(rs2);
+        }
+
+        // Does x3 / x4 appear in any used register field?
+        let appears = |x: u8| (has_rd && rd == x) || (has_rs1 && rs1 == x) || (has_rs2 && rs2 == x);
+        let need3 = appears(3);
+        let need4 = appears(4);
+
+        // Pick donor RV regs from the host-mapped set, avoiding real operands.
+        const CANDIDATES: [u8; 13] = [1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let pick = |blocked: &mut [bool; 16]| -> u8 {
+            for &c in &CANDIDATES {
+                if !blocked[c as usize] {
+                    blocked[c as usize] = true;
+                    return c;
+                }
+            }
+            unreachable!("≤2 operands block ≤2 of 13 candidates")
+        };
+        let donor3 = if need3 { pick(&mut blocked) } else { 0 };
+        let donor4 = if need4 { pick(&mut blocked) } else { 0 };
+
+        // Save the donor host registers (restored after the emit).
+        let mut donors = [0u8; 2];
+        let mut n = 0;
+        if need3 {
+            donors[n] = donor3;
+            n += 1;
+        }
+        if need4 {
+            donors[n] = donor4;
+            n += 1;
+        }
+        for d in &donors[..n] {
+            self.asm.push(REG_MAP[rv_slot(*d).unwrap()]);
+        }
+
+        // Load spilled *sources* into their donor host regs.
+        let src3 = (has_rs1 && rs1 == 3) || (has_rs2 && rs2 == 3);
+        let src4 = (has_rs1 && rs1 == 4) || (has_rs2 && rs2 == 4);
+        if need3 && src3 {
+            self.asm
+                .mov_load64_rip_rel(REG_MAP[rv_slot(donor3).unwrap()], spill_va(3));
+        }
+        if need4 && src4 {
+            self.asm
+                .mov_load64_rip_rel(REG_MAP[rv_slot(donor4).unwrap()], spill_va(4));
+        }
+
+        // Donor reg_defs must not carry stale const/scaled-add tracking into
+        // the fast-path emit (we restore the donor's value afterwards).
+        for d in &donors[..n] {
+            self.invalidate_reg(rv_slot(*d).unwrap());
+        }
+
+        // Rewrite the word: x3 → donor3, x4 → donor4 in the used fields.
+        let repl = |r: u8| -> u8 {
+            if r == 3 {
+                donor3
+            } else if r == 4 {
+                donor4
+            } else {
+                r
+            }
+        };
+        let mut wr = w;
+        if has_rd {
+            wr = (wr & !(0x1F << 7)) | ((repl(rd) as u32) << 7);
+        }
+        if has_rs1 {
+            wr = (wr & !(0x1F << 15)) | ((repl(rs1) as u32) << 15);
+        }
+        if has_rs2 {
+            wr = (wr & !(0x1F << 20)) | ((repl(rs2) as u32) << 20);
+        }
+
+        // Re-dispatch with no lookahead (empty `rest` → no fusion). Gas is
+        // already suppressed by the caller.
+        let _ = self.compile_rv4(wr, pc, inst_len, &[]);
+
+        // Store a spilled destination back to its home.
+        if has_rd && reg_is_spilled(rd) {
+            let donor = if rd == 3 { donor3 } else { donor4 };
+            self.asm
+                .mov_store64_rip_rel(spill_va(rd), REG_MAP[rv_slot(donor).unwrap()]);
+        }
+
+        // Restore donors (value + reg_defs).
+        for d in &donors[..n] {
+            self.invalidate_reg(rv_slot(*d).unwrap());
+        }
+        for d in donors[..n].iter().rev() {
+            self.asm.pop(REG_MAP[rv_slot(*d).unwrap()]);
+        }
+    }
+
+    /// `jal rd, imm` where `rd ∈ {x3, x4}` (the only register field of a
+    /// J-type). Writes the return-address VA (a constant `< 4 GiB`, so the
+    /// high word is 0) straight to the spilled home, then jumps.
+    fn rv_jal_spilled(&mut self, rd: u8, imm: i32, pc: u32, next_pc: u32) {
+        let ret = self.code_base.wrapping_add(next_pc);
+        self.asm.mov_store32_rip_rel_imm(spill_va(rd), ret as i32);
+        self.asm.mov_store32_rip_rel_imm(spill_va(rd) + 4, 0);
+        let target = (pc as i64).wrapping_add(imm as i64) as u32;
+        self.emit_static_branch(target, true, next_pc, pc);
+    }
+
+    /// `jalr rd, rs1, imm` with `x3`/`x4` in `rd` and/or `rs1`. Mirrors
+    /// [`rv_jalr`] but reads `rs1` via the spill-aware [`rv_read`] (into
+    /// SCRATCH) and writes a spilled `rd` to its home as two 32-bit stores
+    /// (low = return VA, high = 0), leaving SCRATCH holding the target.
+    fn rv_jalr_spilled(&mut self, rd: u8, rs1: u8, imm: i32, pc: u32, next_pc: u32) {
+        use super::asm::Cc;
+        // SCRATCH = (rs1 + imm) & 0xFFFFFFFF.
+        self.rv_read(rs1, SCRATCH, pc);
+        if imm != 0 {
+            self.asm.add_ri(SCRATCH, imm);
+        }
+        self.asm.shl_ri64(SCRATCH, 32);
+        self.asm.shr_ri64(SCRATCH, 32);
+        // Return address (a guest VA) into rd — after the SCRATCH read, so a
+        // spilled rd == rs1 doesn't perturb the target already in SCRATCH.
+        if rd != 0 {
+            let ret = self.code_base.wrapping_add(next_pc);
+            if reg_is_spilled(rd) {
+                self.asm.mov_store32_rip_rel_imm(spill_va(rd), ret as i32);
+                self.asm.mov_store32_rip_rel_imm(spill_va(rd) + 4, 0);
+            } else {
+                let slot = rv_slot(rd).unwrap();
+                self.asm.mov_ri64(REG_MAP[slot], ret as u64);
+                self.invalidate_reg(slot);
+            }
+        }
+        if self.code_base != 0 {
+            self.asm.sub_ri(SCRATCH, self.code_base as i32);
+        }
+        self.asm.mov_store32_rip_rel(CTX_PC, SCRATCH);
+        self.asm.cmp_ri32(SCRATCH, self.code_len as i32);
+        self.asm.jcc_label(Cc::AE, self.panic_label);
+        self.asm.push(Reg::RAX);
+        self.asm.mov_load64_rip_rel(Reg::RAX, CTX_DISPATCH_TABLE);
+        self.asm.movsxd_load_sib4(Reg::RAX, Reg::RAX, SCRATCH);
+        self.asm.add_r64_mem_rip_rel(Reg::RAX, CTX_CODE_BASE);
+        self.asm.mov_rr(SCRATCH, Reg::RAX);
+        self.asm.pop(Reg::RAX);
+        self.asm.jmp_reg(SCRATCH);
+    }
+
+    /// Conditional branch with `x3`/`x4` in `rs1` and/or `rs2`. `rs1` loads
+    /// via the spill-aware [`rv_read_into`]; `rs2` is compared as a register,
+    /// the immediate 0, or directly from its spilled memory home (so the
+    /// both-spilled case needs no second scratch).
+    fn rv_branch_spilled(&mut self, rs1: u8, rs2: u8, f3: u8, imm: i32, pc: u32) {
+        let cc = match f3 {
+            0b000 => Cc::E,
+            0b001 => Cc::NE,
+            0b100 => Cc::L,
+            0b101 => Cc::GE,
+            0b110 => Cc::B,
+            0b111 => Cc::AE,
+            _ => {
+                self.rv_emit_panic_at(pc);
+                return;
+            }
+        };
+        let target = (pc as i64).wrapping_add(imm as i64) as u32;
+        let a = self.rv_read_into(rs1, SCRATCH, pc);
+        if reg_is_spilled(rs2) {
+            self.asm.cmp_r64_mem_rip_rel(a, spill_va(rs2));
+        } else if rs2 == 0 {
+            self.asm.cmp_ri32(a, 0);
+        } else {
+            self.asm.cmp_rr(a, REG_MAP[rv_slot(rs2).unwrap()]);
+        }
+        self.emit_cond_branch_to(cc, target, pc);
+    }
+
+    /// Emit a conditional jump to `target` assuming flags are already set
+    /// (the spilled-branch path emits its own `cmp`). Mirrors the streaming
+    /// deferral / non-block-start-panic logic of [`emit_branch_reg`]; byte
+    /// layout differs (cold path), but the control-flow outcome is identical.
+    fn emit_cond_branch_to(&mut self, cc: Cc, target: u32, pc: u32) {
+        if self.rv_streaming && target > pc {
+            let label = self.label_for_pc(target);
+            let fixup_idx = self.asm.fixups_len();
+            self.asm.jcc_label(cc, label);
+            self.rv_pending_fwd_branches.push((target, pc, fixup_idx));
+            return;
+        }
+        if !self.is_basic_block_start(target) {
+            self.asm.mov_store32_rip_rel_imm(CTX_PC, pc as i32);
+            self.asm.jcc_label(cc, self.panic_label);
+            return;
+        }
+        let label = self.label_for_pc(target);
+        self.asm.jcc_label(cc, label);
     }
 
     // === Per-opcode dispatchers (4-byte path) =====================
@@ -2321,10 +2651,13 @@ impl Compiler {
     // RV-side helpers — resolve x0/x3/x4 aliases and call through asm.
     // ----------------------------------------------------------------
 
-    /// Read RV source register into `dst_reg`. x0 → load 0; x3/x4 → panic.
+    /// Read RV source register into `dst_reg`. x0 → load 0; `x3`/`x4`
+    /// (host-spilled) → load from `JitContext.regs[13|14]`; x16..x31 → panic.
     fn rv_read(&mut self, rs: u8, dst_reg: Reg, pc: u32) {
         if rs == 0 {
             self.asm.mov_ri64(dst_reg, 0);
+        } else if reg_is_spilled(rs) {
+            self.asm.mov_load64_rip_rel(dst_reg, spill_va(rs));
         } else if rv_is_reserved(rs) {
             self.rv_emit_panic_at(pc);
         } else {
@@ -2333,10 +2666,14 @@ impl Compiler {
     }
 
     /// Return the x86 register holding rs's value. For x0, materialise 0
-    /// into `scratch` and return `scratch`.
+    /// into `scratch` and return `scratch`. For a host-spilled `x3`/`x4`,
+    /// load from `JitContext.regs[13|14]` into `scratch` and return it.
     fn rv_read_into(&mut self, rs: u8, scratch: Reg, pc: u32) -> Reg {
         if rs == 0 {
             self.asm.mov_ri64(scratch, 0);
+            scratch
+        } else if reg_is_spilled(rs) {
+            self.asm.mov_load64_rip_rel(scratch, spill_va(rs));
             scratch
         } else if rv_is_reserved(rs) {
             self.rv_emit_panic_at(pc);

--- a/rust/javm-recompiler-x86/src/lib.rs
+++ b/rust/javm-recompiler-x86/src/lib.rs
@@ -25,17 +25,20 @@ pub mod codegen;
 /// `CTX_*` offset constants in [`codegen`].
 #[repr(C)]
 pub struct JitContext {
-    /// PVM registers (offset 0, 13 × 8 = 104 bytes).
-    pub regs: [u64; 13],
-    /// Gas counter (offset 104). Signed to detect underflow.
+    /// PVM2 registers (offset 0, 15 × 8 = 120 bytes). Slots 0..12 are the
+    /// host-mapped GPRs (flushed to/from x86 registers at the prologue /
+    /// epilogue); slots 13/14 are the spilled `x3`/`x4`, which live here in
+    /// memory for the whole block and are materialised per access.
+    pub regs: [u64; 15],
+    /// Gas counter. Signed to detect underflow.
     pub gas: i64,
-    /// Exit reason code (offset 112).
+    /// Exit reason code.
     pub exit_reason: u32,
-    /// Exit argument (offset 116) — host call ID, page fault addr, etc.
+    /// Exit argument — host call ID, page fault addr, etc.
     pub exit_arg: u32,
-    /// Heap base address (offset 120).
+    /// Heap base address.
     pub heap_base: u32,
-    /// Current heap top (offset 124).
+    /// Current heap top.
     pub heap_top: u32,
     /// Entry PC for re-entry after host calls.
     pub entry_pc: u32,

--- a/rust/javm-recompiler-x86/tests/x3_x4_spill.rs
+++ b/rust/javm-recompiler-x86/tests/x3_x4_spill.rs
@@ -1,0 +1,172 @@
+//! Compile-time exercise of the x3/x4 (host-spilled register) path.
+//!
+//! `x3`/`x4` are valid RV64E registers but have no host register, so the
+//! recompiler routes any instruction naming them to its cold spill path
+//! (`compile_rv_spilled`). This test drives **every** instruction form that
+//! can name x3/x4 — ALU (rr/imm), 32-bit ALU, load, store, lui, auipc, jal,
+//! jalr, and every branch — through `Compiler::compile`, asserting it emits
+//! code without panicking. That exercises the donor selection/rewrite, the
+//! spilled-source loads, the spilled-dest store-backs, and the dedicated
+//! terminator handlers — the paths most at risk of an out-of-bounds
+//! `REG_MAP[13]` index or a bad donor choice. (Execution semantics are
+//! covered by the interpreter tests in `javm-exec`; the fast path's
+//! byte-for-byte stability is covered by the 12-guest conformance suite.)
+
+use javm_recompiler_x86::codegen::{CTX_VA, Compiler, HelperFns};
+
+/// Dummy helper addresses — this test only *compiles*, never executes, so
+/// the emitted `call` targets are never reached.
+fn dummy_helpers() -> HelperFns {
+    HelperFns {
+        mem_read_u8: 0x1000,
+        mem_read_u16: 0x1000,
+        mem_read_u32: 0x1000,
+        mem_read_u64: 0x1000,
+        mem_write_u8: 0x1000,
+        mem_write_u16: 0x1000,
+        mem_write_u32: 0x1000,
+        mem_write_u64: 0x1000,
+    }
+}
+
+/// Encode a little-endian instruction stream.
+fn enc(words: &[u32]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(words.len() * 4);
+    for w in words {
+        v.extend_from_slice(&w.to_le_bytes());
+    }
+    v
+}
+
+/// Compile `code`; assert it produced non-empty native code without panic.
+fn compile_ok(code: &[u8]) {
+    // jit_va_base near CTX_VA so the RIP-relative CTX accesses fit in disp32
+    // (the real runtime places the JIT arena adjacent to the context).
+    let c = Compiler::new(dummy_helpers(), code.len(), CTX_VA, 25, 0);
+    let result = c.compile(code);
+    assert!(
+        !result.native_code.is_empty(),
+        "recompiler emitted no native code for {} bytes of guest code",
+        code.len()
+    );
+}
+
+// Instruction encoders (RV little-endian).
+const HALT: u32 = 0x0000_200B; // ecalli 0 (HostCall(0) — clean halt)
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+fn add(rd: u8, rs1: u8, rs2: u8) -> u32 {
+    ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x33
+}
+fn addw(rd: u8, rs1: u8, rs2: u8) -> u32 {
+    ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x3B
+}
+fn ld(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | (0b011 << 12) | ((rd as u32) << 7) | 0x03
+}
+fn sd(rs1: u8, rs2: u8, imm: i32) -> u32 {
+    let i = imm as u32 & 0xFFF;
+    ((i >> 5) << 25)
+        | ((rs2 as u32) << 20)
+        | ((rs1 as u32) << 15)
+        | (0b011 << 12)
+        | ((i & 0x1F) << 7)
+        | 0x23
+}
+fn lui(rd: u8, imm20: u32) -> u32 {
+    (imm20 << 12) | ((rd as u32) << 7) | 0x37
+}
+fn auipc(rd: u8, imm20: u32) -> u32 {
+    (imm20 << 12) | ((rd as u32) << 7) | 0x17
+}
+fn jal(rd: u8, imm: i32) -> u32 {
+    let i = imm as u32;
+    let b20 = (i >> 20) & 1;
+    let b10_1 = (i >> 1) & 0x3FF;
+    let b11 = (i >> 11) & 1;
+    let b19_12 = (i >> 12) & 0xFF;
+    (b20 << 31) | (b10_1 << 21) | (b11 << 20) | (b19_12 << 12) | ((rd as u32) << 7) | 0x6F
+}
+fn jalr(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x67
+}
+fn beq(rs1: u8, rs2: u8, imm: i32) -> u32 {
+    let i = imm as u32;
+    let b12 = (i >> 12) & 1;
+    let b10_5 = (i >> 5) & 0x3F;
+    let b4_1 = (i >> 1) & 0xF;
+    let b11 = (i >> 11) & 1;
+    (b12 << 31)
+        | (b10_5 << 25)
+        | (rs2 as u32) << 20
+        | (rs1 as u32) << 15
+        | (b4_1 << 8)
+        | (b11 << 7)
+        | 0x63
+}
+
+#[test]
+fn alu_rr_with_x3_x4() {
+    // Every operand-spill shape of a register-register ALU op.
+    compile_ok(&enc(&[add(10, 3, 4), HALT])); // both sources spilled, host dest
+    compile_ok(&enc(&[add(3, 5, 6), HALT])); // spilled dest, host sources
+    compile_ok(&enc(&[add(3, 3, 4), HALT])); // spilled dest + both spilled sources
+    compile_ok(&enc(&[add(3, 3, 3), HALT])); // same spilled reg in all three fields
+    compile_ok(&enc(&[add(5, 3, 6), HALT])); // one spilled source
+    compile_ok(&enc(&[addw(4, 3, 5), HALT])); // 32-bit ALU, mixed
+}
+
+#[test]
+fn alu_imm_with_x3_x4() {
+    compile_ok(&enc(&[addi(3, 0, 7), HALT])); // li into x3
+    compile_ok(&enc(&[addi(4, 0, -1), HALT])); // li into x4
+    compile_ok(&enc(&[addi(3, 3, 1), HALT])); // x3 += 1 (spilled src + dest)
+    compile_ok(&enc(&[addi(10, 3, 5), HALT])); // host dest, spilled source
+}
+
+#[test]
+fn load_store_with_x3_x4() {
+    compile_ok(&enc(&[ld(3, 5, 0), HALT])); // load into x3
+    compile_ok(&enc(&[ld(10, 3, 8), HALT])); // x3 as address base
+    compile_ok(&enc(&[ld(3, 3, 0), HALT])); // x3 both base and dest
+    compile_ok(&enc(&[sd(5, 3, 0), HALT])); // store x3 (value spilled)
+    compile_ok(&enc(&[sd(3, 5, 0), HALT])); // x3 as address base
+    compile_ok(&enc(&[sd(3, 4, 0), HALT])); // base x3, value x4 (both spilled)
+}
+
+#[test]
+fn upper_imm_with_x3_x4() {
+    compile_ok(&enc(&[lui(3, 0x12345), HALT]));
+    compile_ok(&enc(&[lui(4, 0x1), HALT]));
+    compile_ok(&enc(&[auipc(3, 0), HALT]));
+    compile_ok(&enc(&[auipc(4, 0x10), HALT]));
+}
+
+#[test]
+fn jumps_with_x3_x4() {
+    // jal writing the link register to a spilled slot.
+    compile_ok(&enc(&[jal(3, 8), HALT, HALT]));
+    compile_ok(&enc(&[jal(4, 8), HALT, HALT]));
+    // jalr: target in x3, link in a host reg; and link in x3.
+    compile_ok(&enc(&[jalr(6, 3, 0), HALT]));
+    compile_ok(&enc(&[jalr(3, 5, 0), HALT]));
+    compile_ok(&enc(&[jalr(3, 3, 0), HALT])); // x3 both target and link
+    compile_ok(&enc(&[jalr(4, 3, 4), HALT])); // x3 target, x4 link
+}
+
+#[test]
+fn branches_with_x3_x4() {
+    compile_ok(&enc(&[beq(3, 4, 8), HALT, HALT])); // both operands spilled
+    compile_ok(&enc(&[beq(3, 5, 8), HALT, HALT])); // rs1 spilled
+    compile_ok(&enc(&[beq(5, 3, 8), HALT, HALT])); // rs2 spilled
+    compile_ok(&enc(&[beq(3, 0, 8), HALT, HALT])); // rs1 spilled vs x0
+    compile_ok(&enc(&[beq(0, 4, 8), HALT, HALT])); // x0 vs rs2 spilled
+}
+
+#[test]
+fn conformant_blob_has_no_spill_overhead() {
+    // A blob with no x3/x4 compiles via the fast path only (sanity: the
+    // spill fork is not taken).
+    compile_ok(&enc(&[addi(10, 0, 42), add(10, 10, 5), HALT]));
+}

--- a/rust/javm/src/vm.rs
+++ b/rust/javm/src/vm.rs
@@ -19,7 +19,7 @@
 //! into it) and in-flight resolution (host calls read referenced caps
 //! by their `CapHashOrRef` target).
 
-use javm_cap::{CacheDirectory, Cap, CapHash, CapHashOrRef, SlotIdx};
+use javm_cap::{CacheDirectory, Cap, CapHash, CapHashOrRef, NUM_REGS, SlotIdx};
 use javm_exec::{Access, CopyingMemory, ExitReason, GasCounter, Mem, Regs, interp::Interpreter};
 
 use crate::callstack::{CallStack, DEFAULT_MAX_DEPTH, Entry, EntryStatus, InstanceEntry};
@@ -215,7 +215,10 @@ impl<K: KernelAssist> Vm<K> {
         // wins) → caller args at φ[7..=10].
         let mut regs = Regs::new();
         regs.pc = endpoint.entry_pc;
-        regs.gpr = endpoint.initial_regs;
+        // The persisted register file is the 13 host-mapped slots; x3/x4
+        // (slots 13/14) are invocation-local and start at 0 (Regs::new zeros
+        // them), matching the recompiler.
+        regs.gpr[..NUM_REGS].copy_from_slice(&endpoint.initial_regs);
         for (i, v) in inst.regs.iter().enumerate() {
             if *v != 0 {
                 regs.gpr[i] = *v;
@@ -602,7 +605,10 @@ impl<K: KernelAssist> Vm<K> {
             cnode_hash,
             &overlays_borrowed,
             mem_size,
-            entry.regs.gpr,
+            // Persist the 13 host-mapped slots; x3/x4 are invocation-local.
+            entry.regs.gpr[..NUM_REGS]
+                .try_into()
+                .expect("13 persisted regs"),
             entry.regs.pc,
             entry.gas.remaining(),
         ))?;

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -120,7 +120,9 @@ pub fn run_instance(
     // Endpoint baseline first, then layer the InstanceCap's persisted
     // regs on top (publish_instance writes them; subsequent invokes
     // observe them). Args overlay φ[7..=10] last.
-    regs.gpr = endpoint.initial_regs;
+    // Persisted file is the 13 host-mapped slots; x3/x4 (slots 13/14) start
+    // at 0 (Regs::new zeros them), matching the recompiler.
+    regs.gpr[..javm_cap::NUM_REGS].copy_from_slice(&endpoint.initial_regs);
     for (i, v) in instance.regs.iter().enumerate() {
         if *v != 0 {
             regs.gpr[i] = *v;

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -531,7 +531,12 @@ pub unsafe fn enter_frame(
     let ctx = rt.ctx_kva as *mut JitContext;
     // SAFETY: ctx_kva owned by `rt.ctx_buf`, alive across this call.
     unsafe {
-        (*ctx).regs = initial_regs;
+        // The persisted register file is the 13 host-mapped slots; the two
+        // spilled slots (x3/x4) are invocation-local and start at 0, matching
+        // the interpreter (which rebuilds from the same 13-register cap).
+        let mut all_regs = [0u64; 15];
+        all_regs[..13].copy_from_slice(&initial_regs);
+        (*ctx).regs = all_regs;
         (*ctx).gas = initial_gas;
         (*ctx).exit_reason = 0;
         (*ctx).exit_arg = 0;
@@ -578,11 +583,16 @@ pub unsafe fn enter_frame(
 
     // SAFETY: ctx_kva still points to the same page (ctx_buf alive).
     unsafe {
+        // Copy the 15-register file out first (avoids autoref on the raw
+        // pointer deref), then persist only the 13 host-mapped slots — x3/x4
+        // (slots 13/14) are invocation-local and dropped at exit (matching
+        // the interpreter).
+        let all_regs = (*ctx).regs;
         ExitInfo {
             exit_reason: (*ctx).exit_reason,
             exit_arg: (*ctx).exit_arg,
             gas_remaining: (*ctx).gas,
-            regs: (*ctx).regs,
+            regs: all_regs[..13].try_into().expect("13 persisted regs"),
             pc: (*ctx).pc,
         }
     }

--- a/website/content/spec/implementation/architecture.md
+++ b/website/content/spec/implementation/architecture.md
@@ -175,7 +175,7 @@ cap awareness.
 
 ### Responsibilities
 
-- **Interpreter.** PVM instruction set; register state (13 GPRs +
+- **Interpreter.** PVM2 instruction set; register state (15 GPRs +
   internal); memory pages; gas counter; trap handling.
 
 - **Recompiler.** JIT to native (Linux x86-64 only initially).

--- a/website/content/spec/javm.md
+++ b/website/content/spec/javm.md
@@ -1,382 +1,254 @@
-# JAVM (PVM2) differential spec
+# JAVM (PVM2) — RV64E + Xjar + EEI
 
-JAVM is the virtual machine for JAR's guest execution. This
-document specifies **PVM2**, the ISA that is used by JAVM, *as a delta from RV64E + standard extensions*.
+JAVM is the virtual machine for JAR's guest execution. Its ISA, **PVM2**,
+is **fully conformant RISC-V**: the **RV64E** base, a fixed set of standard
+extensions, **one custom extension `Xjar`** (in the RV-reserved custom-0
+space), and a specific **execution-environment interface (EEI)**. Nothing
+in PVM2 contradicts the behavior the RISC-V unprivileged spec defines for a
+base-or-standard instruction.
+
+```
+PVM2  ::=  RV64E  +  {M, C, Zbb, Zba, Zbs, Zicond, Zicclsm}  +  Xjar  +  EEI
+```
 
 ## Rationale
 
-The predecessor design of JAVM is based on PVM ISA. Our benchmarks show that the custom PVM ISA is not necessary. With a mostly-standard-compliant RISC-V, we still manage to get a recompiler that is as fast as the old design.
+The predecessor design of JAVM is based on the custom PVM ISA. Our
+benchmarks show that the custom ISA is not necessary: with a
+standard-compliant RISC-V we still get a recompiler as fast as the old
+design. We therefore moved to standard RISC-V — a battle-tested ISA is less
+likely to harbor design issues, and adopting new RISC-V extensions becomes
+much easier.
 
-We therefore decide to get closer to standard RISC-V. This has enourmous advantage for JAVM. An already battle-tested ISA is less likely to have unexpected design issues. We'll also have a much easier time to adopt new RISC-V extensions.
+An earlier draft of this spec framed PVM2 as RV64E with "four hard
+divergences." Each has since been resolved into one of the three conformant
+buckets below — the `Xjar` extension or the EEI — with no behavior change.
 
-We call the new ISA "PVM2". The specification is defined as a small set of differential from RV64E.
+## How PVM2 relates to RV64E
 
-## Components
+Every part of PVM2 is one of three things, none a contradiction of the base
+ISA:
 
-```
-PVM2  ::=  PVM2-Base  +  RV-extensions  +  custom-0 ops
-```
+- **Standard RV64E + standard extensions**, used unchanged — including
+  **plain RISC-V control flow** (`jal`, `jalr`, `auipc`, branches, and the
+  compressed `c.j`/`c.jr`/`c.jalr` forms all behave as the RV spec
+  defines). An earlier draft routed calls through a custom `br_table`; that
+  static-dispatch model has been removed.
+- **The `Xjar` custom extension** (custom-0 opcode), which adds behavior in
+  the blessed mold of RISC-V's own security extensions: **landing-pad
+  control-flow integrity** on indirect jumps (cf. Zicfilp) and the
+  **custom-0 host / control ops** (`trap`, `ecall.jar`, `ecalli`,
+  `fallthrough`).
+- **EEI configuration**: choices the RISC-V spec delegates to the execution
+  environment — the aliased memory map, the `ecall`/`ebreak` handler,
+  guaranteed misaligned support, `fence` retirement, and the absence of
+  CSRs / privilege / atomics / FP.
 
-(Custom-1 was used in an earlier draft for `callf`; PVM2 no longer
-uses it — the entire custom-1 major opcode is reserved.)
+The register model — RV64E's 15 GPRs — is plain base ISA.
 
-PVM2 uses **plain RISC-V control flow**: `jal`, `jalr`, `auipc`,
-branches, and the compressed `c.j`/`c.jr`/`c.jalr` forms all behave as
-the RV spec defines. An earlier draft forbade `jalr`/`auipc` and routed
-every call/return through a custom `br_table` backed by Image-side jump
-tables; that static-dispatch model has been removed. The single
-control-flow divergence that remains is a *runtime* one: an indirect
-jump (`jalr`) must land on a basic-block start (Category 1 #2) —
-validated when it executes, never trusted from metadata.
+## The Xjar extension
 
-## Two kinds of divergence
+`Xjar` occupies the RV-reserved `custom-0` major opcode (`opcode =
+0001011`) and adds one architectural rule beyond its custom instructions:
 
-PVM2's deltas split into two cleanly separated buckets. Keeping them
-apart matters: Category 1 is where PVM2 is *not* RV64E; Category 2 is
-where PVM2 is a *particular* RV64E.
+**Xjar CFI — every indirect-jump (`jalr`) target must be a basic-block
+start.** A `jalr` (and `c.jr`/`c.jalr`) whose target lands mid-block or
+mid-instruction takes a **fatal trap** (ε = panic). The valid-target set is
+`bb_starts(code)` (see [Basic-block boundaries](#basic-block-boundaries-bb_starts));
+a block start is an implicit landing pad.
 
-- **Category 1 — hard spec divergences.** The RISC-V unprivileged spec
-  defines a behavior and PVM2 produces a different one — either changing
-  the architectural result of an instruction both ISAs accept, or
-  removing/constraining a base-ISA instruction in a way the spec does
-  not grant an EEI. A stock RV64E core and PVM2 disagree exactly here.
-- **Category 2 — platform / EEI configuration.** The spec explicitly
-  delegates the choice to the execution-environment interface (EEI),
-  the platform memory map, or the extension profile, and PVM2 selects
-  one allowed point. A conforming RV64E implementation could legally be
-  configured the same way — these are not divergences, just choices.
+This is the shape of the ratified RISC-V CFI extension **Zicfilp** (the
+Control-Flow Integrity chapter), which constrains standard-`jalr` targets
+to landing-pad instructions and faults otherwise. `Xjar`'s variant is
+coarser and stricter: the landing pads are *structurally derived* from the
+instruction stream (no explicit `lpad` marker, no label), **every** `jalr`
+target must be one (no exemptions), and the fault is terminal. Native
+`jalr` is retained.
 
-Anything in neither bucket behaves exactly as the RISC-V unprivileged
-spec defines it.
+*Why:* per-block gas is precharged at block entry, so entering a block
+anywhere but its start would bypass the charge. The check is a runtime one,
+derived from the instruction stream — the recompiler runs untrusted code
+and never trusts a linker-supplied target table. In the x86 recompiler it
+is folded into the dispatch table: a dense `offset → native` table whose
+every non-block-start slot holds the panic stub, so `jalr` is a bounds
+check plus the dispatch jump. `jal`/branch targets are immediates,
+validated at recompile time against the same set; the linker injects
+`fallthrough` markers so every reachable target is a block start.
 
-## Category 1 — hard spec divergences
+The custom-0 host / control ops are in [Custom-0 opcodes](#custom-0-opcodes).
 
-These are the only points where PVM2 contradicts RV64E.
+## Register model
 
-1. **Memory address space wraps at 2³² — data *and* code, uniformly.**
+PVM2 uses **RV64E's 15 GPRs** — `x1`, `x2`, `x5`–`x15` plus `x3`, `x4`,
+with `x0` hardwired to zero. `x16`–`x31` do not exist in the E base
+(naming one is an illegal encoding). This is plain RV64E.
 
-   Every effective address is masked to 32 bits before use; the high
-   32 bits are discarded regardless of what the source register holds.
-   The mask is applied identically to data and to code targets, so
-   there is no addressing path that escapes the 4 GiB window:
+`x3`/`x4` carry special meaning only by RISC-V psABI convention; the
+unprivileged ISA defines them as ordinary GPRs and PVM2 executes them as
+such. **The jar toolchain does not emit `x3`/`x4`** (the transpiler rejects
+them at build; jar's guests use the other 13 registers), but the *runtime*
+executes them so any valid RV64E blob runs — this is what keeps PVM2
+conformant rather than "RV64E minus two registers."
 
-   - **Loads / stores:** `addr = (rs1 + sext(imm)) & 0xFFFFFFFF`.
-     Affects `lb`, `lh`, `lw`, `ld`, `lbu`, `lhu`, `lwu`, `sb`, `sh`,
-     `sw`, `sd` and all RVC equivalents.
-   - **`jalr` targets:** `target = (rs1 + sext(imm)) & 0xFFFFFFFF`
-     (then `offset = target − CODE_BASE`; see #2). A register value
-     ≥ 2³² is truncated to its low 32 bits before the bounds/dispatch
-     check, exactly as a data pointer is — *not* rejected for being
-     large.
+**Host spill and gas.** An implementation must provide at least 13 host
+registers; the 13 commonly-used slots (`x1`, `x2`, `x5`–`x15`) are
+register-resident on every host. `x3`/`x4` are not guaranteed resident — a
+host with exactly 13 registers (today's x86-64 JIT) holds them in memory
+and spills on each access. Because the worst-case host spills, `x3`/`x4`
+accesses are **gas-charged at memory-spill cost unconditionally** on every
+host. A host with spare registers may keep them resident and run faster
+than charged (permitted; gas is an upper bound, the charge is spec-fixed,
+consensus unaffected). See [08-pvm2-gas-cost.md] and [09-portability.md].
 
-   RV64E computes a full 64-bit effective address; PVM2 does not. This
-   is the one divergence that changes the result of an instruction both
-   ISAs accept (a load through `rs1 = 0x1_0000_1000` reads `0x1000`,
-   not `0x1_0000_1000`).
+## EEI configuration
 
-   The wrap is free on x86/ARM (a 4 GiB host reservation makes the
-   guest's u32 space a native VA window) and ~1 op on RISC-V. It does
-   real isolation work: it keeps a guest pointer from reaching the
-   execution context the runtime maps above 4 GiB.
+Each is a knob the RISC-V spec hands to the EEI/platform/profile; a
+conforming RV64E implementation could be built the same way.
 
-   The 4 GiB ceiling on the combined code+data map (Category 2 #1) is a
-   *consequence* of this wrap, not a separate divergence.
+1. **Memory map: a 2³²-fold alias of one 4 GiB main-memory region.**
+   Address computation is **stock RV64E** (full 64-bit, circular mod 2⁶⁴,
+   §1.4). The EEI maps main memory so the whole 2⁶⁴ space is tiled with 2³²
+   aliased copies of one 4 GiB region: address `A` is backed by byte
+   `A mod 2³²`. This is ordinary incomplete address decoding (a core that
+   decodes only bits [31:0] aliases its RAM). The guest can't distinguish
+   it from a 32-bit mask — `load(0x1000) == load(0x1_0000_1000)` under both
+   — but the instruction itself is unchanged; the *map* aliases. Isolation
+   is then a host-VA fact: the runtime's execution context lives in host
+   VA above 4 GiB, outside the guest's address space entirely.
 
-2. **Every indirect-jump (`jalr`) target must be a basic-block start.**
+   Within one alias period the 4 GiB region is partitioned:
+   - `[0, CODE_BASE)` — **unmapped null guard** (`CODE_BASE = 0x0040_0000`).
+   - `[CODE_BASE, DATA_BASE)` — **code**, read-only, `PC = CODE_BASE +
+     byte_offset`, capped at `MAX_CODE_SIZE` (252 MiB).
+   - `[DATA_BASE, 4 GiB)` — **data** (`DATA_BASE = 0x1000_0000`, 256 MiB).
 
-   After the 2³² mask (#1), `jalr` computes `offset = target −
-   CODE_BASE` and requires `offset ∈ bb_starts(code)` (see
-   [Basic-block boundaries](#basic-block-boundaries-bb_starts)). A
-   target that lands mid-block or mid-instruction faults (ε = panic).
-   RV64E has no such precondition — any instruction-aligned target is a
-   legal jump. PVM2 adds the trap so per-block gas is sound: gas is
-   precharged at block entry, so entering a block anywhere but its
-   start would bypass the charge.
+   `auipc`, `jal`, `jalr`, branches compute real PC values as RV defines.
+   Code is position-independent (maps at `CODE_BASE`); the transpiler
+   relocates absolute data references by `+DATA_BASE`. A guest can read its
+   own code (PIC idiom) but not write it (read-only).
 
-   This is a *runtime* check, derived from the instruction stream — the
-   recompiler runs untrusted code and never trusts a linker-supplied
-   target table. In the x86 recompiler the check is *folded into the
-   dispatch table*: a dense `offset → native` table whose every
-   non-block-start slot holds the panic stub, so `jalr` is a bounds
-   check plus the dispatch jump (no separate `bb_starts` lookup) and a
-   bad target jumps to the panic stub. `jal` and branch targets are
-   immediates and are validated at recompile time against the same set;
-   the linker injects `fallthrough` markers (below) so every reachable
-   target is a block start.
+2. **Standard `ecall`/`ebreak` → unconditional fatal trap.** They decode
+   and execute as ordinary instructions; the EEI's defined handler
+   terminates (ε = panic). The spec delegates exactly this — the EEI
+   handles "environment calls" (§1.2), and `ebreak` returns control to the
+   environment (§2.9), which here terminates. PVM2's host functionality
+   lives in custom-0 (`ecalli` carries the 20-bit selector standard `ecall`
+   lacks), so standard `ecall`/`ebreak` are simply "always panic." This is
+   a fatal trap (instance discarded).
 
-3. **Standard `ecall` and `ebreak` opcodes are reserved.**
+3. **Misaligned loads/stores fully supported** (RV §2.1.6's EEI option;
+   also stated as the **Zicclsm** extension). x86 handles misaligned at
+   near-native speed; single-threaded, so atomicity is moot.
 
-   PVM2 has its own `ecall` and `trap` operations in custom-0 space
-   (Category 2 #5). The standard RV `ecall` / `ebreak` encodings are
-   reserved (decoded as illegal) so a future RV CPU running PVM2 by
-   mistake doesn't accidentally do something.
+4. **`fence`/`fence.i` are no-ops** — single-threaded, no I/O bus, code
+   mapped read-only, so nothing to order. Conforming, encoding unchanged.
 
-   *Why Category 1:* the base ISA defines `ecall`/`ebreak` as legal
-   SYSTEM instructions (`ecall` makes an environment request); making
-   the standard encodings illegal — and relocating the function into
-   custom-0 — is the divergence. (Reservation-flavoured: it narrows the
-   decode rather than changing an accepted instruction's result.)
-
-4. **`x3` and `x4` are reserved.**
-
-   In RV64E, `x3` (`gp`) and `x4` (`tp`) are general-purpose registers
-   populated by the OS/loader. PVM2 has no OS and no thread-local
-   storage; these two registers are reserved and must not be read or
-   written. Programs that do so are rejected at deblob.
-
-   Result: 13 usable architectural registers (`x1`, `x2`, `x5`–`x15`),
-   matching today's PVM register count. The encoding doesn't change —
-   the 5-bit reg field still uses RV's standard layout; `x3`/`x4` are
-   just statically forbidden.
-
-   *Why Category 1 (borderline):* `gp`/`tp` are reserved by the RISC-V
-   psABI *by convention*, so one could argue an EEI reserving them is a
-   platform choice (Category 2). It is filed here because the
-   *unprivileged ISA* defines all 15 non-zero E-registers as
-   general-purpose and has no notion of a platform forbidding a GPR —
-   PVM2 narrows what the base ISA permits.
-
-## Category 2 — platform / EEI configuration choices
-
-Each of these is a knob the RISC-V spec hands to the EEI, the platform,
-or the extension profile. A conforming RV64E implementation could be
-built the same way; PVM2 just fixes the setting.
-
-1. **Memory map: code low (read-only), data high, null guard below.**
-   PC is a real low-4 GiB virtual address.
-
-   The EEI determines the mapping of resources into the address space
-   and each region's permissions. PVM2 partitions it as:
-
-   - `[0, CODE_BASE)` — **unmapped null guard**. `CODE_BASE` is
-     `0x0040_0000` (4 MiB), so a `PC = 0` fetch or a null data deref
-     faults instead of hitting valid memory.
-   - `[CODE_BASE, DATA_BASE)` — **code**, read-only, so `PC =
-     CODE_BASE + byte_offset`. Capped at `MAX_CODE_SIZE` (252 MiB =
-     `DATA_BASE − CODE_BASE`).
-   - `[DATA_BASE, 4 GiB)` — **data** (stack/ro/rw/heap), with
-     `DATA_BASE = 0x1000_0000` (256 MiB).
-
-   `auipc`, `jal`, `jalr`, and branches compute over real PC values
-   exactly as RV defines. A guest can read its own code bytes (`auipc`
-   + load, the PIC idiom); it cannot write them (read-only mapping).
-
-   Code is position-independent (PC-relative internal control flow), so
-   it maps at `CODE_BASE` regardless of the linked address. Data is
-   addressed absolutely, so the transpiler **relocates** data
-   references: it folds data-referencing `auipc` pairs to absolute
-   `lui`+lo12 and shifts every data address — the folds *and* any
-   initialised absolute data pointers — by `+DATA_BASE`, from the
-   linker's `[0, extent)` layout to the runtime `[DATA_BASE, …)`
-   mapping. Code-referencing `auipc` pairs stay native (PC-relative
-   against `CODE_BASE`). Code low gives the null guard; data high keeps
-   the whole data region contiguous above code rather than wrapping it.
-
-2. **Misaligned loads and stores are fully supported.**
-
-   As permitted by RV §2.1.6 ("Load and Store Instructions"), PVM2 is
-   an EEI that **guarantees full support for misaligned loads and
-   stores** — no address-misaligned exception is ever raised. This is
-   one of the two options §2.1.6 explicitly offers EEIs ("An EEI may
-   guarantee that misaligned loads and stores are fully supported");
-   PVM2 selects it. We additionally implement the **Zicclsm** extension
-   (§4.13) as the standard extension-level statement of the same
-   guarantee. Matches today's PVM.
-
-   The RV-spec caveats about "might run extremely slowly" and "not
-   guaranteed atomic" don't apply: PVM2 is software-recompiled (x86
-   handles misaligned at near-native speed) and single-threaded
-   (atomicity is moot).
-
-3. **`fence` and `fence.i` are no-ops.**
-
-   `fence` orders accesses as seen by *other harts and devices*;
-   `fence.i` orders instruction fetch against prior writes
-   (self-modifying code). PVM2 is single-threaded, has no I/O bus, and
-   maps code read-only — so neither has anything to order. Retiring
-   them as no-ops is *conforming* under this configuration, not a
-   semantic change. (Encoding unchanged.)
-
-4. **No CSRs, no privilege levels, no atomics, no FP/vector.**
-
-   These are *optional* — none are part of the RV64E base. PVM2 does
-   not implement Zicsr (`csrr*`), the A extension (atomics), privileged
-   modes (`mret`/`sret`/`uret`, WFI, SFENCE.VMA), or F/D/Q/V (FP,
-   vector), Zfh, Zfa, Zifencei, supervisor/hypervisor. Their encodings
-   therefore decode as illegal — which is the standard reserved-encoding
-   behaviour for an unimplemented extension, not a redefinition. The EEI
-   presents a single flat privilege environment.
-
-5. **Extension profile and custom-0 ops.**
-
-   - **Standard extensions included:** M, C, Zbb, Zba, Zbs, Zicond,
-     Zicclsm — all unchanged from their specs (see
-     [Extensions included](#extensions-included)). Selecting an
-     extension set is a profile choice.
-   - **Custom ops in custom-0:** RISC-V reserves the `custom-0` major
-     opcode for non-standard extensions; PVM2 defines four ops there —
-     `trap`, `ecall.jar`, `ecalli`, `fallthrough` (see
-     [Custom-0 opcodes](#custom-0-opcodes)). Using the spec's
-     designated custom space is configuration, not divergence.
+5. **No CSRs, privilege levels, atomics, or FP/vector** — all optional, not
+   in the RV64E base; their encodings decode as illegal (standard
+   reserved-encoding behavior for an unimplemented extension). A single
+   flat privilege environment.
 
 ## Extensions included
 
-*(Category 2 #5.)* The following RV extensions apply to PVM2 unchanged
-from their standard specifications. None of them touch memory
-addressing beyond the base ISA's load/store ops (which carry the
-Category 1 #1 mask).
+Applied unchanged from their standard specs:
 
 | ext | name | notes |
 |---|---|---|
-| M | multiplication / division | `mul`, `mulh`, `mulhu`, `mulhsu`, `mulw`, `div`, `divu`, `rem`, `remu`, `divw`, `divuw`, `remw`, `remuw` |
-| C | compressed | 16-bit forms; compressed loads/stores inherit PVM2-Base's address mask. `c.jr`/`c.jalr`/`c.j` are standard control flow |
-| Zbb | basic bit manipulation | `clz`, `ctz`, `cpop` + W-variants, `sext.b`, `sext.h`, `zext.h`, `min`, `max`, `minu`, `maxu`, `andn`, `orn`, `xnor`, `rol`, `ror`, `rolw`, `rorw`, `rori`, `roriw`, `rev8`, `orc.b` |
-| Zba | shift-add | `sh1add`, `sh2add`, `sh3add` + UW-variants, `add.uw`, `slli.uw` |
+| M | mul / div | `mul`, `mulh*`, `mulw`, `div*`, `rem*`, `*w` |
+| C | compressed | 16-bit forms; `c.jr`/`c.jalr`/`c.j` are standard control flow (the `jalr` forms carry the Xjar CFI precondition) |
+| Zbb | bit manipulation | `clz`, `ctz`, `cpop`, `sext.*`, `zext.h`, `min/max[u]`, `andn`, `orn`, `xnor`, `rol/ror[i][w]`, `rev8`, `orc.b` |
+| Zba | shift-add | `sh{1,2,3}add[.uw]`, `add.uw`, `slli.uw` |
 | Zbs | single-bit | `bset`, `bclr`, `binv`, `bext` + imm forms |
-| Zicond | integer conditional | `czero.eqz`, `czero.nez` |
-| Zicclsm | misaligned-access support | per §4.13: implementation guarantees misaligned loads/stores to main memory work. Adds no new instructions; documents the EEI choice in Category 2 #2 as a standard extension |
+| Zicond | int conditional | `czero.eqz`, `czero.nez` |
+| Zicclsm | misaligned support | per §4.13; documents the EEI misaligned guarantee as a standard extension |
 
-Not included (explicitly): A (atomics), F/D/Q/V (FP, vector), Zfh,
-Zfa, Zicsr, Zifencei, supervisor/hypervisor. (Category 2 #4.)
+Not included: A (atomics), F/D/Q/V, Zfh, Zfa, Zicsr, Zifencei,
+supervisor/hypervisor.
 
 ## Custom-0 opcodes
 
-*(Category 2 #5 — the `custom-0` major opcode is RV-reserved for
-custom extensions.)* Four host / control operations occupy the RV
-`custom-0` opcode slot (`opcode = 0001011`). They are discriminated by
-`funct3` (I-type bits [14:12]); other fields are described per-op.
+The host / control ops of `Xjar`, in the RV-reserved `custom-0` slot
+(`opcode = 0001011`), discriminated by `funct3` (I-type bits [14:12]):
 
 | funct3 | mnemonic | wire pattern | semantics |
 |---:|---|---|---|
 | 000 | `trap` | `(funct3=000) (rest=0)` | unconditional execution abort. ε = panic |
-| 001 | `ecall.jar` | `(funct3=001) (rest=0)` | jar management op. φ[11] = op-code, φ[12] = subject\|object. Same semantics as PVM opcode 3 today |
-| 010 | `ecalli imm` | `(funct3=010) (imm[19:0])` | host-call with 20-bit signed immediate selector. Same semantics as PVM opcode 10 today, with `imm = sext20(imm[19:0])` |
-| 100 | `fallthrough` | `(funct3=100) (rest=0)` | structured no-op terminator. Decodes and retires with no effect on architectural state, but acts as a basic-block boundary: the *following* instruction is a `bb_start`. Used by the linker to widen the bb_start set before branch targets that aren't naturally post-terminator |
+| 001 | `ecall.jar` | `(funct3=001) (rest=0)` | jar management op. φ[11] = op-code, φ[12] = subject\|object. Same as PVM opcode 3 |
+| 010 | `ecalli imm` | `(funct3=010) (imm[19:0])` | host-call with 20-bit signed selector. Same as PVM opcode 10, `imm = sext20(imm[19:0])` |
+| 100 | `fallthrough` | `(funct3=100) (rest=0)` | structured no-op terminator; the *following* instruction is a `bb_start`. Used by the linker to widen the bb_start set |
 
-(Naming `ecall.jar` to distinguish from RV's standard `ecall`, which
-remains reserved/illegal — Category 1 #3.)
+(`ecall.jar` is named to distinguish it from standard `ecall`, which decodes
+normally but is handled by the EEI's fatal trap — so host functionality
+lives here in custom-0.)
 
-`funct3 = 011` was `br_table` in the static-dispatch draft; it is now
-**reserved** (PVM2 uses plain `jalr`). There is no Image-side jump
-table: control flow lives entirely in the instruction stream.
-
-No `sbrk` opcode. Bench guests don't use sbrk (zero static
-occurrences across all 12 bench programs). Real services that
-need dynamic heap growth call a host function via `ecalli` —
-no architectural opcode required.
-
-No `cmov_*` opcode either. The four PVM cmov variants are
-unused in benches except for `cmov_iz_imm` (0.69%); we let
-that fall back to a Zicond + or sequence (~4 RV insns).
-
-## Custom-1 opcode
-
-The entire `custom-1` major opcode (`0101011`) is reserved in
-PVM2 and traps at decode. (An earlier draft used it for `callf`;
-the structured-call design has since been replaced with plain
-RISC-V `jal`/`jalr`.) Trapping an unused custom slot is default
-behaviour, not a divergence.
+`funct3 = 011` (the removed `br_table`) is reserved. The entire `custom-1`
+major opcode (`0101011`) is reserved and traps at decode. No `sbrk` /
+`cmov_*` opcodes (heap growth via `ecalli`; `cmov` falls back to Zicond).
 
 ## Basic-block boundaries (`bb_starts`)
 
-*(The mechanism behind Category 1 #2.)* PVM2 defines a static set
-`bb_starts ⊆ valid_pc` that the recompiler and interpreter treat as
-basic-block boundaries (gas-check sites, label-emission sites, valid
-resume PCs, valid `jalr` targets):
+*(The mechanism behind Xjar CFI.)* PVM2 defines a static set `bb_starts ⊆
+valid_pc` that both engines treat as basic-block boundaries (gas-check
+sites, label sites, valid resume PCs, valid `jalr` targets / Xjar landing
+pads):
 
 ```
 bb_starts(code) = {0} ∪ { pc | pc immediately follows a terminator }
 ```
 
-The set is **derived from the instruction stream**, never from
-external metadata — both engines compute it identically by walking
-`code` and flagging the byte after each terminator. This is what lets
-the recompiler validate untrusted `jalr` targets safely.
+The set is **derived from the instruction stream**, never from external
+metadata — both engines compute it identically by walking `code` and
+flagging the byte after each terminator. This is what lets the recompiler
+validate untrusted `jalr` targets safely.
 
-**Terminator instructions** (kinds whose successor PC is either
-undefined or supplied by a register/branch rather than fallthrough):
+**Terminators:** `trap`, `fallthrough`, `ecalli`, `ecall.jar`; all static
+branches (`beq`/`bne`/`blt`/`bge`/`bltu`/`bgeu`/`c.beqz`/`c.bnez`); `jal`
+and `jalr` (any `rd`, including `c.j`/`c.jr`/`c.jalr`); any reserved
+encoding (defensive).
 
-- `trap`, `fallthrough`, `ecalli`, `ecall.jar` (custom-0)
-- All static branches: `beq`, `bne`, `blt`, `bge`, `bltu`,
-  `bgeu`, `c.beqz`, `c.bnez`
-- `jal` (any `rd`) and `jalr` (any `rd`), including the compressed
-  `c.j` / `c.jr` / `c.jalr` forms
-- Any reserved encoding (defensive — a decoder that reaches a
-  reserved instruction will trap, so the next instruction must be a
-  fresh block start if reached at all)
+**Linker invariant.** Every reachable branch/`jal` target and every
+statically-known `jalr` target must be in `bb_starts`; if not naturally
+post-terminator, the linker injects a `fallthrough` before it and re-encodes
+upstream offsets. Return sites are free (a call's `jalr`/`jal` is a
+terminator).
 
-**Linker invariant.** Every reachable target of a branch or `jal`
-(immediates), and every statically-known `jalr` target (call-site
-function entries, endpoint entries, `.rodata` code pointers), must be
-in `bb_starts`. If a target is not naturally post-terminator, the
-linker injects a `fallthrough` immediately before it and re-encodes
-upstream branch/`jal`/`auipc` offsets through an offset-map pass.
-Return sites are covered for free: a call's `jalr`/`jal` is a
-terminator, so the instruction after it is already a block start.
+**Pause-point constraint.** A `Paused { pc, regs }` state must have `pc ∈
+bb_starts`; out-of-gas can only fire at the per-block gas check, which sits
+at a `bb_start`. Faults stay terminal (panic/trap/page-fault discard the
+instance, never resume mid-block). `bb_starts` is derived from `code`; it
+is not part of the wire format.
 
-**Pause-point constraint.** A `Paused { pc, regs }` execution state
-must have `pc ∈ bb_starts`. Out-of-gas can only fire at the per-block
-gas check, which sits at the start of a `bb_start`. `bb_starts` is
-derived from `code`; it is not part of the wire format.
+## Reserved / EEI-trapped encodings
 
-## Forbidden encodings (explicit list)
+These standard RV encodings **panic when reached** — each for a base/EEI or
+unimplemented-extension reason, not a contradiction of the base ISA:
 
-The following standard RV encodings are reserved and must trap at
-decode time. The right column marks which divergence category each
-falls under.
-
-| encoding | category |
+| encoding | reason |
 |---|---|
-| ECALL, EBREAK (standard RV) and `c.ebreak` | 1 #3 — base instructions reserved |
-| Any instruction with rs1, rs2, or rd ∈ {x3, x4} | 1 #4 — reserved registers |
-| All CSR ops (Zicsr): CSRRW/S/C, CSRRWI/SI/CI | 2 #4 — unimplemented extension |
-| All atomics (A): LR.W/D, SC.W/D, AMO* | 2 #4 — unimplemented extension |
-| All privileged ops: MRET, SRET, URET, WFI, SFENCE.VMA | 2 #4 — no privilege levels |
-| Any FP/vector encoding (F, D, Q, V) | 2 #4 — unimplemented extensions |
-| The entire custom-1 major opcode (`0101011`) | 2 — unused custom slot |
-| custom-0 `funct3 = 011` (the removed `br_table`) | 2 — unused custom encoding |
+| ECALL, EBREAK, `c.ebreak` | EEI fatal-trap handler (§EEI #2) — decode/execute as standard; environment terminates |
+| rs1/rs2/rd ∈ {x16..x31} | RV64E base — register does not exist |
+| CSR ops (Zicsr) | unimplemented extension |
+| atomics (A) | unimplemented extension |
+| privileged ops (MRET/SRET/URET/WFI/SFENCE.VMA) | no privilege levels |
+| FP/vector (F/D/Q/V) | unimplemented extensions |
+| custom-1 major opcode (`0101011`) | unused custom slot |
+| custom-0 `funct3 = 011` | unused custom encoding |
 
-`auipc`, `jal`, `jalr` (and `c.jr`/`c.jalr`) are **not** forbidden —
-they are standard PVM2 control flow. Programs containing any of the
-reserved encodings above are rejected at deblob with a diagnostic
-naming the first offending instruction.
+`x3`/`x4` are **not** reserved — they are valid GPRs the runtime executes;
+only the jar toolchain declines to emit them. Refusal is **lazy** (decode
+as illegal / trap *if executed*); the toolchain also rejects them at build
+as a convenience, not the consensus rule.
 
-## Spec-version-independent invariants
+## Invariants
 
-These hold for every PVM2 conformant implementation:
-
-- An RV decoder + disassembler can render *and correctly interpret*
-  PVM2 bytes — the control flow is standard RV. The only places PVM2
-  and a stock RV64E core actually disagree are the **Category 1**
-  divergences: the 2³² address wrap (data + code), the `jalr` →
-  `bb_start` precondition, and the reserved `ecall`/`ebreak` and
-  `x3`/`x4` encodings. Category 2 settings are legal RV64E
-  configurations.
-- The aggregate execution result is deterministic for a given
-  program + initial state + gas budget. (Same as PVM today.)
-- Gas accounting is implementation-independent; the gas-cost
-  table is published separately ([08-pvm2-gas-cost.md](08-pvm2-gas-cost.md)).
-  PVM2 uses the single-pass pipeline model from
-  `spec/Jar/JAVM/GasCostSinglePass.lean`: per basic block, walk
-  the instructions tracking `reg_done[13]` + decode throughput;
-  block cost = `max(max_done − 3, 1)`. (Gas is an EEI execution-control
-  policy, outside the RV ISA proper; it is what *motivates* Category 1
-  #2.)
-
-## What this gets you vs RV64E
-
-- Same encoding format **and** same control-flow semantics: any RV
-  tool reads *and* runs PVM2 bytes (modulo the Category 1 address
-  wrap).
-- A short, closed list of Category 1 divergences — four items, each
-  forced by jar's consensus / single-thread / 32-bit-memory
-  constraints, not by bikeshed choice — and a Category 2 list that is
-  all legal RV64E configuration.
-- Standard RV extension story: M, C, Zbb, Zba, Zbs, Zicond, Zicclsm
-  apply unchanged. New extensions audit cleanly against the Category 1
-  list.
-- 4 custom ops only, all in custom-0: `trap`, `ecall.jar`, `ecalli`,
-  `fallthrough`. Everything else is RV.
-- Native control flow unlocks the standard `Zcmp`/`Zcmt` push/pop and
-  table-jump extensions, and friction-free interop with RV
-  disassemblers, debuggers, and analysers.
+- **PVM2 is RV64E + Xjar + EEI, no raw instruction contradictions.** Any RV
+  decoder/disassembler renders *and correctly interprets* PVM2 bytes. Every
+  departure from a stock RV64E core is an `Xjar` behavior (landing-pad CFI;
+  custom-0 host ops) or an EEI choice (aliased map; `ecall`/`ebreak` fatal
+  trap; misaligned support; `fence` retirement) — all legal RISC-V.
+- Aggregate execution is deterministic for a given program + initial state
+  + gas budget.
+- Gas accounting is implementation-independent (single-pass pipeline model,
+  `reg_done[15]` + decode throughput, block cost `max(max_done − 3, 1)`;
+  `x3`/`x4` operands additionally charge memory-spill cost). See
+  [08-pvm2-gas-cost.md].


### PR DESCRIPTION
Makes PVM2 **fully-conformant RISC-V**: the RV64E base + standard extensions + one custom extension (`Xjar`) + a specific EEI, with **no hard divergences**. The four former "Category 1 divergences" are each reframed as a conformant RISC-V construct; only the register model required code.

[Rendered spec](https://github.com/jarchain/jar/blob/86794abdaa1a24833cd095b542e7d37e410a3797/website/content/spec/javm.md).

## Spec reframe (docs + website mirror)
- **2³² address wrap** → an EEI **aliased memory map** (2³²-fold alias of one 4 GiB region — incomplete address decoding). Address computation is stock RV64E; the recompiler's existing mask realizes it.
- **`jalr` → bb_start** → the **`Xjar` landing-pad CFI extension**, modeled on the RISC-V Control-Flow Integrity chapter (cf. Zicfilp). Native `jalr` retained.
- **reserved `ecall`/`ebreak`** → the EEI handles them by an unconditional **fatal trap** (observably identical to the prior reserved encoding).
- **reserved `x3`/`x4`** → RV64E's full **15 GPRs**.

*(The spec lives in the separate `~/docs/pvm-isa` tree; this PR carries the mirrored copy under `website/content/spec`.)*

## Implementation — `x3`/`x4` as real registers (slots 13/14)
- **regs/instruction**: 15-register classification; `reg_is_spilled`; the shared decode predicate split into `word_uses_reserved_reg` (x16..x31) and `word_uses_spilled_reg` (x3/x4).
- **interp + gas**: the interpreter executes x3/x4 as ordinary GPRs; gas charges `mem_cycles` per x3/x4 operand via the shared `rv_feed_gas_kind`, so both engines agree by construction.
- **recompiler**: a cold `compile_rv_spilled` fork, taken **before** the fast-path dispatch so conformant code stays byte-identical. ALU/load/store/lui/auipc use collision-free **donor** host registers + re-dispatch (gas suppressed, fed once with the original x3/x4 slots); `jal`/`jalr`/`branch` have dedicated spill-aware handlers. `JitContext.regs` 13→15.
- **persisted cap format unchanged at 13**: x3/x4 are invocation-local and reset on (re)entry in both engines (the toolchain never emits them, so conformant instances always have x3=x4=0).
- **transpiler unchanged**: still rejects x3/x4 at build.

## Why it's free for conformant code
Every bench guest hits the unchanged fast-path dispatch; the only new per-instruction compile cost is an always-false `word_uses_spilled_reg` check. The x3/x4 spill path is reached only by untrusted RV64E blobs.

## Verification
- Full workspace tests pass (434); `clippy --workspace --all-targets -D warnings` clean.
- **interp↔recompiler execution differential** through the real KVM JIT — bit-for-bit agreement on return value **and gas** for donor ALU + dedicated branch handlers.
- Recompiler **compile-success** suite over every x3/x4 instruction form (structural safety of the spill emit).
- Gas spill-cost + interp-semantics unit tests.
- `javm-bench` within noise of baseline (max cold Δ 3.8% ed25519, scattered both directions; warm/steady-state within ±1%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)