### PR TITLE
feat(nub-arch-x86): cache the ring-3 page table on the resident instance's cap (CachedCap) + CALL-time materialization gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bench-pt-cache"
+version = "0.1.0"
+dependencies = [
+ "subsoil",
+]
+
+[[package]]
 name = "bench-sub-vm-data-recurse"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "components/benches/prime-sieve",
     "components/benches/sub-vm-recurse",
     "components/benches/sub-vm-data-recurse",
+    "components/benches/pt-cache",
     "components/examples/simple-chain",
     "components/tests/sub-vm-reread-recurse",
 ]

--- a/components/benches/pt-cache/Cargo.toml
+++ b/components/benches/pt-cache/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bench-pt-cache"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+subsoil = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_env, values("javm"))', 'cfg(target_os, values("none"))'] }

--- a/components/benches/pt-cache/src/kernel_abi.rs
+++ b/components/benches/pt-cache/src/kernel_abi.rs
@@ -1,0 +1,51 @@
+//! Inline-asm wrappers around the kernel's `ecall` interface for the
+//! page-table-cache caller endpoint. Two ops: `derive_spawn` (op 18)
+//! to mint the resident child once, and a return-value form of
+//! `host_call` (op 26) that threads `arg` via `a2` (→ the callee's
+//! `φ[7]`) and reads the callee's return value back out of `a0`.
+
+#![allow(dead_code, unsafe_op_in_unsafe_fn)]
+
+const OP_DERIVE_SPAWN: u64 = 18;
+const OP_HOST_CALL: u64 = 26;
+
+/// `derive_spawn(image=φ[7], cnode=φ[8], dst=φ[9])`: mint a fresh
+/// `Cap::Instance` from the image in slot `image` (the kernel falls
+/// back to the running frame's own image when that slot is empty) and
+/// store it `Owned` in slot `dst`.
+#[inline]
+pub unsafe fn host_derive_spawn(image: u8, cnode: u8, dst: u8) {
+    core::arch::asm!(
+        "csrw 0x800, zero",
+        "ecall",
+        inlateout("a0") image as u64 => _,
+        inlateout("a1") cnode as u64 => _,
+        inlateout("a2") dst as u64 => _,
+        inlateout("a4") OP_DERIVE_SPAWN => _,
+        lateout("a3") _,
+        lateout("a5") _,
+        options(nostack, preserves_flags),
+    );
+}
+
+/// `host_call(instance=φ[7], endpoint=φ[8])` threading one u64 `arg`
+/// via `a2` (= `φ[9]`, which the kernel maps onto the child's `φ[7]`).
+/// Returns the callee's return value: the kernel writes it to the
+/// caller's `φ[7]` (a0) before re-entering the caller right after this
+/// `ecall`.
+#[inline]
+pub unsafe fn host_call_ret(instance: u8, endpoint: u8, arg: u64) -> u64 {
+    let ret: u64;
+    core::arch::asm!(
+        "csrw 0x800, zero",
+        "ecall",
+        inlateout("a0") instance as u64 => ret,
+        inlateout("a1") endpoint as u64 => _,
+        inlateout("a2") arg => _,
+        inlateout("a4") OP_HOST_CALL => _,
+        lateout("a3") _,
+        lateout("a5") _,
+        options(nostack, preserves_flags),
+    );
+    ret
+}

--- a/components/benches/pt-cache/src/lib.rs
+++ b/components/benches/pt-cache/src/lib.rs
@@ -1,0 +1,20 @@
+//! Page-table-cache bench guest (one image, two endpoints).
+//!
+//! - **Endpoint 0 (caller `A`):** reads a count `n` from `φ[7]`,
+//!   `derive_spawn`s a child Instance once (from its own image — the
+//!   kernel's `derive_spawn` falls back to the running frame's image
+//!   when the image slot is empty), then `host_call`s that resident
+//!   child's **echo** endpoint `n` times, summing the echoes. Because
+//!   the child is an `Owned` sub-VM that HALT folds back into the same
+//!   cnode slot, every iteration re-CALLs the *same* resident `B`.
+//! - **Endpoint 1 (echo `B`):** returns its argument (`φ[7]`)
+//!   unchanged. No data-region access ⇒ no CoW, no per-instance
+//!   page-table delta.
+//!
+//! Goal: a steady-state CALL into the resident `B` allocates nothing
+//! beyond a small `KernelFrame` — no per-CALL page-table rebuild. The
+//! companion `tests/pt_cache_heap.rs` measures that directly.
+
+#![cfg_attr(target_os = "none", no_std)]
+
+use subsoil as _;

--- a/components/benches/pt-cache/src/main.rs
+++ b/components/benches/pt-cache/src/main.rs
@@ -1,0 +1,61 @@
+#![cfg_attr(target_env = "javm", no_std)]
+#![cfg_attr(target_env = "javm", no_main)]
+
+use bench_pt_cache as _;
+use subsoil as _;
+
+#[cfg(target_env = "javm")]
+mod kernel_abi;
+
+/// Image slot `derive_spawn` reads to find the child's image. Left
+/// empty in this guest, so the kernel falls back to the running
+/// frame's own image — the child `B` is another Instance of *this*
+/// image, entered at the echo endpoint.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const SLOT_IMAGE: u8 = 3;
+
+/// Slot the spawned child `B` lives in (`Owned`); HALT folds the
+/// updated child back here after each CALL, so it stays resident.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const SLOT_CHILD: u8 = 6;
+
+/// Endpoint index of the echo function — what the caller CALLs.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+const ECHO_ENDPOINT: u8 = 1;
+
+/// Endpoint 0 — caller `A`. Spawn the resident child `B` once, then
+/// `host_call` its echo endpoint `n` times, summing the echoes.
+/// Returns `Σ_{i<n} i = n·(n−1)/2`, which the harness checks. The
+/// accumulator stays in a register (no data-region store), so `A`
+/// triggers no CoW of its own — the run measures only the per-CALL
+/// frame round-trip into the resident `B`.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+#[subsoil::endpoint(0)]
+fn caller(n: u64) -> u64 {
+    use kernel_abi::*;
+
+    // Mint the resident child once. host_call below moves it out and
+    // HALT folds it back into SLOT_CHILD, so every iteration re-CALLs
+    // the same B.
+    unsafe { host_derive_spawn(SLOT_IMAGE, 0, SLOT_CHILD) };
+
+    let mut acc = 0u64;
+    let mut i = 0u64;
+    while i < n {
+        acc = acc.wrapping_add(unsafe { host_call_ret(SLOT_CHILD, ECHO_ENDPOINT, i) });
+        i += 1;
+    }
+    acc
+}
+
+/// Endpoint 1 — echo `B`. Return the caller-threaded argument
+/// (`φ[7]`) unchanged. No data-region access ⇒ no CoW, no
+/// per-instance page-table delta.
+#[cfg(all(target_env = "javm", target_os = "none"))]
+#[subsoil::endpoint(1)]
+fn echo(arg: u64) -> u64 {
+    arg
+}
+
+#[cfg(not(target_env = "javm"))]
+fn main() {}

--- a/rust/javm-bench/Cargo.toml
+++ b/rust/javm-bench/Cargo.toml
@@ -43,3 +43,7 @@ harness = false
 name = "sub_vm_data_recurse"
 harness = false
 
+[[bench]]
+name = "pt_cache_call"
+harness = false
+

--- a/rust/javm-bench/benches/pt_cache_call.rs
+++ b/rust/javm-bench/benches/pt_cache_call.rs
@@ -1,0 +1,37 @@
+//! Page-table-cache bench for the in-kernel JIT path.
+//!
+//! Measures the steady-state cost of a CALL into an already-resident
+//! `Cap::Instance`. The caller `A`
+//! ([`components/benches/pt-cache-call`]) reads a count `n` from φ[7]
+//! and `host_call`s the echo callee `B`
+//! ([`components/benches/pt-cache-echo`]) `n` times; `B` returns its
+//! argument unchanged (no data-region writes, no sub-calls). `B` is
+//! published once as an Instance and lives in a fixed cnode slot, so
+//! every iteration re-CALLs the same `B`.
+//!
+//! ## What this measures
+//!
+//! Per CALL the kernel pays a frame round-trip into `B`: build the
+//! child `KernelFrame`, set up its ring-3 page table, enter/exit
+//! ring 3, fold state back. The page-table-cache work caches the
+//! per-instance page table across CALLs so the steady-state CALL
+//! allocates nothing beyond a small `KernelFrame` — this bench (with
+//! `Throughput::Elements(n)`, reporting per-CALL) tracks that win.
+//! The companion `tests/pt_cache_heap.rs` asserts the per-CALL
+//! allocation churn directly.
+//!
+//! The build/invoke/criterion driver is shared via
+//! [`javm_bench::run_pt_cache_bench`].
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const BLOB: &[u8] = include_bytes!(env!("PT_CACHE_BLOB"));
+
+fn pt_cache_call(c: &mut Criterion) {
+    javm_bench::run_pt_cache_bench(c, BLOB, "pt_cache_call");
+}
+
+criterion_group!(benches, pt_cache_call);
+criterion_main!(benches);

--- a/rust/javm-bench/build.rs
+++ b/rust/javm-bench/build.rs
@@ -71,6 +71,11 @@ fn main() {
             "SUB_VM_DATA_RECURSE_BLOB",
         ),
         (
+            "../../components/benches/pt-cache",
+            "bench-pt-cache",
+            "PT_CACHE_BLOB",
+        ),
+        (
             "../../components/tests/sub-vm-reread-recurse",
             "test-sub-vm-reread-recurse",
             "SUB_VM_REREAD_RECURSE_BLOB",

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -348,22 +348,15 @@ pub struct SubVmTop {
     pub image_hash: CapHash,
 }
 
-/// Build + publish (once) the recurse Image, its cnode, and the top
-/// Instance into `nub` from the SSZ-encoded Image `blob`. Returns the
-/// top instance hash so the bench loop can invoke it directly.
-pub fn build_sub_vm_top(nub: &mut Nub, blob: &[u8]) -> SubVmTop {
-    use javm_cap::{CNodeCap, CapHashOrRef};
-    use ssz::Decode;
-
-    const ENDPOINT_IDX: u8 = 0;
-
-    let image = Image::from_ssz_bytes(blob).expect("decode sub-vm image");
-
-    // The bench guest ships .rodata + a small stack (and, for the data
-    // variant, a 64 KiB pinned blob) via its image mappings. Publish a
-    // Cap::Data per pinned/initial slot and reference them from the
-    // Cap::Image; the in-kernel call_loop reads those bytes from the
-    // shared cache when building a child frame's mem image.
+/// Publish an Image's data slots (`Cap::Data` per pinned/initial
+/// slot) and the `Cap::Image` that references them into `nub`, and
+/// return the image hash.
+///
+/// The bench guests ship `.rodata` + a small stack (and, for the data
+/// variants, a pinned blob) via their image mappings; the in-kernel
+/// call_loop reads those bytes from the shared cache when building a
+/// frame's mem image.
+fn publish_image(nub: &mut Nub, image: &Image) -> CapHash {
     let mut data_caps: Vec<(CapHash, Cap)> = Vec::new();
     let mut pinned_hashes: Vec<(Key, CapHash)> = Vec::new();
     let mut initial_hashes: Vec<(Key, CapHash)> = Vec::new();
@@ -391,18 +384,26 @@ pub fn build_sub_vm_top(nub: &mut Nub, blob: &[u8]) -> SubVmTop {
         nub.put_cap_with_hash(*h, cap).expect("put data");
     }
     let image_cap =
-        Cap::image_with_slots(&image, &pinned_hashes, &initial_hashes).expect("image_with_slots");
+        Cap::image_with_slots(image, &pinned_hashes, &initial_hashes).expect("image_with_slots");
     let image_hash = ssz::hash_tree_root(&image_cap);
     nub.put_cap_with_hash(image_hash, &image_cap)
         .expect("put image");
+    image_hash
+}
 
-    let mut cn = CNodeCap::new();
-    cn.set(
-        &Key::from(SLOT_IMAGE_RECURSE as u8),
-        Some(CapHashOrRef::Hash(image_hash)),
-    )
-    .expect("set image slot");
-    let cnode_cap = Cap::CNode(cn);
+/// Publish `cnode` and an endpoint-0 `Cap::Instance` (backed by
+/// `image`'s memory) into `nub`, and return the instance hash. The
+/// `image_hash` must be the hash returned by [`publish_image`] for the
+/// same `image`.
+fn publish_instance(
+    nub: &mut Nub,
+    image: &Image,
+    image_hash: CapHash,
+    cnode: javm_cap::CNodeCap,
+) -> CapHash {
+    const ENDPOINT_IDX: u8 = 0;
+
+    let cnode_cap = Cap::CNode(cnode);
     let cnode_hash = ssz::hash_tree_root(&cnode_cap);
     nub.put_cap_with_hash(cnode_hash, &cnode_cap)
         .expect("put cnode");
@@ -420,7 +421,30 @@ pub fn build_sub_vm_top(nub: &mut Nub, blob: &[u8]) -> SubVmTop {
     let inst_hash = ssz::hash_tree_root(&inst_cap);
     nub.put_cap_with_hash(inst_hash, &inst_cap)
         .expect("put instance");
+    inst_hash
+}
 
+/// Build + publish (once) the recurse Image, its cnode, and the top
+/// Instance into `nub` from the SSZ-encoded Image `blob`. Returns the
+/// top instance hash so the bench loop can invoke it directly.
+pub fn build_sub_vm_top(nub: &mut Nub, blob: &[u8]) -> SubVmTop {
+    use javm_cap::{CNodeCap, CapHashOrRef};
+    use ssz::Decode;
+
+    let image = Image::from_ssz_bytes(blob).expect("decode sub-vm image");
+    let image_hash = publish_image(nub, &image);
+
+    // The top instance's cnode holds the recurse image at
+    // SLOT_IMAGE_RECURSE; every spawned child inherits it, so each
+    // level finds the same image to derive_spawn again.
+    let mut cn = CNodeCap::new();
+    cn.set(
+        &Key::from(SLOT_IMAGE_RECURSE as u8),
+        Some(CapHashOrRef::Hash(image_hash)),
+    )
+    .expect("set image slot");
+
+    let inst_hash = publish_instance(nub, &image, image_hash, cn);
     SubVmTop {
         top_instance: inst_hash,
         image_hash,
@@ -525,6 +549,106 @@ pub fn run_recurse_bench(c: &mut Criterion, blob: &[u8], label: &str) {
         g.throughput(Throughput::Elements(depth));
         g.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, &d| {
             b.iter(|| invoke_sub_vm(&mut nub_hyperlight_lock(), &top, d))
+        });
+    }
+    g.finish();
+}
+
+// ---- page-table-cache bench (A repeatedly CALLs a resident B) ----
+
+/// Top instance of the page-table-cache bench: a single image whose
+/// endpoint 0 (`A`) `derive_spawn`s a child of the same image once and
+/// repeatedly `host_call`s its echo endpoint (`B`).
+pub struct PtCacheTop {
+    /// Caller `A`'s instance hash — the one the bench invokes.
+    pub top_instance: CapHash,
+    /// The shared image hash (kept warm in the JIT cache).
+    pub image_hash: CapHash,
+}
+
+/// Build + publish (once) the page-table-cache image and its top
+/// Instance into `nub` from the SSZ-encoded Image `blob`. Returns the
+/// top instance hash so the bench loop can invoke endpoint 0 directly.
+pub fn build_pt_cache_top(nub: &mut Nub, blob: &[u8]) -> PtCacheTop {
+    use javm_cap::CNodeCap;
+    use ssz::Decode;
+
+    let image = Image::from_ssz_bytes(blob).expect("decode pt-cache image");
+    let image_hash = publish_image(nub, &image);
+    // Empty cnode: the guest's `derive_spawn` reads an empty image
+    // slot and falls back to its own image to mint the resident child.
+    let top_instance = publish_instance(nub, &image, image_hash, CNodeCap::new());
+    PtCacheTop {
+        top_instance,
+        image_hash,
+    }
+}
+
+/// `A` returns `Σ_{i<n} i = n·(n−1)/2` (each echo returns its index).
+/// `wrapping`-safe to mirror the guest's `wrapping_add` accumulator.
+fn pt_cache_expected_return(n: u64) -> u64 {
+    let mut acc = 0u64;
+    for i in 0..n {
+        acc = acc.wrapping_add(i);
+    }
+    acc
+}
+
+/// One page-table-cache bench iteration: invoke endpoint 0, which
+/// `host_call`s the resident `B` `n` times. Asserts a clean trampoline
+/// halt and that the summed echoes match. Returns
+/// `(return_value, gas_used)`.
+pub fn invoke_pt_cache(nub: &mut Nub, top: &PtCacheTop, n: u64) -> (u64, u64) {
+    let result = nub
+        .invoke_cached(top.top_instance, 0, [n, 0, 0, 0], INITIAL_GAS)
+        .expect("invoke_cached");
+    assert!(
+        result.exit_reason == EXIT_HOSTCALL && result.exit_arg == 0,
+        "pt-cache exited non-cleanly: reason={} arg={} ret={} gas={}",
+        result.exit_reason,
+        result.exit_arg,
+        result.return_value,
+        result.gas_remaining,
+    );
+    assert_eq!(
+        result.return_value,
+        pt_cache_expected_return(n),
+        "pt-cache n={n} summed echoes {} (expected {})",
+        result.return_value,
+        pt_cache_expected_return(n),
+    );
+    (
+        result.return_value,
+        INITIAL_GAS.saturating_sub(result.gas_remaining),
+    )
+}
+
+/// Run the page-table-cache criterion bench: endpoint 0 `host_call`s
+/// the resident `B` a swept number of times. Publishes the top once
+/// (the kernel stays warm), runs an n=1/2 sanity check, then sweeps
+/// `{10, 100, 1000}` CALLs with `Throughput::Elements(n)` so the
+/// reported figure is per-CALL.
+pub fn run_pt_cache_bench(c: &mut Criterion, blob: &[u8], label: &str) {
+    let top = build_pt_cache_top(&mut nub_hyperlight_lock(), blob);
+    eprintln!(
+        "[{label}] image={} top={}",
+        hex_short(&top.image_hash),
+        hex_short(&top.top_instance),
+    );
+
+    {
+        let mut nub = nub_hyperlight_lock();
+        invoke_pt_cache(&mut nub, &top, 1);
+        invoke_pt_cache(&mut nub, &top, 2);
+    }
+    eprintln!("[{label}] n 1/2 ok");
+
+    let mut g = c.benchmark_group(label);
+    g.sample_size(20);
+    for &n in &[10u64, 100, 1_000] {
+        g.throughput(Throughput::Elements(n));
+        g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter(|| invoke_pt_cache(&mut nub_hyperlight_lock(), &top, n))
         });
     }
     g.finish();

--- a/rust/javm-bench/tests/pt_cache_heap.rs
+++ b/rust/javm-bench/tests/pt_cache_heap.rs
@@ -1,0 +1,105 @@
+//! Regression test: a steady-state CALL into an already-resident
+//! `Cap::Instance` must allocate nothing beyond a small `KernelFrame`
+//! — no per-CALL page-table rebuild.
+//!
+//! The caller `A` (endpoint 0 of `components/benches/pt-cache`)
+//! `host_call`s the resident echo `B` (endpoint 1 of the same image)
+//! `n` times. We measure the guest
+//! heap's **cumulative** allocation counter
+//! (`total_allocation_count`) — not the live count — because the page
+//! table a CALL builds is freed again at HALT, so it never shows up in
+//! the live counter (that's what `heap_drift.rs` guards). The churn of
+//! one `A`-invoke is `fixed + n · per_call`; taking the two-point
+//! difference `(churn(2n) − churn(n)) / n` cancels `A`'s fixed
+//! per-invoke overhead and yields the per-CALL allocation count.
+//!
+//! Before the page-table cache each CALL rebuilt `B`'s ring-3 page
+//! table (PML4 → PDPT → PD → PT intermediates + the CoW'd page),
+//! measuring **7** allocations per CALL. Caching the resident
+//! instance's page table across CALLs collapses that to **4** — the
+//! `KernelFrame` floor (its `mat_state` / cnode / pinned-slot vectors).
+//! `CEILING` locks the win: a regression that rebuilds the page table
+//! per CALL jumps back to ≥7 and trips it. The test also asserts the
+//! churn is **bit-stable** across repeats (determinism).
+//!
+//! Requires the `heap-diag` feature. Run with:
+//!
+//! ```bash
+//! cargo test -p javm-bench --test pt_cache_heap --features heap-diag \
+//!     --release -- --ignored --nocapture
+//! ```
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64", feature = "heap-diag"))]
+
+use javm_bench::{PtCacheTop, build_pt_cache_top};
+use nub::Nub;
+
+const BLOB: &[u8] = include_bytes!(env!("PT_CACHE_BLOB"));
+
+/// Inner CALL count for the low point of the two-point measurement.
+const N: u64 = 50;
+/// How many times to re-measure `churn(N)` to assert determinism.
+const ROUNDS: usize = 5;
+/// Upper bound for the per-CALL allocation churn. The page-table cache
+/// brings this to the `KernelFrame` floor (4); the pre-cache behaviour
+/// (rebuild the page table every CALL) measured 7, so this ceiling trips
+/// on a reintroduced rebuild while leaving headroom for an extra small
+/// `KernelFrame` vector.
+const CEILING: u64 = 5;
+
+/// Cumulative guest allocations performed during a single invoke of
+/// `A` with `n` inner CALLs (the `total_allocation_count` delta across
+/// the invoke).
+fn invoke_churn(nub: &mut Nub, top: &PtCacheTop, n: u64) -> u64 {
+    let before = nub.heap_stats().expect("heap_stats before");
+    javm_bench::invoke_pt_cache(nub, top, n);
+    let after = nub.heap_stats().expect("heap_stats after");
+    after
+        .total_allocation_count
+        .checked_sub(before.total_allocation_count)
+        .expect("total_allocation_count is monotonic")
+}
+
+#[test]
+#[ignore]
+fn pt_cache_heap_per_call_churn() {
+    let mut nub = Nub::new_hyperlight().expect("sandbox");
+    let top = build_pt_cache_top(&mut nub, BLOB);
+
+    // Warm up (A's + B's JIT compile, the per-image mem backing, any
+    // one-shot static init) so the measured churn is steady-state.
+    javm_bench::invoke_pt_cache(&mut nub, &top, N);
+    javm_bench::invoke_pt_cache(&mut nub, &top, 2 * N);
+
+    // Determinism: the churn of invoking with the same `n` must be
+    // bit-identical across repeats.
+    let base = invoke_churn(&mut nub, &top, N);
+    for r in 0..ROUNDS {
+        let again = invoke_churn(&mut nub, &top, N);
+        assert_eq!(
+            again, base,
+            "pt-cache churn not deterministic at round {r}: {again} vs {base}",
+        );
+    }
+
+    // Per-CALL churn via the two-point difference (cancels A's fixed
+    // per-invoke overhead). `churn` is linear in `n`, so churn(2N) ≥
+    // churn(N).
+    let d_n = invoke_churn(&mut nub, &top, N);
+    let d_2n = invoke_churn(&mut nub, &top, 2 * N);
+    assert!(
+        d_2n >= d_n,
+        "churn not monotone in n: churn(N)={d_n} churn(2N)={d_2n}",
+    );
+    let per_call = (d_2n - d_n) / N;
+
+    eprintln!(
+        "pt_cache per-CALL allocation churn = {per_call}  \
+         (churn(N={N})={d_n}, churn(2N={})={d_2n})",
+        2 * N,
+    );
+    assert!(
+        per_call <= CEILING,
+        "per-CALL allocation churn {per_call} exceeds ceiling {CEILING}",
+    );
+}

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -51,7 +51,7 @@ fn prime_sieve() {
         "prime_sieve",
         include_bytes!(env!("PRIME_SIEVE_BLOB")),
         0x2578,
-        8_974_623,
+        8_972_959,
     );
 }
 
@@ -61,7 +61,7 @@ fn ed25519() {
         "ed25519",
         include_bytes!(env!("ED25519_BLOB")),
         0x1,
-        2_361_145,
+        2_360_953,
     );
 }
 
