### PR TITLE
perf(nub-arch-x86): mark image arena PTEs global

### DIFF
--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -88,8 +88,6 @@
 //!
 //! [df]: ../../../../website/content/spec/discussions/data-flow-principle.md
 
-#![cfg(target_os = "none")]
-
 extern crate alloc;
 
 use alloc::boxed::Box;

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -27,13 +27,12 @@
 //! `code_base` (a `JitContext` field) to land on absolute native
 //! addresses.
 
-#![cfg(target_os = "none")]
-
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 
@@ -68,6 +67,12 @@ pub struct CompiledImage {
     pub dispatch_offset: usize,
     pub jit_offset: usize,
     pub tramp_offset: usize,
+    /// Page-rounded arena byte size. All arena leaf PTEs are global, so
+    /// switching away from this Image must invalidate this VA range.
+    pub arena_size: usize,
+    /// Monotonic identity for this compiled Image's arena mappings. Physical
+    /// page reuse after `evict_all` cannot alias this token.
+    pub global_arena_token: u64,
     /// Byte size of the JIT region (page-rounded). Read by the #PF
     /// handler to bound the JIT-window check.
     pub jit_size: usize,
@@ -111,6 +116,8 @@ unsafe impl Sync for CompileCache {}
 static CACHE: CompileCache = CompileCache {
     inner: UnsafeCell::new(BTreeMap::new()),
 };
+
+static NEXT_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Round a byte count up to the next [`PAGE_SIZE`] boundary, with a
 /// minimum of one page (so even empty regions occupy a single page
@@ -184,6 +191,7 @@ pub fn get_or_compile(
         let tramp_offset = jit_offset + jit_size;
         let tramp_size = PAGE_SIZE;
         let total = tramp_offset + tramp_size;
+        let global_arena_token = NEXT_GLOBAL_ARENA_TOKEN.fetch_add(1, Ordering::Relaxed);
 
         let mut arena = PageBuf::new(total).expect("PageBuf alloc for Image arena");
         let buf = arena.as_mut_slice();
@@ -246,9 +254,9 @@ pub fn get_or_compile(
         let mut off = 0usize;
         while off < total {
             let perm = if off < ro_end {
-                Perm::user_ro()
+                Perm::user_ro_global()
             } else {
-                Perm::user_rx()
+                Perm::user_rx_global()
             };
             template
                 .map_leaf(off as u64, arena_pa + off as u64, perm)
@@ -283,6 +291,8 @@ pub fn get_or_compile(
                 dispatch_offset,
                 jit_offset,
                 tramp_offset,
+                arena_size: total,
+                global_arena_token,
                 jit_size,
                 exit_label_offset,
                 trap_table,

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -48,8 +48,6 @@
 //! faults outside `[MEM_VA, MEM_VA + mem_size)` route via
 //! `jit_pf_handler`.
 
-#![cfg(target_os = "none")]
-
 extern crate alloc;
 
 use crate::jit_cache;
@@ -74,6 +72,8 @@ static EXIT_LABEL_VA: AtomicU64 = AtomicU64::new(0);
 static TRAP_TABLE_PTR: AtomicPtr<(u32, u32, u32)> = AtomicPtr::new(core::ptr::null_mut());
 static TRAP_TABLE_LEN: AtomicU64 = AtomicU64::new(0);
 static CTX_KVA: AtomicU64 = AtomicU64::new(0);
+static LAST_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(0);
+static LAST_GLOBAL_ARENA_PAGES: AtomicU64 = AtomicU64::new(0);
 
 // === Per-invocation category-#3 materialization state =====================
 //
@@ -786,6 +786,11 @@ pub struct FrameRuntime {
     trap_table_len: u64,
     tramp_va: u64,
     new_cr3: u64,
+    /// Identity + page count for the per-Image META arena whose template leaf
+    /// PTEs are marked global. Used to invalidate stale global translations
+    /// only when switching Images.
+    global_arena_token: u64,
+    global_arena_pages: u64,
     // ---- Category-#3 lazy-materialization map (region bounds + kind;
     // published to the #PF handler each entry). The mutable per-page *state*
     // lives on the `KernelFrame` so it survives any future reclamation of this
@@ -935,6 +940,8 @@ pub unsafe fn build_frame_runtime(
         trap_table_len: cached.trap_table.len() as u64,
         tramp_va,
         new_cr3,
+        global_arena_token: cached.global_arena_token,
+        global_arena_pages: (cached.arena_size / PAGE_SIZE) as u64,
         mat_ranges,
         data_base: data_base as u32,
         mem_top,
@@ -1029,6 +1036,9 @@ pub unsafe fn enter_frame(
     OWNED_VEC_PTR.store(rt.pt.owned_vec_ptr(), Ordering::SeqCst);
     HANDLERS[14].store(jit_pf_handler as *const () as u64, Ordering::Release);
 
+    crate::paging::enable_global_pages();
+    flush_global_arena_on_image_switch(rt.global_arena_token, rt.global_arena_pages);
+
     let user_stack_top = STACK_VA_M + STACK_SIZE;
     // SAFETY: trampoline (inside the Image arena) + stack mapped above;
     // new_cr3 carries kernel half.
@@ -1069,4 +1079,16 @@ pub unsafe fn enter_frame(
             pc: (*ctx).pc,
         }
     }
+}
+
+fn flush_global_arena_on_image_switch(next_token: u64, next_pages: u64) {
+    let prev_token = LAST_GLOBAL_ARENA_TOKEN.load(Ordering::SeqCst);
+    if prev_token != 0 && prev_token != next_token {
+        let prev_pages = LAST_GLOBAL_ARENA_PAGES.load(Ordering::SeqCst);
+        for page in 0..prev_pages {
+            crate::paging::invlpg(META_BASE_M + page * PAGE_SIZE as u64);
+        }
+    }
+    LAST_GLOBAL_ARENA_PAGES.store(next_pages, Ordering::SeqCst);
+    LAST_GLOBAL_ARENA_TOKEN.store(next_token, Ordering::SeqCst);
 }

--- a/rust/nub-arch-x86/src/page_alloc.rs
+++ b/rust/nub-arch-x86/src/page_alloc.rs
@@ -8,8 +8,6 @@
 //! [`Layout`] guarantees physical pages we can plug into a ring-3
 //! page table directly.
 
-#![cfg(target_os = "none")]
-
 extern crate alloc;
 
 use alloc::alloc::{alloc_zeroed, dealloc};

--- a/rust/nub-arch-x86/src/paging.rs
+++ b/rust/nub-arch-x86/src/paging.rs
@@ -44,8 +44,6 @@
 //!   PT we build for ring-3 PVM programs; ring-0 paging helpers below
 //!   return `None` for these addresses.
 
-#![cfg(target_os = "none")]
-
 extern crate alloc;
 
 use alloc::alloc::{alloc_zeroed, dealloc};
@@ -89,6 +87,9 @@ pub mod flag {
     pub const RW: u64 = 1 << 1;
     /// User/Supervisor. Set → ring 3 can access; clear → ring 0 only.
     pub const US: u64 = 1 << 2;
+    /// Global TLB entry. When CR4.PGE is set, CR3 reloads do not flush
+    /// leaf entries carrying this bit.
+    pub const G: u64 = 1 << 8;
     /// No-Execute (bit 63). Set → instruction fetch faults.
     pub const NX: u64 = 1 << 63;
 }
@@ -129,6 +130,7 @@ pub struct Perm {
     pub writable: bool,
     pub user: bool,
     pub executable: bool,
+    pub global: bool,
 }
 
 impl Perm {
@@ -137,6 +139,7 @@ impl Perm {
             writable: true,
             user: true,
             executable: false,
+            global: false,
         }
     }
     pub const fn user_rx() -> Self {
@@ -144,6 +147,7 @@ impl Perm {
             writable: false,
             user: true,
             executable: true,
+            global: false,
         }
     }
     pub const fn user_ro() -> Self {
@@ -151,6 +155,23 @@ impl Perm {
             writable: false,
             user: true,
             executable: false,
+            global: false,
+        }
+    }
+    pub const fn user_rx_global() -> Self {
+        Self {
+            writable: false,
+            user: true,
+            executable: true,
+            global: true,
+        }
+    }
+    pub const fn user_ro_global() -> Self {
+        Self {
+            writable: false,
+            user: true,
+            executable: false,
+            global: true,
         }
     }
     /// Encode as the low-bit + high-bit flags of a leaf PTE.
@@ -161,6 +182,9 @@ impl Perm {
         }
         if self.user {
             bits |= flag::US;
+        }
+        if self.global {
+            bits |= flag::G;
         }
         if !self.executable {
             bits |= flag::NX;
@@ -614,4 +638,22 @@ pub fn read_cr3() -> u64 {
         core::arch::asm!("mov {0}, cr3", out(reg) cr3, options(nomem, nostack, preserves_flags));
     }
     cr3
+}
+
+/// Enable CR4.PGE so leaf PTEs with [`flag::G`] survive CR3 reloads.
+///
+/// Idempotent: callers can run this on the hot path before ring-3 entry.
+pub fn enable_global_pages() {
+    const CR4_PGE: u64 = 1 << 7;
+    let mut cr4: u64;
+    // SAFETY: reading/writing CR4 is privileged and valid in the guest kernel.
+    // We only set PGE, preserving all other control bits installed by
+    // Hyperlight/boot code.
+    unsafe {
+        core::arch::asm!("mov {0}, cr4", out(reg) cr4, options(nomem, nostack, preserves_flags));
+        if cr4 & CR4_PGE == 0 {
+            cr4 |= CR4_PGE;
+            core::arch::asm!("mov cr4, {0}", in(reg) cr4, options(nomem, nostack, preserves_flags));
+        }
+    }
 }

--- a/rust/nub-arch-x86/src/ring3.rs
+++ b/rust/nub-arch-x86/src/ring3.rs
@@ -45,8 +45,6 @@
 //!   invocations we'll need to thread these through a per-call
 //!   context.
 
-#![cfg(target_os = "none")]
-
 use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Vector for the ring-3 exit gate.

--- a/rust/nub-arch-x86/src/segments.rs
+++ b/rust/nub-arch-x86/src/segments.rs
@@ -20,8 +20,6 @@
 //! Hyperlight reserves after its 5-entry GDT (the `PADDING_BEFORE_TSS`
 //! region) and re-loads GDTR with a larger limit.
 
-#![cfg(target_os = "none")]
-
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem::size_of;

--- a/rust/nub-arch-x86/src/state_cache.rs
+++ b/rust/nub-arch-x86/src/state_cache.rs
@@ -30,8 +30,6 @@
 //! section from the kernel ELF after sandbox startup to learn where
 //! to find the cap directory.
 
-#![cfg(target_os = "none")]
-
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use foldhash::fast::FixedState;


### PR DESCRIPTION
## Summary

- add global page-table permissions and enable CR4.PGE before ring-3 entry
- mark per-Image arena template mappings global so repeated entries can survive CR3 reloads
- invalidate the previous image arena on image switches to avoid stale global TLB translations

## Scope

This PR addresses the #855 sub-task: global PT entries for per-Image template mappings.

Remaining sub-tasks in #855:
- Direct DataCap to PT mapping review/follow-up, if any gaps remain after the current lazy materialization work
- Broader CoW/HALT auto-mint follow-up, if any semantics remain beyond the current overlay persistence path

Addresses #855.

## Test plan

- cargo fmt --all
- cargo build -p nub
- cargo clippy -p nub --all-targets -- -D warnings
- cargo test -p nub-arch-x86
- cargo test -p nub
- cargo test -p javm-recompiler-x86