@@ -71,7 +71,7 @@ fn keccak() {
         "keccak",
         include_bytes!(env!("KECCAK_BLOB")),
         0x39e5_0259,
-        101_062,
+        100_934,
     );
 }
 
@@ -81,7 +81,7 @@ fn blake2b() {
         "blake2b",
         include_bytes!(env!("BLAKE2B_BLOB")),
         0xee1f_55f1,
-        62_524,
+        62_396,
     );
 }
 
@@ -91,7 +91,7 @@ fn ecrecover() {
         "ecrecover",
         include_bytes!(env!("ECRECOVER_BLOB")),
         0x1,
-        6_812_008,
+        6_811_560,
     );
 }
 
@@ -101,7 +101,7 @@ fn goldilocks_mul() {
         "goldilocks_mul",
         include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
         0x2cf7_3e57,
-        2_400_230,
+        2_400_166,
     );
 }
 
@@ -111,7 +111,7 @@ fn poseidon2_perm() {
         "poseidon2_perm",
         include_bytes!(env!("POSEIDON2_PERM_BLOB")),
         0x3ce3_3156,
-        14_561_585,
+        14_561_457,
     );
 }
 
@@ -121,7 +121,7 @@ fn mini_verifier() {
         "mini_verifier",
         include_bytes!(env!("MINI_VERIFIER_BLOB")),
         0xf98f_c4ab,
-        5_879_303,
+        5_879_175,
     );
 }
 
@@ -131,7 +131,7 @@ fn poly_eval() {
         "poly_eval",
         include_bytes!(env!("POLY_EVAL_BLOB")),
         0x01da_34e2,
-        9_006_693,
+        9_005_925,
     );
 }
 
@@ -141,6 +141,6 @@ fn fri_fold_tree() {
         "fri_fold_tree",
         include_bytes!(env!("FRI_FOLD_TREE_BLOB")),
         0x37e6_76f4,
-        6_195_652,
+        6_194_372,
     );
 }

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -45,12 +45,15 @@
 //! `sweep_instances` reclaims entries whose stored `CapRef.strong_count`
 //! is 1 (i.e., the directory is the sole holder). Removal drops the
 //! entry's `Arc<Cap>`; if that was the last strong ref to the Cap, the
-//! Cap drops; the Cap's `Ref(CapRef)` slot values drop too, decrementing
-//! more entries' refcounts. The sweep loops until a pass finds nothing.
+//! Cap drops. Caps no longer hold `Ref(CapRef)` slot targets (a cnode
+//! slot is a `Hash` or an inline `Owned` cap), so a drop never cascades
+//! into other instance entries — the sweep is a single self-contained
+//! pass per orphan. The loop is retained as a cheap fixed-point guard.
 //!
-//! Cycles are structurally impossible (data-flow principle:
-//! `website/content/spec/discussions/data-flow-principle.md`), so the
-//! sweep is guaranteed to make forward progress.
+//! The instances tier is currently **dormant**: the recompiler keeps
+//! sub-VMs inline as `Owned` caps and never publishes a `CapRef`. The
+//! tier (and `CapRef`) survive as the host-side key for the future
+//! deferred-persist path.
 //!
 //! ## blob retention
 //!
@@ -128,89 +131,117 @@ impl core::hash::Hash for CapRef {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for alloc::boxed::Box<crate::cap::Cap> {}
+}
+
+/// Marker for `CapHashOrRef::Owned` payloads that participate in the
+/// content-addressed **wire** form. Implemented only for `Box<Cap>` (the
+/// default payload).
+///
+/// It is a deliberately *leaf* marker — implemented directly for
+/// `Box<Cap>` with no supertrait that recurses into `Cap: Archive` — so
+/// gating the wire impls (`HashTreeRoot` / `Encode` / `Decode` / rkyv
+/// `Archive` / `Serialize`) of `CapHashOrRef<O>` on `O: WireOwned`
+/// resolves by a single lookup, exactly as the original non-generic
+/// impls did (which required nothing of the inline `Box<Cap>`). Gating on
+/// `O: rkyv::Archive` instead would re-introduce the cyclic
+/// `Box<Cap>: Archive → Cap: Archive` bound and overflow the solver.
+///
+/// Engine-private cache payloads (e.g. `Box<CachedCap>`) deliberately do
+/// **not** implement it, so a cnode carrying one has no wire impl and
+/// cannot be hashed or serialised — a compile error, strictly stronger
+/// than the runtime `Owned` panic.
+///
+/// Sealed: only `javm-cap` implements it.
+pub trait WireOwned: sealed::Sealed {}
+impl WireOwned for Box<Cap> {}
+
 /// Slot/field reference: a content-addressed blob in `cache.blobs`
-/// (`Hash`), a mutable working entry in `cache.instances` (`Ref`), or a
-/// single-owner cap held **inline** by the running kernel frame
-/// (`Owned`).
+/// (`Hash`), or a single-owner cap held **inline** by the running kernel
+/// frame (`Owned`).
 ///
 /// **`Owned(Box<Cap>)`** is the zero-copy ownership form: a cap the
 /// kernel frame owns outright and moves between cnode slots (and between
 /// frames, at HALT) with no cache round-trip and no data copy — the move
-/// is a `Box` pointer swap. Like `Ref` it is **runtime-only**: it never
-/// crosses the wire and is never hashed. The recompiler mints it on
-/// `derive_spawn` and moves it through `host_call`; it never `settle`s
-/// one (the host-side `settle` arm folds it into a blob for the deferred
-/// persist path).
+/// is a `Box` pointer swap. It is **runtime-only**: it never crosses the
+/// wire and is never hashed. The recompiler mints it on `derive_spawn`
+/// and moves it through `host_call`; it never `settle`s one (the
+/// host-side `settle` arm folds it into a blob for the deferred persist
+/// path).
 ///
 /// **SSZ note**: `CapHashOrRef`'s `HashTreeRoot` impl is hand-rolled,
 /// not derived. The pass-through semantics — `Hash(h)` hashes to `h` —
-/// let a freshly-published cap substitute for a `Ref` reference without
-/// changing the hash of any cap that holds it. The `Ref` and `Owned`
-/// arms panic: callers must `settle` a cap graph before hashing it.
-/// `Encode` mirrors `HashTreeRoot` (panic on the runtime-only arms);
-/// `Decode` only ever produces `Hash` (the wire carries selector 0).
+/// let a freshly-published cap substitute for a content reference without
+/// changing the hash of any cap that holds it. The `Owned` arm panics:
+/// callers must `settle` a cap graph before hashing it. `Encode` mirrors
+/// `HashTreeRoot` (panic on the runtime-only arm); `Decode` only ever
+/// produces `Hash` (the wire carries selector 0).
 ///
-/// **Not `Copy`**: the `Ref(CapRef)` arm carries a refcounted handle and
-/// the `Owned(Box<Cap>)` arm carries a heap allocation, so the enum is
-/// `Clone`-only.
+/// **Generic over the owned payload `O`** (default `Box<Cap>`). The wire
+/// form (the cnode inside a serialised `Cap`) is always
+/// `CapHashOrRef<Box<Cap>>`, so `Cap` and its hash are unaffected. An
+/// engine may instantiate a *running frame's* cnode with a richer,
+/// deliberately non-wire payload (e.g. `Box<CachedCap>`); the
+/// serialisation impls below are gated on `O: rkyv::Archive`, so such a
+/// payload makes the cnode non-hashable and non-serialisable at **compile
+/// time** (a strictly stronger guarantee than the runtime `Owned` panic).
 ///
-/// **`PartialEq`/`Eq`/`Hash` are hand-written**: `Box<Cap>` blocks the
-/// derive (`Cap` is not `Eq`/`Hash`). `Hash`/`Ref` arms compare/hash by
-/// value as before; the `Owned` arm uses pointer identity (sound — the
-/// only holder, `CNodeSlots = RadixMap<_, KEY_BYTES>`, keys by the
-/// 32-byte physical key, never by value).
+/// **Not `Copy`**: the `Owned(O)` arm carries the (usually heap-allocated)
+/// payload, so the enum is `Clone`-only (when `O: Clone`).
+///
+/// **`PartialEq`/`Eq`/`Hash` are hand-written**: a `Box<Cap>` payload
+/// blocks the derive (`Cap` is not `Eq`/`Hash`). The `Hash` arm
+/// compares/hashes its 32-byte digest by value; the `Owned` arm uses
+/// pointer identity of the inline payload (sound — the only holder,
+/// `CNodeSlots = RadixMap<_, KEY_BYTES>`, keys by the 32-byte physical
+/// key, never by value — and `O`-agnostic, so it needs no bound).
 #[derive(Clone, Debug)]
-pub enum CapHashOrRef {
+pub enum CapHashOrRef<O = Box<Cap>> {
     Hash(CapHash),
-    Ref(CapRef),
-    Owned(Box<Cap>),
+    Owned(O),
 }
 
-impl PartialEq for CapHashOrRef {
+impl<O> PartialEq for CapHashOrRef<O> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (CapHashOrRef::Hash(a), CapHashOrRef::Hash(b)) => a == b,
-            (CapHashOrRef::Ref(a), CapHashOrRef::Ref(b)) => a == b,
             // Owned is single-owner and never content-compared; pointer
-            // identity is reflexive (Eq-sound) and consistent with the
-            // pointer-keyed `Hash` impl below.
-            (CapHashOrRef::Owned(a), CapHashOrRef::Owned(b)) => {
-                core::ptr::eq(a.as_ref(), b.as_ref())
-            }
+            // identity of the inline payload is reflexive (Eq-sound) and
+            // consistent with the pointer-keyed `Hash` impl below.
+            (CapHashOrRef::Owned(a), CapHashOrRef::Owned(b)) => core::ptr::eq(a, b),
             _ => false,
         }
     }
 }
-impl Eq for CapHashOrRef {}
+impl<O> Eq for CapHashOrRef<O> {}
 
-impl core::hash::Hash for CapHashOrRef {
+impl<O> core::hash::Hash for CapHashOrRef<O> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         match self {
             CapHashOrRef::Hash(h) => {
                 0u8.hash(state);
                 h.hash(state);
             }
-            CapHashOrRef::Ref(r) => {
+            CapHashOrRef::Owned(o) => {
                 1u8.hash(state);
-                r.hash(state);
-            }
-            CapHashOrRef::Owned(b) => {
-                2u8.hash(state);
-                (b.as_ref() as *const Cap).hash(state);
+                (o as *const O).hash(state);
             }
         }
     }
 }
 
-impl ssz::HashTreeRoot for CapHashOrRef {
+// Gated on `O: WireOwned` — the wire-payload marker. `Box<Cap>` (the
+// content-addressed default) implements it; a non-wire payload such as
+// `Box<CachedCap>` does not, so a cache-carrying cnode has no `HashTreeRoot`
+// impl and cannot be content-hashed (a compile error, not a runtime panic).
+impl<O: WireOwned> ssz::HashTreeRoot for CapHashOrRef<O> {
     fn hash_tree_root<D: ::ssz::digest::Digest<OutputSize = ::ssz::digest::typenum::U32>>(
         &self,
     ) -> [u8; 32] {
         match self {
             CapHashOrRef::Hash(h) => *h,
-            CapHashOrRef::Ref(_) => {
-                panic!("cap_hash: unresolved CapRef in cap graph; settle first")
-            }
             CapHashOrRef::Owned(_) => {
                 panic!("cap_hash: in-flight Owned cap in cap graph; settle first")
             }
@@ -218,7 +249,7 @@ impl ssz::HashTreeRoot for CapHashOrRef {
     }
 }
 
-impl ssz::Encode for CapHashOrRef {
+impl<O: WireOwned> ssz::Encode for CapHashOrRef<O> {
     fn is_ssz_fixed_len() -> bool {
         false
     }
@@ -228,12 +259,8 @@ impl ssz::Encode for CapHashOrRef {
     fn ssz_bytes_len(&self) -> usize {
         match self {
             CapHashOrRef::Hash(_) => 1 + 32,
-            // Ref / Owned must be settled before serialisation; matches
-            // the `HashTreeRoot` contract above. Reached only by buggy
-            // code.
-            CapHashOrRef::Ref(_) => {
-                panic!("ssz_bytes_len: unresolved CapRef in cap graph; settle first")
-            }
+            // Owned must be settled before serialisation; matches the
+            // `HashTreeRoot` contract above. Reached only by buggy code.
             CapHashOrRef::Owned(_) => {
                 panic!("ssz_bytes_len: in-flight Owned cap in cap graph; settle first")
             }
@@ -245,9 +272,6 @@ impl ssz::Encode for CapHashOrRef {
                 buf.push(0);
                 buf.extend_from_slice(h);
             }
-            CapHashOrRef::Ref(_) => {
-                panic!("ssz_append: unresolved CapRef in cap graph; settle first")
-            }
             CapHashOrRef::Owned(_) => {
                 panic!("ssz_append: in-flight Owned cap in cap graph; settle first")
             }
@@ -255,7 +279,7 @@ impl ssz::Encode for CapHashOrRef {
     }
 }
 
-impl ssz::Decode for CapHashOrRef {
+impl<O: WireOwned> ssz::Decode for CapHashOrRef<O> {
     fn is_ssz_fixed_len() -> bool {
         false
     }
@@ -281,12 +305,9 @@ impl ssz::Decode for CapHashOrRef {
                 h.copy_from_slice(&bytes[1..1 + 32]);
                 Ok(CapHashOrRef::Hash(h))
             }
-            // Refs are cache-local lifetime handles; the wire has no
-            // directory context to reconstruct one. Caller bugs that
-            // serialise a Ref into wire bytes surface here.
-            1 => Err(ssz::DecodeError::Custom(
-                "CapHashOrRef::Ref cannot be decoded from wire bytes",
-            )),
+            // Selector 0 (`Hash`) is the only wire form; `Owned` is
+            // runtime-only and never serialises, so any other selector is
+            // invalid wire bytes.
             v => Err(ssz::DecodeError::InvalidSelector(v)),
         }
     }
@@ -303,23 +324,22 @@ impl ssz::Decode for CapHashOrRef {
 
 /// Error returned by `<CapHashOrRef as rkyv::Serialize<_>>::serialize`
 /// when the cap graph still holds a runtime-only target — a
-/// [`CapHashOrRef::Ref`] or [`CapHashOrRef::Owned`]. Callers must
-/// `settle` (or otherwise rewrite the target to a hash) before
-/// rkyv-encoding the cap.
+/// [`CapHashOrRef::Owned`]. Callers must `settle` (or otherwise rewrite
+/// the target to a hash) before rkyv-encoding the cap.
 #[derive(Debug)]
 pub struct CapHasRefError;
 
 impl core::fmt::Display for CapHasRefError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(
-            "cap holds a runtime-only CapHashOrRef target (Ref/Owned); settle before rkyv encode",
+            "cap holds a runtime-only CapHashOrRef::Owned target; settle before rkyv encode",
         )
     }
 }
 
 impl core::error::Error for CapHasRefError {}
 
-impl rkyv::Archive for CapHashOrRef {
+impl<O: WireOwned> rkyv::Archive for CapHashOrRef<O> {
     type Archived = <CapHash as rkyv::Archive>::Archived;
     type Resolver = <CapHash as rkyv::Archive>::Resolver;
 
@@ -327,11 +347,8 @@ impl rkyv::Archive for CapHashOrRef {
         match self {
             CapHashOrRef::Hash(h) => <CapHash as rkyv::Archive>::resolve(h, resolver, out),
             // Unreachable if Serialize was called first (it errors on the
-            // runtime-only arms). Defensive panic for the "hand-built
+            // runtime-only arm). Defensive panic for the "hand-built
             // resolver" path.
-            CapHashOrRef::Ref(_) => {
-                panic!("CapHashOrRef::Ref in archive resolve; Serialize should have rejected first")
-            }
             CapHashOrRef::Owned(_) => {
                 panic!(
                     "CapHashOrRef::Owned in archive resolve; Serialize should have rejected first"
@@ -341,8 +358,9 @@ impl rkyv::Archive for CapHashOrRef {
     }
 }
 
-impl<S> rkyv::Serialize<S> for CapHashOrRef
+impl<O, S> rkyv::Serialize<S> for CapHashOrRef<O>
 where
+    O: WireOwned,
     S: rkyv::rancor::Fallible + ?Sized,
     <S as rkyv::rancor::Fallible>::Error: rkyv::rancor::Source,
     CapHash: rkyv::Serialize<S>,
@@ -353,9 +371,7 @@ where
     ) -> Result<Self::Resolver, <S as rkyv::rancor::Fallible>::Error> {
         match self {
             CapHashOrRef::Hash(h) => <CapHash as rkyv::Serialize<S>>::serialize(h, serializer),
-            CapHashOrRef::Ref(_) | CapHashOrRef::Owned(_) => {
-                Err(rkyv::rancor::Source::new(CapHasRefError))
-            }
+            CapHashOrRef::Owned(_) => Err(rkyv::rancor::Source::new(CapHasRefError)),
         }
     }
 }
@@ -364,14 +380,14 @@ where
 // `<CapHash as Archive>::Archived` to avoid a coherence-checker false
 // conflict with rkyv's blanket `Deserialize for With<F, W>` impl
 // (associated-type opacity).
-impl<D> rkyv::Deserialize<CapHashOrRef, D> for [u8; 32]
+impl<O, D> rkyv::Deserialize<CapHashOrRef<O>, D> for [u8; 32]
 where
     D: rkyv::rancor::Fallible + ?Sized,
 {
     fn deserialize(
         &self,
         _deserializer: &mut D,
-    ) -> Result<CapHashOrRef, <D as rkyv::rancor::Fallible>::Error> {
+    ) -> Result<CapHashOrRef<O>, <D as rkyv::rancor::Fallible>::Error> {
         Ok(CapHashOrRef::Hash(*self))
     }
 }
@@ -497,7 +513,6 @@ impl<S: BuildHasher> CacheDirectory<S> {
     pub fn get(&self, key: CapHashOrRef) -> Option<Arc<Cap>> {
         match key {
             CapHashOrRef::Hash(h) => self.get_blob(&h),
-            CapHashOrRef::Ref(r) => self.get_instance(&r),
             // `Owned` lives inline on the kernel frame, not in the
             // directory; the holder dereferences the `Box` directly.
             CapHashOrRef::Owned(_) => None,
@@ -612,26 +627,22 @@ impl<S: BuildHasher> CacheDirectory<S> {
         }
     }
 
-    /// Settle a `Ref`-keyed working entry: walk nested `Ref` targets,
-    /// resolve each to a `Hash`, then hash the surviving cap. Non-
-    /// Instance entries (Data / CNode) graduate from `instances` to
-    /// `blobs` under the computed hash; Instance entries stay in
-    /// instances (they're the live mutable state) and the returned
-    /// hash is a snapshot identifier.
+    /// Settle an inline `Owned` cap to a content hash: recursively rewrite
+    /// its nested `Owned` slot targets to `Hash`, flush a dirty `Data` cap's
+    /// CoW overlay, content-address it into `blobs`, and return the hash.
     ///
     /// For `Hash`-keyed input, returns it unchanged.
     pub fn settle(&self, key: CapHashOrRef) -> Result<CapHash, CacheError> {
         match key {
             CapHashOrRef::Hash(h) => Ok(h),
-            CapHashOrRef::Ref(r) => self.settle_ref(&r),
             CapHashOrRef::Owned(b) => self.settle_owned(*b),
         }
     }
 
     /// Settle an inline `Owned` cap: recursively rewrite its nested slot
-    /// targets (`Ref`/`Owned`) to `Hash`, flush a `Data` cap's CoW
-    /// overlay so it is hashable, then content-address it into `blobs`
-    /// and return the hash.
+    /// targets (`Owned`) to `Hash`, flush a `Data` cap's CoW overlay so it
+    /// is hashable, then content-address it into `blobs` and return the
+    /// hash.
     ///
     /// The recompiler never calls this — it *moves* `Owned` caps and
     /// drops them at frame pop. It exists for the host-side deferred
@@ -652,8 +663,8 @@ impl<S: BuildHasher> CacheDirectory<S> {
     }
 
     /// Rewrite every direct slot target of `cap` (CNode slots, Instance
-    /// `root_cnode`) from a runtime-only `Ref`/`Owned` to its settled
-    /// `Hash`, recursing into nested `Owned` caps.
+    /// `root_cnode`) from a runtime-only `Owned` to its settled `Hash`,
+    /// recursing into nested `Owned` caps.
     fn settle_targets_in(&self, cap: &mut Cap) -> Result<(), CacheError> {
         match cap {
             Cap::CNode(cn) => {
@@ -669,16 +680,11 @@ impl<S: BuildHasher> CacheDirectory<S> {
         Ok(())
     }
 
-    /// Settle one slot target in place: `Hash` unchanged, `Ref` via
-    /// [`Self::settle_ref`], `Owned` recursively via [`Self::settle_owned`].
+    /// Settle one slot target in place: `Hash` unchanged, `Owned`
+    /// recursively via [`Self::settle_owned`].
     fn settle_target(&self, t: &mut CapHashOrRef) -> Result<(), CacheError> {
         match t {
             CapHashOrRef::Hash(_) => Ok(()),
-            CapHashOrRef::Ref(r) => {
-                let h = self.settle_ref(r)?;
-                *t = CapHashOrRef::Hash(h);
-                Ok(())
-            }
             CapHashOrRef::Owned(_) => {
                 let CapHashOrRef::Owned(b) = core::mem::replace(t, CapHashOrRef::Hash([0u8; 32]))
                 else {
@@ -689,120 +695,5 @@ impl<S: BuildHasher> CacheDirectory<S> {
                 Ok(())
             }
         }
-    }
-
-    fn settle_ref(&self, capref: &CapRef) -> Result<CapHash, CacheError> {
-        // Step 1: settle any nested Refs the cap holds, rewriting
-        // them to Hash in place.
-        loop {
-            // Pull the cap out as an owned Arc<Cap> so we can read it
-            // outside the lock.
-            let arc = self
-                .get_instance(capref)
-                .ok_or_else(|| CacheError::InstanceMissing(capref.id()))?;
-            let nested = collect_ref_targets(&arc);
-            if nested.is_empty() {
-                break;
-            }
-            // Settle each nested ref. settle_ref recurses cleanly
-            // because nested refs are strictly downstream (data-flow
-            // principle).
-            let mut resolved: Vec<(CapRef, CapHash)> = Vec::with_capacity(nested.len());
-            for n in &nested {
-                let h = self.settle_ref(n)?;
-                resolved.push((n.clone(), h));
-            }
-            // Mutate the cap to rewrite the nested Refs to Hash. Need
-            // exclusive access to the Arc<Cap>; use Arc::make_mut on a
-            // fresh clone so the change is visible to other holders of
-            // the same id by replacing the directory's stored Arc.
-            let mut new_arc = arc.clone();
-            rewrite_ref_targets(Arc::make_mut(&mut new_arc), &resolved);
-            self.set_instance(capref, new_arc)?;
-        }
-
-        // Step 2: hash the (now Ref-free) cap.
-        let arc = self
-            .get_instance(capref)
-            .ok_or_else(|| CacheError::InstanceMissing(capref.id()))?;
-        let hash = arc.cap_hash();
-
-        // Step 3: graduate non-Instance entries to blobs. Instance
-        // entries stay in instances (the snapshot hash is returned but
-        // the live cell isn't removed — the kernel may keep mutating).
-        let is_instance = matches!(&*arc, Cap::Instance(_));
-        if !is_instance {
-            // Insert into blobs if not already present; idempotent.
-            self.put_cap_with_hash(hash, &arc)?;
-            // Remove the instances entry. The local `capref`
-            // parameter still has one strong ref to it (the caller's);
-            // removing the directory's stored self-ref drops the
-            // entry's `Arc<Cap>` (one of two strong refs — the other
-            // is the local `arc` we're still holding). The cap data
-            // stays alive in `blobs` via the put_cap_with_hash above.
-            let _removed = {
-                let mut g = self.inner.lock();
-                g.instances.remove(&capref.id())
-            };
-            drop(_removed);
-            drop(arc);
-        }
-        Ok(hash)
-    }
-}
-
-// --- Helpers (free functions) ---
-
-/// Collect the directly-referenced `CapRef`s held by `cap`. Used by
-/// `settle` to know which sub-refs to resolve before hashing.
-fn collect_ref_targets(cap: &Cap) -> Vec<CapRef> {
-    let mut out: Vec<CapRef> = Vec::new();
-    match cap {
-        Cap::CNode(cn) => {
-            for (_, mo) in cn.slots.iter() {
-                if let ssz::MissingOr::Materialized(CapHashOrRef::Ref(r)) = mo {
-                    out.push(r.clone());
-                }
-            }
-        }
-        Cap::Instance(inst) => {
-            if let CapHashOrRef::Ref(r) = &inst.root_cnode {
-                out.push(r.clone());
-            }
-        }
-        Cap::Data(_) | Cap::Image(_) | Cap::Type(_) => {}
-    }
-    out
-}
-
-/// Rewrite `cap`'s direct `CapHashOrRef::Ref(r)` targets to
-/// `CapHashOrRef::Hash(h)` according to the `(r, h)` mapping in
-/// `resolved`. Matches CapRef by id.
-fn rewrite_ref_targets(cap: &mut Cap, resolved: &[(CapRef, CapHash)]) {
-    let lookup = |r: &CapRef| -> Option<CapHash> {
-        resolved
-            .iter()
-            .find(|(k, _)| k.id() == r.id())
-            .map(|(_, h)| *h)
-    };
-    match cap {
-        Cap::CNode(cn) => {
-            for (_, mo) in cn.slots.iter_mut() {
-                if let ssz::MissingOr::Materialized(t) = mo
-                    && let CapHashOrRef::Ref(r) = t
-                    && let Some(h) = lookup(r)
-                {
-                    *t = CapHashOrRef::Hash(h);
-                }
-            }
-        }
-        Cap::Instance(inst) => {
-            if let CapHashOrRef::Ref(r) = &inst.root_cnode
-                && let Some(h) = lookup(r)
-            {
-                inst.root_cnode = CapHashOrRef::Hash(h);
-            }
-        }
-        Cap::Data(_) | Cap::Image(_) | Cap::Type(_) => {}
     }
 }

--- a/rust/javm-cap/src/cap/cnode.rs
+++ b/rust/javm-cap/src/cap/cnode.rs
@@ -21,9 +21,25 @@
 //! native contracts. A `Missing(h)` placeholder substitutes losslessly for
 //! the materialized value whose `hash_tree_root` equals `h`, the
 //! load-bearing property for cold-loading a CNode by hash.
+//!
+//! ## The `O` (owned-payload) parameter
+//!
+//! `CNodeCap<O>` is generic over the inline `CapHashOrRef::Owned(O)` payload.
+//! The default `O = Box<Cap>` is the wire/content-addressed form: the cnode
+//! inside a serialised [`Cap`] (`Cap::CNode`, `InstanceCap.root_cnode`) is
+//! always `CNodeCap<Box<Cap>>`, so the wire type is unaffected by this
+//! parameter. An engine that needs to attach engine-private state to a
+//! resident instance instantiates the *running frame's* cnode with a richer
+//! payload (e.g. `Box<CachedCap>` in the recompiler) — that payload is
+//! deliberately **not** wire-serialisable, so a cache-carrying cnode cannot
+//! cross the host/guest boundary or be content-hashed (a compile error, not
+//! a runtime panic). See [`CapHashOrRef`] for the gate.
+
+use alloc::boxed::Box;
 
 use ssz::{MissingOr, RadixMap};
 
+use super::Cap;
 use crate::cache::CapHashOrRef;
 use crate::error::CapError;
 use crate::hash::{Hash, Hasher};
@@ -32,26 +48,68 @@ use crate::slot::Key;
 /// Physical radix-key width: a 32-byte digest of the logical key.
 pub const CNODE_KEY_BYTES: usize = 32;
 
-/// Radix map backing a CNode: `Hasher(k) -> CapHashOrRef`.
-pub type CNodeSlots = RadixMap<CapHashOrRef, CNODE_KEY_BYTES>;
+/// Radix map backing a CNode: `Hasher(k) -> CapHashOrRef<O>`.
+pub type CNodeSlots<O = Box<Cap>> = RadixMap<CapHashOrRef<O>, CNODE_KEY_BYTES>;
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    ssz_derive::HashTreeRoot,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct CNodeCap {
-    /// Sparse hash-keyed slot table: `Hasher(k) -> CapHashOrRef`. Absent
+/// CNode cap: a sparse, hash-keyed `key -> CapHashOrRef<O>` map.
+///
+/// rkyv (the wire form) is derived; the derive adds a `slots: Archive` field
+/// bound, which for the wire payload resolves via `CapHashOrRef<Box<Cap>>:
+/// Archive` (gated on `Box<Cap>: WireOwned`, a leaf marker — no recursion into
+/// `Cap: Archive`). A non-wire payload such as `Box<CachedCap>` does not
+/// satisfy the field bound, so a `CNodeCap<Box<CachedCap>>` has no rkyv impl
+/// and cannot cross the wire — non-serialisable by construction. `Clone` /
+/// `Debug` / `Default` / `HashTreeRoot` are hand-rolled with payload-specific
+/// bounds (a blanket derive would over-constrain `Box<Cap>`, which is not
+/// `Default`, and `ssz_derive::HashTreeRoot` adds no bound at all, so it would
+/// not compile for a generic field).
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct CNodeCap<O = Box<Cap>> {
+    /// Sparse hash-keyed slot table: `Hasher(k) -> CapHashOrRef<O>`. Absent
     /// keys contribute the radix `EMPTY` summary; a `Missing(h)` entry
     /// substitutes losslessly for the value rooting at `h`.
-    pub slots: CNodeSlots,
+    pub slots: CNodeSlots<O>,
 }
 
-impl CNodeCap {
+impl<O> Default for CNodeCap<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Clone> Clone for CNodeCap<O> {
+    fn clone(&self) -> Self {
+        Self {
+            slots: self.slots.clone(),
+        }
+    }
+}
+
+impl<O: core::fmt::Debug> core::fmt::Debug for CNodeCap<O> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CNodeCap")
+            .field("slots", &self.slots)
+            .finish()
+    }
+}
+
+// Hand-rolled to match the `ssz_derive::HashTreeRoot` output for a single
+// named field (`merkleize` over the one field root), but with a
+// payload-specific bound: only an archivable `O` (the wire payload) admits a
+// content hash, so a cache-carrying cnode is non-hashable at compile time.
+impl<O> ssz::HashTreeRoot for CNodeCap<O>
+where
+    CNodeSlots<O>: ssz::HashTreeRoot,
+{
+    fn hash_tree_root<D: ssz::digest::Digest<OutputSize = ssz::digest::typenum::U32>>(
+        &self,
+    ) -> [u8; 32] {
+        let roots: [[u8; 32]; 1] = [self.slots.hash_tree_root::<D>()];
+        ssz::merkleize::<D>(&roots, 1)
+    }
+}
+
+impl<O> CNodeCap<O> {
     /// Construct an empty CNode (no slots). A CNode grows on demand and is
     /// bounded by storage quota, not a fixed slot count.
     pub fn new() -> Self {
@@ -68,23 +126,12 @@ impl CNodeCap {
 
     // ---- logical byte-string key API ----
 
-    /// Look up the cap bound to logical key `k`. Returns `None` for an
-    /// absent key or a `Missing(_)` placeholder (callers needing to tell
-    /// "absent" from "missing placeholder" apart inspect `self.slots`).
-    pub fn get_key(&self, k: &[u8]) -> Option<CapHashOrRef> {
-        match self.slots.get(&Self::key_of(k))? {
-            MissingOr::Materialized(t) => Some(t.clone()),
-            MissingOr::Missing(_) => None,
-        }
-    }
-
     /// Borrow the cap bound to logical key `k` **without cloning** — the
     /// read-only peek used to inspect an `Owned` cap (e.g. read a callee's
     /// `image_hash` to price a CALL) before deciding whether to
-    /// [`take_key`](Self::take_key) it. Same placeholder semantics as
-    /// [`get_key`](Self::get_key): `None` for an absent key or a `Missing(_)`
-    /// placeholder.
-    pub fn peek_key(&self, k: &[u8]) -> Option<&CapHashOrRef> {
+    /// [`take_key`](Self::take_key) it. `None` for an absent key or a
+    /// `Missing(_)` placeholder.
+    pub fn peek_key(&self, k: &[u8]) -> Option<&CapHashOrRef<O>> {
         match self.slots.get(&Self::key_of(k))? {
             MissingOr::Materialized(t) => Some(t),
             MissingOr::Missing(_) => None,
@@ -93,9 +140,13 @@ impl CNodeCap {
 
     /// Bind logical key `k` to `target`, or clear the binding if `target`
     /// is `None`. Returns the prior materialized target, if any —
-    /// **moved out**, not cloned, so a `CapHashOrRef::Owned(Box<Cap>)`
-    /// transfers with no deep copy (the zero-copy cnode move).
-    pub fn set_key(&mut self, k: &[u8], target: Option<CapHashOrRef>) -> Option<CapHashOrRef> {
+    /// **moved out**, not cloned, so a `CapHashOrRef::Owned(O)` transfers
+    /// with no deep copy (the zero-copy cnode move).
+    pub fn set_key(
+        &mut self,
+        k: &[u8],
+        target: Option<CapHashOrRef<O>>,
+    ) -> Option<CapHashOrRef<O>> {
         let key = Self::key_of(k);
         // `insert` / `remove` hand back the displaced entry by value — no
         // clone of the prior `CapHashOrRef`.
@@ -113,17 +164,11 @@ impl CNodeCap {
     /// prior materialized target (or `None`), **moved out** — the
     /// zero-copy half of an `Owned` cnode-to-cnode (or frame-to-frame)
     /// move.
-    pub fn take_key(&mut self, k: &[u8]) -> Option<CapHashOrRef> {
+    pub fn take_key(&mut self, k: &[u8]) -> Option<CapHashOrRef<O>> {
         self.set_key(k, None)
     }
 
     // ---- Key API ----
-
-    /// Look up the slot named by `key`. See [`CNodeCap::get_key`] for the
-    /// placeholder semantics.
-    pub fn get(&self, key: &Key) -> Option<CapHashOrRef> {
-        self.get_key(key.as_slice())
-    }
 
     /// Bind `key` to `target`, or clear it if `None`. Returns the prior
     /// materialized target, if any. The radix map is unbounded, so this is
@@ -132,14 +177,32 @@ impl CNodeCap {
     pub fn set(
         &mut self,
         key: &Key,
-        target: Option<CapHashOrRef>,
-    ) -> Result<Option<CapHashOrRef>, CapError> {
+        target: Option<CapHashOrRef<O>>,
+    ) -> Result<Option<CapHashOrRef<O>>, CapError> {
         Ok(self.set_key(key.as_slice(), target))
     }
 
     /// Take the binding at `key`, leaving it empty. Returns the prior
     /// materialized target (or `None`).
-    pub fn take(&mut self, key: &Key) -> Result<Option<CapHashOrRef>, CapError> {
+    pub fn take(&mut self, key: &Key) -> Result<Option<CapHashOrRef<O>>, CapError> {
         self.set(key, None)
+    }
+}
+
+impl<O: Clone> CNodeCap<O> {
+    /// Look up the cap bound to logical key `k`. Returns `None` for an
+    /// absent key or a `Missing(_)` placeholder (callers needing to tell
+    /// "absent" from "missing placeholder" apart inspect `self.slots`).
+    pub fn get_key(&self, k: &[u8]) -> Option<CapHashOrRef<O>> {
+        match self.slots.get(&Self::key_of(k))? {
+            MissingOr::Materialized(t) => Some(t.clone()),
+            MissingOr::Missing(_) => None,
+        }
+    }
+
+    /// Look up the slot named by `key`. See [`CNodeCap::get_key`] for the
+    /// placeholder semantics.
+    pub fn get(&self, key: &Key) -> Option<CapHashOrRef<O>> {
+        self.get_key(key.as_slice())
     }
 }

--- a/rust/javm-cap/src/cap/cnode.rs
+++ b/rust/javm-cap/src/cap/cnode.rs
@@ -78,6 +78,19 @@ impl CNodeCap {
         }
     }
 
+    /// Borrow the cap bound to logical key `k` **without cloning** — the
+    /// read-only peek used to inspect an `Owned` cap (e.g. read a callee's
+    /// `image_hash` to price a CALL) before deciding whether to
+    /// [`take_key`](Self::take_key) it. Same placeholder semantics as
+    /// [`get_key`](Self::get_key): `None` for an absent key or a `Missing(_)`
+    /// placeholder.
+    pub fn peek_key(&self, k: &[u8]) -> Option<&CapHashOrRef> {
+        match self.slots.get(&Self::key_of(k))? {
+            MissingOr::Materialized(t) => Some(t),
+            MissingOr::Missing(_) => None,
+        }
+    }
+
     /// Bind logical key `k` to `target`, or clear the binding if `target`
     /// is `None`. Returns the prior materialized target, if any —
     /// **moved out**, not cloned, so a `CapHashOrRef::Owned(Box<Cap>)`

--- a/rust/javm-cap/src/cap/instance.rs
+++ b/rust/javm-cap/src/cap/instance.rs
@@ -2,8 +2,9 @@
 //!
 //! Holds the mutable working state of a running Cap::Instance:
 //! image reference (by hash, since Images are immutable), root
-//! cnode reference (by hash when clean / by ref while mutating),
-//! the read-write memory image, register file, PC, gas counter.
+//! cnode reference (by hash when clean / inline `Owned` while the kernel
+//! frame mutates it), the read-write memory image, register file, PC,
+//! gas counter.
 
 use crate::cache::CapHashOrRef;
 
@@ -21,8 +22,8 @@ pub struct InstanceCap {
     /// addressed (Images are immutable).
     pub image_hash: CapHash,
     /// Reference to the root cnode. `Hash` when clean / not yet
-    /// promoted for mutation; `Ref` while the running Instance is
-    /// mutating it via CoW.
+    /// promoted for mutation; an inline `Owned` cnode cap while the
+    /// running kernel frame is mutating it.
     pub root_cnode: CapHashOrRef,
     /// The Instance's read-write memory image: a dense `DataCap` covering the
     /// data extent `[DATA_BASE, DATA_BASE + mem.size)`. Holds the initial

--- a/rust/javm-cap/src/cap/mod.rs
+++ b/rust/javm-cap/src/cap/mod.rs
@@ -14,14 +14,13 @@
 //! `rkyv::to_bytes(&cap)?` directly. The slot-target
 //! [`super::cache::CapHashOrRef`] has a hand-rolled rkyv impl whose
 //! `Serialize` returns an error ([`super::cache::CapHasRefError`]) if
-//! the cap graph still contains a `Ref`. The
-//! archived form for both `Hash` and `Ref` arms is `[u8; 32]` (= the
-//! `CapHash` archived form), so settled cap graphs serialise to the
-//! same bytes regardless of provenance, and `Ref`-bearing graphs
-//! surface as a typed `Result::Err` at encode time (no panic).
+//! the cap graph still contains an inline `Owned` cap. The archived form
+//! of the `Hash` arm is `[u8; 32]` (= the `CapHash` archived form), so a
+//! settled cap graph serialises to a stable byte form and an
+//! `Owned`-bearing graph surfaces as a typed `Result::Err` at encode
+//! time (no panic).
 //!
-//! See [`super::cache::CapRef`] for the cache-handle lifecycle and
-//! `Cap`-cloning semantics.
+//! See [`super::cache::CapRef`] for the (dormant) cache-handle lifecycle.
 
 pub mod cnode;
 pub mod data;
@@ -59,12 +58,12 @@ pub const MAX_ENDPOINTS: usize = 64;
 ///
 /// **rkyv note**: the `Archive`/`Serialize`/`Deserialize` derives
 /// provide the I/O-boundary wire form. Serialization errors out (no
-/// panic) if any slot target is a `CapHashOrRef::Ref` — see the
-/// module docs.
+/// panic) if any slot target is an inline `CapHashOrRef::Owned` cap —
+/// see the module docs.
 ///
-/// **Clone**: the derived `Clone` recursively clones field-by-field.
-/// `Ref(CapRef)` arms `Arc::clone` the handle, deep-bumping every
-/// nested instance reference. Drop is symmetric.
+/// **Clone**: the derived `Clone` recursively clones field-by-field. An
+/// inline `Owned(Box<Cap>)` slot deep-clones the boxed cap. Drop is
+/// symmetric.
 #[derive(
     Clone, Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
@@ -113,14 +112,14 @@ impl Cap {
     ///   substitutes for a missing page without changing the
     ///   enclosing cap's hash.
     /// - `CapHashOrRef::Hash(h)` hashes to `h` exactly — a freshly-
-    ///   published cap blob substitutes for a `CapRef` reference
+    ///   published cap blob substitutes for a content reference
     ///   without changing the enclosing cap's hash.
     ///
-    /// **Unresolved refs panic**: hashing a `Cap` whose graph still
-    /// contains `CapHashOrRef::Ref(_)` targets will panic in the SSZ
-    /// path. Callers must `settle` the cap graph first. (The rkyv
-    /// serialise path is fallible for the same case — see the module
-    /// docs.)
+    /// **In-flight `Owned` caps panic**: hashing a `Cap` whose graph
+    /// still contains an inline `CapHashOrRef::Owned(_)` target will
+    /// panic in the SSZ path. Callers must `settle` the cap graph first.
+    /// (The rkyv serialise path is fallible for the same case — see the
+    /// module docs.)
     ///
     /// **Image hash distinction**: `Cap::Image(_).cap_hash()` and
     /// `crate::image::image_content_hash` hash different types — the

--- a/rust/javm-cap/tests/cap_hash.rs
+++ b/rust/javm-cap/tests/cap_hash.rs
@@ -1,6 +1,6 @@
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, ImageCap, InstanceCap, Key, NUM_REGS,
-    PAGE_SIZE, PageBytes, PageRef, PageSlab, PageSlot, TypeCap,
+    CNodeCap, Cap, CapHashOrRef, DataCap, ImageCap, InstanceCap, Key, NUM_REGS, PAGE_SIZE,
+    PageBytes, PageRef, PageSlab, PageSlot, TypeCap,
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -68,20 +68,9 @@ fn cnode_empty_vs_one_populated_differ() {
 }
 
 #[test]
-fn cnode_with_ref_target_panics() {
-    let cache = CacheDirectory::new();
-    let r = cache.put_instance(Cap::CNode(CNodeCap::new()));
-    let mut cn: CNodeCap = CNodeCap::new();
-    cn.set(&Key::from(0u8), Some(CapHashOrRef::Ref(r))).unwrap();
-    let cap: Cap = Cap::CNode(cn);
-    let result = std::panic::catch_unwind(|| cap.cap_hash());
-    assert!(result.is_err());
-}
-
-#[test]
 fn cnode_with_owned_target_panics() {
-    // Like an unsettled `Ref`, an in-flight `Owned` slot has no wire/hash
-    // form — hashing a graph that still holds one panics (callers settle first).
+    // An in-flight `Owned` slot has no wire/hash form — hashing a graph that
+    // still holds one panics (callers settle first).
     let mut cn: CNodeCap = CNodeCap::new();
     cn.set(
         &Key::from(0u8),

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -151,19 +151,23 @@ fn cnode_lookup_after_set() {
     cnode
         .set(&Key::from(7u8), Some(CapHashOrRef::Hash([0x11; 32])))
         .unwrap();
-    // Mint a real CapRef via the cache so the bookkeeping test
-    // doesn't depend on the crate-internal `CapRef::new`.
-    let cache = CacheDirectory::new();
-    let r = cache.put_instance(Cap::CNode(CNodeCap::new()));
     cnode
-        .set(&Key::from(42u8), Some(CapHashOrRef::Ref(r.clone())))
+        .set(
+            &Key::from(42u8),
+            Some(CapHashOrRef::Owned(Box::new(Cap::data_inline(b"x")))),
+        )
         .unwrap();
 
     assert_eq!(
         cnode.get(&Key::from(7u8)),
         Some(CapHashOrRef::Hash([0x11; 32]))
     );
-    assert_eq!(cnode.get(&Key::from(42u8)), Some(CapHashOrRef::Ref(r)));
+    // `Owned` clones out by value (a fresh Box), so `get` reports presence;
+    // pointer identity makes value equality unsuitable here.
+    assert!(matches!(
+        cnode.get(&Key::from(42u8)),
+        Some(CapHashOrRef::Owned(_))
+    ));
     assert_eq!(cnode.get(&Key::from(100u8)), None);
 }
 
@@ -309,17 +313,16 @@ fn cache_round_trips_full_publish_chain() {
         .expect("put instance");
     assert!(cache.contains_blob(&inst_h));
 
-    // 5. Promote the cnode to a mutable instance via Arc::clone +
-    //    settle. With Arc storage the blob entry stays put; the
-    //    instances tier shares the same Arc until mutation.
-    let new_ref = cache
-        .promote_blob_to_instance(&cnode_h)
-        .expect("promote cnode");
+    // 5. Settle an inline `Owned` cnode (the deferred-persist path): a
+    //    freshly-built CNode referencing the same Data blob by hash settles
+    //    to the same content hash as the published cnode blob.
+    let mut owned_cn: CNodeCap = CNodeCap::new();
+    owned_cn
+        .set(&Key::from(0u8), Some(CapHashOrRef::Hash(data_h)))
+        .unwrap();
     let settled_h = cache
-        .settle(CapHashOrRef::Ref(new_ref))
-        .expect("settle resolves the ref");
-    // Settling an unchanged cnode-clone produces the same content
-    // hash as the original blob.
+        .settle(CapHashOrRef::Owned(Box::new(Cap::CNode(owned_cn))))
+        .expect("settle owned cnode");
     assert_eq!(settled_h, cnode_h);
 }
 
@@ -338,37 +341,6 @@ fn capref_sweep_reclaims_orphaned_instance() {
 
     // Drop the external holder; sweep reclaims.
     drop(r);
-    cache.sweep_instances();
-    assert_eq!(cache.instance_count(), 0);
-}
-
-#[test]
-fn capref_sweep_cascades_through_cnode_ref_chain() {
-    let cache = CacheDirectory::new();
-
-    // Leaf instance with no nested Refs.
-    let leaf = cache.put_instance(Cap::CNode(CNodeCap::new()));
-
-    // Parent cnode holding the leaf via Ref. Cap::Clone bumps the
-    // leaf's strong count when we clone the CNodeCap into the cap.
-    let mut parent_cn: CNodeCap = CNodeCap::new();
-    parent_cn
-        .set(&Key::from(0u8), Some(CapHashOrRef::Ref(leaf.clone())))
-        .unwrap();
-    let parent = cache.put_instance(Cap::CNode(parent_cn));
-
-    // Counts: leaf has 3 strong refs (our local + parent's cnode slot
-    // + directory's self-ref); parent has 2 (our local + directory).
-    assert_eq!(leaf.strong_count(), 3);
-    assert_eq!(parent.strong_count(), 2);
-
-    drop(leaf);
-    drop(parent);
-    // Leaf still alive in parent's cnode; parent still alive in
-    // directory's self-ref. Sweep reclaims parent first (its
-    // self-ref count is 1 after we dropped our local). Reclaiming
-    // parent drops its Cap which drops its `Ref(leaf)` slot which
-    // drops leaf's last external clone — next pass reclaims leaf.
     cache.sweep_instances();
     assert_eq!(cache.instance_count(), 0);
 }

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -145,35 +145,9 @@ fn cnode_with_populated_slot_roundtrips() {
 }
 
 #[test]
-fn ref_in_cap_errors_on_encode() {
-    use javm_cap::CacheDirectory;
-    let cache = CacheDirectory::new();
-    let blob = Cap::Type(TypeCap {
-        image_hash_chain: [0x11; 32],
-    });
-    let h = cache.put_cap(&blob).expect("put_cap");
-    let capref = cache.promote_blob_to_instance(&h).expect("promote");
-    let mut cn = CNodeCap::new();
-    cn.set(&Key::from(0u8), Some(CapHashOrRef::Ref(capref)))
-        .expect("set ref");
-    let cap = Cap::CNode(cn);
-    let err = rkyv::to_bytes::<rkyv::rancor::Error>(&cap).expect_err("must reject Ref");
-    // Release builds strip rancor's source-chain detail (it requires
-    // both debug assertions and rancor's `alloc` feature), so we only
-    // assert on the message contents when debug assertions are on.
-    if cfg!(debug_assertions) {
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("CapHashOrRef::Ref") || msg.contains("CapRef") || msg.contains("settle"),
-            "expected CapHasRefError in chain, got: {msg}"
-        );
-    }
-}
-
-#[test]
 fn owned_in_cap_errors_on_encode() {
-    // An in-flight `Owned(Box<Cap>)` slot is runtime-only — like `Ref`, it
-    // has no wire form and rkyv encode must surface a typed error (no panic).
+    // An in-flight `Owned(Box<Cap>)` slot is runtime-only — it has no wire
+    // form and rkyv encode must surface a typed error (no panic).
     let mut cn = CNodeCap::new();
     cn.set(
         &Key::from(0u8),

--- a/rust/javm-exec/src/gas_const.rs
+++ b/rust/javm-exec/src/gas_const.rs
@@ -6,23 +6,36 @@
 //! See `~/docs/spec-staging/gas-cost.md`.
 //!
 //! NOTE: the category-#3 constants ([`PAGE_IN_COST`], [`COW_COST`],
-//! [`CALL_FRAME_COST`], [`HOST_CALL_FLOOR`], [`MGMT_OP_COST`]) are
-//! **placeholders**. TODO(gas-calibration): calibrate against the
-//! kernel page-fault / call-setup handler; these values are subject to
-//! change. [`MAX_PAGES_PER_ACCESS`] is an invariant, not a tunable.
+//! [`COMPILE_COST_PER_PAGE`], [`CALL_FRAME_COST`], [`HOST_CALL_FLOOR`],
+//! [`MGMT_OP_COST`]) are **placeholders**. TODO(gas-calibration): calibrate
+//! against the kernel page-fault / call-setup handler; these values are
+//! subject to change. [`MAX_PAGES_PER_ACCESS`] is an invariant, not a tunable.
 
 /// Base load/store latency at the smallest footprint tier (×1).
 /// Same value as [`crate::gas_cost::DEFAULT_MEM_CYCLES`]; the #2 tier
 /// scales it (see [`mem_cycles_for`]).
 pub const MEM_CYCLES_BASE: u8 = 25;
 
-/// #3 page-in (first read of a page): fault + map content-addressed RO.
+/// #3 read-only page-in, charged **per declared 2 MiB unit at the CALL**
+/// (no longer per touched unit at a fault): the cost of admitting one
+/// read-only unit — code or a pinned DataCap intersected with a 2 MiB
+/// cluster — into the working set. Folded into [`call_frame_cost`]; a
+/// read at a fault charges nothing.
 /// TODO(gas-calibration): placeholder, subject to change.
 pub const PAGE_IN_COST: u64 = 64;
 
-/// #3 copy-on-write (first write of a page): allocate + copy + map RW.
+/// #3 copy-on-write (first write of a page): allocate + copy + map RW. The
+/// **only** fault-driven #3 charge (read-only page-in moved to the CALL).
 /// TODO(gas-calibration): placeholder (~4 KiB copy), subject to change.
 pub const COW_COST: u64 = 256;
+
+/// #3 JIT-compile cost per 4 KiB of callee code, charged at the CALL that
+/// first materializes a callee Image (`O(code)`, bounded by `MAX_CODE_SIZE`).
+/// Folded into [`call_frame_cost`]. Charged in full on every CALL — the
+/// compiled image is memoized for *work*, never for gas — so a re-CALL into
+/// a warm Image pays the same and gas stays independent of the node-local
+/// compile cache. TODO(gas-calibration): placeholder, subject to change.
+pub const COMPILE_COST_PER_PAGE: u64 = 512;
 
 /// Max consensus 4 KiB pages a single scalar access can span.
 ///
@@ -33,11 +46,12 @@ pub const COW_COST: u64 = 256;
 /// MUST revisit this constant, or the worst-case-#3 reserve undercounts.
 pub const MAX_PAGES_PER_ACCESS: u64 = 2;
 
-/// #3 call-frame: materialize a sub-invocation (compile + code page-in +
-/// callee address-space setup + frame push), charged dynamically at a
-/// CALL (`ecall.jar` OP_HOST_CALL / OP_DERIVE_SPAWN).
-/// TODO(gas-calibration): placeholder; should ultimately scale with the
-/// callee's code size (bounded by MAX_CODE_SIZE). Subject to change.
+/// #3 call-frame **base**: the fixed per-CALL frame-setup cost (callee
+/// address-space page table + dispatch table + frame push), independent of
+/// code size. The code-size (compile) and read-only-page-in components are
+/// added on top by [`call_frame_cost`]. Charged at an in-kernel CALL
+/// (`ecall.jar` OP_HOST_CALL).
+/// TODO(gas-calibration): placeholder, subject to change.
 pub const CALL_FRAME_COST: u64 = 1024;
 
 /// Dynamic floor charged for a bubbled host call (`ecalli imm`).
@@ -49,16 +63,16 @@ pub const HOST_CALL_FLOOR: u64 = 100;
 /// TODO(gas-calibration): placeholder, subject to change.
 pub const MGMT_OP_COST: u64 = 100;
 
-/// Dynamic gas charged at an `ecall` block (its category-#3 call-frame /
-/// host cost), keyed only on the instruction type — which both engines
-/// know at the ecall, so they charge identically:
-/// `ecalli` (host call) → [`HOST_CALL_FLOOR`]; `ecall.jar` (MGMT / CALL)
-/// → [`MGMT_OP_COST`].
+/// Dynamic **floor** charged at every `ecall` block (the per-op base),
+/// keyed only on the instruction type — which both engines know at the
+/// ecall, so they charge identically: `ecalli` (host call) →
+/// [`HOST_CALL_FLOOR`]; `ecall.jar` (MGMT / CALL) → [`MGMT_OP_COST`].
 ///
-/// TODO(gas-calibration): placeholder granularity. A real CALL that
-/// compiles + pages-in a callee should pay [`CALL_FRAME_COST`] (op-aware
-/// costing); refine once the kernel dispatch distinguishes CALL from a
-/// plain MGMT op. Both engines must keep using this one function.
+/// An in-kernel CALL (`ecall.jar` OP_HOST_CALL) pays this floor **plus**
+/// [`call_frame_cost`] (compile + eager read-only page-in + frame setup),
+/// charged by the kernel CALL dispatch once it has resolved the callee
+/// Image. TODO(gas-calibration): placeholder. Both engines must keep using
+/// this one function for the floor.
 #[inline]
 pub fn ecall_dynamic_cost(is_ecalli: bool) -> u64 {
     if is_ecalli {
@@ -66,6 +80,33 @@ pub fn ecall_dynamic_cost(is_ecalli: bool) -> u64 {
     } else {
         MGMT_OP_COST
     }
+}
+
+/// Category-#3 cost of materializing a callee sub-invocation at an
+/// in-kernel CALL, charged to the **caller's** meter **in addition to** the
+/// [`ecall_dynamic_cost`] floor, and computed **statically from the callee
+/// Image** so both engines agree:
+///
+/// - **JIT compile** — `O(code)`: `ceil(code_len / PAGE_SIZE)` pages ×
+///   [`COMPILE_COST_PER_PAGE`].
+/// - **Eager read-only page-in** — one [`PAGE_IN_COST`] per declared 2 MiB
+///   read-only `unit` (the callee's code region plus its pinned mappings) —
+///   the cost that used to be charged lazily per touched unit at a fault.
+/// - **Frame-setup base** — [`CALL_FRAME_COST`].
+///
+/// Always charged in full: the compiled image and its page table are
+/// memoized as a node-local **performance** optimization, never a gas
+/// discount — so a re-CALL into a warm Image pays identically and gas stays
+/// independent of the cache (the architectural "eager compile + eager
+/// RO-map at CALL" model; the implementation may stay lazy/demand-paged
+/// without changing this charge). TODO(gas-calibration): placeholder
+/// coefficients.
+#[inline]
+pub fn call_frame_cost(code_len: u32, ro_units: u32) -> u64 {
+    let code_pages = (code_len as u64).div_ceil(crate::mem::PAGE_SIZE as u64);
+    CALL_FRAME_COST
+        .saturating_add(code_pages.saturating_mul(COMPILE_COST_PER_PAGE))
+        .saturating_add((ro_units as u64).saturating_mul(PAGE_IN_COST))
 }
 
 /// Category-#2 memory-access-latency footprint multiplier (×1..4),

--- a/rust/javm-exec/src/gas_cost.rs
+++ b/rust/javm-exec/src/gas_cost.rs
@@ -585,15 +585,18 @@ pub fn rv_kind_mem_class(kind: u8) -> MemClass {
 }
 
 /// Per-instruction worst-case category-#3 reserve contribution for a
-/// gas `kind`: `load → PAGE_IN×2`, `store → (PAGE_IN+COW)×2` (×2 =
-/// `MAX_PAGES_PER_ACCESS`), else 0. **Both engines** accumulate this at
-/// every real gas feed, so the block reserve matches bit-for-bit.
+/// gas `kind`: `store → COW×2` (×2 = `MAX_PAGES_PER_ACCESS`), else 0.
+/// **Loads no longer reserve** — read-only page-in is charged eagerly at
+/// the CALL (`gas_const::call_frame_cost`), not at a fault, so the only
+/// #3 a block can debit mid-flight is a store's copy-on-write. **Both
+/// engines** accumulate this at every real gas feed, so the block reserve
+/// matches bit-for-bit.
 #[inline]
 pub fn rv_kind_reserve(kind: u8) -> u32 {
-    use crate::gas_const::{COW_COST, MAX_PAGES_PER_ACCESS, PAGE_IN_COST};
+    use crate::gas_const::{COW_COST, MAX_PAGES_PER_ACCESS};
     let r = match rv_kind_mem_class(kind) {
-        MemClass::Load => PAGE_IN_COST.saturating_mul(MAX_PAGES_PER_ACCESS),
-        MemClass::Store => (PAGE_IN_COST + COW_COST).saturating_mul(MAX_PAGES_PER_ACCESS),
+        MemClass::Load => 0,
+        MemClass::Store => COW_COST.saturating_mul(MAX_PAGES_PER_ACCESS),
         MemClass::None => 0,
     };
     r.min(u32::MAX as u64) as u32

--- a/rust/javm-exec/src/mat.rs
+++ b/rust/javm-exec/src/mat.rs
@@ -8,31 +8,33 @@
 //!
 //! The charge rules key strictly on the per-page [`PageState`] and the
 //! static [`PageKind`] — never on the instruction — so a load-then-store
-//! to one page charges identically regardless of engine. `page_in` is
-//! charged at most once and `cow` at most once per page (per frame); the
-//! only re-page-in is a `MGMT_MOVE`/`MGMT_DROP` slot eviction, which is a
-//! block terminator.
+//! to one page charges identically regardless of engine. The **sole
+//! fault-driven #3 charge is copy-on-write** (the first write to a writable
+//! page), charged at most once per page (per frame). **Read-only page-in is
+//! not charged at the fault**: bringing a read-only region into the working
+//! set is accounted eagerly at the CALL that maps it
+//! ([`crate::gas_const::call_frame_cost`], computed statically from the
+//! callee Image), so a read — first or not — debits nothing here. A read
+//! only records the residency [`PageState`] transition. The one re-touch
+//! event is a `MGMT_MOVE`/`MGMT_DROP` slot eviction, a block terminator.
 //!
-//! ## Read-only units (per-cap × 2 MiB cluster)
+//! ## Read-only materialization is a mapping event, not a charge
 //!
 //! Read-only ([`PageKind::PinnedCapRo`]) regions — the program's code and
-//! pinned data caps — are materialized in **units**, where a unit is the
-//! intersection of one DataCap with one 2 MiB cluster ([`CLUSTER_SHIFT`],
-//! [`unit_base`]): the first read anywhere in a unit pays a single
-//! [`PAGE_IN_COST`] and brings the unit's RO pages into the working set
-//! (the recompiler fault-arounds them; the interpreter just accounts the
-//! unit). This frames `page_in` as the O(1) *map* event — one fault, one
-//! mapping, touching exactly one DataCap — so a large RO input materializes
-//! for one fault per 2 MiB instead of one per page, while the per-block
-//! reserve is unchanged (a single access spans ≤ 2 pages ⇒ ≤ 2 units ⇒ ≤ 2
-//! events: see [`crate::gas_const::MAX_PAGES_PER_ACCESS`]). Clamping the
-//! unit to one cap means two distinct caps sharing a 2 MiB cluster each pay
-//! their own page-in (no cross-cap dedup, no cross-cap under-charge).
-//! Copy-on-write (RW) regions stay 4 KiB-granular (a write copies one
-//! page). Both engines key on the same [`unit_base`], so they charge
-//! identically.
+//! pinned data caps — are still materialized in **units**, where a unit is
+//! the intersection of one DataCap with one 2 MiB cluster
+//! ([`CLUSTER_SHIFT`], [`unit_base`]): the recompiler fault-arounds a whole
+//! unit's RO pages on first touch so later reads in the unit hit no further
+//! faults, and both engines record the same unit set. That clustering is
+//! now purely a **mapping / fault-reduction** optimization with **zero
+//! gas** — the read-only page-in cost is charged once, eagerly, at the CALL
+//! (one [`crate::gas_const::PAGE_IN_COST`] per declared 2 MiB unit), not
+//! lazily per touched unit at the fault. Copy-on-write (RW) regions stay
+//! 4 KiB-granular: a write copies one page and charges [`COW_COST`]. Both
+//! engines key on the same [`unit_base`], so the (gas-free) unit set and the
+//! per-page CoW charge match bit-for-bit.
 
-use crate::gas_const::{COW_COST, PAGE_IN_COST};
+use crate::gas_const::COW_COST;
 use crate::mem::PAGE_SIZE;
 
 /// log2 of the read-only materialization cluster size. `21` → 2 MiB, the
@@ -49,20 +51,20 @@ pub fn cluster_of(addr: u32) -> u32 {
 
 /// Identity of the read-only materialization **unit** containing `addr`: the
 /// `cap ∩ cluster` region, named by its base address `max(cluster_lo,
-/// cap_start)`. Both engines charge one [`PAGE_IN_COST`] per distinct unit
-/// (and the recompiler fault-arounds exactly the unit's pages), so a unit
-/// pays page-in at most once on each engine.
+/// cap_start)`. The recompiler fault-arounds exactly the unit's pages on its
+/// first touch (mapping them all read-only in one go), so a unit is mapped
+/// at most once — a pure fault-reduction key. It carries **no gas**:
+/// read-only page-in is charged eagerly at the CALL
+/// ([`crate::gas_const::call_frame_cost`]), not per touched unit.
 ///
 /// A unit is keyed by **both** the cap (`cap_start`) and the 2 MiB cluster,
-/// so two distinct caps sharing a cluster are two units (each pays its own
-/// page-in) — a single fault/map event touches at most one DataCap. Because
-/// caps are disjoint, at most one cap per cluster starts at/below the cluster
-/// boundary (yielding `unit_base == cluster_lo`); every other cap in that
-/// cluster starts strictly later with a distinct `cap_start`, so this single
+/// so two distinct caps sharing a cluster are two units — a single
+/// fault/map event touches at most one DataCap. Because caps are disjoint,
+/// at most one cap per cluster starts at/below the cluster boundary
+/// (yielding `unit_base == cluster_lo`); every other cap in that cluster
+/// starts strictly later with a distinct `cap_start`, so this single
 /// `max(cluster_lo, cap_start)` value uniquely names one `(cap, cluster)`
-/// pair. For a cap spanning a cluster boundary the per-cluster split still
-/// holds (≤ 2 units per straddling access), so the worst-case #3 reserve
-/// ([`crate::gas_const::MAX_PAGES_PER_ACCESS`]) is unchanged.
+/// pair.
 #[inline]
 pub fn unit_base(addr: u32, cap_start: u32) -> u32 {
     let cluster_lo = cluster_of(addr) << CLUSTER_SHIFT;
@@ -148,9 +150,14 @@ pub struct HardFault;
 
 /// The category-#3 charge and resulting state for one page touch.
 ///
-/// - first read (`NotPresent`)  → `PAGE_IN_COST`,            → `PresentRo`
-/// - first write (`NotPresent`) → `PAGE_IN_COST + COW_COST`, → `PresentRw`
-/// - write after read (`PresentRo`) → `COW_COST`,            → `PresentRw`
+/// Read-only page-in is **free at the fault** — the cost of bringing a
+/// region into the working set is charged eagerly at the CALL that maps it
+/// ([`crate::gas_const::call_frame_cost`]). Copy-on-write (the first write
+/// to a writable page) is the only fault-driven #3 charge:
+///
+/// - first read (`NotPresent`)  → `0`,         → `PresentRo`
+/// - first write (`NotPresent`) → `COW_COST`,  → `PresentRw`
+/// - write after read (`PresentRo`) → `COW_COST`,  → `PresentRw`
 /// - already present for this access kind → `0`
 /// - write to `PinnedCapRo` → [`HardFault`]
 #[inline]
@@ -163,8 +170,13 @@ pub fn charge_for(
         return Err(HardFault);
     }
     Ok(match (state, is_write) {
-        (PageState::NotPresent, false) => (PAGE_IN_COST, PageState::PresentRo),
-        (PageState::NotPresent, true) => (PAGE_IN_COST + COW_COST, PageState::PresentRw),
+        // First read pages the page in read-only and records residency —
+        // but read-only page-in no longer charges at the fault (it is
+        // accounted eagerly at the CALL).
+        (PageState::NotPresent, false) => (0, PageState::PresentRo),
+        // First write copies-on-write: the sole remaining fault-driven #3
+        // charge (the page-in half is free, as above).
+        (PageState::NotPresent, true) => (COW_COST, PageState::PresentRw),
         (PageState::PresentRo, true) => (COW_COST, PageState::PresentRw),
         (PageState::PresentRo, false) => (0, PageState::PresentRo),
         (PageState::PresentRw, _) => (0, PageState::PresentRw),
@@ -228,16 +240,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_read_pays_page_in() {
+    fn first_read_is_free() {
+        // Read-only page-in is charged eagerly at the CALL, not here.
         let (c, s) = charge_for(PageState::NotPresent, PageKind::UnpinnedCapCow, false).unwrap();
-        assert_eq!(c, PAGE_IN_COST);
+        assert_eq!(c, 0);
         assert_eq!(s, PageState::PresentRo);
     }
 
     #[test]
-    fn first_write_pays_page_in_plus_cow() {
+    fn first_write_pays_cow_only() {
+        // The page-in half is free; only the CoW copy is charged.
         let (c, s) = charge_for(PageState::NotPresent, PageKind::EphemeralZero, true).unwrap();
-        assert_eq!(c, PAGE_IN_COST + COW_COST);
+        assert_eq!(c, COW_COST);
         assert_eq!(s, PageState::PresentRw);
     }
 
@@ -261,14 +275,15 @@ mod tests {
     }
 
     #[test]
-    fn pinned_store_hard_faults_and_reads_are_free_after_first() {
+    fn pinned_store_hard_faults_and_reads_are_always_free() {
         assert_eq!(
             charge_for(PageState::PresentRo, PageKind::PinnedCapRo, true),
             Err(HardFault)
         );
-        // A read of a pinned page still pays page-in once, then is free.
+        // A read of a pinned page is free (RO page-in is charged at CALL),
+        // and only records residency.
         let (c, s) = charge_for(PageState::NotPresent, PageKind::PinnedCapRo, false).unwrap();
-        assert_eq!((c, s), (PAGE_IN_COST, PageState::PresentRo));
+        assert_eq!((c, s), (0, PageState::PresentRo));
     }
 
     #[test]

--- a/rust/javm-exec/src/mem.rs
+++ b/rust/javm-exec/src/mem.rs
@@ -192,25 +192,15 @@ pub struct CopyingMemory {
     pub mat_state: Vec<u8>,
     /// Guest VA base of the read-only CODE region (`PinnedCapRo`). Guest
     /// data loads (PIC `auipc`+load) of the program's own bytecode page it
-    /// in on first read and charge category-#3 page-in, identical to the
-    /// recompiler. `code_top == code_base` (the default) means no code
+    /// in on first read (read-only page-in is charged eagerly at the CALL,
+    /// not at this fault, but a PIC read still records residency), identical
+    /// to the recompiler. `code_top == code_base` (the default) means no code
     /// region is declared — code reads then skip #3 (unit tests).
     pub code_base: u32,
     /// Exclusive top of the code region, **page-rounded**:
     /// `code_base + round_up(code_len)`. The last code page's zero-padded
     /// tail is readable (matching the recompiler, which maps whole pages).
     pub code_top: u32,
-    /// Materialized read-only **units** — sorted set of [`crate::mat::unit_base`]
-    /// values (one per `cap ∩ 2 MiB cluster` paged in). The first read in a
-    /// unit pays one `page_in`; later reads of the same unit are free. The
-    /// recompiler tracks the same unit set, so both charge a read-only unit
-    /// exactly once and a single fault touches at most one DataCap.
-    pub ro_units: Vec<u32>,
-    /// Read-only DataCap ranges `[start, end)` (page-aligned), recorded as
-    /// RO mappings are declared. Resolves an RO data page to its cap's start
-    /// (the `cap_start` half of [`crate::mat::unit_base`]); the CODE region
-    /// uses `code_base` directly. Disjoint, so a page lies in at most one.
-    pub ro_cap_ranges: Vec<(u32, u32)>,
     /// Heap base address (for sbrk).
     pub heap_base: u32,
     /// Current heap top.
@@ -240,8 +230,6 @@ impl CopyingMemory {
             mat_state: Vec::new(),
             code_base: 0,
             code_top: 0,
-            ro_units: Vec::new(),
-            ro_cap_ranges: Vec::new(),
             heap_base: 0,
             heap_top: 0,
             max_heap_pages: 0,
@@ -261,14 +249,6 @@ impl CopyingMemory {
     /// `n_pages` is the number of `PAGE_SIZE`-pages. `base = 0`.
     pub fn with_pages(n_pages: u32, default_perm: u8) -> Self {
         let bytes = (n_pages as usize) * (PAGE_SIZE as usize);
-        // A whole-buffer RO region (base = 0) is one DataCap for #3 unit
-        // accounting: record its range so RO touches resolve `cap_start = 0`,
-        // matching how a real pinned cap is recorded by `map_region`.
-        let ro_cap_ranges = if default_perm == perm::RO && n_pages > 0 {
-            vec![(0u32, bytes as u32)]
-        } else {
-            Vec::new()
-        };
         Self {
             base: 0,
             flat_mem: vec![0u8; bytes],
@@ -276,47 +256,19 @@ impl CopyingMemory {
             mat_state: vec![crate::mat::PageState::NotPresent.as_u8(); n_pages as usize],
             code_base: 0,
             code_top: 0,
-            ro_units: Vec::new(),
-            ro_cap_ranges,
             heap_base: 0,
             heap_top: 0,
             max_heap_pages: 0,
         }
     }
 
-    /// Charge for a **read-only** access to `addr` in a cap starting at
-    /// `cap_start`: returns [`crate::gas_const::PAGE_IN_COST`] on the first
-    /// read of the unit ([`crate::mat::unit_base`] = `cap ∩ 2 MiB cluster`),
-    /// marking it materialized, `0` thereafter. The recompiler keys on the
-    /// same `unit_base`, so a unit pays page-in exactly once on each engine.
-    fn ro_unit_charge(&mut self, addr: u32, cap_start: u32) -> u64 {
-        let ub = crate::mat::unit_base(addr, cap_start);
-        match self.ro_units.binary_search(&ub) {
-            Ok(_) => 0,
-            Err(pos) => {
-                self.ro_units.insert(pos, ub);
-                crate::gas_const::PAGE_IN_COST
-            }
-        }
-    }
-
-    /// Start of the read-only DataCap containing the page-aligned `page`, or
-    /// `None` if `page` is in no recorded RO cap range. Used to derive the
-    /// `cap_start` for [`Self::ro_unit_charge`] of RO **data** pages (the
-    /// CODE region passes `code_base` directly).
-    fn ro_cap_start_of(&self, page: u32) -> Option<u32> {
-        self.ro_cap_ranges
-            .iter()
-            .find(|&&(s, e)| page >= s && page < e)
-            .map(|&(s, _)| s)
-    }
-
     /// Declare the read-only CODE region for category-#3 accounting:
     /// `[code_base, code_base + round_up(code_len))`. Guest data loads of
-    /// the program's own bytecode (PIC) then page each touched code page in
-    /// on first read (charging `PAGE_IN`) and hard-fault on any write —
-    /// matching the recompiler, which lazily materializes code pages too.
-    /// `code_len` is the exact byte length; the region is page-rounded.
+    /// the program's own bytecode (PIC) then read each touched code page
+    /// with no per-fault charge (read-only page-in is accounted eagerly at
+    /// the CALL) and hard-fault on any write — matching the recompiler,
+    /// which lazily materializes code pages too. `code_len` is the exact
+    /// byte length; the region is page-rounded.
     pub fn set_code_region(&mut self, code_base: u32, code_len: u32) {
         let rounded = code_len.next_multiple_of(PAGE_SIZE);
         self.code_base = code_base;
@@ -398,7 +350,7 @@ impl CopyingMemory {
         {
             self.touch_data(pages, is_write, gas)
         } else if self.is_code_page(pages[0]) {
-            self.touch_code(pages, is_write, gas)
+            self.touch_code(pages, is_write)
         } else {
             // Null guard / inter-region gap / fully-unmapped: `#3` does not
             // apply — the caller's normal load/store path resolves it (the
@@ -429,20 +381,15 @@ impl CopyingMemory {
             }
         }
 
-        // Materialize-all. Read-only (pinned-cap) pages materialize per
-        // unit — one `page_in` per `cap ∩ 2 MiB cluster` (the recompiler
-        // fault-arounds the unit); copy-on-write (writable) pages stay
-        // per-page. A write to a read-only page was excluded by the perm
-        // gate above, so RO pages here are reads.
+        // Materialize-all. Read-only (pinned-cap) pages charge no per-fault
+        // #3 — read-only page-in is accounted eagerly at the CALL; only their
+        // residency is implicit. Copy-on-write (writable) pages stay per-page:
+        // a write copies one page and charges `COW_COST`. A write to a
+        // read-only page was excluded by the perm gate above.
         let mut total: u64 = 0;
         for &p in pages {
             let i = self.page_index(p).expect("checked accessible above");
-            if self.perms[i] == perm::RO {
-                let cap_start = self
-                    .ro_cap_start_of(p)
-                    .expect("RO data page lies outside every recorded cap range");
-                total += self.ro_unit_charge(p, cap_start);
-            } else {
+            if self.perms[i] != perm::RO {
                 let state = crate::mat::PageState::from_u8(self.mat_state[i]);
                 let (charge, next) =
                     crate::mat::charge_for(state, crate::mat::PageKind::UnpinnedCapCow, is_write)
@@ -456,38 +403,24 @@ impl CopyingMemory {
         Ok(())
     }
 
-    /// `#3` for a CODE-region access: `PinnedCapRo`, read-only and
-    /// unit-materialized — a read pays one `page_in` per unit
-    /// (`code ∩ 2 MiB cluster`, deduped across the access's page set), a
-    /// write hard-faults, and a read straddling out of the region faults
-    /// charging nothing (all-or-nothing). The code region is one cap, so its
-    /// `cap_start` is `code_base`. Mirrors the recompiler's lazy code
-    /// materialization.
-    fn touch_code(
-        &mut self,
-        pages: &[u32],
-        is_write: bool,
-        gas: &mut GasCounter,
-    ) -> Result<(), TouchFault> {
+    /// `#3` for a CODE-region access: `PinnedCapRo`, read-only. A read
+    /// charges nothing (read-only page-in is accounted eagerly at the CALL),
+    /// a write hard-faults, and a read straddling out of the region faults
+    /// charging nothing (all-or-nothing). Mirrors the recompiler's lazy code
+    /// materialization (which likewise maps code pages without a per-fault
+    /// charge).
+    fn touch_code(&self, pages: &[u32], is_write: bool) -> Result<(), TouchFault> {
         // Code is read-only: any write hard-faults (charging nothing).
         if is_write {
             return Err(TouchFault);
         }
-        // Accessibility-all: every page in the set must be a code page.
+        // Accessibility-all: every page in the set must be a code page. A
+        // read charges no #3 (read-only page-in is accounted at the CALL).
         for &p in pages {
             if !self.is_code_page(p) {
                 return Err(TouchFault);
             }
         }
-        // Materialize-all: one `page_in` per touched read-only unit
-        // (`code ∩ cluster`); the code region is a single cap at `code_base`.
-        let code_base = self.code_base;
-        let mut total: u64 = 0;
-        for &p in pages {
-            total += self.ro_unit_charge(p, code_base);
-        }
-        gas.charge(total)
-            .expect("#3 materialization charge within block reserve");
         Ok(())
     }
 
@@ -684,14 +617,6 @@ impl CopyingMemory {
         if size > 0 {
             for p in first_page..=last_page {
                 self.perms[p] = perm_byte;
-            }
-            // Record a read-only cap range so #3 unit accounting can resolve
-            // this page's `cap_start` ([`Self::ro_cap_start_of`]). `start`/
-            // `end` are absolute guest addresses (page-aligned, validated
-            // above); the recompiler keys on the matching `MatRange.start`.
-            if access == Access::ReadOnly {
-                self.ro_cap_ranges
-                    .push((start as u32, (start + size) as u32));
             }
         }
 

--- a/rust/javm-exec/tests/mem.rs
+++ b/rust/javm-exec/tests/mem.rs
@@ -1,4 +1,4 @@
-use javm_exec::gas_const::{COW_COST, PAGE_IN_COST};
+use javm_exec::gas_const::COW_COST;
 use javm_exec::{Access, GasCounter, MapError, Mem, MemAccess, PAGE_SIZE, TouchFault, perm};
 
 #[test]
@@ -142,42 +142,32 @@ fn spent(initial: u64, f: impl FnOnce(&mut GasCounter)) -> u64 {
 }
 
 #[test]
-fn first_read_charges_page_in_once() {
+fn first_read_is_free() {
     let mut m = Mem::with_pages(2, perm::RW);
-    // First read of page 0 pays page-in.
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
-    // A second read of the same page is free (already present).
+    // Reads no longer charge #3: read-only page-in is accounted at the CALL.
+    assert_eq!(spent(10_000, |g| m.touch_read(0, 8, g).unwrap()), 0);
     assert_eq!(spent(10_000, |g| m.touch_read(0x40, 8, g).unwrap()), 0);
-    // A read of a different page pays its own page-in.
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(PAGE_SIZE, 4, g).unwrap()),
-        PAGE_IN_COST
-    );
+    assert_eq!(spent(10_000, |g| m.touch_read(PAGE_SIZE, 4, g).unwrap()), 0);
 }
 
 #[test]
-fn first_write_charges_page_in_plus_cow() {
+fn first_write_charges_cow_only() {
     let mut m = Mem::with_pages(1, perm::RW);
+    // First write charges CoW only (the page-in half is free).
     assert_eq!(
         spent(10_000, |g| m.touch_write(0x10, 8, g).unwrap()),
-        PAGE_IN_COST + COW_COST
+        COW_COST
     );
     // Subsequent writes to the now-present-RW page are free.
     assert_eq!(spent(10_000, |g| m.touch_write(0x20, 8, g).unwrap()), 0);
 }
 
 #[test]
-fn read_then_write_same_page_pays_page_in_then_cow_only() {
-    // D-2: read-then-write must not double-charge page-in.
+fn read_then_write_same_page_pays_cow_only() {
+    // D-2: read-then-write charges only the CoW (the read is free).
     let mut m = Mem::with_pages(1, perm::RW);
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
-    // The page is PresentRo; a write CoWs it — COW only, no second page-in.
+    assert_eq!(spent(10_000, |g| m.touch_read(0, 8, g).unwrap()), 0);
+    // The page is PresentRo; a write CoWs it — COW only.
     assert_eq!(spent(10_000, |g| m.touch_write(0, 8, g).unwrap()), COW_COST);
     // And it is now PresentRw: further reads/writes are free.
     assert_eq!(spent(10_000, |g| m.touch_read(0, 8, g).unwrap()), 0);
@@ -185,12 +175,12 @@ fn read_then_write_same_page_pays_page_in_then_cow_only() {
 }
 
 #[test]
-fn aligned_straddle_charges_both_pages() {
-    // An 8-byte read crossing the page boundary pays page-in for both pages.
+fn aligned_straddle_charges_cow_on_both_pages() {
+    // An 8-byte read crossing the page boundary is free (reads charge nothing).
     let mut m = Mem::with_pages(2, perm::RW);
     assert_eq!(
         spent(10_000, |g| m.touch_read(PAGE_SIZE - 4, 8, g).unwrap()),
-        2 * PAGE_IN_COST
+        0
     );
     // Both pages are now PresentRo; a straddling write CoWs both.
     assert_eq!(
@@ -207,27 +197,20 @@ fn write_to_pinned_page_hard_faults_charging_nothing() {
     let mut g = GasCounter::new(10_000);
     assert_eq!(m.touch_write(0, 8, &mut g), Err(TouchFault));
     assert_eq!(g.remaining(), 10_000);
-    // A read of the same pinned page is fine and pays page-in once.
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
+    // A read of the same pinned page is fine and charges nothing.
+    assert_eq!(spent(10_000, |g| m.touch_read(0, 8, g).unwrap()), 0);
 }
 
 #[test]
 fn straddle_into_unmapped_hard_faults_all_or_nothing() {
     // D-3: an access whose base page is mapped but straddles into an
-    // unmapped page faults wholesale — nothing is charged, and the mapped
-    // page is NOT paged in (so a later in-range read still pays page-in).
+    // unmapped page faults wholesale — nothing is charged.
     let mut m = Mem::with_pages(1, perm::RW); // only page 0 exists
     let mut g = GasCounter::new(10_000);
     assert_eq!(m.touch_read(PAGE_SIZE - 4, 8, &mut g), Err(TouchFault));
     assert_eq!(g.remaining(), 10_000);
-    // Page 0 was not materialized by the failed straddle.
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
+    // A later in-range read succeeds, charging nothing.
+    assert_eq!(spent(10_000, |g| m.touch_read(0, 8, g).unwrap()), 0);
 }
 
 #[test]
@@ -245,15 +228,13 @@ fn unmapped_base_page_is_skipped_not_charged() {
 // ---- CODE region (PinnedCapRo) #3 -----------------------------------------
 
 #[test]
-fn code_first_read_pages_in_then_free() {
-    // A read of the declared code region pages it in once (PAGE_IN), then is
-    // free; a write hard-faults (code is read-only), charging nothing.
+fn code_reads_are_free() {
+    // A read of the declared code region charges nothing (read-only page-in
+    // is accounted at the CALL); a write hard-faults (code is read-only),
+    // charging nothing.
     let mut m = Mem::new();
     m.set_code_region(0x40_0000, PAGE_SIZE); // one code page
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0x40_0000, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
+    assert_eq!(spent(10_000, |g| m.touch_read(0x40_0000, 8, g).unwrap()), 0);
     assert_eq!(spent(10_000, |g| m.touch_read(0x40_0040, 8, g).unwrap()), 0);
     // A write to code hard-faults, charging nothing.
     let mut g = GasCounter::new(10_000);
@@ -262,22 +243,20 @@ fn code_first_read_pages_in_then_free() {
 }
 
 #[test]
-fn ro_cluster_charges_page_in_once_for_whole_cluster() {
-    // 16 read-only pages in one 2 MiB cluster: reading every page charges a
-    // SINGLE page_in (cluster materialization), not 16 — mirroring the
-    // recompiler's fault-around of the whole cluster on the first fault.
+fn ro_reads_are_free() {
+    // Read-only pages charge no per-fault #3 (page-in is accounted at the
+    // CALL): reading every page of a 2 MiB-spanning RO region charges nothing.
     let mut m = Mem::with_pages(16, perm::RO);
     let mut total = 0u64;
     for pg in 0..16u32 {
         total += spent(10_000, |g| m.touch_read(pg * PAGE_SIZE, 8, g).unwrap());
     }
-    assert_eq!(total, PAGE_IN_COST);
+    assert_eq!(total, 0);
 }
 
 #[test]
-fn ro_cluster_straddle_charges_each_cluster() {
-    // An RO read straddling a 2 MiB cluster boundary pays one page_in per
-    // cluster (two here); re-reads are then free.
+fn ro_straddle_reads_are_free() {
+    // An RO read straddling a 2 MiB cluster boundary still charges nothing.
     const TWO_MIB: u32 = 1 << 21;
     let mut m = Mem::new();
     m.base = TWO_MIB - PAGE_SIZE;
@@ -290,7 +269,7 @@ fn ro_cluster_straddle_charges_each_cluster() {
     .unwrap();
     assert_eq!(
         spent(10_000, |g| m.touch_read(TWO_MIB - 4, 8, g).unwrap()),
-        2 * PAGE_IN_COST
+        0
     );
     assert_eq!(
         spent(10_000, |g| m.touch_read(TWO_MIB - PAGE_SIZE, 8, g).unwrap()),
@@ -301,14 +280,14 @@ fn ro_cluster_straddle_charges_each_cluster() {
 
 #[test]
 fn rw_pages_stay_per_page_not_clustered() {
-    // Writable (CoW) pages are NOT clustered: each page pays its own
-    // page_in+cow, unchanged from the per-page model.
+    // Writable (CoW) pages are per-page: each first write charges its own
+    // COW (the page-in half is free), never clustered.
     let mut m = Mem::with_pages(4, perm::RW);
     let mut total = 0u64;
     for pg in 0..4u32 {
         total += spent(10_000, |g| m.touch_write(pg * PAGE_SIZE, 8, g).unwrap());
     }
-    assert_eq!(total, 4 * (PAGE_IN_COST + COW_COST));
+    assert_eq!(total, 4 * COW_COST);
 }
 
 #[test]
@@ -328,13 +307,7 @@ fn code_data_adjacency_straddle_faults() {
     // 8-byte read at 0x1FFC straddles code page 0x1000 → data page 0x2000.
     assert_eq!(m.touch_read(0x2000 - 4, 8, &mut g), Err(TouchFault));
     assert_eq!(g.remaining(), 10_000); // all-or-nothing: charged nothing
-    // Sanity: a read wholly inside each region still charges its own page-in.
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0x1000, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
-    assert_eq!(
-        spent(10_000, |g| m.touch_read(0x2000, 8, g).unwrap()),
-        PAGE_IN_COST
-    );
+    // Sanity: a read wholly inside each region succeeds, charging nothing.
+    assert_eq!(spent(10_000, |g| m.touch_read(0x1000, 8, g).unwrap()), 0);
+    assert_eq!(spent(10_000, |g| m.touch_read(0x2000, 8, g).unwrap()), 0);
 }

--- a/rust/nub-arch-x86/src/cached_cap.rs
+++ b/rust/nub-arch-x86/src/cached_cap.rs
@@ -1,0 +1,95 @@
+//! `CachedCap` — a cap plus its engine-private derived runtime cache.
+//!
+//! A resident sub-VM instance owns its memory (the overlay `Arc` pages) for as
+//! long as it lives in a frame's cnode; its ring-3 page table
+//! ([`FrameRuntime`]) stays valid for exactly that lifetime. So the page-table
+//! cache belongs **with the cap**: `cache lifetime == cap lifetime`. A running
+//! frame's cnode is a [`CNodeCap<Box<CachedCap>>`](javm_cap::CNodeCap), and a
+//! `derive_spawn`'d instance lives in it as `CapHashOrRef::Owned(Box<CachedCap>)`
+//! — its parked page table riding in [`CacheSlot`], dropped automatically when
+//! the slot is overwritten or the frame pops. This replaces the parent-side
+//! `child_runtimes` side-table: no slot-keying, no manual `derive_spawn`
+//! invalidation, no per-frame `BTreeMap` allocation, and the cache follows the
+//! instance through any future move (return-as-value, yield/resume).
+//!
+//! `CachedCap` has **no** rkyv/ssz impl. Because the wire impls of
+//! [`CapHashOrRef`](javm_cap::CapHashOrRef) are gated on the
+//! [`WireOwned`](javm_cap::cache::WireOwned) leaf marker (implemented only for
+//! `Box<Cap>`), a `CNodeCap<Box<CachedCap>>` cannot be content-hashed or
+//! serialised — a **compile error**, strictly stronger than the runtime
+//! `Owned` panic. The cache is, by construction, guest-local.
+
+use alloc::boxed::Box;
+
+use javm_cap::cap::Cap;
+
+use crate::jit_run::FrameRuntime;
+
+/// A cap paired with the derived runtime cache that rides with it inside a
+/// running frame's cnode (`CapHashOrRef::Owned(Box<CachedCap>)`).
+///
+/// **`Clone` drops the cache.** A clone is a *distinct* instance (its own
+/// memory after the next CoW), so it must start with a fresh, empty cache;
+/// [`FrameRuntime`] is non-`Clone` anyway. The recompiler's cnode-inherit loop
+/// already skips `Owned` slots (single-owner, move-only), so a clone of a
+/// cache-carrying cnode never actually happens in the hot path — the impl
+/// exists only to satisfy the `CNodeCap<O>: Clone` bound (which clones `Hash`
+/// entries).
+pub struct CachedCap {
+    /// The underlying cap (an `Instance` for a resident sub-VM; any cap for a
+    /// moved scratchpad slot).
+    pub cap: Cap,
+    /// The engine-private derived cache attached to this cap.
+    pub cache: CacheSlot,
+}
+
+/// The derived runtime cache attached to a resident cap. `None` for a cap with
+/// no cached runtime (freshly spawned, or a non-instance scratchpad cap).
+#[derive(Default)]
+pub enum CacheSlot {
+    /// No cached runtime.
+    #[default]
+    None,
+    /// A resident sub-VM instance's ring-3 page table, parked (re-armed for
+    /// CoW) between CALLs so the next CALL of this same instance reuses the
+    /// whole page table instead of rebuilding it.
+    Instance(FrameRuntime),
+}
+
+impl CachedCap {
+    /// Wrap a cap with an empty cache (a freshly `derive_spawn`'d instance, or
+    /// a moved scratchpad cap).
+    pub fn new(cap: Cap) -> Self {
+        Self {
+            cap,
+            cache: CacheSlot::None,
+        }
+    }
+
+    /// Box a cap with an empty cache, ready to drop into a cnode slot as
+    /// `CapHashOrRef::Owned`.
+    pub fn boxed(cap: Cap) -> Box<Self> {
+        Box::new(Self::new(cap))
+    }
+}
+
+impl Clone for CachedCap {
+    fn clone(&self) -> Self {
+        // A clone is a distinct instance → fresh, empty cache.
+        Self {
+            cap: self.cap.clone(),
+            cache: CacheSlot::None,
+        }
+    }
+}
+
+impl core::fmt::Debug for CachedCap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // `FrameRuntime` is not `Debug`; report only cache presence.
+        let cached = !matches!(self.cache, CacheSlot::None);
+        f.debug_struct("CachedCap")
+            .field("cap", &self.cap)
+            .field("cached_runtime", &cached)
+            .finish()
+    }
+}

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -403,6 +403,32 @@ pub fn run_top(
                         if stack.len() >= MAX_DEPTH {
                             return Err(ERR_DEPTH_LIMIT);
                         }
+                        // Charge the call-frame materialization — JIT compile
+                        // (O(code)) + eager read-only page-in (per declared
+                        // 2 MiB unit) + frame-setup base — computed statically
+                        // from the callee Image and billed to the CALLER (on
+                        // top of the ecall floor above). Check-before-charge,
+                        // gated **before** `dispatch_host_call` moves the
+                        // instance, so an OOG here leaves the parent slot
+                        // untouched and the re-attempt is clean (gas-cost.md
+                        // §3). Charged in full on every CALL — the compiled
+                        // image + page table are memoized for *work* only,
+                        // never a gas discount — so gas is independent of the
+                        // node-local compile/PT cache (gas_const::call_frame_cost).
+                        let frame_cost = {
+                            let parent = stack.last().expect("non-empty");
+                            host_call_frame_cost(parent)?
+                        };
+                        if gas < frame_cost {
+                            break LoopOutcome {
+                                exit_reason: EXIT_OOG,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: gas,
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
+                        gas -= frame_cost;
                         let mut child = {
                             let parent = stack.last_mut().expect("non-empty");
                             dispatch_host_call(parent)?
@@ -889,6 +915,69 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
         }
     }
     Ok(child)
+}
+
+/// Category-#3 call-frame cost for materializing the callee `image_hash`,
+/// computed **statically** from its Image so both engines agree (see
+/// [`javm_exec::gas_const::call_frame_cost`]): the JIT compile (`O(code)`),
+/// the eager read-only page-in (one page-in per declared 2 MiB read-only
+/// unit — the code region plus every pinned mapping, each clustered per
+/// 2 MiB), and the fixed frame-setup base. Charged to the caller at an
+/// in-kernel CALL, in full on every CALL (compile/PT memoization is a
+/// node-local performance optimization, never a gas discount), so gas is
+/// independent of the cache.
+fn call_frame_cost_for(image_hash: &CapHash) -> Result<i64, u32> {
+    let img_arc = CACHE
+        .get(CapHashOrRef::Hash(*image_hash))
+        .ok_or(ERR_IMAGE_NOT_FOUND)?;
+    let img = match &*img_arc {
+        Cap::Image(i) => i,
+        _ => return Err(ERR_IMAGE_KIND),
+    };
+    // Declared read-only 2 MiB units: the code region (one cap) plus each
+    // pinned (read-only) mapping, clustered per 2 MiB.
+    let cluster = 1u64 << javm_exec::mat::CLUSTER_SHIFT;
+    let mut ro_units = (img.code.len() as u64).div_ceil(cluster);
+    for m in img.mappings.iter() {
+        if img.mapping_is_pinned(m.start as u32) {
+            ro_units = ro_units.saturating_add(m.size.div_ceil(cluster));
+        }
+    }
+    let cost = javm_exec::gas_const::call_frame_cost(
+        img.code.len().min(u32::MAX as usize) as u32,
+        ro_units.min(u32::MAX as u64) as u32,
+    );
+    Ok(cost.min(i64::MAX as u64) as i64)
+}
+
+/// The CALL frame cost for the instance in `parent`'s host_call slot,
+/// resolved by **peeking** the slot (no move) so the gas gate can run
+/// **before** [`dispatch_host_call`] mutates the parent. This keeps an OOG
+/// at a CALL a clean, no-work re-attempt (gas-cost.md §3): the parent slot
+/// is untouched, so a top-up `CALL_RESUME` re-runs the CALL from a
+/// pristine state. Resolves the callee `image_hash` exactly as
+/// `dispatch_host_call` will (same slot, same `Owned`/`Hash` handling), so
+/// the cost gated here equals the cost the built child would have.
+fn host_call_frame_cost(parent: &KernelFrame) -> Result<i64, u32> {
+    let instance_slot = Key::from((parent.regs[7] & 0xFF) as u8);
+    let image_hash = match parent.cnode.peek_key(instance_slot.as_slice()) {
+        Some(CapHashOrRef::Owned(boxed)) => match &**boxed {
+            Cap::Instance(i) => i.image_hash,
+            _ => return Err(ERR_INSTANCE_KIND),
+        },
+        Some(CapHashOrRef::Hash(h)) => {
+            let arc = CACHE
+                .get(CapHashOrRef::Hash(*h))
+                .ok_or(ERR_INSTANCE_NOT_FOUND)?;
+            match &*arc {
+                Cap::Instance(i) => i.image_hash,
+                _ => return Err(ERR_INSTANCE_KIND),
+            }
+        }
+        Some(CapHashOrRef::Ref(_)) => return Err(ERR_INSTANCE_KIND),
+        None => return Err(ERR_HOST_CALL_SLOT_EMPTY),
+    };
+    call_frame_cost_for(&image_hash)
 }
 
 /// Build a frame from a `Cap::Instance` published in the heap-

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -228,7 +228,26 @@ pub struct KernelFrame {
     /// pays N page-table builds, not one per re-entry. It is *not* evicted:
     /// the synchronous call stack is bounded structurally (cnode nesting depth;
     /// see the doc above), so all live page tables stay resident.
+    ///
+    /// On a child HALT this runtime is **not** dropped if the child was a
+    /// resident `Owned` sub-VM — instead [`pop_and_reflect`] re-arms it (clears
+    /// W on each CoW'd leaf) and parks it in the parent's [`Self::child_runtimes`]
+    /// so the next CALL of that same instance reuses the whole page table.
     runtime: Option<FrameRuntime>,
+    /// Parked page tables of this frame's resident `Owned` child instances,
+    /// keyed by the cnode slot the child lives in. A `host_call` of an `Owned`
+    /// instance whose runtime is parked here moves it into the child frame
+    /// (reuse — no page-table rebuild); the child's HALT re-arms and parks it
+    /// back. Invalidated when a slot is overwritten (`derive_spawn`), and
+    /// dropped wholesale when this frame pops — so peak live page tables match
+    /// the no-cache case (one per stack frame, plus the just-popped child).
+    ///
+    /// The value is an `Option` so the map node survives the round trip: it
+    /// holds `None` while the runtime is borrowed into the running child and is
+    /// refilled at the child's HALT. Re-CALLs of a resident instance therefore
+    /// add **no** allocation churn for the parking itself — only the small
+    /// `KernelFrame` is (re)built.
+    child_runtimes: BTreeMap<Key, Option<FrameRuntime>>,
 }
 
 /// One cap-backed data mapping projected into the guest address space,
@@ -640,17 +659,12 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
 fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
     let mut popped = stack.pop().expect("non-empty");
 
-    // REQUIRED ordering: drop the child's ring-3 runtime (its page table)
-    // FIRST, so the cap's overlay pages are unmapped before the cap moves
-    // anywhere. Single-threaded Hyperlight + stack discipline then guarantee no
-    // live PT references the cap once its own PT is gone; a later host_call of
-    // the returned instance builds a fresh PT.
-    popped.runtime = None;
-
     if stack.is_empty() {
-        // Top-level HALT: the scratchpad + mem stay on the popped frame; the
-        // host return path surfaces slot[0] / `scratchpad_head` as the result.
-        // The frame is dropped at scope end (top-level mem persistence deferred).
+        // Top-level HALT: no parent to park the runtime in, so drop it (its
+        // page table). The scratchpad + mem stay on the popped frame; the host
+        // return path surfaces slot[0] / `scratchpad_head` as the result. The
+        // frame is dropped at scope end (top-level mem persistence deferred).
+        popped.runtime = None;
         return true;
     }
 
@@ -659,15 +673,30 @@ fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
 
     // If the child was a moved-in `Owned` instance, fold its final state back
     // into the parked `InstanceCap` (mem moved, regs/pc copied) so the parent's
-    // slot gets the *updated* instance — sub-VM state persists across calls.
+    // slot gets the *updated* instance — sub-VM state persists across calls —
+    // AND carry its re-armed page table back so the parent can park it for the
+    // next CALL. The page table travels **paired** with the cap (their overlay
+    // pages stay mapped): no PT references a cap whose PT it doesn't own. A
+    // non-`Owned` (host-published `Hash`) child is not resident, so its runtime
+    // is dropped (the next CALL rebuilds it from the blob).
     let owned_back = match popped.owned_origin.take() {
         Some((slot, mut inst)) => {
+            // Re-arm BEFORE the overlay moves into the cap: clear W on every
+            // CoW'd leaf so the next CALL re-faults on first write and re-charges
+            // its CoW (gas-neutral — the page is reused, only the W bit toggles).
+            let runtime = popped.runtime.take();
+            if let Some(rt) = &runtime {
+                rt.rearm_cow(popped.mem.overlay.keys().copied());
+            }
             inst.regs = popped.regs;
             inst.pc = popped.pc as u64;
             inst.mem = popped.mem; // move the (overlaid) mem back into the cap
-            Some((slot, inst))
+            Some((slot, inst, runtime))
         }
-        None => None,
+        None => {
+            popped.runtime = None;
+            None
+        }
     };
 
     let parent = stack.last_mut().unwrap();
@@ -677,7 +706,14 @@ fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
             .cnode
             .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
     }
-    if let Some((slot, inst)) = owned_back {
+    if let Some((slot, inst, runtime)) = owned_back {
+        // Park the page table keyed by the slot the instance returns to, so the
+        // next `host_call` of that slot reuses it (paired with the cap below).
+        // Reuse the existing map node (left as `None` when the runtime was
+        // borrowed out) so a steady-state re-CALL allocates nothing here.
+        if let Some(rt) = runtime {
+            *parent.child_runtimes.entry(slot.clone()).or_insert(None) = Some(rt);
+        }
         parent.cnode.set_key(
             slot.as_slice(),
             Some(CapHashOrRef::Owned(Box::new(Cap::Instance(inst)))),
@@ -842,6 +878,9 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
         pc: 0,
         gas_remaining: 0,
     });
+    // A fresh instance takes this slot, so any page table parked for the slot's
+    // previous occupant is stale — drop it (its mem/overlay is a different cap).
+    frame.child_runtimes.remove(&dst_slot);
     // CNode ops run in ring-0 dispatch (kernel heap live); `set` on the
     // unbounded radix map is infallible here. The child lives inline in the
     // parent's slot as `Owned` — the unique owner until host_call moves it.
@@ -879,7 +918,26 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
         // Single-owner instance: move it into the child frame; record the
         // origin slot so HALT folds the updated instance back.
         CapHashOrRef::Owned(boxed) => {
-            build_frame_from_owned(*boxed, instance_slot.clone(), endpoint_idx, args)?
+            let mut child =
+                build_frame_from_owned(*boxed, instance_slot.clone(), endpoint_idx, args)?;
+            // Page-table reuse: if this resident instance's runtime is parked
+            // from a previous CALL (re-armed at its last HALT), move it into the
+            // child frame instead of rebuilding the page table. Leaves the map
+            // node behind holding `None` (refilled at HALT). The data extent is
+            // fixed per image (immutable), so the parked extent must match.
+            if let Some(rt) = parent
+                .child_runtimes
+                .get_mut(&instance_slot)
+                .and_then(Option::take)
+            {
+                debug_assert_eq!(
+                    rt.data_extent(),
+                    child.mem.content_len(),
+                    "parked runtime extent must match the resident instance's mem",
+                );
+                child.runtime = Some(rt);
+            }
+            child
         }
         // Host-published instance: not consumed by host_call — put the hash
         // back and build read-only from the blob.
@@ -1124,5 +1182,6 @@ fn build_frame_inner(
         mat_state: alloc::vec![0u8; mat_state_pages],
         ro_units: Vec::new(),
         runtime: None,
+        child_runtimes: BTreeMap::new(),
     })
 }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -169,15 +169,16 @@ pub struct KernelFrame {
     /// child's chain. Cached locally to avoid a cap deref per
     /// derive.
     image_hash_chain: CapHash,
-    /// Set when this frame was built by moving an `Owned` instance out of a
-    /// parent cnode slot (`host_call` of a `derive_spawn`'d sub-VM): the
-    /// `(parent slot, parked InstanceCap)`. The instance's `mem` was moved
-    /// into [`Self::mem`]; the rest (image, chain, root_cnode, regs, pc, gas)
-    /// is parked here. At HALT, [`pop_and_reflect`] folds this frame's final
-    /// mem/regs/pc back into the `InstanceCap`, boxes it `Owned`, and moves it
-    /// back into the parent's slot — the single-owner round trip. `None` for a
-    /// top-level (Hash) frame.
-    owned_origin: Option<(Key, InstanceCap)>,
+    /// The parent cnode slot to return this instance to, set when the frame was
+    /// built by moving an `Owned` sub-VM out of that slot (`host_call` of a
+    /// `derive_spawn`'d instance). The instance is fully **decomposed** into
+    /// this frame's own fields — `image_hash` / `image_hash_chain` (identity),
+    /// [`Self::mem`], [`Self::regs`], [`Self::pc`] — so only the return slot
+    /// needs remembering; at HALT [`pop_and_reflect`] reconstructs the
+    /// `InstanceCap` from those fields, boxes it `Owned`, and moves it back into
+    /// the slot — the single-owner round trip. `None` for a top-level /
+    /// host-published (`Hash`) frame (nothing to return).
+    owned_origin: Option<Key>,
     /// The frame's **owned** read-write memory: a [`DataCap`] cloned from the
     /// running Instance at frame build (Arc-backing bump + empty overlay). The
     /// #PF handler copy-on-writes guest writes straight into its `overlay`
@@ -649,10 +650,11 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
 
 /// Pop the top frame; if a parent exists, reflect the popped child's
 /// `return_value` into the parent's φ[7], move its scratchpad (slot[0]) back,
-/// and — when the child was a moved-in `Owned` sub-VM — fold the child's final
-/// mem/regs/pc back into its `InstanceCap` and move it back into the parent's
-/// origin slot (the single-owner round trip). Returns `true` when the stack
-/// has been drained (the RPC caller hands a result back to the host).
+/// and — when the child was a moved-in `Owned` sub-VM — reconstruct its
+/// `InstanceCap` from the frame's final mem/regs/pc (+ carried identity) and
+/// move it back into the parent's origin slot (the single-owner round trip).
+/// Returns `true` when the stack has been drained (the RPC caller hands a
+/// result back to the host).
 fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
     let mut popped = stack.pop().expect("non-empty");
 
@@ -668,26 +670,38 @@ fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
     // Move the callee's scratchpad (slot[0]) back to the caller.
     let scratch = popped.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT]);
 
-    // If the child was a moved-in `Owned` instance, fold its final state back
-    // into the parked `InstanceCap` (mem moved, regs/pc copied) so the parent's
-    // slot gets the *updated* instance — sub-VM state persists across calls —
-    // AND carry its re-armed page table back so the parent can park it for the
-    // next CALL. The page table travels **paired** with the cap (their overlay
-    // pages stay mapped): no PT references a cap whose PT it doesn't own. A
-    // non-`Owned` (host-published `Hash`) child is not resident, so its runtime
-    // is dropped (the next CALL rebuilds it from the blob).
+    // If the child was a moved-in `Owned` instance, reconstruct its
+    // `InstanceCap` from this frame's final state so the parent's slot gets the
+    // *updated* instance — sub-VM state persists across calls — AND carry its
+    // re-armed page table back so the parent can park it for the next CALL. The
+    // page table travels **paired** with the cap (their overlay pages stay
+    // mapped): no PT references a cap whose PT it doesn't own. A non-`Owned`
+    // (host-published `Hash`) child is not resident, so its runtime is dropped
+    // (the next CALL rebuilds it from the blob).
     let owned_back = match popped.owned_origin.take() {
-        Some((slot, mut inst)) => {
-            // Re-arm BEFORE the overlay moves into the cap: clear W on every
-            // CoW'd leaf so the next CALL re-faults on first write and re-charges
-            // its CoW (gas-neutral — the page is reused, only the W bit toggles).
+        Some(slot) => {
+            // Re-arm BEFORE the mem moves into the cap: clear W on every CoW'd
+            // leaf so the next CALL re-faults on first write and re-charges its
+            // CoW (gas-neutral — the page is reused, only the W bit toggles).
             let runtime = popped.runtime.take();
             if let Some(rt) = &runtime {
                 rt.rearm_cow(popped.mem.overlay.keys().copied());
             }
-            inst.regs = popped.regs;
-            inst.pc = popped.pc as u64;
-            inst.mem = popped.mem; // move the (overlaid) mem back into the cap
+            // Reconstruct from the frame's authoritative running state: identity
+            // (`image_hash` / `image_hash_chain`) is carried on the frame, and
+            // the final `mem` / `regs` / `pc` are the frame's. `root_cnode` and
+            // `gas_remaining` stay spawn-time placeholders — V1 persists neither
+            // the running cnode nor residual gas into the cap (the exact values
+            // the parked shell used to carry).
+            let inst = InstanceCap {
+                image_hash_chain: popped.image_hash_chain,
+                image_hash: popped.image_hash,
+                root_cnode: CapHashOrRef::Hash([0u8; 32]),
+                mem: popped.mem, // the (overlaid) mem
+                regs: popped.regs,
+                pc: popped.pc as u64,
+                gas_remaining: 0,
+            };
             Some((slot, inst, runtime))
         }
         None => {
@@ -1063,32 +1077,35 @@ fn build_frame_from_published(
 }
 
 /// Build a frame by **moving** an `Owned` `Cap::Instance` into it: the
-/// instance's `mem` becomes the frame's owned memory, and the rest of the
-/// instance (image, chain, root_cnode, regs, pc, gas) is parked in
-/// [`KernelFrame::owned_origin`] alongside `origin_slot` so HALT can fold the
-/// frame's final state back and return the instance to the parent's slot.
+/// instance is fully decomposed — its `mem` becomes the frame's owned memory
+/// and its identity (`image_hash` / `image_hash_chain`) + `regs` seed the
+/// frame. `root_cnode`, `pc`, and `gas_remaining` are not needed at build (the
+/// frame starts at the endpoint's entry-pc with a freshly-seeded cnode). Only
+/// `origin_slot` is remembered in [`KernelFrame::owned_origin`] so HALT can
+/// reconstruct the instance from the frame's final state and return it.
 fn build_frame_from_owned(
     cap: Cap,
     origin_slot: Key,
     endpoint_idx: u32,
     args: [u64; 4],
 ) -> Result<KernelFrame, u32> {
-    let Cap::Instance(mut inst) = cap else {
+    let Cap::Instance(inst) = cap else {
         return Err(ERR_INSTANCE_KIND);
     };
-    // Move the instance's mem into the frame; the parked instance keeps an
-    // empty mem until HALT folds the frame's (overlaid) mem back.
-    let mem = core::mem::replace(&mut inst.mem, DataCap::empty());
-    let image_hash = inst.image_hash;
-    let image_hash_chain = inst.image_hash_chain;
-    let inst_regs = inst.regs;
+    let InstanceCap {
+        image_hash,
+        image_hash_chain,
+        regs,
+        mem,
+        ..
+    } = inst;
     build_frame_inner(
         image_hash,
         image_hash_chain,
-        Some((origin_slot, inst)),
+        Some(origin_slot),
         endpoint_idx,
         args,
-        Some(&inst_regs),
+        Some(&regs),
         mem,
     )
 }
@@ -1099,13 +1116,13 @@ fn build_frame_from_owned(
 
 /// Core frame builder: reads the image cap to seed regs/pc/cnode +
 /// CoW ranges, stores only IDs on the frame (no `CapHandle` pins).
-/// `owned_origin` is the parent slot + parked `InstanceCap` for a moved-in
-/// `Owned` sub-VM (`None` for a top-level / `Hash` frame).
+/// `owned_origin` is the parent return slot for a moved-in `Owned` sub-VM
+/// (`None` for a top-level / `Hash` frame).
 #[allow(clippy::too_many_arguments)]
 fn build_frame_inner(
     image_hash: CapHash,
     image_hash_chain: CapHash,
-    owned_origin: Option<(Key, InstanceCap)>,
+    owned_origin: Option<Key>,
     endpoint_idx: u32,
     args: [u64; 4],
     inst_regs: Option<&[u64; NUM_REGS]>,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -106,6 +106,7 @@ use javm_cap::slot::Key;
 use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
+use crate::cached_cap::{CacheSlot, CachedCap};
 use crate::jit_run::{self, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
@@ -192,12 +193,17 @@ pub struct KernelFrame {
     /// Current PVM PC. Same lifecycle as `regs`.
     pc: u32,
     /// Per-frame cnode snapshot: the radix kv-map (`Hasher(Key) ->
-    /// CapHashOrRef`) seeded from the running `Cap::Instance`'s image
-    /// (pinned/initial) and grown by `derive_spawn`. No fixed slot count —
-    /// a normal `CNodeCap`. CNode ops run only in the call-loop dispatch
-    /// (ring 0 after the JIT context switch), so the kernel-heap `RadixMap`
-    /// is live; the JIT-compiled guest code never touches this directly.
-    cnode: CNodeCap,
+    /// CapHashOrRef<Box<CachedCap>>`) seeded from the running `Cap::Instance`'s
+    /// image (pinned/initial, as `Hash` entries) and grown by `derive_spawn`
+    /// (as inline `Owned(CachedCap)`). No fixed slot count — a normal
+    /// `CNodeCap`. The payload is [`CachedCap`] — a cap plus its engine-private
+    /// page-table cache — so a resident sub-VM's runtime rides *with* the cap
+    /// in its slot (no parent-side side-table). CNode ops run only in the
+    /// call-loop dispatch (ring 0 after the JIT context switch), so the
+    /// kernel-heap `RadixMap` is live; the JIT-compiled guest code never
+    /// touches this directly. The `CachedCap` payload is deliberately
+    /// non-wire-serialisable, so this cnode cannot be hashed or shipped.
+    cnode: CNodeCap<Box<CachedCap>>,
     /// Slot keys this frame's image declares pinned (read-only), sorted —
     /// the recompiler's mirror of the interpreter's
     /// `InstanceEntry.pinned_slots`. A write to one of these (e.g. a
@@ -231,23 +237,14 @@ pub struct KernelFrame {
     ///
     /// On a child HALT this runtime is **not** dropped if the child was a
     /// resident `Owned` sub-VM — instead [`pop_and_reflect`] re-arms it (clears
-    /// W on each CoW'd leaf) and parks it in the parent's [`Self::child_runtimes`]
-    /// so the next CALL of that same instance reuses the whole page table.
+    /// W on each CoW'd leaf) and re-attaches it to the returning instance's
+    /// [`CachedCap`] cache slot, so the next CALL of that same instance reuses
+    /// the whole page table. The cache rides *with* the cap in the parent's
+    /// cnode slot — no parent-side side-table — and is freed automatically when
+    /// the slot is overwritten (`derive_spawn`) or the frame pops, so peak live
+    /// page tables match the no-cache case (one per stack frame, plus the
+    /// just-popped child).
     runtime: Option<FrameRuntime>,
-    /// Parked page tables of this frame's resident `Owned` child instances,
-    /// keyed by the cnode slot the child lives in. A `host_call` of an `Owned`
-    /// instance whose runtime is parked here moves it into the child frame
-    /// (reuse — no page-table rebuild); the child's HALT re-arms and parks it
-    /// back. Invalidated when a slot is overwritten (`derive_spawn`), and
-    /// dropped wholesale when this frame pops — so peak live page tables match
-    /// the no-cache case (one per stack frame, plus the just-popped child).
-    ///
-    /// The value is an `Option` so the map node survives the round trip: it
-    /// holds `None` while the runtime is borrowed into the running child and is
-    /// refilled at the child's HALT. Re-CALLs of a resident instance therefore
-    /// add **no** allocation churn for the parking itself — only the small
-    /// `KernelFrame` is (re)built.
-    child_runtimes: BTreeMap<Key, Option<FrameRuntime>>,
 }
 
 /// One cap-backed data mapping projected into the guest address space,
@@ -707,16 +704,21 @@ fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
             .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
     }
     if let Some((slot, inst, runtime)) = owned_back {
-        // Park the page table keyed by the slot the instance returns to, so the
-        // next `host_call` of that slot reuses it (paired with the cap below).
-        // Reuse the existing map node (left as `None` when the runtime was
-        // borrowed out) so a steady-state re-CALL allocates nothing here.
-        if let Some(rt) = runtime {
-            *parent.child_runtimes.entry(slot.clone()).or_insert(None) = Some(rt);
-        }
+        // Re-attach the (re-armed) page table to the returning instance's
+        // `CachedCap` cache slot, so the next `host_call` of this instance
+        // reuses it. The cache rides *with* the cap in the parent's cnode slot
+        // — no side-table, freed automatically when the slot is overwritten or
+        // the parent frame pops.
+        let cache = match runtime {
+            Some(rt) => CacheSlot::Instance(rt),
+            None => CacheSlot::None,
+        };
         parent.cnode.set_key(
             slot.as_slice(),
-            Some(CapHashOrRef::Owned(Box::new(Cap::Instance(inst)))),
+            Some(CapHashOrRef::Owned(Box::new(CachedCap {
+                cap: Cap::Instance(inst),
+                cache,
+            }))),
         );
     }
     false
@@ -851,7 +853,7 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
 
     let image_hash = match frame.cnode.get(&image_slot) {
         Some(CapHashOrRef::Hash(h)) => h,
-        Some(CapHashOrRef::Ref(_) | CapHashOrRef::Owned(_)) | None => frame.image_hash,
+        Some(CapHashOrRef::Owned(_)) | None => frame.image_hash,
     };
     let child_chain = Blake2b256::hash_pair(&frame.image_hash_chain, &image_hash);
 
@@ -878,15 +880,15 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
         pc: 0,
         gas_remaining: 0,
     });
-    // A fresh instance takes this slot, so any page table parked for the slot's
-    // previous occupant is stale — drop it (its mem/overlay is a different cap).
-    frame.child_runtimes.remove(&dst_slot);
     // CNode ops run in ring-0 dispatch (kernel heap live); `set` on the
     // unbounded radix map is infallible here. The child lives inline in the
-    // parent's slot as `Owned` — the unique owner until host_call moves it.
+    // parent's slot as `Owned(CachedCap)` — the unique owner until host_call
+    // moves it. Overwriting the slot drops any previous occupant's `CachedCap`
+    // (and its parked page table), so a stale cache for that slot is
+    // invalidated automatically — no separate side-table to maintain.
     frame
         .cnode
-        .set(&dst_slot, Some(CapHashOrRef::Owned(Box::new(cap))))
+        .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
         .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
     Ok(false)
 }
@@ -902,7 +904,6 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
 ///   instance back ([`KernelFrame::owned_origin`] → [`pop_and_reflect`]).
 /// - `Hash` (a host-published instance): NOT consumed — the hash is
 ///   reinserted and the frame built read-only from the blob.
-/// - `Ref`: the recompiler no longer mints `Ref`; a stray one is a bug.
 fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
     let instance_slot = Key::from((parent.regs[7] & 0xFF) as u8);
     let endpoint_idx = (parent.regs[8] & 0xFF) as u32;
@@ -915,21 +916,17 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
         .ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
 
     let mut child = match target {
-        // Single-owner instance: move it into the child frame; record the
-        // origin slot so HALT folds the updated instance back.
+        // Single-owner instance: move it (and its parked page table) into the
+        // child frame; record the origin slot so HALT folds the updated
+        // instance back.
         CapHashOrRef::Owned(boxed) => {
-            let mut child =
-                build_frame_from_owned(*boxed, instance_slot.clone(), endpoint_idx, args)?;
-            // Page-table reuse: if this resident instance's runtime is parked
-            // from a previous CALL (re-armed at its last HALT), move it into the
-            // child frame instead of rebuilding the page table. Leaves the map
-            // node behind holding `None` (refilled at HALT). The data extent is
-            // fixed per image (immutable), so the parked extent must match.
-            if let Some(rt) = parent
-                .child_runtimes
-                .get_mut(&instance_slot)
-                .and_then(Option::take)
-            {
+            let CachedCap { cap, cache } = *boxed;
+            let mut child = build_frame_from_owned(cap, instance_slot.clone(), endpoint_idx, args)?;
+            // Page-table reuse: if this resident instance carries a parked
+            // runtime (re-armed at its last HALT), move it into the child frame
+            // instead of rebuilding the page table. The data extent is fixed
+            // per image (immutable), so the parked extent must match.
+            if let CacheSlot::Instance(rt) = cache {
                 debug_assert_eq!(
                     rt.data_extent(),
                     child.mem.content_len(),
@@ -947,7 +944,6 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
                 .set_key(instance_slot.as_slice(), Some(CapHashOrRef::Hash(h)));
             build_frame_from_published(&h, endpoint_idx, args)?
         }
-        CapHashOrRef::Ref(_) => return Err(ERR_INSTANCE_KIND),
     };
 
     // The child inherits the parent's cnode entries its image didn't
@@ -960,7 +956,9 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
     //
     // The scratchpad slot (slot[0]) is EXCLUDED here: it is not inherited by
     // copy but *moved* by the caller (the `OP_HOST_CALL` arm).
-    let scratch_phys = CNodeCap::key_of(&[javm_cap::abi::SCRATCHPAD_SLOT]);
+    // `key_of` is payload-independent (it hashes the logical key); annotate
+    // the generic so it resolves, matching the parent frame's cnode payload.
+    let scratch_phys = CNodeCap::<Box<CachedCap>>::key_of(&[javm_cap::abi::SCRATCHPAD_SLOT]);
     for (phys_key, val) in parent.cnode.slots.iter() {
         if *phys_key == scratch_phys {
             continue;
@@ -1019,7 +1017,7 @@ fn call_frame_cost_for(image_hash: &CapHash) -> Result<i64, u32> {
 fn host_call_frame_cost(parent: &KernelFrame) -> Result<i64, u32> {
     let instance_slot = Key::from((parent.regs[7] & 0xFF) as u8);
     let image_hash = match parent.cnode.peek_key(instance_slot.as_slice()) {
-        Some(CapHashOrRef::Owned(boxed)) => match &**boxed {
+        Some(CapHashOrRef::Owned(boxed)) => match &boxed.cap {
             Cap::Instance(i) => i.image_hash,
             _ => return Err(ERR_INSTANCE_KIND),
         },
@@ -1032,7 +1030,6 @@ fn host_call_frame_cost(parent: &KernelFrame) -> Result<i64, u32> {
                 _ => return Err(ERR_INSTANCE_KIND),
             }
         }
-        Some(CapHashOrRef::Ref(_)) => return Err(ERR_INSTANCE_KIND),
         None => return Err(ERR_HOST_CALL_SLOT_EMPTY),
     };
     call_frame_cost_for(&image_hash)
@@ -1096,9 +1093,9 @@ fn build_frame_from_owned(
     )
 }
 
-// `build_frame_from_instance_ref` / `build_frame_from_cap` were removed: the
-// recompiler no longer mints `CapHashOrRef::Ref`, so `dispatch_host_call`
-// dispatches `Owned`/`Hash` inline (and rejects a stray `Ref`).
+// `build_frame_from_instance_ref` / `build_frame_from_cap` were removed: a
+// cnode slot is a `Hash` or an inline `Owned` cap, so `dispatch_host_call`
+// dispatches both inline.
 
 /// Core frame builder: reads the image cap to seed regs/pc/cnode +
 /// CoW ranges, stores only IDs on the frame (no `CapHandle` pins).
@@ -1182,6 +1179,5 @@ fn build_frame_inner(
         mat_state: alloc::vec![0u8; mat_state_pages],
         ro_units: Vec::new(),
         runtime: None,
-        child_runtimes: BTreeMap::new(),
     })
 }

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -165,26 +165,30 @@ fn error_hash_sentinel() -> Vec<u8> {
     alloc::vec![0xFFu8; 32]
 }
 
-/// Diagnostic: report talc's current allocation state as 32 LE
-/// bytes packing `[allocated_bytes, allocation_count,
-/// fragment_count, available_bytes]` (four u64s). Used to detect
-/// per-iter heap leaks — `allocated_bytes` growing monotonically
-/// indicates a real leak; `allocated_bytes` oscillating with
-/// `fragment_count` climbing indicates fragmentation.
+/// Diagnostic: report talc's current allocation state as 40 LE
+/// bytes packing `[allocation_count, total_allocation_count,
+/// allocated_bytes, fragment_count, available_bytes]` (five u64s).
+/// Used to detect per-iter heap leaks and per-CALL allocation churn:
+/// - `allocation_count` is the *live* count (alloc − free) — a
+///   non-zero per-invoke drift is a leak.
+/// - `total_allocation_count` is *cumulative* (monotonic) — its
+///   per-invoke delta is the allocation churn, which catches transient
+///   allocations (e.g. a rebuilt page table) that are freed again
+///   before the next snapshot and so leave `allocation_count` flat.
+/// - `allocated_bytes` oscillating with `fragment_count` climbing
+///   indicates fragmentation.
 ///
 /// Gated on `heap-diag` because reading the counters requires
 /// talc's `counters` feature, which adds a small per-alloc cost.
 #[cfg(feature = "heap-diag")]
 #[guest_function(fn_id = FN_ID_NUB_HEAP_STATS)]
 pub fn nub_heap_stats(_input: &[u8]) -> Vec<u8> {
-    let counters = hyperlight_guest_bin::HEAP_ALLOCATOR
-        .lock()
-        .counters()
-        .clone();
-    let mut buf = alloc::vec![0u8; 32];
-    buf[0..8].copy_from_slice(&(counters.allocated_bytes as u64).to_le_bytes());
-    buf[8..16].copy_from_slice(&(counters.allocation_count as u64).to_le_bytes());
-    buf[16..24].copy_from_slice(&(counters.fragment_count as u64).to_le_bytes());
-    buf[24..32].copy_from_slice(&(counters.available_bytes as u64).to_le_bytes());
+    let counters = *hyperlight_guest_bin::HEAP_ALLOCATOR.lock().counters();
+    let mut buf = alloc::vec![0u8; 40];
+    buf[0..8].copy_from_slice(&(counters.allocation_count as u64).to_le_bytes());
+    buf[8..16].copy_from_slice(&counters.total_allocation_count.to_le_bytes());
+    buf[16..24].copy_from_slice(&(counters.allocated_bytes as u64).to_le_bytes());
+    buf[24..32].copy_from_slice(&(counters.fragment_count as u64).to_le_bytes());
+    buf[32..40].copy_from_slice(&(counters.available_bytes as u64).to_le_bytes());
     buf
 }

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -50,9 +50,9 @@ pub fn nub_invoke_cached(packet_bytes: &[u8]) -> Vec<u8> {
         packet.initial_gas as i64,
     );
 
-    // Defensive: reclaim any `cache.instances` entries. The recompiler no
-    // longer mints `CapHashOrRef::Ref` (sub-VMs are inline `Owned` caps that
-    // drop with their frame), so this is a no-op in the current call path —
+    // Defensive: reclaim any `cache.instances` entries. The recompiler keeps
+    // sub-VMs as inline `Owned` caps that drop with their frame (there is no
+    // `Ref` cnode-slot variant), so this is a no-op in the current call path —
     // kept as a cheap safety net in case a host-published instance ever lands
     // in the tier. The talc-OOM that originally required it is gone: `Owned`
     // sub-VMs are freed directly at frame pop, not parked in the directory.

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -436,10 +436,10 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
         unsafe { &mut *ro_units_ptr }
     };
 
-    // Materialize-all (low→high), accumulating the charge. Read-only pages
-    // (code + PinnedCapRo data caps) materialize per unit (one page_in per
-    // `cap ∩ 2 MiB cluster`, fault-around the unit's RO pages); writable
-    // (CoW / ephemeral) pages stay per-page.
+    // Materialize-all (low→high), accumulating the CoW charge. Read-only
+    // pages (code + PinnedCapRo data caps) are fault-arounded per unit
+    // (`cap ∩ 2 MiB cluster`) with **no gas** — read-only page-in is charged
+    // at the CALL; only writable (CoW / ephemeral) pages charge per page here.
     let mut total: u64 = 0;
     for &p in set.as_slice() {
         let pv = p as u64;
@@ -629,20 +629,20 @@ fn cow_into_fresh(
 }
 
 /// Materialize the read-only **unit** containing `pv`: the intersection of
-/// the cap `[r_start, r_end)` (physical base `r_pa`) with the 2 MiB cluster
-/// containing `pv`, named by [`javm_exec::mat::unit_base`]. Charges one
-/// `page_in` the first time the unit faults (a fresh `unit_base` inserted
-/// into the sorted `ro_units` set), `0` thereafter — so a large read-only
-/// input materializes for one fault per 2 MiB, not one per page, and two
-/// caps sharing a cluster each pay their own page-in (the fault-around is
-/// clamped to one cap, so a page-in touches at most one DataCap). The unit's
-/// RO pages are **fault-arounded**: mapped present read-only straight from
-/// the cap so the retry (and later reads in the unit) hit no further faults.
+/// the cap `[r_start, r_end)` with the 2 MiB cluster containing `pv`, named
+/// by [`javm_exec::mat::unit_base`]. The first time the unit faults (a fresh
+/// `unit_base` inserted into the sorted `ro_units` set) its RO pages are
+/// **fault-arounded** — mapped present read-only straight from the cap so
+/// the retry (and later reads in the unit) hit no further faults — and a
+/// later fault on the same unit is a no-op. This **charges no gas**:
+/// read-only page-in is accounted eagerly at the CALL
+/// ([`javm_exec::gas_const::call_frame_cost`]); the `ro_units` set here is
+/// purely a fault-reduction / mapping optimization. Clamping the fault-around
+/// to one cap means a single map event touches at most one DataCap.
 ///
 /// No `invlpg`: every page mapped here goes `NotPresent → present`, which is
 /// not TLB-cached, so the faulting retry walks the fresh entries. Returns
-/// the charge, or `None` on a page-table allocation failure. Mirrors the
-/// interpreter's `ro_unit_charge` so the two agree bit-for-bit.
+/// `Some(0)` on success, or `None` on a page-table allocation failure.
 fn materialize_ro_unit(
     pv: u64,
     r_start: u64,
@@ -679,7 +679,8 @@ fn materialize_ro_unit(
         // No invlpg: NotPresent → present is not TLB-cached.
         q += PAGE_SIZE as u64;
     }
-    Some(javm_exec::gas_const::PAGE_IN_COST)
+    // Read-only page-in is charged at the CALL, not here: mapping is free.
+    Some(0)
 }
 
 /// Result of an in-kernel PVM run.

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -339,6 +339,23 @@ fn mem_source_pa_in(
     }
 }
 
+/// Whether guest data page `page_va` is **privately CoW'd** — present in the
+/// running frame's `mem` overlay (rather than sourced read-only from the
+/// shared backing). The page-table reuse path keys off this: a write fault
+/// on an already-private page (its leaf re-armed read-only at the previous
+/// HALT) only needs its leaf W bit flipped back, whereas a write to a shared
+/// backing page must CoW a fresh private copy.
+fn overlay_has_page(page_va: u64, data_base: u64) -> bool {
+    let sink = OVERLAY_SINK.load(Ordering::SeqCst);
+    if sink.is_null() {
+        return false;
+    }
+    let idx = ((page_va - data_base) / PAGE_SIZE as u64) as u32;
+    // SAFETY: OVERLAY_SINK is the running frame's `mem` DataCap, exclusively
+    // ours under Hyperlight serialisation; borrowed read-only here.
+    unsafe { (*sink).overlay.contains_key(&idx) }
+}
+
 /// Read-only materialization source for a 2 MiB unit: a contiguous slab (code —
 /// page PA = `base_pa + offset`) or a cap-backed range whose page PAs are
 /// resolved lazily from the frame's `mem` (see [`mem_source_pa`]).
@@ -517,23 +534,38 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
                 // (not-present) page and the loop re-visits this present partner;
                 // charge_for already returned 0, so skipping the map is gas-neutral.
                 if cur != javm_exec::mat::PageState::PresentRw {
-                    // Flush only when an *existing* present (RO) mapping is being
-                    // changed to RW (read-then-write CoW): that stale RO entry may
-                    // be TLB-cached. A first-touch write (cur == NotPresent) maps a
-                    // page that was never present, so it needs no invlpg.
-                    let flush = cur == javm_exec::mat::PageState::PresentRo;
-                    // Resolve the source PA lazily (from the frame's `mem`): a
-                    // `Loaded` cap slab, or the shared zero page for an ephemeral
-                    // page (so the CoW yields a fresh zeroed page). `None`
-                    // (a `Missing` page) → fault.
-                    let Some(src_pa) = mem_source_pa(pv) else {
-                        return false;
-                    };
-                    if !cow_into_fresh(pv, src_pa, pml4, owned_vec, data_base, flush) {
-                        // Allocation / remap failure → fault (nothing charged
-                        // yet for THIS page, but earlier pages of a straddle
-                        // were already advanced; an OOM here is fatal anyway).
-                        return false;
+                    // Page-table reuse fast path: if this page is already a
+                    // private (overlay) page whose leaf was re-armed read-only at
+                    // the previous HALT, just flip the leaf's W bit back and reuse
+                    // the existing private page — no fresh allocation, no re-copy.
+                    // (A present-RO leaf mapping the *shared backing* is NOT in the
+                    // overlay, so it correctly falls through to a real CoW.) The
+                    // RO translation may be TLB-cached by the faulting write, so
+                    // invlpg after the flip.
+                    let flipped = overlay_has_page(pv, data_base)
+                        && unsafe { crate::paging::pt_set_leaf_w(pml4, pv, true) };
+                    if flipped {
+                        crate::paging::invlpg(pv);
+                    } else {
+                        // Flush only when an *existing* present (RO) mapping is
+                        // being changed to RW (read-then-write CoW): that stale RO
+                        // entry may be TLB-cached. A first-touch write (cur ==
+                        // NotPresent) maps a page that was never present, so it
+                        // needs no invlpg.
+                        let flush = cur == javm_exec::mat::PageState::PresentRo;
+                        // Resolve the source PA lazily (from the frame's `mem`): a
+                        // `Loaded` cap slab, or the shared zero page for an
+                        // ephemeral page (so the CoW yields a fresh zeroed page).
+                        // `None` (a `Missing` page) → fault.
+                        let Some(src_pa) = mem_source_pa(pv) else {
+                            return false;
+                        };
+                        if !cow_into_fresh(pv, src_pa, pml4, owned_vec, data_base, flush) {
+                            // Allocation / remap failure → fault (nothing charged
+                            // yet for THIS page, but earlier pages of a straddle
+                            // were already advanced; an OOM here is fatal anyway).
+                            return false;
+                        }
                     }
                 }
             }
@@ -797,6 +829,40 @@ pub struct FrameRuntime {
     code_base: u32,
     code_top: u32,
     code_pa: u64,
+}
+
+impl FrameRuntime {
+    /// Page-aligned byte size of the lazily-materialized data extent
+    /// (`mem_top − data_base`). For a reused runtime this must equal the
+    /// instance's `mem.content_len()` — images are immutable, so the extent
+    /// is fixed per image (asserted on reuse).
+    pub fn data_extent(&self) -> u64 {
+        (self.mem_top as u64).saturating_sub(self.data_base as u64)
+    }
+
+    /// HALT re-arm for a runtime that is about to be **parked** for reuse by
+    /// the next CALL of its resident instance: clear the Writable bit on the
+    /// leaf of every privately-CoW'd page (the keys of the instance's
+    /// `overlay`), so the next CALL re-faults on first write and re-charges
+    /// its CoW — exactly the per-frame CoW charge a fresh frame would pay, so
+    /// gas stays identical whether or not the page table was cached. The page
+    /// itself is reused: only the W bit toggles, no allocation.
+    ///
+    /// No `invlpg`: every `enter_frame` reloads CR3, which flushes every
+    /// non-global TLB entry, so the cleared-W leaves are re-walked next CALL.
+    pub fn rearm_cow<I: Iterator<Item = u32>>(&self, overlay_page_indices: I) {
+        let pml4 = self.pt.pml4_kva();
+        let data_base = self.data_base as u64;
+        for idx in overlay_page_indices {
+            let va = data_base + (idx as u64) * PAGE_SIZE as u64;
+            // SAFETY: `pml4` is this runtime's live page table; single-threaded
+            // (the guest is suspended). A leaf that is absent (never faulted in)
+            // simply returns `false` — nothing to re-arm.
+            unsafe {
+                crate::paging::pt_set_leaf_w(pml4, va, false);
+            }
+        }
+    }
 }
 
 /// Build a per-frame runtime: compile the Image (cached) and build the

--- a/rust/nub-arch-x86/src/lib.rs
+++ b/rust/nub-arch-x86/src/lib.rs
@@ -27,6 +27,8 @@ extern crate hyperlight_guest_bin;
 
 // Kernel modules — guest-only.
 #[cfg(target_os = "none")]
+pub mod cached_cap;
+#[cfg(target_os = "none")]
 pub mod call_loop;
 #[cfg(target_os = "none")]
 pub mod jit_cache;

--- a/rust/nub-arch-x86/src/paging.rs
+++ b/rust/nub-arch-x86/src/paging.rs
@@ -561,6 +561,71 @@ pub unsafe fn pt_map_leaf(
     Some(())
 }
 
+/// Set (`writable = true`) or clear (`writable = false`) the Writable bit
+/// on an **existing** leaf PTE for `virt`, without allocating any
+/// intermediate tables. Walks PML4→PDPT→PD→PT and returns `false` if any
+/// level — or the leaf itself — is not present (nothing to toggle), so the
+/// caller can fall back to a full map.
+///
+/// This powers page-table **reuse** across CALLs of a resident instance:
+/// - the HALT re-arm clears W on every privately-CoW'd leaf, so the next
+///   CALL re-faults on first write and re-charges its CoW (the page itself
+///   is reused — only the W bit toggles, gas-neutral);
+/// - the #PF handler sets W back when an already-private (overlay) page is
+///   written again, flipping the bit instead of re-allocating + re-copying.
+///
+/// Does **not** invalidate the TLB. The handler must [`invlpg`] after a
+/// clear→RW flip (the RO translation may be cached by the faulting write);
+/// the re-arm needs none (a CR3 reload at the next `enter_frame` flushes
+/// every non-global entry).
+///
+/// # Safety
+/// `pml4_va` must be the kernel VA of a live 4-level page table; the caller
+/// must be the only writer (single-threaded guest).
+pub unsafe fn pt_set_leaf_w(pml4_va: u64, virt: u64, writable: bool) -> bool {
+    const PS: u64 = 1 << 7;
+    let idx4 = ((virt >> 39) & 0x1FF) as usize;
+    let idx3 = ((virt >> 30) & 0x1FF) as usize;
+    let idx2 = ((virt >> 21) & 0x1FF) as usize;
+    let idx1 = ((virt >> 12) & 0x1FF) as usize;
+
+    // Descend one present, non-large-page level at a time; bail to `false`
+    // the moment the path is absent (the caller then does a full map).
+    let descend = |table_va: u64, idx: usize| -> Option<u64> {
+        // SAFETY: table_va is a live 4 KiB-aligned table (the PML4 or a
+        // recovered inner table); 512 entries are readable.
+        let entry = unsafe { (*(table_va as *const Table)).get(idx).copied()? };
+        if entry & flag::P == 0 || entry & PS != 0 {
+            return None;
+        }
+        pa_to_va(entry & PA_MASK)
+    };
+
+    let pdpt_va = match descend(pml4_va, idx4) {
+        Some(v) => v,
+        None => return false,
+    };
+    let pd_va = match descend(pdpt_va, idx3) {
+        Some(v) => v,
+        None => return false,
+    };
+    let pt_va = match descend(pd_va, idx2) {
+        Some(v) => v,
+        None => return false,
+    };
+    // SAFETY: pt_va is a live PT this caller owns; idx1 < 512.
+    let leaf = unsafe { &mut (*(pt_va as *mut Table))[idx1] };
+    if *leaf & flag::P == 0 {
+        return false;
+    }
+    if writable {
+        *leaf |= flag::RW;
+    } else {
+        *leaf &= !flag::RW;
+    }
+    true
+}
+
 /// Like [`PageTable::ensure_inner`] but records a freshly-allocated table
 /// into the raw `owned` Vec pointer (for the #PF handler, which has no
 /// `&PageTable`). Returns the inner table's KVA, or `None` on large-page

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -47,8 +47,16 @@ use rkyv::util::AlignedVec;
 #[cfg(feature = "heap-diag")]
 #[derive(Debug, Clone, Copy)]
 pub struct HeapStats {
-    pub allocated_bytes: u64,
+    /// Live allocation count (incremented on alloc, decremented on
+    /// free) — a non-zero per-invoke drift here is a leak.
     pub allocation_count: u64,
+    /// Cumulative allocations ever performed (monotonic, never
+    /// decremented) — its per-invoke delta is the allocation *churn*,
+    /// the right yardstick for "this CALL allocated nothing but a
+    /// `KernelFrame`" even when the transient allocations are freed
+    /// again before the next snapshot.
+    pub total_allocation_count: u64,
+    pub allocated_bytes: u64,
     pub fragment_count: u64,
     pub available_bytes: u64,
 }
@@ -178,18 +186,19 @@ impl Nub {
             )),
             Backend::Hyperlight(h) => {
                 let raw: Vec<u8> = h.sandbox.call_raw(FN_ID_NUB_HEAP_STATS, &[])?;
-                if raw.len() != 32 {
+                if raw.len() != 40 {
                     return Err(anyhow::anyhow!(
-                        "heap_stats: expected 32 bytes, got {}",
+                        "heap_stats: expected 40 bytes, got {}",
                         raw.len()
                     ));
                 }
                 let parse = |off: usize| u64::from_le_bytes(raw[off..off + 8].try_into().unwrap());
                 Ok(HeapStats {
-                    allocated_bytes: parse(0),
-                    allocation_count: parse(8),
-                    fragment_count: parse(16),
-                    available_bytes: parse(24),
+                    allocation_count: parse(0),
+                    total_allocation_count: parse(8),
+                    allocated_bytes: parse(16),
+                    fragment_count: parse(24),
+                    available_bytes: parse(32),
                 })
             }
         }


### PR DESCRIPTION
Makes repeated CALLs of a **resident** sub-VM instance cheap by caching its ring-3 page table across calls — while keeping gas independent of that cache — and reworks the cap layer so the cache rides the instance's cap instead of a parent-side side-table.

## What's in here (5 commits)

**`4e67de16` gas — charge read-only page-in + compile at the CALL, not at the fault.** Category-#3 materialization cost (JIT compile `O(code)` + eager RO page-in per declared 2 MiB unit + frame-setup base) is charged to the caller at the in-kernel CALL, computed statically from the callee Image — so gas is independent of the node-local compile/PT cache (a cache is a performance optimization, never a gas discount). Check-before-charge, gated before the instance is moved, so an OOG at a CALL is a clean no-work re-attempt.

**`f7e2111f` bench — pt-cache allocation bench + cumulative heap counter.** A `pt_cache_call` criterion bench (derive_spawn once, then loop `host_call` to the same resident instance) and a cumulative `total_allocation_count` heap-diag counter, so per-CALL allocation *churn* (transient allocs freed before the next snapshot) is measurable, not just live-leak drift.

**`8a4338d7` pt-cache — cache the ring-3 page table across CALLs.** A resident `Owned` sub-VM's `FrameRuntime` (its ring-3 page table) is reused across CALLs instead of rebuilt: at HALT it is re-armed (clear W on each CoW'd leaf so the next CALL re-faults and re-charges its CoW — gas-neutral) and parked; the next CALL flips W rather than rebuilding the page table.

**`a0538dec` CachedCap — move the cache onto the cap; retire `CapHashOrRef::Ref`.** The page-table cache now rides *with* the instance's cap (`CapHashOrRef::Owned(Box<CachedCap>)`, `CachedCap { cap, cache }`) instead of a parent-side `child_runtimes: BTreeMap` side-table — cache lifetime == cap lifetime, dropped automatically on slot overwrite / frame pop, no manual `derive_spawn` invalidation, no per-spawn `BTreeMap` allocation. `CapHashOrRef` / `CNodeCap` gain a defaulted payload param `O`, with the wire impls (`HashTreeRoot` / `Encode` / `Decode` / rkyv) gated on a sealed `WireOwned` leaf marker implemented only for `Box<Cap>`; a cache-carrying cnode (`Box<CachedCap>`) is therefore **non-serialisable / non-hashable at compile time**, strictly stronger than the previous runtime panic. `Cap` stays pinned to `Box<Cap>`, so the wire type and every cap hash are byte-identical. `CapHashOrRef::Ref` (dead in the cnode graph — the recompiler mints only `Hash` + `Owned`) is removed; `CapRef` + the instances tier stay dormant for the future persist path.

**`6a076d8a` reconstruct the InstanceCap at HALT instead of parking a shell.** `owned_origin` shrinks from `(Key, InstanceCap)` to just the return `Key`; the `InstanceCap` is reconstructed at HALT from the frame's authoritative fields (identity is already a frame field; `mem`/`regs`/`pc` are the frame's; `root_cnode`/`gas_remaining` are the same spawn-time placeholders), dropping the hollowed-shell + `DataCap::empty()` hack — one fewer transient allocation per CALL.

## Performance

Criterion A/B (each layer vs its pre-change state): `pt_cache_call` (resident re-CALL) **−2.0%..−2.6%**; `sub_vm_recurse` (fresh spawn-and-call) **−1.6%..−2.1%** (BTreeMap park alloc removed); `sub_vm_data_recurse` neutral. Per-CALL allocation churn dropped to **3** (from 7 pre-cache).

## Verification

`cargo build --workspace` + guest cross-compile; `cargo fmt --all --check`, workspace clippy `-D warnings`, guest-target clippy on `nub-arch-x86` (`--target x86_64-unknown-none`), `RUSTDOCFLAGS=-D warnings cargo doc`. 3-way conformance (`every_suite_matches_three_ways`), recomp pinned-trap regression, interp==recomp workloads, sub_vm gas parity (×10), pt-cache churn (bit-stable, ≤ ceiling). Gas + return values are unchanged: no transpiler change, and the CachedCap / HALT-reconstruct reworks are pure mechanism relocation, adversarially reviewed for byte-equivalence of the reconstructed instance (identity, regs/pc carry, `root_cnode`/`gas` placeholders).

Phase 3 (folding `jit_cache::CACHE` + `MEM_CACHE` into the cap directory) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
