### PR TITLE
Implement owner-edge yield routing and resident CNode runtime

### DIFF
--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -69,7 +69,7 @@ impl BuiltCaps {
     pub fn for_image(image: &Image, endpoint_idx: u8) -> Self {
         let endpoint = image
             .endpoints
-            .get(&endpoint_idx)
+            .get(&Key::from(endpoint_idx))
             .unwrap_or_else(|| panic!("endpoint {endpoint_idx} not declared"));
 
         // 1. Build a Cap::Data per non-empty pinned/initial slot. Track
@@ -408,7 +408,10 @@ fn publish_instance(
     nub.put_cap_with_hash(cnode_hash, &cnode_cap)
         .expect("put cnode");
 
-    let endpoint = image.endpoints.get(&ENDPOINT_IDX).expect("endpoint 0");
+    let endpoint = image
+        .endpoints
+        .get(&Key::from(ENDPOINT_IDX))
+        .expect("endpoint 0");
     let mut regs = [0u64; NUM_REGS];
     for (&i, &v) in &endpoint.initial_regs {
         if let Some(slot) = regs.get_mut(i as usize) {

--- a/rust/javm-bench/tests/x3_x4_differential.rs
+++ b/rust/javm-bench/tests/x3_x4_differential.rs
@@ -22,6 +22,7 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use javm_bench::{BuiltCaps, run_interpreter};
+use javm_cap::Key;
 use javm_cap::image::{EndpointDef, Image};
 use std::collections::BTreeMap;
 
@@ -59,7 +60,7 @@ fn image(code: Vec<u8>) -> Image {
     let mut img = Image::empty();
     img.code = code;
     img.endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,

--- a/rust/javm-cap/src/abi.rs
+++ b/rust/javm-cap/src/abi.rs
@@ -28,24 +28,16 @@ pub const BARE_GAS_SLOT: u8 = 7;
 /// `BARE_GAS_SLOT`).
 pub const BARE_QUOTA_SLOT: u8 = 8;
 
-/// Chain's `Cap::Instance[YieldCatcher]` (its own catcher; per-block
-/// reset). The chain Image's `yield_marker_slot` points here.
-pub const BARE_YIELD_CATCHER_SLOT: u8 = 9;
-
-/// `Cap::Instance[SetGasMeter]` factory.
-pub const BARE_SET_GAS_METER_SLOT: u8 = 10;
-
-/// `Cap::Instance[SetStorageQuota]` factory.
-pub const BARE_SET_STORAGE_QUOTA_SLOT: u8 = 11;
-
-/// `Cap::Instance[MintGas]` factory.
-pub const BARE_MINT_GAS_SLOT: u8 = 12;
-
-/// `Cap::Instance[MintQuota]` factory.
-pub const BARE_MINT_QUOTA_SLOT: u8 = 13;
-
-/// `Cap::Instance[CreateYieldCatcher]` factory.
-pub const BARE_CREATE_YIELD_CATCHER_SLOT: u8 = 14;
+/// Slot the chain Image's `yield_receiver_slot` points at, holding the chain's
+/// `Cap::Instance[YieldReceiver]` (its catch-set; per-block reset). The kernel
+/// reads it when routing a yield.
+///
+/// The per-syscall factory/marker slots (set_gas_meter, mint_gas,
+/// create_yield_catcher, …) that used to follow are gone: a syscall is a
+/// `host_yield` of a named `kernel:*` YieldSender from the top-level scratchpad
+/// CNode, caught by the kernel as the root YieldReceiver — not a CALL into a
+/// factory Instance pinned at a well-known slot.
+pub const BARE_YIELD_RECEIVER_SLOT: u8 = 9;
 
 /// `Cap::Instance[HostOpen]` — read-only entry handle for `host_open`.
 pub const BARE_HOST_OPEN_SLOT: u8 = 15;

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -1,10 +1,10 @@
 //! `CacheDirectory<S>` — two-tier cap store.
 //!
-//! - **`blobs: HashMap<CapHash, Arc<Cap>>`** — content-addressed
-//!   immutable caps. Pure cache: the host populates it; the kernel
-//!   reads. If a lookup misses, the host hasn't published the cap yet.
+//! - **`blobs: HashMap<CapHash, Arc<C>>`** — content-addressed
+//!   immutable resident caps. Pure cache: the host populates it; the
+//!   kernel reads. If a lookup misses, the host hasn't published the cap yet.
 //!
-//! - **`instances: HashMap<u64, (CapRef, Arc<Cap>)>`** — identity-keyed
+//! - **`instances: HashMap<u64, (CapRef, Arc<C>)>`** — identity-keyed
 //!   mutable working state. The stored `CapRef` is the directory's
 //!   self-reference; its `Arc::strong_count` is the number of live
 //!   external holders + 1.
@@ -44,7 +44,7 @@
 //!
 //! `sweep_instances` reclaims entries whose stored `CapRef.strong_count`
 //! is 1 (i.e., the directory is the sole holder). Removal drops the
-//! entry's `Arc<Cap>`; if that was the last strong ref to the Cap, the
+//! entry's `Arc<C>`; if that was the last strong ref to the resident cap, the
 //! Cap drops. Caps no longer hold `Ref(CapRef)` slot targets (a cnode
 //! slot is a `Hash` or an inline `Owned` cap), so a drop never cascades
 //! into other instance entries — the sweep is a single self-contained
@@ -406,17 +406,44 @@ pub enum CacheError {
     SlotOutOfRange,
 }
 
-pub struct CacheDirectory<S = DefaultHashBuilder> {
-    inner: Mutex<DirectoryInner<S>>,
+/// Payload stored by a [`CacheDirectory`]. The public/wire directory stores
+/// plain [`Cap`]; engines may store a resident wrapper that carries derived
+/// runtime caches while still exposing the underlying wire cap for hashing and
+/// inspection.
+pub trait ResidentCap {
+    /// Wrap a public wire cap for resident storage.
+    fn from_cap(cap: Cap) -> Self;
+    /// Borrow the public wire cap.
+    fn as_cap(&self) -> &Cap;
+    /// Consume the resident payload back into its wire cap.
+    fn into_cap(self) -> Cap;
 }
 
-struct DirectoryInner<S> {
-    blobs: HashMap<CapHash, Arc<Cap>, S>,
-    instances: HashMap<u64, (CapRef, Arc<Cap>), S>,
+impl ResidentCap for Cap {
+    fn from_cap(cap: Cap) -> Self {
+        cap
+    }
+
+    fn as_cap(&self) -> &Cap {
+        self
+    }
+
+    fn into_cap(self) -> Cap {
+        self
+    }
+}
+
+pub struct CacheDirectory<S = DefaultHashBuilder, C = Cap> {
+    inner: Mutex<DirectoryInner<S, C>>,
+}
+
+struct DirectoryInner<S, C> {
+    blobs: HashMap<CapHash, Arc<C>, S>,
+    instances: HashMap<u64, (CapRef, Arc<C>), S>,
     next_ref: u64,
 }
 
-impl CacheDirectory<DefaultHashBuilder> {
+impl CacheDirectory<DefaultHashBuilder, Cap> {
     /// Construct an empty cache using the default per-process-randomized
     /// hasher.
     pub fn new() -> Self {
@@ -424,13 +451,13 @@ impl CacheDirectory<DefaultHashBuilder> {
     }
 }
 
-impl Default for CacheDirectory<DefaultHashBuilder> {
+impl Default for CacheDirectory<DefaultHashBuilder, Cap> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<S: BuildHasher> CacheDirectory<S> {
+impl<S: BuildHasher, C> CacheDirectory<S, C> {
     /// Construct an empty cache with an explicit hasher.
     pub fn with_hasher(hasher: S) -> Self
     where
@@ -447,7 +474,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
     }
 }
 
-impl<S> CacheDirectory<S> {
+impl<S, C> CacheDirectory<S, C> {
     /// `const fn` constructor for static initialisation. Used by the
     /// guest's `state_cache::CACHE` static. Takes both hashers
     /// separately because `const fn` can't call `S::clone()` and not
@@ -465,7 +492,7 @@ impl<S> CacheDirectory<S> {
     }
 }
 
-impl<S: BuildHasher> CacheDirectory<S> {
+impl<S: BuildHasher, C> CacheDirectory<S, C> {
     /// Number of blob entries.
     pub fn blob_count(&self) -> usize {
         self.inner.lock().blobs.len()
@@ -482,13 +509,13 @@ impl<S: BuildHasher> CacheDirectory<S> {
 
     /// Get an `Arc::clone` of the blob cap at `hash`, or `None` if
     /// absent.
-    pub fn get_blob(&self, hash: &CapHash) -> Option<Arc<Cap>> {
+    pub fn get_blob(&self, hash: &CapHash) -> Option<Arc<C>> {
         self.inner.lock().blobs.get(hash).cloned()
     }
 
     /// Get an `Arc::clone` of the instance cap at `capref`, or `None`
     /// if absent.
-    pub fn get_instance(&self, capref: &CapRef) -> Option<Arc<Cap>> {
+    pub fn get_instance(&self, capref: &CapRef) -> Option<Arc<C>> {
         self.inner
             .lock()
             .instances
@@ -496,10 +523,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
             .map(|(_, arc)| arc.clone())
     }
 
-    /// Snapshot the blob tier into a `Vec<(CapHash, Arc<Cap>)>`. Order
+    /// Snapshot the blob tier into a `Vec<(CapHash, Arc<C>)>`. Order
     /// is unspecified (HashMap iteration); callers that need
     /// deterministic order (state-root computations) sort by hash.
-    pub fn iter_blobs(&self) -> Vec<(CapHash, Arc<Cap>)> {
+    pub fn iter_blobs(&self) -> Vec<(CapHash, Arc<C>)> {
         self.inner
             .lock()
             .blobs
@@ -510,7 +537,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
 
     /// Polymorphic lookup that dispatches on the `CapHashOrRef` arm.
     /// Returns an `Arc::clone` of the matching cap.
-    pub fn get(&self, key: CapHashOrRef) -> Option<Arc<Cap>> {
+    pub fn get(&self, key: CapHashOrRef) -> Option<Arc<C>> {
         match key {
             CapHashOrRef::Hash(h) => self.get_blob(&h),
             // `Owned` lives inline on the kernel frame, not in the
@@ -519,11 +546,11 @@ impl<S: BuildHasher> CacheDirectory<S> {
         }
     }
 
-    /// Replace the instance at `capref` with a fresh `Arc<Cap>`. The
-    /// old `Arc<Cap>` drops outside the lock (so any cascading
+    /// Replace the instance at `capref` with a fresh `Arc<C>`. The
+    /// old `Arc<C>` drops outside the lock (so any cascading
     /// `Cap::drop → CapRef::drop` chain doesn't try to re-enter the
     /// directory while we hold the guard).
-    pub fn set_instance(&self, capref: &CapRef, new_arc: Arc<Cap>) -> Result<(), CacheError> {
+    pub fn set_instance(&self, capref: &CapRef, new_arc: Arc<C>) -> Result<(), CacheError> {
         let _old = {
             let mut g = self.inner.lock();
             let entry = g
@@ -531,7 +558,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
                 .get_mut(&capref.id())
                 .ok_or_else(|| CacheError::InstanceMissing(capref.id()))?;
             // Swap in the new Arc, keeping the existing self-ref CapRef.
-            // The old Arc<Cap> is returned and dropped after the lock guard.
+            // The old Arc<C> is returned and dropped after the lock guard.
             core::mem::replace(&mut entry.1, new_arc)
         };
         Ok(())
@@ -539,7 +566,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
 
     /// Hash + insert into blobs. Idempotent: re-puts of identical
     /// content are a no-op. Returns the content hash.
-    pub fn put_cap(&self, cap: &Cap) -> Result<CapHash, CacheError> {
+    pub fn put_cap(&self, cap: &Cap) -> Result<CapHash, CacheError>
+    where
+        C: ResidentCap,
+    {
         let hash = cap.cap_hash();
         self.put_cap_with_hash(hash, cap)?;
         Ok(hash)
@@ -548,14 +578,19 @@ impl<S: BuildHasher> CacheDirectory<S> {
     /// Pre-hashed insert. Debug-asserts the claimed hash matches the
     /// cap; release trusts the caller (the SSZ merkleize is the hot
     /// cost on the publish path).
-    pub fn put_cap_with_hash(&self, hash: CapHash, cap: &Cap) -> Result<(), CacheError> {
+    pub fn put_cap_with_hash(&self, hash: CapHash, cap: &Cap) -> Result<(), CacheError>
+    where
+        C: ResidentCap,
+    {
         debug_assert_eq!(
             cap.cap_hash(),
             hash,
             "put_cap_with_hash: claimed hash does not match cap content",
         );
         let mut g = self.inner.lock();
-        g.blobs.entry(hash).or_insert_with(|| Arc::new(cap.clone()));
+        g.blobs
+            .entry(hash)
+            .or_insert_with(|| Arc::new(C::from_cap(cap.clone())));
         Ok(())
     }
 
@@ -564,14 +599,17 @@ impl<S: BuildHasher> CacheDirectory<S> {
     /// returned handle internally as the entry's self-reference; when
     /// all external clones drop, `sweep_instances` will reclaim the
     /// entry.
-    pub fn put_instance(&self, cap: Cap) -> CapRef {
-        self.put_instance_arc(Arc::new(cap))
+    pub fn put_instance(&self, cap: Cap) -> CapRef
+    where
+        C: ResidentCap,
+    {
+        self.put_instance_arc(Arc::new(C::from_cap(cap)))
     }
 
-    /// `put_instance` variant that takes a pre-built `Arc<Cap>`. Used
+    /// `put_instance` variant that takes a pre-built `Arc<C>`. Used
     /// internally by [`Self::promote_blob_to_instance`] to share the
     /// blob's Arc rather than deep-copying.
-    fn put_instance_arc(&self, arc: Arc<Cap>) -> CapRef {
+    fn put_instance_arc(&self, arc: Arc<C>) -> CapRef {
         let mut g = self.inner.lock();
         let id = g.next_ref;
         g.next_ref = g.next_ref.checked_add(1).expect("CapRef space exhausted");
@@ -581,7 +619,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
     }
 
     /// Lazily promote a blob to a fresh instance entry. The blob and
-    /// the new instance entry share the same `Arc<Cap>` (no Cap
+    /// the new instance entry share the same `Arc<C>` (no resident cap
     /// data deep-copy); the next `Arc::make_mut` call on either side
     /// clones-on-write if both still hold the Arc.
     ///
@@ -619,7 +657,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
                     g.instances.remove(&id)
                 };
                 // _removed drops here, outside the lock. If its
-                // Arc<Cap> was the last strong ref, Cap::drop runs and
+                // Arc<C> was the last strong ref, Cap::drop runs and
                 // cascades: nested CapRef::drop calls decrement other
                 // entries' refcounts. Those entries get reclaimed on
                 // the next pass.
@@ -632,7 +670,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
     /// CoW overlay, content-address it into `blobs`, and return the hash.
     ///
     /// For `Hash`-keyed input, returns it unchanged.
-    pub fn settle(&self, key: CapHashOrRef) -> Result<CapHash, CacheError> {
+    pub fn settle(&self, key: CapHashOrRef) -> Result<CapHash, CacheError>
+    where
+        C: ResidentCap,
+    {
         match key {
             CapHashOrRef::Hash(h) => Ok(h),
             CapHashOrRef::Owned(b) => self.settle_owned(*b),
@@ -647,7 +688,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
     /// The recompiler never calls this — it *moves* `Owned` caps and
     /// drops them at frame pop. It exists for the host-side deferred
     /// persist path (turn a finished frame's owned cap into a blob).
-    fn settle_owned(&self, mut cap: Cap) -> Result<CapHash, CacheError> {
+    fn settle_owned(&self, mut cap: Cap) -> Result<CapHash, CacheError>
+    where
+        C: ResidentCap,
+    {
         // 1. Settle every nested slot target to a Hash, in place.
         self.settle_targets_in(&mut cap)?;
         // 2. Hashing requires an empty overlay; fold a dirty Data cap.
@@ -665,7 +709,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
     /// Rewrite every direct slot target of `cap` (CNode slots, Instance
     /// `root_cnode`) from a runtime-only `Owned` to its settled `Hash`,
     /// recursing into nested `Owned` caps.
-    fn settle_targets_in(&self, cap: &mut Cap) -> Result<(), CacheError> {
+    fn settle_targets_in(&self, cap: &mut Cap) -> Result<(), CacheError>
+    where
+        C: ResidentCap,
+    {
         match cap {
             Cap::CNode(cn) => {
                 for (_, mo) in cn.slots.iter_mut() {
@@ -682,7 +729,10 @@ impl<S: BuildHasher> CacheDirectory<S> {
 
     /// Settle one slot target in place: `Hash` unchanged, `Owned`
     /// recursively via [`Self::settle_owned`].
-    fn settle_target(&self, t: &mut CapHashOrRef) -> Result<(), CacheError> {
+    fn settle_target(&self, t: &mut CapHashOrRef) -> Result<(), CacheError>
+    where
+        C: ResidentCap,
+    {
         match t {
             CapHashOrRef::Hash(_) => Ok(()),
             CapHashOrRef::Owned(_) => {

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -675,7 +675,7 @@ impl<S: BuildHasher> CacheDirectory<S> {
                 }
             }
             Cap::Instance(inst) => self.settle_target(&mut inst.root_cnode)?,
-            Cap::Data(_) | Cap::Image(_) | Cap::Type(_) => {}
+            Cap::Data(_) | Cap::Image(_) => {}
         }
         Ok(())
     }

--- a/rust/javm-cap/src/cache.rs
+++ b/rust/javm-cap/src/cache.rs
@@ -194,9 +194,9 @@ impl WireOwned for Box<Cap> {}
 /// **`PartialEq`/`Eq`/`Hash` are hand-written**: a `Box<Cap>` payload
 /// blocks the derive (`Cap` is not `Eq`/`Hash`). The `Hash` arm
 /// compares/hashes its 32-byte digest by value; the `Owned` arm uses
-/// pointer identity of the inline payload (sound — the only holder,
-/// `CNodeSlots = RadixMap<_, KEY_BYTES>`, keys by the 32-byte physical
-/// key, never by value — and `O`-agnostic, so it needs no bound).
+/// pointer identity of the inline payload (sound — `Owned` is single-owner
+/// runtime state, never content-compared — and `O`-agnostic, so it needs no
+/// bound).
 #[derive(Clone, Debug)]
 pub enum CapHashOrRef<O = Box<Cap>> {
     Hash(CapHash),

--- a/rust/javm-cap/src/cap/cnode.rs
+++ b/rust/javm-cap/src/cap/cnode.rs
@@ -1,20 +1,21 @@
-//! `CNodeCap` — CNode cap: a sparse, hash-keyed key→cap map.
+//! `CNodeCap` — CNode cap: a sparse, Key-addressed key→cap map.
 //!
-//! A CNode is a [`RadixMap`] from `Hasher(k)` to a [`CapHashOrRef`] slot
-//! target, where the logical key `k` is a byte string. The structurally-
-//! compressed binary radix (EIP-7864 "minimal InternalNodes", no 256-value
-//! stem subtree) gives a canonical, shallow commitment to the key→cap set
-//! (depth ≈ `log2(entries)` for well-spread digests), with **no fixed
-//! capacity bound** — a CNode is bounded by storage quota, not a
-//! compile-time slot count, and a single-entry CNode is one leaf at depth 1.
+//! A CNode is a direct map from logical [`Key`] byte strings to
+//! [`CapHashOrRef`] slot targets. There is **no fixed capacity bound** — a
+//! CNode is bounded by storage quota, not a compile-time slot count.
 //!
 //! A slot is named by a [`Key`] (a short byte string); [`CNodeCap::get`]
-//! / [`CNodeCap::set`] / [`CNodeCap::take`] hash the key to its physical
-//! radix key. The V1 ABI uses single-byte keys (`Key::from(b)`), but the
-//! map admits arbitrary-length keys natively (the same `get`/`set`/`take`
+//! / [`CNodeCap::set`] / [`CNodeCap::take`] operate on that logical key
+//! directly. The V1 ABI uses single-byte keys (`Key::from(b)`), but the map
+//! admits arbitrary-length keys natively (the same `get`/`set`/`take`
 //! surface), so a future ABI can key e.g. `address -> Cap::Instance` with no
-//! structural change. The raw `&[u8]` form is exposed via
+//! structural change. The raw `&[u8]` convenience form is exposed via
 //! [`CNodeCap::get_key`] / [`CNodeCap::set_key`] / [`CNodeCap::take_key`].
+//!
+//! The hash-keyed radix tree is a commitment/proof representation, not the
+//! runtime storage model. [`HashTreeRoot`](ssz::HashTreeRoot) derives that
+//! view on demand by hashing each logical key into a 32-byte radix path; normal
+//! kernel execution never hashes a CNode key just to read or mutate a slot.
 //!
 //! The leaf value is **always a cap** ([`CapHashOrRef`]), never raw data —
 //! this is what lets a CNode model e.g. `address -> Cap::Instance` for
@@ -36,6 +37,7 @@
 //! a runtime panic). See [`CapHashOrRef`] for the gate.
 
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use ssz::{MissingOr, RadixMap};
 
@@ -45,13 +47,96 @@ use crate::error::CapError;
 use crate::hash::{Hash, Hasher};
 use crate::slot::Key;
 
-/// Physical radix-key width: a 32-byte digest of the logical key.
-pub const CNODE_KEY_BYTES: usize = 32;
+/// Commitment radix-key width: a 32-byte digest of the logical key.
+///
+/// This width is used only when deriving a Merkle/radix commitment in
+/// [`HashTreeRoot`](ssz::HashTreeRoot). Runtime CNode access is direct by
+/// [`Key`].
+pub const CNODE_COMMITMENT_KEY_BYTES: usize = 32;
 
-/// Radix map backing a CNode: `Hasher(k) -> CapHashOrRef<O>`.
-pub type CNodeSlots<O = Box<Cap>> = RadixMap<CapHashOrRef<O>, CNODE_KEY_BYTES>;
+/// Direct runtime slot map backing a CNode: `Key -> CapHashOrRef<O>`.
+///
+/// Stored as a sorted vector, not a `BTreeMap`: CNodes are usually tiny in the
+/// hot guest path, and avoiding per-entry tree-node allocations matters. The
+/// API is map-shaped and preserves strictly-ascending keys.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct CNodeSlots<O = Box<Cap>> {
+    entries: Vec<(Key, MissingOr<CapHashOrRef<O>>)>,
+}
 
-/// CNode cap: a sparse, hash-keyed `key -> CapHashOrRef<O>` map.
+impl<O> CNodeSlots<O> {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn get(&self, key: &Key) -> Option<&MissingOr<CapHashOrRef<O>>> {
+        self.entries
+            .binary_search_by(|(k, _)| k.cmp(key))
+            .ok()
+            .map(|pos| &self.entries[pos].1)
+    }
+
+    pub fn insert(
+        &mut self,
+        key: Key,
+        value: MissingOr<CapHashOrRef<O>>,
+    ) -> Option<MissingOr<CapHashOrRef<O>>> {
+        match self.entries.binary_search_by(|(k, _)| k.cmp(&key)) {
+            Ok(pos) => Some(core::mem::replace(&mut self.entries[pos].1, value)),
+            Err(pos) => {
+                self.entries.insert(pos, (key, value));
+                None
+            }
+        }
+    }
+
+    pub fn remove(&mut self, key: &Key) -> Option<MissingOr<CapHashOrRef<O>>> {
+        match self.entries.binary_search_by(|(k, _)| k.cmp(key)) {
+            Ok(pos) => Some(self.entries.remove(pos).1),
+            Err(_) => None,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &MissingOr<CapHashOrRef<O>>)> {
+        self.entries.iter().map(|(k, v)| (k, v))
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Key, &mut MissingOr<CapHashOrRef<O>>)> {
+        self.entries.iter_mut().map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<O> Default for CNodeSlots<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Clone> Clone for CNodeSlots<O> {
+    fn clone(&self) -> Self {
+        Self {
+            entries: self.entries.clone(),
+        }
+    }
+}
+
+impl<O: core::fmt::Debug> core::fmt::Debug for CNodeSlots<O> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.entries.iter()).finish()
+    }
+}
+
+/// CNode cap: a sparse, direct `Key -> CapHashOrRef<O>` map.
 ///
 /// rkyv (the wire form) is derived; the derive adds a `slots: Archive` field
 /// bound, which for the wire payload resolves via `CapHashOrRef<Box<Cap>>:
@@ -65,9 +150,8 @@ pub type CNodeSlots<O = Box<Cap>> = RadixMap<CapHashOrRef<O>, CNODE_KEY_BYTES>;
 /// not compile for a generic field).
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct CNodeCap<O = Box<Cap>> {
-    /// Sparse hash-keyed slot table: `Hasher(k) -> CapHashOrRef<O>`. Absent
-    /// keys contribute the radix `EMPTY` summary; a `Missing(h)` entry
-    /// substitutes losslessly for the value rooting at `h`.
+    /// Sparse slot table keyed by logical [`Key`]. Absent keys are empty; a
+    /// `Missing(h)` entry substitutes losslessly for the value rooting at `h`.
     pub slots: CNodeSlots<O>,
 }
 
@@ -99,12 +183,17 @@ impl<O: core::fmt::Debug> core::fmt::Debug for CNodeCap<O> {
 // content hash, so a cache-carrying cnode is non-hashable at compile time.
 impl<O> ssz::HashTreeRoot for CNodeCap<O>
 where
-    CNodeSlots<O>: ssz::HashTreeRoot,
+    O: Clone,
+    CapHashOrRef<O>: ssz::HashTreeRoot,
 {
     fn hash_tree_root<D: ssz::digest::Digest<OutputSize = ssz::digest::typenum::U32>>(
         &self,
     ) -> [u8; 32] {
-        let roots: [[u8; 32]; 1] = [self.slots.hash_tree_root::<D>()];
+        let mut commitment = RadixMap::<CapHashOrRef<O>, CNODE_COMMITMENT_KEY_BYTES>::new();
+        for (key, value) in self.slots.iter() {
+            commitment.insert(Self::commitment_key(key), value.clone());
+        }
+        let roots: [[u8; 32]; 1] = [commitment.hash_tree_root::<D>()];
         ssz::merkleize::<D>(&roots, 1)
     }
 }
@@ -118,10 +207,12 @@ impl<O> CNodeCap<O> {
         }
     }
 
-    /// Physical radix key for a logical byte-string key `k`: `Hasher(k)`.
+    /// Commitment radix key for a logical key: `Hasher(key)`.
+    ///
+    /// This is intentionally not used by ordinary `get` / `set` / `take`.
     #[inline]
-    pub fn key_of(k: &[u8]) -> [u8; CNODE_KEY_BYTES] {
-        <Hasher as Hash>::hash(k)
+    pub fn commitment_key(key: &Key) -> [u8; CNODE_COMMITMENT_KEY_BYTES] {
+        <Hasher as Hash>::hash(key.as_slice())
     }
 
     // ---- logical byte-string key API ----
@@ -132,7 +223,7 @@ impl<O> CNodeCap<O> {
     /// [`take_key`](Self::take_key) it. `None` for an absent key or a
     /// `Missing(_)` placeholder.
     pub fn peek_key(&self, k: &[u8]) -> Option<&CapHashOrRef<O>> {
-        match self.slots.get(&Self::key_of(k))? {
+        match self.slots.get(&Key::from(k))? {
             MissingOr::Materialized(t) => Some(t),
             MissingOr::Missing(_) => None,
         }
@@ -147,7 +238,7 @@ impl<O> CNodeCap<O> {
         k: &[u8],
         target: Option<CapHashOrRef<O>>,
     ) -> Option<CapHashOrRef<O>> {
-        let key = Self::key_of(k);
+        let key = Key::from(k);
         // `insert` / `remove` hand back the displaced entry by value — no
         // clone of the prior `CapHashOrRef`.
         let old = match target {
@@ -179,7 +270,16 @@ impl<O> CNodeCap<O> {
         key: &Key,
         target: Option<CapHashOrRef<O>>,
     ) -> Result<Option<CapHashOrRef<O>>, CapError> {
-        Ok(self.set_key(key.as_slice(), target))
+        // `insert` / `remove` hand back the displaced entry by value — no
+        // clone of the prior `CapHashOrRef`.
+        let old = match target {
+            Some(t) => self.slots.insert(key.clone(), MissingOr::Materialized(t)),
+            None => self.slots.remove(key),
+        };
+        Ok(match old {
+            Some(MissingOr::Materialized(t)) => Some(t),
+            Some(MissingOr::Missing(_)) | None => None,
+        })
     }
 
     /// Take the binding at `key`, leaving it empty. Returns the prior
@@ -194,7 +294,7 @@ impl<O: Clone> CNodeCap<O> {
     /// absent key or a `Missing(_)` placeholder (callers needing to tell
     /// "absent" from "missing placeholder" apart inspect `self.slots`).
     pub fn get_key(&self, k: &[u8]) -> Option<CapHashOrRef<O>> {
-        match self.slots.get(&Self::key_of(k))? {
+        match self.slots.get(&Key::from(k))? {
             MissingOr::Materialized(t) => Some(t.clone()),
             MissingOr::Missing(_) => None,
         }
@@ -203,6 +303,9 @@ impl<O: Clone> CNodeCap<O> {
     /// Look up the slot named by `key`. See [`CNodeCap::get_key`] for the
     /// placeholder semantics.
     pub fn get(&self, key: &Key) -> Option<CapHashOrRef<O>> {
-        self.get_key(key.as_slice())
+        match self.slots.get(key)? {
+            MissingOr::Materialized(t) => Some(t.clone()),
+            MissingOr::Missing(_) => None,
+        }
     }
 }

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -62,8 +62,8 @@ pub struct ImageCap {
     pub pinned: Vec<ImageSlotEntry>,
     /// Initial mutable slot state for non-pinned slots.
     pub initial: Vec<ImageSlotEntry>,
-    /// Slot holding `Cap::Instance[YieldCatcher]`, if any.
-    pub yield_marker_slot: Option<Key>,
+    /// Slot holding `Cap::Instance[YieldReceiver]` (the catch-set), if any.
+    pub yield_receiver_slot: Option<Key>,
     /// Cnode slots holding the `Cap::Instance[Gas{meter_key}]` unit handles;
     /// `gas_slots[0]` is the active meter the kernel reads at frame entry.
     /// See [`crate::image::Image::gas_slots`].
@@ -87,7 +87,7 @@ impl Clone for ImageCap {
             mappings: self.mappings.clone(),
             pinned: self.pinned.clone(),
             initial: self.initial.clone(),
-            yield_marker_slot: self.yield_marker_slot.clone(),
+            yield_receiver_slot: self.yield_receiver_slot.clone(),
             gas_slots: self.gas_slots.clone(),
             quota_slots: self.quota_slots.clone(),
         }
@@ -319,7 +319,7 @@ pub fn image_cap(
         mappings,
         pinned,
         initial,
-        yield_marker_slot: image.yield_marker_slot.clone(),
+        yield_receiver_slot: image.yield_receiver_slot.clone(),
         gas_slots: image.gas_slots.clone(),
         quota_slots: image.quota_slots.clone(),
     })

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -64,9 +64,8 @@ pub struct ImageCap {
     pub initial: Vec<ImageSlotEntry>,
     /// Slot holding `Cap::Instance[YieldReceiver]` (the catch-set), if any.
     pub yield_receiver_slot: Option<Key>,
-    /// Cnode slots holding the `Cap::Instance[Gas{meter_key}]` unit handles;
-    /// `gas_slots[0]` is the active meter the kernel reads at frame entry.
-    /// See [`crate::image::Image::gas_slots`].
+    /// Cnode slots holding the `Cap::Instance[Gas{meter_key}]` unit handles,
+    /// consulted in order. See [`crate::image::Image::gas_slots`].
     pub gas_slots: Vec<Key>,
     /// Cnode slots holding the `Cap::Instance[Quota{quota_key}]` unit handles.
     pub quota_slots: Vec<Key>,

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use crate::slot::{Key, SlotPath};
 
-use super::{CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
+use super::{CapHash, MAX_SOURCE_DEPTH, NUM_REGS};
 
 /// # Validation model: structure is eager, semantics are lazy
 ///
@@ -47,10 +47,13 @@ pub struct ImageCap {
     /// constant [`crate::layout::CODE_BASE`]. Empty for codeless
     /// images. See [`ImageCap::code_mapping`].
     pub code: Vec<u8>,
-    /// Endpoint definitions. Stored as a dense array keyed by
-    /// endpoint index — `endpoints[i].entry_pc == 0` means the
-    /// endpoint at index `i` is not defined.
-    pub endpoints: Vec<EndpointDef>,
+    /// Endpoint definitions, keyed by a [`Key`] selector. A sparse, sorted
+    /// association list (`Dict`-style — kept sorted by key, no fixed capacity);
+    /// an absent key is an undefined endpoint. There is no dense array and no
+    /// `entry_pc == 0` sentinel, so an endpoint may legitimately start at code
+    /// offset 0. (`Vec<(Key, _)>` rather than `BTreeMap` because the rkyv wire
+    /// form has no `Ord` on the archived key.)
+    pub endpoints: Vec<(Key, EndpointDef)>,
     /// Memory mappings.
     pub mappings: Vec<MemoryMapping>,
     /// Pinned read-only slots (Cap::Data / Cap::Image). Images only
@@ -149,22 +152,6 @@ pub struct EndpointDef {
     pub initial_regs: [u64; NUM_REGS],
 }
 
-impl EndpointDef {
-    /// Empty endpoint — `entry_pc == 0` is the canonical sentinel
-    /// for "not defined" (since a real entry PC is never zero — PC 0
-    /// is reserved as the fallback PC in our convention). Not `const`:
-    /// `Key`'s `SmallVec` storage has no const constructor.
-    pub fn empty() -> Self {
-        Self {
-            entry_pc: 0,
-            stack_top: 0,
-            arg_cnode_slot: Key::from(0u8),
-            arg_cnode_size: 0,
-            initial_regs: [0; NUM_REGS],
-        }
-    }
-}
-
 /// One mapped region. The kernel resolves `source` (a [`SlotPath`] to a
 /// `Cap::Data`) at instance start, reads the bytes, and lays them at
 /// `[start, start + size)`.
@@ -235,8 +222,6 @@ pub enum ImageConvertError {
     SourcePathEmpty,
     #[error("memory mapping source path too deep (steps={0} > MAX_SOURCE_DEPTH)")]
     SourcePathTooDeep(usize),
-    #[error("endpoint index {0} >= MAX_ENDPOINTS")]
-    EndpointIndexOutOfRange(u8),
     #[error("register index {0} >= NUM_REGS")]
     RegisterIndexOutOfRange(u8),
 }
@@ -255,10 +240,9 @@ pub enum ImageConvertError {
 ///   in the new shape.
 ///
 /// **Field mappings:**
-/// - Endpoints are stored in a dense `MAX_ENDPOINTS`-sized array,
-///   indexed by endpoint id. Empty slots use [`EndpointDef::empty`].
-///   `stack_top` is extracted from the old `initial_regs[1]` (RISC-V
-///   SP convention); `arg_cnode_slot` defaults to `Key::from(0)`.
+/// - Endpoints are stored in a sparse `Key -> EndpointDef` map (no fixed
+///   capacity). `stack_top` is extracted from the old `initial_regs[1]`
+///   (RISC-V SP convention); `arg_cnode_slot` defaults to `Key::from(0)`.
 /// - `MemoryMapping.source` (a [`SlotPath`]) is carried through verbatim;
 ///   paths that are empty or deeper than `MAX_SOURCE_DEPTH` error.
 pub fn image_cap(
@@ -283,16 +267,12 @@ pub fn image_cap(
     // `layout::CODE_BASE`.
     let code = alloc_page_aligned_code(&image.code);
 
-    // Endpoints: dense `MAX_ENDPOINTS`-sized array; empty entries have
-    // `entry_pc == 0`.
-    let mut endpoints = Vec::with_capacity(MAX_ENDPOINTS);
-    for _ in 0..MAX_ENDPOINTS {
-        endpoints.push(EndpointDef::empty());
-    }
-    for (&idx, ep) in &image.endpoints {
-        if (idx as usize) >= MAX_ENDPOINTS {
-            return Err(ImageConvertError::EndpointIndexOutOfRange(idx));
-        }
+    // Endpoints: a sparse, sorted `Key -> EndpointDef` association list (no
+    // fixed capacity, no dense `entry_pc == 0` sentinel — presence is what
+    // defines an endpoint). `image.endpoints` is a BTreeMap, so iterating it
+    // yields keys in sorted order and the resulting Vec stays sorted by Key.
+    let mut endpoints = Vec::with_capacity(image.endpoints.len());
+    for (key, ep) in &image.endpoints {
         let mut initial_regs = [0u64; NUM_REGS];
         for (&reg_idx, &val) in &ep.initial_regs {
             if (reg_idx as usize) >= NUM_REGS {
@@ -302,13 +282,16 @@ pub fn image_cap(
         }
         // RISC-V SP convention: φ[1] = stack pointer.
         let stack_top = ep.initial_regs.get(&1).copied().unwrap_or(0);
-        endpoints[idx as usize] = EndpointDef {
-            entry_pc: ep.entry_pc,
-            stack_top,
-            arg_cnode_slot: Key::from(0u8),
-            arg_cnode_size: ep.arg_cnode_size,
-            initial_regs,
-        };
+        endpoints.push((
+            key.clone(),
+            EndpointDef {
+                entry_pc: ep.entry_pc,
+                stack_top,
+                arg_cnode_slot: Key::from(0u8),
+                arg_cnode_size: ep.arg_cnode_size,
+                initial_regs,
+            },
+        ));
     }
 
     let mut mappings = Vec::with_capacity(image.memory_mappings.len());

--- a/rust/javm-cap/src/cap/instance.rs
+++ b/rust/javm-cap/src/cap/instance.rs
@@ -6,16 +6,16 @@
 //! frame mutates it), the read-write memory image, register file, PC,
 //! gas counter.
 
+use alloc::boxed::Box;
+
 use crate::cache::CapHashOrRef;
 
-use super::CapHash;
 use super::NUM_REGS;
 use super::data::{DataCap, PAGE_SIZE};
+use super::{Cap, CapHash};
 
-#[derive(
-    Clone, Debug, ssz_derive::HashTreeRoot, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
-)]
-pub struct InstanceCap {
+#[derive(Clone, Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub struct InstanceCap<O = Box<Cap>> {
     /// Cumulative chain hash identifying the Instance's type.
     pub image_hash_chain: CapHash,
     /// Hash of the Image cap currently bound. Always content-
@@ -24,7 +24,7 @@ pub struct InstanceCap {
     /// Reference to the root cnode. `Hash` when clean / not yet
     /// promoted for mutation; an inline `Owned` cnode cap while the
     /// running kernel frame is mutating it.
-    pub root_cnode: CapHashOrRef,
+    pub root_cnode: CapHashOrRef<O>,
     /// The Instance's read-write memory image: a dense `DataCap` covering the
     /// data extent `[DATA_BASE, DATA_BASE + mem.size)`. Holds the initial
     /// content at boot and the settled (folded) content after each HALT — the
@@ -45,7 +45,27 @@ pub struct InstanceCap {
     pub gas_remaining: u64,
 }
 
-impl InstanceCap {
+impl<O> ssz::HashTreeRoot for InstanceCap<O>
+where
+    CapHashOrRef<O>: ssz::HashTreeRoot,
+{
+    fn hash_tree_root<D: ssz::digest::Digest<OutputSize = ssz::digest::typenum::U32>>(
+        &self,
+    ) -> [u8; 32] {
+        let roots: [[u8; 32]; 7] = [
+            self.image_hash_chain.hash_tree_root::<D>(),
+            self.image_hash.hash_tree_root::<D>(),
+            self.root_cnode.hash_tree_root::<D>(),
+            self.mem.hash_tree_root::<D>(),
+            self.regs.hash_tree_root::<D>(),
+            self.pc.hash_tree_root::<D>(),
+            self.gas_remaining.hash_tree_root::<D>(),
+        ];
+        ssz::merkleize::<D>(&roots, roots.len())
+    }
+}
+
+impl<O> InstanceCap<O> {
     /// Absolute exclusive top of the data region (`DATA_BASE + mem.size`). The
     /// data extent `[DATA_BASE, mem_size)` is what the engines map; this matches
     /// the legacy `mem_size` field's semantics for call sites.

--- a/rust/javm-cap/src/cap/mod.rs
+++ b/rust/javm-cap/src/cap/mod.rs
@@ -1,7 +1,7 @@
 //! `Cap` — cap enum + shared constants.
 //!
-//! The five Cap variants live one-per-submodule under this directory:
-//! [`cnode`], [`data`], [`image`], [`instance`], [`page`] (a `data`
+//! The four Cap variants live one-per-submodule under this directory:
+//! [`cnode`], [`data`], [`image`], [`instance`] (plus [`page`], a `data`
 //! detail). The root [`Cap`] enum dispatches to those structs.
 //!
 //! Cap types and their inner storage use the default `Global` allocator
@@ -46,10 +46,10 @@ pub const MAX_SOURCE_DEPTH: usize = 8;
 /// Maximum number of endpoints per Image.
 pub const MAX_ENDPOINTS: usize = 64;
 
-/// One of the five v3 cap kinds.
+/// One of the four v3 cap kinds.
 ///
 /// **SSZ note**: the `HashTreeRoot` derive treats `Cap` as an SSZ
-/// Union over the five variants. Each variant's selector provides the
+/// Union over the four variants. Each variant's selector provides the
 /// domain separation that the legacy byte-protocol kind tags
 /// (`0x10..0x50`) provided; the per-variant root is computed by that
 /// variant's own `HashTreeRoot` impl. We do not derive `Encode +
@@ -76,27 +76,6 @@ pub enum Cap {
     Data(DataCap),
     #[ssz(selector = 3)]
     CNode(CNodeCap),
-    #[ssz(selector = 4)]
-    Type(TypeCap),
-}
-
-/// `Cap::Type` payload. Pure identifier; no slot references.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    ssz_derive::Encode,
-    ssz_derive::Decode,
-    ssz_derive::HashTreeRoot,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
-)]
-pub struct TypeCap {
-    pub image_hash_chain: CapHash,
 }
 
 impl Cap {

--- a/rust/javm-cap/src/cap/mod.rs
+++ b/rust/javm-cap/src/cap/mod.rs
@@ -43,9 +43,6 @@ pub const NUM_REGS: usize = 13;
 /// stay shallow; eight is plenty.
 pub const MAX_SOURCE_DEPTH: usize = 8;
 
-/// Maximum number of endpoints per Image.
-pub const MAX_ENDPOINTS: usize = 64;
-
 /// One of the four v3 cap kinds.
 ///
 /// **SSZ note**: the `HashTreeRoot` derive treats `Cap` as an SSZ

--- a/rust/javm-cap/src/hash.rs
+++ b/rust/javm-cap/src/hash.rs
@@ -55,10 +55,8 @@ impl Hash for Blake2b256 {
     }
 }
 
-/// Central alias for the content-addressing / key-derivation hash.
-///
-/// Used to derive fixed-width physical keys from program-supplied bytes —
-/// e.g. a `Cap::CNode` slot key `<Hasher as Hash>::hash(k)` (`[u8; 32]`).
+/// Central alias for content-addressing and the few places that deliberately
+/// need fixed-width derived keys.
 ///
 /// TODO(hash-unify): this is Blake2b-256, but the SSZ merkle digest used by
 /// [`crate::cap::Cap::cap_hash`] (`ssz::hash_tree_root`, the `ssz` `sha2`

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -34,7 +34,7 @@ use ssz_derive::{Decode, Encode};
 /// Image: the program spec (code, endpoints, memory layout, slot
 /// declarations, pinned ro caps).
 ///
-/// `pinned_slots` and `yield_marker_slot` reference cnode slots; the
+/// `pinned_slots` and `yield_receiver_slot` reference cnode slots; the
 /// kernel installs declared pinned content into the Instance's cnode
 /// at `set_image` / `host_derive_spawn` time and treats them as
 /// read-only thereafter.
@@ -74,9 +74,10 @@ pub struct Image {
     /// honored at standalone (root) Instance bootstrap — a
     /// parented Instance receives its cnode from the spawner.
     pub initial_slots: BTreeMap<Key, InitialDataCap>,
-    /// Slot holding `Cap::Instance[YieldCatcher]`, if this Instance
-    /// catches yields. None = no catcher.
-    pub yield_marker_slot: Option<Key>,
+    /// Slot holding `Cap::Instance[YieldReceiver]` — the set of yield_keys this
+    /// Instance catches. The kernel snapshots it at each downward CALL and
+    /// consults the snapshot when routing a yield. None = catches no yields.
+    pub yield_receiver_slot: Option<Key>,
     /// Cnode slots holding the `Cap::Instance[Gas{meter_key}]` unit handles
     /// the kernel debits while this Instance runs. `gas_slots[0]` is the
     /// **active** meter (the kernel reads its `meter_key` at frame entry to
@@ -162,7 +163,7 @@ impl Image {
             memory_mappings: Vec::new(),
             pinned_slots: BTreeMap::new(),
             initial_slots: BTreeMap::new(),
-            yield_marker_slot: None,
+            yield_receiver_slot: None,
             gas_slots: Vec::new(),
             quota_slots: Vec::new(),
         }

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -56,9 +56,11 @@ pub struct Image {
     /// read its own bytes (AUIPC+load PIC); the JIT executes the native
     /// translation. Empty for codeless images (kernel placeholders).
     pub code: Vec<u8>,
-    /// Endpoints addressable by `endpoint_idx` (u8). Sparse — only
-    /// declared endpoints are present.
-    pub endpoints: BTreeMap<u8, EndpointDef>,
+    /// Endpoints addressable by a [`Key`] selector (the same byte-string key
+    /// type as a cnode slot; in the V1 single-byte ABI the selector is one
+    /// byte). Sparse — only declared endpoints are present, with no fixed
+    /// capacity. An absent key is an undefined endpoint.
+    pub endpoints: BTreeMap<Key, EndpointDef>,
     /// Memory layout. Each entry maps a `Cap::Data` (resolved through
     /// the `source` slot path) into the address space at `[start, start
     /// + size)`. RO vs RW is derived from whether the target slot

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -79,11 +79,11 @@ pub struct Image {
     /// consults the snapshot when routing a yield. None = catches no yields.
     pub yield_receiver_slot: Option<Key>,
     /// Cnode slots holding the `Cap::Instance[Gas{meter_key}]` unit handles
-    /// the kernel debits while this Instance runs. `gas_slots[0]` is the
-    /// **active** meter (the kernel reads its `meter_key` at frame entry to
-    /// seed/settle gas against the kernel-maintained meter mapping); later
-    /// entries are fallback reserves (chain-spec policy). Empty = no
-    /// Image-declared meter (the kernel uses the call-supplied budget).
+    /// the kernel debits while this Instance runs. Slots are consulted in order:
+    /// empty declared slots are skipped, the first valid non-empty slot is the
+    /// primary meter used in OOG payloads, and later valid slots are fallback
+    /// reserves. Empty list = no Image-declared meter (the frame loans its
+    /// caller's gas scope, or the host budget at root).
     pub gas_slots: Vec<Key>,
     /// Cnode slots holding the `Cap::Instance[Quota{quota_key}]` unit handles.
     /// Same convention as [`Self::gas_slots`].

--- a/rust/javm-cap/src/kernel_image.rs
+++ b/rust/javm-cap/src/kernel_image.rs
@@ -15,24 +15,34 @@ use crate::cap::CapHash;
 use crate::hash::{Blake2b256, Hash};
 
 /// Identifies which kernel-assisted Image a given `image_hash_chain` refers to.
+///
+/// The four kernel-assisted Instance variants of the v3 design are
+/// `Gas{meter_key}`, `Quota{quota_key}`, `YieldSender{yield_key}` (the EMIT
+/// right) and `YieldReceiver{Vec<yield_key>}` (the CATCH right), plus the two
+/// kernel-internal tables (`GasMeter`, `StorageQuota`) the unit handles index.
+/// The older per-syscall factory/marker images (set_gas_meter, mint_gas,
+/// yield_catcher, oog_marker, …) are gone: a syscall is now a `host_yield` of a
+/// `YieldSender` carrying a `kernel:*` yield_key, caught by the kernel as the
+/// root YieldReceiver — so those names are yield_keys, not Images.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum KernelImage {
+    /// Kernel-internal gas meter table (never in chain hands).
     GasMeter,
+    /// Kernel-internal storage quota table (never in chain hands).
     StorageQuota,
-    YieldCatcher,
     /// Per-Instance `Gas{meter_key}` unit handle. State: a `meter_key: Key`
     /// packed into the handle's registers (see
     /// [`crate::slot::key_to_regs`]).
     Gas,
     /// Per-Instance `Quota{quota_key}` unit handle.
     Quota,
-    SetGasMeter,
-    SetStorageQuota,
-    MintGas,
-    MintQuota,
-    CreateYieldCatcher,
-    OogMarker,
-    StorageExhaustedMarker,
+    /// `YieldSender{yield_key}` — the EMIT right for a yield_key. State: the
+    /// `yield_key: Key` packed into the handle's registers.
+    YieldSender,
+    /// `YieldReceiver{Vec<yield_key>}` — the CATCH right: the set of yield_keys
+    /// an Instance catches. State (a serialized `Set<Key>`) lives in the
+    /// handle's `mem` DataCap; the kernel short-circuits it during routing.
+    YieldReceiver,
     /// Per-Instance `File{file_id}` handle.
     File,
     /// Per-Instance HostOpen handle.
@@ -42,19 +52,13 @@ pub enum KernelImage {
 }
 
 /// All kernel Images, for registry iteration.
-pub const ALL_KERNEL_IMAGES: [KernelImage; 15] = [
+pub const ALL_KERNEL_IMAGES: [KernelImage; 9] = [
     KernelImage::GasMeter,
     KernelImage::StorageQuota,
-    KernelImage::YieldCatcher,
     KernelImage::Gas,
     KernelImage::Quota,
-    KernelImage::SetGasMeter,
-    KernelImage::SetStorageQuota,
-    KernelImage::MintGas,
-    KernelImage::MintQuota,
-    KernelImage::CreateYieldCatcher,
-    KernelImage::OogMarker,
-    KernelImage::StorageExhaustedMarker,
+    KernelImage::YieldSender,
+    KernelImage::YieldReceiver,
     KernelImage::File,
     KernelImage::HostOpen,
     KernelImage::HostSave,
@@ -64,16 +68,10 @@ const fn const_kernel_image_label(kind: KernelImage) -> &'static [u8] {
     match kind {
         KernelImage::GasMeter => b"kernel:gasmeter",
         KernelImage::StorageQuota => b"kernel:storagequota",
-        KernelImage::YieldCatcher => b"kernel:yieldcatcher",
         KernelImage::Gas => b"kernel:gas",
         KernelImage::Quota => b"kernel:quota",
-        KernelImage::SetGasMeter => b"kernel:set_gas_meter",
-        KernelImage::SetStorageQuota => b"kernel:set_storage_quota",
-        KernelImage::MintGas => b"kernel:mint_gas",
-        KernelImage::MintQuota => b"kernel:mint_quota",
-        KernelImage::CreateYieldCatcher => b"kernel:create_yield_catcher",
-        KernelImage::OogMarker => b"kernel:oog_marker",
-        KernelImage::StorageExhaustedMarker => b"kernel:storage_exhausted_marker",
+        KernelImage::YieldSender => b"kernel:yieldsender",
+        KernelImage::YieldReceiver => b"kernel:yieldreceiver",
         KernelImage::File => b"kernel:file",
         KernelImage::HostOpen => b"kernel:host_open",
         KernelImage::HostSave => b"kernel:host_save",

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -52,8 +52,8 @@ pub use image::{
 pub use kernel_image::{ALL_KERNEL_IMAGES, KernelImage, kernel_image_hash, recognize_kernel_image};
 pub use slot::{Key, MAX_KEY_LEN, SlotPath, key_from_regs, key_to_regs};
 pub use yield_cap::{
-    is_kernel_yield_key, merge_yield_receivers, yield_receiver, yield_receiver_keys, yield_sender,
-    yield_sender_key,
+    gas_handle, gas_meter_key, is_kernel_yield_key, merge_yield_receivers, quota_handle, quota_key,
+    yield_receiver, yield_receiver_keys, yield_sender, yield_sender_key,
 };
 // `CNodeCap::slots` (`CNodeSlots = RadixMap<CapHashOrRef, _>`) exposes
 // `MissingOr` through `iter()`; re-export it so cnode-slot walkers (e.g. the

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -42,7 +42,7 @@ pub use cap::image::{
 };
 pub use cap::instance::InstanceCap;
 pub use cap::page::{PageBytes, PageRef, PageSlot};
-pub use cap::{Cap, CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
+pub use cap::{Cap, CapHash, MAX_SOURCE_DEPTH, NUM_REGS};
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash, Hasher};
 pub use image::{

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -55,7 +55,7 @@ pub use yield_cap::{
     gas_handle, gas_meter_key, is_kernel_yield_key, merge_yield_receivers, quota_handle, quota_key,
     yield_receiver, yield_receiver_keys, yield_sender, yield_sender_key,
 };
-// `CNodeCap::slots` (`CNodeSlots = RadixMap<CapHashOrRef, _>`) exposes
-// `MissingOr` through `iter()`; re-export it so cnode-slot walkers (e.g. the
-// recompiler's cnode-inherit loop) don't need a direct `ssz` dependency.
+// `CNodeCap::slots` stores `MissingOr<CapHashOrRef>` values; re-export it so
+// cnode-slot walkers (e.g. the recompiler's cnode-inherit loop) don't need a
+// direct `ssz` dependency.
 pub use ssz::MissingOr;

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -33,6 +33,7 @@ pub mod image;
 pub mod kernel_image;
 pub mod layout;
 pub mod slot;
+pub mod yield_cap;
 
 pub use cache::{CacheDirectory, CacheError, CapHasRefError, CapHashOrRef, CapRef};
 pub use cap::cnode::CNodeCap;
@@ -50,6 +51,10 @@ pub use image::{
 };
 pub use kernel_image::{ALL_KERNEL_IMAGES, KernelImage, kernel_image_hash, recognize_kernel_image};
 pub use slot::{Key, MAX_KEY_LEN, SlotPath, key_from_regs, key_to_regs};
+pub use yield_cap::{
+    is_kernel_yield_key, merge_yield_receivers, yield_receiver, yield_receiver_keys, yield_sender,
+    yield_sender_key,
+};
 // `CNodeCap::slots` (`CNodeSlots = RadixMap<CapHashOrRef, _>`) exposes
 // `MissingOr` through `iter()`; re-export it so cnode-slot walkers (e.g. the
 // recompiler's cnode-inherit loop) don't need a direct `ssz` dependency.

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -35,7 +35,7 @@ pub mod layout;
 pub mod slot;
 pub mod yield_cap;
 
-pub use cache::{CacheDirectory, CacheError, CapHasRefError, CapHashOrRef, CapRef};
+pub use cache::{CacheDirectory, CacheError, CapHasRefError, CapHashOrRef, CapRef, ResidentCap};
 pub use cap::cnode::CNodeCap;
 pub use cap::data::{DataCap, GROUP_SIZE, PAGE_SIZE, PageResolution, PageSlab};
 pub use cap::image::{

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -42,7 +42,7 @@ pub use cap::image::{
 };
 pub use cap::instance::InstanceCap;
 pub use cap::page::{PageBytes, PageRef, PageSlot};
-pub use cap::{Cap, CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS, TypeCap};
+pub use cap::{Cap, CapHash, MAX_ENDPOINTS, MAX_SOURCE_DEPTH, NUM_REGS};
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash, Hasher};
 pub use image::{

--- a/rust/javm-cap/src/slot.rs
+++ b/rust/javm-cap/src/slot.rs
@@ -6,14 +6,13 @@
 //! see the kernel-assisted Gas/Quota handles). A [`SlotPath`] walks from the
 //! root cnode through nested `Cap::CNode` slots down to a target slot.
 //!
-//! A cnode is a hash-keyed kv-map (`Hasher(k) -> Cap`, see
-//! [`crate::cap::cnode::CNodeCap`]) whose logical key `k` is a **byte
-//! string**, not an integer index — so a slot name is a `Key` (a short
-//! byte string), and a path is a `SlotPath` (a sequence of `Key`s). There
-//! is no fixed slot count: a cnode is bounded by storage quota, not a
-//! compile-time capacity. The V1 ABI uses single-byte keys (`Key::from(b)`),
-//! but the type admits arbitrary-length keys for future ABI extensions
-//! (e.g. `address -> Cap::Instance`).
+//! A cnode is a sparse direct map keyed by logical byte strings, not an
+//! integer-indexed array — so a slot name is a `Key` (a short byte string),
+//! and a path is a `SlotPath` (a sequence of `Key`s). There is no fixed slot
+//! count: a cnode is bounded by storage quota, not a compile-time capacity.
+//! The V1 ABI uses single-byte keys (`Key::from(b)`), but the type admits
+//! arbitrary-length keys for future ABI extensions (e.g.
+//! `address -> Cap::Instance`).
 
 use crate::cap::MAX_SOURCE_DEPTH;
 use crate::error::CapError;
@@ -28,11 +27,10 @@ pub const MAX_KEY_LEN: usize = 8;
 
 /// The logical key naming one slot in a single cnode.
 ///
-/// A short byte string hashed (`Hasher(key)`) to the cnode's physical radix
-/// key. Backed by a [`SmallVec`] so the common single-byte key stays inline.
-/// The SSZ wire/hash form is **identical to `Vec<u8>`** (forwarded via
-/// `#[ssz(transparent)]`), so embedding a `Key` is byte-equivalent to
-/// embedding the raw key bytes.
+/// A short byte string used directly as a cnode slot key. Backed by a
+/// [`SmallVec`] so the common single-byte key stays inline. The SSZ wire/hash
+/// form is **identical to `Vec<u8>`** (forwarded via `#[ssz(transparent)]`), so
+/// embedding a `Key` is byte-equivalent to embedding the raw key bytes.
 #[derive(
     Debug,
     Clone,
@@ -48,6 +46,7 @@ pub const MAX_KEY_LEN: usize = 8;
     rkyv::Serialize,
     rkyv::Deserialize,
 )]
+#[rkyv(derive(Debug, PartialEq, Eq, PartialOrd, Ord))]
 pub struct Key(#[ssz(transparent)] pub SmallVec<[u8; MAX_KEY_LEN]>);
 
 impl Key {
@@ -57,8 +56,7 @@ impl Key {
     }
 
     /// True iff this is the empty key (zero bytes). The empty key is a valid
-    /// logical key (`Hasher([])`), distinct from `Key::from(0u8)`
-    /// (`Hasher([0])`).
+    /// logical key (`[]`), distinct from `Key::from(0u8)` (`[0]`).
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/rust/javm-cap/src/yield_cap.rs
+++ b/rust/javm-cap/src/yield_cap.rs
@@ -136,8 +136,8 @@ pub fn merge_yield_receivers(a: &InstanceCap, b: &InstanceCap) -> Option<Instanc
 
 /// Build a `Gas{meter_key}` unit handle: a `Cap::Instance` with the well-known
 /// Gas image-hash chain and the `meter_key` packed into `regs[0..1]` (same
-/// packing as [`yield_sender`]). The kernel reads it from an Instance's
-/// `gas_slots[0]` to index the gas-meter mapping; minted by the
+/// packing as [`yield_sender`]). The kernel reads these handles from an
+/// Instance's ordered `gas_slots` to index the gas-meter mapping; minted by the
 /// `kernel:mint_gas` syscall.
 pub fn gas_handle(meter_key: &Key) -> InstanceCap {
     unit_handle(KernelImage::Gas, meter_key)

--- a/rust/javm-cap/src/yield_cap.rs
+++ b/rust/javm-cap/src/yield_cap.rs
@@ -1,0 +1,150 @@
+//! `YieldSender` / `YieldReceiver` kernel-assisted cap helpers + the reserved
+//! `kernel:*` yield-key namespace.
+//!
+//! A **yield_key** is a ≤[`MAX_KEY_LEN`](crate::slot::MAX_KEY_LEN)-byte
+//! [`Key`] — the same byte-string key type used for cnode slots. It is the
+//! routing key for `host_yield`: the kernel walks the call stack and the
+//! nearest snapshotted [`YieldReceiver`](KernelImage::YieldReceiver) containing
+//! the key catches the yield. Keys whose first byte is [`KERNEL_YIELD_NS`] are
+//! reserved `kernel:*` syscalls, caught by the kernel as the implicit ROOT
+//! YieldReceiver (bottom of the stack); chain/user yield_keys must not use that
+//! namespace.
+//!
+//! The two per-Instance kernel-assisted variants:
+//! - `YieldSender{yield_key}` — the EMIT right. The yield_key is packed into
+//!   the handle's `regs[0..1]` (same packing as `Gas{meter_key}`; see
+//!   [`key_to_regs`]).
+//! - `YieldReceiver{Set<Key>}` — the CATCH right. The catch-set is serialized
+//!   into the handle's `mem` DataCap so the kernel can short-circuit it during
+//!   routing. Wire form: `u16 count` then, per key, `u8 len` + `len` bytes
+//!   (the page-pad tail is ignored).
+
+use alloc::vec::Vec;
+
+use crate::NUM_REGS;
+use crate::cache::CapHashOrRef;
+use crate::cap::data::DataCap;
+use crate::cap::instance::InstanceCap;
+use crate::kernel_image::{KernelImage, kernel_image_hash, recognize_kernel_image};
+use crate::slot::{Key, key_from_regs, key_to_regs};
+
+/// Namespace marker (first byte) of a reserved `kernel:*` yield_key.
+pub const KERNEL_YIELD_NS: u8 = 0xCE;
+
+/// `kernel:mint_yield` — mint a (YieldSender, YieldReceiver) pair for a key.
+pub const YK_MINT_YIELD: [u8; 2] = [KERNEL_YIELD_NS, 0x01];
+/// `kernel:merge_yield_receiver` — union two YieldReceiver catch-sets.
+pub const YK_MERGE_YIELD_RECEIVER: [u8; 2] = [KERNEL_YIELD_NS, 0x02];
+/// `kernel:set_gas_meter` — set a meter, return previous.
+pub const YK_SET_GAS_METER: [u8; 2] = [KERNEL_YIELD_NS, 0x03];
+/// `kernel:mint_gas` — mint a `Gas{meter_key}` handle.
+pub const YK_MINT_GAS: [u8; 2] = [KERNEL_YIELD_NS, 0x04];
+/// `kernel:set_storage_quota` — set a quota, return previous.
+pub const YK_SET_STORAGE_QUOTA: [u8; 2] = [KERNEL_YIELD_NS, 0x05];
+/// `kernel:mint_quota` — mint a `Quota{quota_key}` handle.
+pub const YK_MINT_QUOTA: [u8; 2] = [KERNEL_YIELD_NS, 0x06];
+/// `kernel:oog` — kernel-injected on gas exhaustion.
+pub const YK_OOG: [u8; 2] = [KERNEL_YIELD_NS, 0x10];
+/// `kernel:storage_exhausted` — kernel-injected on quota exhaustion.
+pub const YK_STORAGE_EXHAUSTED: [u8; 2] = [KERNEL_YIELD_NS, 0x11];
+/// `kernel:attest` — attestation request (§15).
+pub const YK_ATTEST: [u8; 2] = [KERNEL_YIELD_NS, 0x20];
+
+/// True iff `key` is in the reserved `kernel:*` namespace (caught by the kernel
+/// as the implicit root receiver).
+pub fn is_kernel_yield_key(key: &Key) -> bool {
+    key.as_slice().first() == Some(&KERNEL_YIELD_NS)
+}
+
+/// Build a `YieldSender{yield_key}` unit handle: a `Cap::Instance` with the
+/// well-known YieldSender image-hash chain and the yield_key packed into
+/// `regs[0..1]`.
+pub fn yield_sender(yield_key: &Key) -> InstanceCap {
+    let (packed, len) = key_to_regs(yield_key);
+    let mut regs = [0u64; NUM_REGS];
+    regs[0] = packed;
+    regs[1] = len;
+    InstanceCap {
+        image_hash_chain: kernel_image_hash(KernelImage::YieldSender),
+        image_hash: [0u8; 32],
+        root_cnode: CapHashOrRef::Hash([0u8; 32]),
+        mem: DataCap::empty(),
+        regs,
+        pc: 0,
+        gas_remaining: 0,
+    }
+}
+
+/// Read the `yield_key` from a `YieldSender` handle. `None` if `inst` is not a
+/// YieldSender.
+pub fn yield_sender_key(inst: &InstanceCap) -> Option<Key> {
+    if recognize_kernel_image(inst.image_hash_chain) != Some(KernelImage::YieldSender) {
+        return None;
+    }
+    Some(key_from_regs(inst.regs[0], inst.regs[1]))
+}
+
+/// Build a `YieldReceiver{keys}` unit handle: a `Cap::Instance` with the
+/// well-known YieldReceiver image-hash chain and the catch-set serialized into
+/// its `mem` DataCap. The set is normalized (sorted, deduped).
+pub fn yield_receiver(keys: &[Key]) -> InstanceCap {
+    let mut set: Vec<Key> = keys.to_vec();
+    set.sort();
+    set.dedup();
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&(set.len() as u16).to_le_bytes());
+    for k in &set {
+        let s = k.as_slice();
+        bytes.push(s.len() as u8);
+        bytes.extend_from_slice(s);
+    }
+    InstanceCap {
+        image_hash_chain: kernel_image_hash(KernelImage::YieldReceiver),
+        image_hash: [0u8; 32],
+        root_cnode: CapHashOrRef::Hash([0u8; 32]),
+        mem: DataCap::from_bytes(&bytes),
+        regs: [0u64; NUM_REGS],
+        pc: 0,
+        gas_remaining: 0,
+    }
+}
+
+/// Read the catch-set from a `YieldReceiver` handle (normalized: sorted,
+/// deduped). `None` if `inst` is not a YieldReceiver; an empty/short mem
+/// decodes to an empty set.
+pub fn yield_receiver_keys(inst: &InstanceCap) -> Option<Vec<Key>> {
+    if recognize_kernel_image(inst.image_hash_chain) != Some(KernelImage::YieldReceiver) {
+        return None;
+    }
+    let len = inst.mem.content_len() as usize;
+    if len < 2 {
+        return Some(Vec::new());
+    }
+    let mut buf = alloc::vec![0u8; len];
+    inst.mem.copy_into(0, &mut buf);
+    let count = u16::from_le_bytes([buf[0], buf[1]]) as usize;
+    let mut keys = Vec::with_capacity(count);
+    let mut off = 2usize;
+    for _ in 0..count {
+        if off >= buf.len() {
+            break;
+        }
+        let klen = buf[off] as usize;
+        off += 1;
+        if off + klen > buf.len() {
+            break;
+        }
+        keys.push(Key::from(&buf[off..off + klen]));
+        off += klen;
+    }
+    Some(keys)
+}
+
+/// Union the catch-sets of two `YieldReceiver` handles (the
+/// `kernel:merge_yield_receiver` operation). `None` if either is not a
+/// YieldReceiver.
+pub fn merge_yield_receivers(a: &InstanceCap, b: &InstanceCap) -> Option<InstanceCap> {
+    let mut keys = yield_receiver_keys(a)?;
+    keys.extend(yield_receiver_keys(b)?);
+    Some(yield_receiver(&keys))
+}

--- a/rust/javm-cap/src/yield_cap.rs
+++ b/rust/javm-cap/src/yield_cap.rs
@@ -60,28 +60,13 @@ pub fn is_kernel_yield_key(key: &Key) -> bool {
 /// well-known YieldSender image-hash chain and the yield_key packed into
 /// `regs[0..1]`.
 pub fn yield_sender(yield_key: &Key) -> InstanceCap {
-    let (packed, len) = key_to_regs(yield_key);
-    let mut regs = [0u64; NUM_REGS];
-    regs[0] = packed;
-    regs[1] = len;
-    InstanceCap {
-        image_hash_chain: kernel_image_hash(KernelImage::YieldSender),
-        image_hash: [0u8; 32],
-        root_cnode: CapHashOrRef::Hash([0u8; 32]),
-        mem: DataCap::empty(),
-        regs,
-        pc: 0,
-        gas_remaining: 0,
-    }
+    unit_handle(KernelImage::YieldSender, yield_key)
 }
 
 /// Read the `yield_key` from a `YieldSender` handle. `None` if `inst` is not a
 /// YieldSender.
 pub fn yield_sender_key(inst: &InstanceCap) -> Option<Key> {
-    if recognize_kernel_image(inst.image_hash_chain) != Some(KernelImage::YieldSender) {
-        return None;
-    }
-    Some(key_from_regs(inst.regs[0], inst.regs[1]))
+    unit_handle_key(KernelImage::YieldSender, inst)
 }
 
 /// Build a `YieldReceiver{keys}` unit handle: a `Cap::Instance` with the
@@ -147,4 +132,59 @@ pub fn merge_yield_receivers(a: &InstanceCap, b: &InstanceCap) -> Option<Instanc
     let mut keys = yield_receiver_keys(a)?;
     keys.extend(yield_receiver_keys(b)?);
     Some(yield_receiver(&keys))
+}
+
+/// Build a `Gas{meter_key}` unit handle: a `Cap::Instance` with the well-known
+/// Gas image-hash chain and the `meter_key` packed into `regs[0..1]` (same
+/// packing as [`yield_sender`]). The kernel reads it from an Instance's
+/// `gas_slots[0]` to index the gas-meter mapping; minted by the
+/// `kernel:mint_gas` syscall.
+pub fn gas_handle(meter_key: &Key) -> InstanceCap {
+    unit_handle(KernelImage::Gas, meter_key)
+}
+
+/// Read the `meter_key` from a `Gas` handle. `None` if `inst` is not a Gas
+/// handle.
+pub fn gas_meter_key(inst: &InstanceCap) -> Option<Key> {
+    unit_handle_key(KernelImage::Gas, inst)
+}
+
+/// Build a `Quota{quota_key}` unit handle (storage-quota analogue of
+/// [`gas_handle`]); minted by the `kernel:mint_quota` syscall.
+pub fn quota_handle(quota_key: &Key) -> InstanceCap {
+    unit_handle(KernelImage::Quota, quota_key)
+}
+
+/// Read the `quota_key` from a `Quota` handle. `None` if `inst` is not a Quota
+/// handle.
+pub fn quota_key(inst: &InstanceCap) -> Option<Key> {
+    unit_handle_key(KernelImage::Quota, inst)
+}
+
+/// A kernel unit handle naming a single `Key` (`Gas{meter_key}` /
+/// `Quota{quota_key}` / `YieldSender{yield_key}`): a `Cap::Instance` carrying
+/// `image`'s well-known image-hash chain with the key packed into `regs[0..1]`.
+fn unit_handle(image: KernelImage, key: &Key) -> InstanceCap {
+    let (packed, len) = key_to_regs(key);
+    let mut regs = [0u64; NUM_REGS];
+    regs[0] = packed;
+    regs[1] = len;
+    InstanceCap {
+        image_hash_chain: kernel_image_hash(image),
+        image_hash: [0u8; 32],
+        root_cnode: CapHashOrRef::Hash([0u8; 32]),
+        mem: DataCap::empty(),
+        regs,
+        pc: 0,
+        gas_remaining: 0,
+    }
+}
+
+/// Read the packed key from a unit handle, requiring it to carry `image`'s
+/// image-hash chain.
+fn unit_handle_key(image: KernelImage, inst: &InstanceCap) -> Option<Key> {
+    if recognize_kernel_image(inst.image_hash_chain) != Some(image) {
+        return None;
+    }
+    Some(key_from_regs(inst.regs[0], inst.regs[1]))
 }

--- a/rust/javm-cap/tests/cap_hash.rs
+++ b/rust/javm-cap/tests/cap_hash.rs
@@ -1,6 +1,6 @@
 use javm_cap::{
     CNodeCap, Cap, CapHashOrRef, DataCap, ImageCap, InstanceCap, Key, NUM_REGS, PAGE_SIZE,
-    PageBytes, PageRef, PageSlab, PageSlot, TypeCap,
+    PageBytes, PageRef, PageSlab, PageSlot,
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -18,32 +18,13 @@ fn data_cap_with_pages(pages: Vec<PageSlot>) -> Cap {
 }
 
 #[test]
-fn type_cap_hash_deterministic() {
-    let chain = [0xAA; 32];
-    let a: Cap = Cap::Type(TypeCap {
-        image_hash_chain: chain,
-    });
-    let b: Cap = Cap::Type(TypeCap {
-        image_hash_chain: chain,
-    });
-    assert_eq!(a.cap_hash(), b.cap_hash());
-    // Different chain → different hash.
-    let c: Cap = Cap::Type(TypeCap {
-        image_hash_chain: [0xBB; 32],
-    });
-    assert_ne!(a.cap_hash(), c.cap_hash());
-}
-
-#[test]
 fn cap_variants_have_distinct_hashes() {
     // The Union mix_in_selector ensures two caps whose payloads
     // happen to merkleize to the same root still differ at the
     // outer hash. Use the simplest distinguishable payloads.
-    let t: Cap = Cap::Type(TypeCap {
-        image_hash_chain: [0; 32],
-    });
+    let d: Cap = Cap::Data(DataCap::empty());
     let cn: Cap = Cap::CNode(CNodeCap::new());
-    assert_ne!(t.cap_hash(), cn.cap_hash());
+    assert_ne!(d.cap_hash(), cn.cap_hash());
 }
 
 #[test]

--- a/rust/javm-cap/tests/cap_hash.rs
+++ b/rust/javm-cap/tests/cap_hash.rs
@@ -81,7 +81,7 @@ fn empty_image() -> ImageCap {
         mappings: Vec::new(),
         pinned: Vec::new(),
         initial: Vec::new(),
-        yield_marker_slot: None,
+        yield_receiver_slot: None,
         gas_slots: Vec::new(),
         quota_slots: Vec::new(),
     }

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -3,8 +3,8 @@
 //! the source tree free of `_tests.rs` sidecars.
 
 use javm_cap::{
-    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, EndpointDef, ImageCap, ImageSlotEntry,
-    InstanceCap, Key, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotPath,
+    CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, ImageCap, ImageSlotEntry, InstanceCap,
+    Key, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotPath,
 };
 use std::sync::Arc;
 
@@ -221,15 +221,6 @@ fn instance_with_mem_image() {
     let mut out = vec![0u8; PAGE_SIZE];
     inst.mem.copy_into(0x1000, &mut out);
     assert_eq!(&out[..2], &[0xDE, 0xAD]);
-}
-
-#[test]
-fn endpoint_def_empty_sentinel() {
-    let e = EndpointDef::empty();
-    assert_eq!(e.entry_pc, 0);
-    for r in &e.initial_regs {
-        assert_eq!(*r, 0);
-    }
 }
 
 #[test]

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -4,7 +4,7 @@
 
 use javm_cap::{
     CNodeCap, CacheDirectory, Cap, CapHashOrRef, DataCap, ImageCap, ImageSlotEntry, InstanceCap,
-    Key, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, SlotPath,
+    Key, MemoryMapping, NUM_REGS, PAGE_SIZE, PageBytes, PageRef, PageSlot, ResidentCap, SlotPath,
 };
 use std::sync::Arc;
 
@@ -143,6 +143,46 @@ fn cache_get_owned_is_none() {
     let cache = CacheDirectory::new();
     let owned = CapHashOrRef::Owned(Box::new(Cap::data_inline(b"x")));
     assert!(cache.get(owned).is_none());
+}
+
+#[derive(Clone)]
+struct TestResidentCap {
+    cap: Cap,
+    resident_wrapped: bool,
+}
+
+impl ResidentCap for TestResidentCap {
+    fn from_cap(cap: Cap) -> Self {
+        Self {
+            cap,
+            resident_wrapped: true,
+        }
+    }
+
+    fn as_cap(&self) -> &Cap {
+        &self.cap
+    }
+
+    fn into_cap(self) -> Cap {
+        self.cap
+    }
+}
+
+#[test]
+fn cache_directory_can_store_resident_payload() {
+    let cache: CacheDirectory<_, TestResidentCap> =
+        CacheDirectory::with_hasher(hashbrown::DefaultHashBuilder::default());
+    let cap = Cap::data_inline(b"resident");
+    let h = cache.put_cap(&cap).expect("put resident cap");
+
+    let blob = cache.get_blob(&h).expect("resident blob");
+    assert!(blob.resident_wrapped);
+    assert!(matches!(blob.as_cap(), Cap::Data(_)));
+
+    let r = cache.put_instance(Cap::empty_cnode());
+    let inst = cache.get_instance(&r).expect("resident instance entry");
+    assert!(inst.resident_wrapped);
+    assert!(matches!(inst.as_cap(), Cap::CNode(_)));
 }
 
 #[test]

--- a/rust/javm-cap/tests/cap_smoke.rs
+++ b/rust/javm-cap/tests/cap_smoke.rs
@@ -15,7 +15,7 @@ fn make_image_cap() -> ImageCap {
         mappings: Vec::new(),
         pinned: Vec::new(),
         initial: Vec::new(),
-        yield_marker_slot: None,
+        yield_receiver_slot: None,
         gas_slots: Vec::new(),
         quota_slots: Vec::new(),
     }

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -64,7 +64,7 @@ fn image_ssz_roundtrip() {
             size: 0x4000,
         },
     );
-    img.yield_marker_slot = Some(Key::from(9u8));
+    img.yield_receiver_slot = Some(Key::from(9u8));
 
     let bytes = ssz::Encode::as_ssz_bytes(&img);
     let decoded = Image::from_ssz_bytes(&bytes).expect("decode");

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -21,7 +21,7 @@ fn image_ssz_roundtrip() {
     let mut img = Image::empty();
     img.code = b"sample code".to_vec();
     img.endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0x100,
             arg_registers: 1,
@@ -32,7 +32,7 @@ fn image_ssz_roundtrip() {
     let mut initial_regs = BTreeMap::new();
     initial_regs.insert(1u8, 0x4000);
     img.endpoints.insert(
-        255,
+        Key::from(255u8),
         EndpointDef {
             entry_pc: 0xDEADBEEF,
             arg_registers: 4,
@@ -85,7 +85,7 @@ fn endpoints_affect_hash() {
     let a = Image::empty();
     let mut b = Image::empty();
     b.endpoints.insert(
-        7,
+        Key::from(7u8),
         EndpointDef {
             entry_pc: 0x1000,
             arg_registers: 2,

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -50,7 +50,7 @@ fn image_cap_roundtrip_preserves_hash() {
     img.code = vec![0u8, 10u8, 42];
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
-        0u8,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 1,
             arg_registers: 0,

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -12,7 +12,7 @@ use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::page::{PageBytes, PageSlot};
 use javm_cap::image::EndpointDef;
 use javm_cap::{
-    CNodeCap, Cap, DataCap, GROUP_SIZE, Key, NUM_REGS, PAGE_SIZE, PageSlab, TypeCap, image::Image,
+    CNodeCap, Cap, DataCap, GROUP_SIZE, Key, NUM_REGS, PAGE_SIZE, PageSlab, image::Image,
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -27,13 +27,6 @@ fn round_trip(cap: Cap) {
     let recovered: Cap =
         rkyv::deserialize::<Cap, rkyv::rancor::Error>(archived).expect("rkyv deserialize");
     assert_eq!(original, recovered.cap_hash());
-}
-
-#[test]
-fn type_cap_roundtrip_preserves_hash() {
-    round_trip(Cap::Type(TypeCap {
-        image_hash_chain: [0xAB; 32],
-    }));
 }
 
 #[test]

--- a/rust/javm-cap/tests/yield_cap.rs
+++ b/rust/javm-cap/tests/yield_cap.rs
@@ -2,10 +2,11 @@
 //! construction/round-trip. Black-box against the public API.
 
 use javm_cap::yield_cap::{
-    KERNEL_YIELD_NS, YK_MINT_YIELD, YK_OOG, is_kernel_yield_key, merge_yield_receivers,
-    yield_receiver, yield_receiver_keys, yield_sender, yield_sender_key,
+    KERNEL_YIELD_NS, YK_MINT_YIELD, YK_OOG, gas_handle, gas_meter_key, is_kernel_yield_key,
+    merge_yield_receivers, quota_handle, quota_key, yield_receiver, yield_receiver_keys,
+    yield_sender, yield_sender_key,
 };
-use javm_cap::{Key, kernel_image_hash};
+use javm_cap::{KernelImage, Key, kernel_image_hash};
 
 #[test]
 fn kernel_keys_are_namespaced() {
@@ -87,4 +88,35 @@ fn merge_unions_catch_sets() {
         got,
         vec![Key::from(1u8), Key::from(2u8), Key::from(&YK_OOG[..])]
     );
+}
+
+#[test]
+fn gas_handle_round_trips_its_meter_key() {
+    let key = Key::from(&[0xAB, 0xCD, 0xEF][..]);
+    let gas = gas_handle(&key);
+    // Identity is the well-known Gas image-hash chain.
+    assert_eq!(gas.image_hash_chain, kernel_image_hash(KernelImage::Gas));
+    assert_eq!(gas_meter_key(&gas), Some(key));
+}
+
+#[test]
+fn quota_handle_round_trips_its_quota_key() {
+    let key = Key::from(7u8);
+    let quota = quota_handle(&key);
+    assert_eq!(
+        quota.image_hash_chain,
+        kernel_image_hash(KernelImage::Quota)
+    );
+    assert_eq!(quota_key(&quota), Some(key));
+}
+
+#[test]
+fn unit_handle_kinds_do_not_cross_decode() {
+    // A Gas handle is not a Quota / YieldSender, and vice versa — each reader
+    // requires its own image-hash chain.
+    let gas = gas_handle(&Key::from(1u8));
+    assert_eq!(quota_key(&gas), None);
+    assert_eq!(yield_sender_key(&gas), None);
+    let quota = quota_handle(&Key::from(1u8));
+    assert_eq!(gas_meter_key(&quota), None);
 }

--- a/rust/javm-cap/tests/yield_cap.rs
+++ b/rust/javm-cap/tests/yield_cap.rs
@@ -1,0 +1,90 @@
+//! `yield_cap` helpers: kernel yield-key namespace + YieldSender/YieldReceiver
+//! construction/round-trip. Black-box against the public API.
+
+use javm_cap::yield_cap::{
+    KERNEL_YIELD_NS, YK_MINT_YIELD, YK_OOG, is_kernel_yield_key, merge_yield_receivers,
+    yield_receiver, yield_receiver_keys, yield_sender, yield_sender_key,
+};
+use javm_cap::{Key, kernel_image_hash};
+
+#[test]
+fn kernel_keys_are_namespaced() {
+    assert!(is_kernel_yield_key(&Key::from(&YK_MINT_YIELD[..])));
+    assert!(is_kernel_yield_key(&Key::from(&YK_OOG[..])));
+    assert_eq!(YK_MINT_YIELD[0], KERNEL_YIELD_NS);
+    // A plain user key (single byte) is not in the kernel namespace.
+    assert!(!is_kernel_yield_key(&Key::from(7u8)));
+    // The empty key is not a kernel key.
+    assert!(!is_kernel_yield_key(&Key::from(&[][..])));
+}
+
+#[test]
+fn yield_sender_round_trips_its_key() {
+    let key = Key::from(&[0xAB, 0xCD, 0xEF][..]);
+    let sender = yield_sender(&key);
+    // Identity is the well-known YieldSender image-hash chain.
+    assert_eq!(
+        sender.image_hash_chain,
+        kernel_image_hash(javm_cap::KernelImage::YieldSender)
+    );
+    assert_eq!(yield_sender_key(&sender), Some(key));
+}
+
+#[test]
+fn yield_sender_reads_kernel_key() {
+    let mint = yield_sender(&Key::from(&YK_MINT_YIELD[..]));
+    assert_eq!(yield_sender_key(&mint), Some(Key::from(&YK_MINT_YIELD[..])));
+    assert!(is_kernel_yield_key(&yield_sender_key(&mint).unwrap()));
+}
+
+#[test]
+fn non_yield_sender_returns_none() {
+    // A YieldReceiver is not a YieldSender.
+    let recv = yield_receiver(&[Key::from(1u8)]);
+    assert_eq!(yield_sender_key(&recv), None);
+}
+
+#[test]
+fn yield_receiver_round_trips_its_set() {
+    let keys = [
+        Key::from(1u8),
+        Key::from(&YK_OOG[..]),
+        Key::from(&[9, 9, 9][..]),
+    ];
+    let recv = yield_receiver(&keys);
+    assert_eq!(
+        recv.image_hash_chain,
+        kernel_image_hash(javm_cap::KernelImage::YieldReceiver)
+    );
+    let mut got = yield_receiver_keys(&recv).expect("is a receiver");
+    let mut want: Vec<Key> = keys.to_vec();
+    want.sort();
+    want.dedup();
+    got.sort();
+    assert_eq!(got, want);
+}
+
+#[test]
+fn yield_receiver_normalizes_sort_and_dedup() {
+    let recv = yield_receiver(&[Key::from(5u8), Key::from(1u8), Key::from(5u8)]);
+    let got = yield_receiver_keys(&recv).expect("receiver");
+    assert_eq!(got, vec![Key::from(1u8), Key::from(5u8)]);
+}
+
+#[test]
+fn empty_receiver_decodes_to_empty_set() {
+    let recv = yield_receiver(&[]);
+    assert_eq!(yield_receiver_keys(&recv), Some(Vec::new()));
+}
+
+#[test]
+fn merge_unions_catch_sets() {
+    let a = yield_receiver(&[Key::from(1u8), Key::from(2u8)]);
+    let b = yield_receiver(&[Key::from(2u8), Key::from(&YK_OOG[..])]);
+    let merged = merge_yield_receivers(&a, &b).expect("both receivers");
+    let got = yield_receiver_keys(&merged).expect("receiver");
+    assert_eq!(
+        got,
+        vec![Key::from(1u8), Key::from(2u8), Key::from(&YK_OOG[..])]
+    );
+}

--- a/rust/javm-fuzz/src/replay.rs
+++ b/rust/javm-fuzz/src/replay.rs
@@ -51,7 +51,7 @@ pub fn image_with_ro(words: &[u32], ro_start: u32, ro_bytes: &[u8]) -> Image {
     let mut img = Image::empty();
     img.code = code;
     img.endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,
@@ -86,7 +86,7 @@ pub fn image_with_ro_caps(words: &[u32], caps: &[(u32, &[u8])]) -> Image {
     let mut img = Image::empty();
     img.code = code;
     img.endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,
@@ -143,7 +143,7 @@ pub fn image_for(prog: &Program) -> Image {
     let mut img = Image::empty();
     img.code = code;
     img.endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,

--- a/rust/javm-guest-tests/tests/call_status.rs
+++ b/rust/javm-guest-tests/tests/call_status.rs
@@ -1,0 +1,158 @@
+//! The kernel writes the caller's φ[8] status on EVERY apply termination (spec
+//! §4): Ok on a normal HALT/REPLY return, YIELDED when a routed yield hands
+//! control to a catcher. Regression for the validation finding that a stale
+//! φ[8]=YIELDED survived a subsequent normal CALL (φ[8] was only ever set on the
+//! yield path, never reset to Ok on a normal return).
+//!
+//! A (catcher of K) CALLs B; B yields K → A runs as handler with φ[8]=YIELDED.
+//! A then makes a NORMAL host_call to C and, after C returns, moves φ[8] into
+//! φ[7] and REPLYs. With the fix φ[8] is Ok(0) after C's return; the bug would
+//! leave the stale YIELDED(1). The clever bit: the normal CALL's endpoint operand
+//! IS φ[8] (=1), so C is invoked at endpoint 1 and the stale value is what we
+//! observe — no extra register write masks it.
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+
+const B_SLOT: u8 = 6;
+const C_SLOT: u8 = 4;
+const SENDER_SLOT: u8 = 5;
+const RECEIVER_SLOT: u8 = 9;
+const YIELD_KEY: u8 = 0x42;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// `addi rd, rs1, imm`. φ7→x10, φ8→x11.
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+/// Endpoints {0} or {0,1}: all entry_pc 0.
+fn endpoints(extra1: bool) -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    let mk = || EndpointDef {
+        entry_pc: 0,
+        arg_registers: 0,
+        arg_cnode_size: 0,
+        initial_regs: BTreeMap::new(),
+    };
+    e.insert(Key::from(0u8), mk());
+    if extra1 {
+        e.insert(Key::from(1u8), mk());
+    }
+    e
+}
+
+fn image(code: Vec<u8>, eps: BTreeMap<Key, EndpointDef>, recv: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: eps,
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: recv,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        mem,
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+#[test]
+fn phi8_status_is_ok_after_normal_call() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    let sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))
+        .expect("put sender");
+    let receiver_h = nub
+        .put_cap(&Cap::Instance(yield_receiver(&[Key::from(YIELD_KEY)])))
+        .expect("put receiver");
+
+    // B: host_yield(φ7=sender); reply.
+    let mut b_code = Vec::new();
+    b_code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    b_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let b_h = put_instance(&mut nub, &image(b_code, endpoints(false), None), [0u8; 32]);
+
+    // C: reply. Has endpoint 1 (the normal CALL invokes it at φ8=YIELDED=1).
+    let c_h = put_instance(
+        &mut nub,
+        &image(
+            ecalli(OP_REPLY).to_le_bytes().to_vec(),
+            endpoints(true),
+            None,
+        ),
+        [0u8; 32],
+    );
+
+    // A: host_call(B) [B yields → A handler, φ8=YIELDED]; addi φ7=C_SLOT;
+    // host_call(C) [normal CALL, φ8=YIELDED=1 is C's endpoint]; addi φ7=φ8;
+    // reply [φ7 = post-return φ8].
+    let mut a_code = Vec::new();
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // call B
+    a_code.extend_from_slice(&addi(10, 0, C_SLOT as i32).to_le_bytes()); // φ7 = C slot
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // normal call C @ φ8
+    a_code.extend_from_slice(&addi(10, 11, 0).to_le_bytes()); // φ7 = φ8 (status)
+    a_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    let mut a_cnode = CNodeCap::new();
+    for (slot, h) in [
+        (B_SLOT, b_h),
+        (C_SLOT, c_h),
+        (SENDER_SLOT, sender_h),
+        (RECEIVER_SLOT, receiver_h),
+    ] {
+        a_cnode
+            .set(&Key::from(slot), Some(CapHashOrRef::Hash(h)))
+            .unwrap();
+    }
+    let a_cnode_h = nub.put_cap(&Cap::CNode(a_cnode)).expect("put A cnode");
+    let a_h = put_instance(
+        &mut nub,
+        &image(a_code, endpoints(false), Some(Key::from(RECEIVER_SLOT))),
+        a_cnode_h,
+    );
+
+    // φ7=B slot, φ8=ep0, φ9=sender slot (→B.φ7), φ10=0.
+    let args = [B_SLOT as u64, 0, SENDER_SLOT as u64, 0];
+    let r = nub
+        .invoke_cached(a_h, 0, args, GAS_BUDGET)
+        .expect("invoke A");
+
+    // After the normal CALL of C returns, A's φ[8] must read Ok(0), not the stale
+    // YIELDED(1) it held from catching B's yield. A moved φ[8] into φ[7] (the
+    // return value) before REPLY.
+    assert_eq!(
+        r.return_value, 0,
+        "φ[8] must reset to Ok after a normal CALL return, got {} (stale YIELDED=1 if the bug)",
+        r.return_value,
+    );
+}

--- a/rust/javm-guest-tests/tests/conformance.rs
+++ b/rust/javm-guest-tests/tests/conformance.rs
@@ -24,7 +24,7 @@
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod backend {
     use javm_cap::image::{Image, PinnedCap};
-    use javm_cap::{Cap, NUM_REGS};
+    use javm_cap::{Cap, Key, NUM_REGS};
     use nub::Nub;
     use ssz::Decode;
     use std::sync::{Mutex, OnceLock};
@@ -66,7 +66,7 @@ mod backend {
     fn run(nub: &mut Nub, image: &Image, ep: u8) -> (u64, u64) {
         let endpoint = image
             .endpoints
-            .get(&ep)
+            .get(&Key::from(ep))
             .unwrap_or_else(|| panic!("endpoint {ep} not declared in Image"));
 
         // Endpoint invocation = process spawn; `initial_regs` is the

--- a/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
+++ b/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
@@ -79,7 +79,7 @@ fn parent_image(child_hash: CapHash) -> Image {
         memory_mappings: Vec::new(),
         pinned_slots,
         initial_slots: BTreeMap::new(),
-        yield_marker_slot: None,
+        yield_receiver_slot: None,
         gas_slots: Vec::new(),
         quota_slots: Vec::new(),
     }

--- a/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
+++ b/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
@@ -49,7 +49,7 @@ fn child_image() -> Image {
 fn parent_image(child_hash: CapHash) -> Image {
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
-        0u8,
+        Key::from(0u8),
         EndpointDef {
             // Code-region byte offset (the runtime adds CODE_BASE); the
             // single instruction sits at offset 0.

--- a/rust/javm-guest-tests/tests/gas_slots.rs
+++ b/rust/javm-guest-tests/tests/gas_slots.rs
@@ -1,0 +1,275 @@
+//! Ordered Image gas slots: empty slots are skipped, present invalid slots are
+//! hard faults, usable meters are exhausted in order before `kernel:oog`, and
+//! the OOG resume path returns to the primary usable meter.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::{YK_OOG, YK_SET_GAS_METER};
+use javm_cap::{
+    gas_handle, yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS,
+};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+
+const SENDER_SLOT: u8 = 5;
+const CHILD_SLOT: u8 = 6;
+const GAS_SLOT_A: u8 = 8;
+const GAS_SLOT_B: u8 = 9;
+const EMPTY_SLOT: u8 = 10;
+const INVALID_SLOT: u8 = 11;
+const RECEIVER_SLOT: u8 = 12;
+const METER_A: u8 = 0;
+const METER_B: u8 = 1;
+const GAS_BUDGET: u64 = 10_000_000_000;
+const FUNDED: u64 = 1_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    e.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    e
+}
+
+fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots,
+        quota_slots: Vec::new(),
+    }
+}
+
+fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        mem,
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+fn emit_set_meter(code: &mut Vec<u8>, meter: u8, funded: bool) {
+    code.extend_from_slice(&addi(10, 0, SENDER_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, meter as i32).to_le_bytes());
+    if funded {
+        code.extend_from_slice(&addi(12, 13, 0).to_le_bytes());
+    } else {
+        code.extend_from_slice(&addi(12, 0, 0).to_le_bytes());
+    }
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+}
+
+fn run_child(
+    nub: &mut Nub,
+    gas_slots: Vec<Key>,
+    install_a: bool,
+    install_b: bool,
+    install_invalid: bool,
+    meter_sets: &[(u8, bool)],
+    catch_oog_and_topup_primary: bool,
+) -> (u32, u32) {
+    let set_gas_sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(
+            &YK_SET_GAS_METER[..],
+        ))))
+        .expect("put set_gas sender");
+    let invalid_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(0x44u8))))
+        .expect("put invalid gas cap");
+
+    let child_img = image(ecalli(OP_REPLY).to_le_bytes().to_vec(), gas_slots, None);
+    let child_h = put_instance(nub, &child_img, [0u8; 32]);
+
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(
+            &Key::from(SENDER_SLOT),
+            Some(CapHashOrRef::Hash(set_gas_sender_h)),
+        )
+        .unwrap();
+    cnode
+        .set(&Key::from(CHILD_SLOT), Some(CapHashOrRef::Hash(child_h)))
+        .unwrap();
+    if install_a {
+        let gas_h = nub
+            .put_cap(&Cap::Instance(gas_handle(&Key::from(METER_A))))
+            .expect("put gas A");
+        cnode
+            .set(&Key::from(GAS_SLOT_A), Some(CapHashOrRef::Hash(gas_h)))
+            .unwrap();
+    }
+    if install_b {
+        let gas_h = nub
+            .put_cap(&Cap::Instance(gas_handle(&Key::from(METER_B))))
+            .expect("put gas B");
+        cnode
+            .set(&Key::from(GAS_SLOT_B), Some(CapHashOrRef::Hash(gas_h)))
+            .unwrap();
+    }
+    if install_invalid {
+        cnode
+            .set(
+                &Key::from(INVALID_SLOT),
+                Some(CapHashOrRef::Hash(invalid_h)),
+            )
+            .unwrap();
+    }
+    if catch_oog_and_topup_primary {
+        let receiver_h = nub
+            .put_cap(&Cap::Instance(yield_receiver(&[Key::from(&YK_OOG[..])])))
+            .expect("put receiver");
+        cnode
+            .set(
+                &Key::from(RECEIVER_SLOT),
+                Some(CapHashOrRef::Hash(receiver_h)),
+            )
+            .unwrap();
+    }
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put cnode");
+
+    let mut code = Vec::new();
+    for (meter, funded) in meter_sets {
+        emit_set_meter(&mut code, *meter, *funded);
+    }
+    code.extend_from_slice(&addi(10, 0, CHILD_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, 0).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    if catch_oog_and_topup_primary {
+        emit_set_meter(&mut code, METER_A, true);
+        code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    }
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    let receiver_slot = catch_oog_and_topup_primary.then_some(Key::from(RECEIVER_SLOT));
+    let chain_img = image(code, Vec::new(), receiver_slot);
+    let chain_h = put_instance(nub, &chain_img, cnode_h);
+    let r = nub
+        .invoke_cached(chain_h, 0, [0, 0, 0, FUNDED], GAS_BUDGET)
+        .expect("invoke chain");
+    (r.exit_reason, r.exit_arg)
+}
+
+#[test]
+fn empty_first_slot_skips_to_later_valid_meter() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    assert_eq!(
+        run_child(
+            &mut nub,
+            vec![Key::from(EMPTY_SLOT), Key::from(GAS_SLOT_B)],
+            false,
+            true,
+            false,
+            &[(METER_B, true)],
+            false,
+        )
+        .0,
+        4,
+        "an empty declared gas slot must be skipped in favor of the later valid meter",
+    );
+}
+
+#[test]
+fn exhausted_first_meter_falls_through_to_second_meter() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    assert_eq!(
+        run_child(
+            &mut nub,
+            vec![Key::from(GAS_SLOT_A), Key::from(GAS_SLOT_B)],
+            true,
+            true,
+            false,
+            &[(METER_A, false), (METER_B, true)],
+            false,
+        )
+        .0,
+        4,
+        "OOG on the first usable gas slot must consult the second before yielding kernel:oog",
+    );
+}
+
+#[test]
+fn invalid_non_empty_gas_slot_hard_faults() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    assert_eq!(
+        run_child(
+            &mut nub,
+            vec![Key::from(INVALID_SLOT)],
+            false,
+            false,
+            true,
+            &[],
+            false,
+        ),
+        (u32::MAX, 73),
+        "a present non-Gas cap in gas_slots must hard fault",
+    );
+}
+
+#[test]
+fn all_empty_declared_gas_slots_hard_fault() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    assert_eq!(
+        run_child(
+            &mut nub,
+            vec![Key::from(EMPTY_SLOT)],
+            false,
+            false,
+            false,
+            &[],
+            false,
+        ),
+        (u32::MAX, 72),
+        "declaring only empty gas slots leaves no primary OOG payload and must hard fault",
+    );
+}
+
+#[test]
+fn exhausted_all_meters_oog_resumes_from_primary() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    assert_eq!(
+        run_child(
+            &mut nub,
+            vec![Key::from(GAS_SLOT_A), Key::from(GAS_SLOT_B)],
+            true,
+            true,
+            false,
+            &[(METER_A, false), (METER_B, false)],
+            true,
+        )
+        .0,
+        4,
+        "after all meters exhaust, OOG must carry/reset to the primary so a primary top-up resumes",
+    );
+}

--- a/rust/javm-guest-tests/tests/gas_slots.rs
+++ b/rust/javm-guest-tests/tests/gas_slots.rs
@@ -10,6 +10,7 @@ use javm_cap::{
 };
 use nub::Nub;
 use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -27,6 +28,14 @@ const METER_A: u8 = 0;
 const METER_B: u8 = 1;
 const GAS_BUDGET: u64 = 10_000_000_000;
 const FUNDED: u64 = 1_000_000;
+
+static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
+    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
+    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    (guard, nub)
+}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -183,7 +192,7 @@ fn run_child(
 
 #[test]
 fn empty_first_slot_skips_to_later_valid_meter() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
     assert_eq!(
         run_child(
             &mut nub,
@@ -202,7 +211,7 @@ fn empty_first_slot_skips_to_later_valid_meter() {
 
 #[test]
 fn exhausted_first_meter_falls_through_to_second_meter() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
     assert_eq!(
         run_child(
             &mut nub,
@@ -221,7 +230,7 @@ fn exhausted_first_meter_falls_through_to_second_meter() {
 
 #[test]
 fn invalid_non_empty_gas_slot_hard_faults() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
     assert_eq!(
         run_child(
             &mut nub,
@@ -239,7 +248,7 @@ fn invalid_non_empty_gas_slot_hard_faults() {
 
 #[test]
 fn all_empty_declared_gas_slots_hard_fault() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
     assert_eq!(
         run_child(
             &mut nub,
@@ -257,7 +266,7 @@ fn all_empty_declared_gas_slots_hard_fault() {
 
 #[test]
 fn exhausted_all_meters_oog_resumes_from_primary() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
     assert_eq!(
         run_child(
             &mut nub,

--- a/rust/javm-guest-tests/tests/host_image_hash_chain.rs
+++ b/rust/javm-guest-tests/tests/host_image_hash_chain.rs
@@ -47,7 +47,7 @@ fn child_image() -> Image {
 fn parent_image(child_hash: CapHash) -> Image {
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
-        0u8,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,

--- a/rust/javm-guest-tests/tests/host_image_hash_chain.rs
+++ b/rust/javm-guest-tests/tests/host_image_hash_chain.rs
@@ -1,0 +1,151 @@
+//! `host_image_hash_chain` (op 20): read a cap's kernel-attested type identity
+//! (an Instance's cumulative `image_hash_chain`, or — as here — an Image's
+//! content hash) and write a `Cap::Data` of its 32 raw bytes at `dst`.
+//!
+//! This op reclaims the removed `HOST_SAME_TYPE`/`HOST_TYPE_OF` ABI slots: with
+//! `Cap::Type` gone, type identity is read as plain bytes and compared in
+//! userspace (memcmp), so there is no separate type cap kind or same-type op.
+//!
+//! Two cases, mirroring `derive_spawn_pinned`'s trap-discipline check:
+//!   1. writing the result into a PINNED dst slot TRAPs (exit_reason 7), and
+//!   2. a valid call (src = pinned Cap::Image, dst = empty mutable slot) runs
+//!      and HALTs cleanly via the trailing `ecalli 0` (exit_reason 4, arg 0).
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64), like the other guest tests.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image, PinnedCap};
+use javm_cap::{Cap, CapHash, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_IMAGE_HASH_CHAIN: u32 = 20;
+const OP_REPLY: u32 = 0;
+/// A pinned `Cap::Image` slot — a valid `src` (read its content-hash identity).
+const IMAGE_SLOT: u8 = 3;
+/// A pinned `Cap::Data` slot — an illegal `dst` (write must trap).
+const PINNED_DST: u8 = 66;
+/// An empty, unpinned slot — a legal `dst`.
+const NORMAL_DST: u8 = 5;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+/// custom-0 `ecalli imm` encoding (funct3=010, opcode=0x0b), mirroring the
+/// transpiler's `encode_custom0_ecalli`.
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// The child image pinned at `IMAGE_SLOT` — minimal; never executed (it is only
+/// read as the `host_image_hash_chain` source).
+fn child_image() -> Image {
+    Image::empty()
+}
+
+/// Parent image: `ecalli OP_IMAGE_HASH_CHAIN` then `ecalli OP_REPLY` (clean
+/// halt). `IMAGE_SLOT` is a pinned `Cap::Image` (the src); `PINNED_DST` is a
+/// pinned `Cap::Data`. Endpoint args φ[7]=src, φ[8]=dst.
+fn parent_image(child_hash: CapHash) -> Image {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        0u8,
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    let mut pinned_slots = BTreeMap::new();
+    pinned_slots.insert(
+        Key::from(IMAGE_SLOT),
+        PinnedCap::Image {
+            content_hash: child_hash,
+        },
+    );
+    pinned_slots.insert(
+        Key::from(PINNED_DST),
+        PinnedCap::Data {
+            content: vec![0xAB; 16],
+            size: 4096,
+        },
+    );
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_IMAGE_HASH_CHAIN).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    Image {
+        code,
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots,
+        initial_slots: BTreeMap::new(),
+        yield_marker_slot: None,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Publish the parent instance and invoke endpoint 0 with the given
+/// (src, dst) slot args, returning the JIT exit_reason / exit_arg.
+///
+/// `Nub::new_hyperlight()` reserves a fixed host VA range, so only one sandbox
+/// can exist at a time; the single `#[test]` below threads one `nub` through
+/// both cases (the harness would otherwise race two sandboxes — see
+/// `conformance.rs`'s shared-sandbox note).
+fn run(nub: &mut Nub, src: u8, dst: u8) -> (u32, u32) {
+    let child_cap = Cap::image_with_slots(&child_image(), &[], &[]).expect("child image");
+    let child_hash = nub.put_cap(&child_cap).expect("put child image");
+    let data_hash = nub
+        .put_cap(&Cap::data_inline_with_size(&[0xAB; 16], 4096))
+        .expect("put pinned data");
+
+    let parent = parent_image(child_hash);
+    let pinned_hashes = [
+        (Key::from(IMAGE_SLOT), child_hash),
+        (Key::from(PINNED_DST), data_hash),
+    ];
+    let parent_cap = Cap::image_with_slots(&parent, &pinned_hashes, &[]).expect("parent image");
+    let image_h = nub.put_cap(&parent_cap).expect("put parent image");
+    let cnode_h = nub.put_cap(&Cap::empty_cnode()).expect("put cnode");
+
+    let mem = parent.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    let result = nub
+        .invoke_cached(inst_h, 0, [src as u64, dst as u64, 0, 0], GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+#[test]
+fn image_hash_chain_traps_on_pinned_and_halts_on_valid() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // 1. Writing the identity DataCap into a PINNED dst slot traps.
+    // JIT codegen ABI: `ExitReason::Trap` surfaces as exit_reason 7.
+    const EXIT_TRAP: u32 = 7;
+    let (reason, arg) = run(&mut nub, IMAGE_SLOT, PINNED_DST);
+    assert_eq!(
+        reason, EXIT_TRAP,
+        "host_image_hash_chain into a pinned dst must Trap (7), got reason={reason} arg={arg}",
+    );
+
+    // 2. A valid call runs, writes the identity DataCap, and reaches the
+    // trailing `ecalli 0` (REPLY/HALT) — surfaced by the JIT as HostCall(0):
+    // reason 4, arg 0.
+    let (reason, arg) = run(&mut nub, IMAGE_SLOT, NORMAL_DST);
+    assert_eq!(
+        (reason, arg),
+        (4, 0),
+        "valid host_image_hash_chain must halt via REPLY (reason 4, arg 0), got reason={reason} arg={arg}",
+    );
+}

--- a/rust/javm-guest-tests/tests/host_image_hash_chain.rs
+++ b/rust/javm-guest-tests/tests/host_image_hash_chain.rs
@@ -78,7 +78,7 @@ fn parent_image(child_hash: CapHash) -> Image {
         memory_mappings: Vec::new(),
         pinned_slots,
         initial_slots: BTreeMap::new(),
-        yield_marker_slot: None,
+        yield_receiver_slot: None,
         gas_slots: Vec::new(),
         quota_slots: Vec::new(),
     }

--- a/rust/javm-guest-tests/tests/host_yield_mint.rs
+++ b/rust/javm-guest-tests/tests/host_yield_mint.rs
@@ -1,0 +1,133 @@
+//! `host_yield` (op 16) with the kernel as the implicit ROOT receiver: a guest
+//! places a `kernel:mint_yield` YieldSender in a slot and yields it; the kernel
+//! handles the syscall INLINE (mints a YieldSender/YieldReceiver pair into the
+//! requested slots) and the guest resumes at the next instruction — the
+//! "system call through yield to the kernel" path.
+//!
+//! Positive: a valid `kernel:mint_yield` yield runs and the guest halts
+//! cleanly. Negative: an empty sender slot traps (the op validates its sender).
+//!
+//! The mint_yield YieldSender is a `Cap::Instance`, so it reaches the guest via
+//! the instance's root cnode (see `root_cnode_seeding`). Gated to the nub
+//! Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::YK_MINT_YIELD;
+use javm_cap::{yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_HOST_YIELD: u32 = 16;
+const OP_REPLY: u32 = 0;
+/// Root-cnode slot holding the `kernel:mint_yield` YieldSender.
+const SENDER_SLOT: u8 = 5;
+/// New yield_key (a single user byte) the guest asks the kernel to mint.
+const NEW_KEY: u8 = 50;
+/// Where the kernel writes the minted YieldSender / YieldReceiver.
+const SENDER_DST: u8 = 6;
+const RECEIVER_DST: u8 = 7;
+/// An empty slot — the negative control sender.
+const EMPTY_SLOT: u8 = 9;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// Image: `host_yield(φ7=sender, φ8=new key, φ9=sender dst, φ10=recv dst)`
+/// then `REPLY`.
+fn prog_image() -> Image {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    Image {
+        code,
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Invoke the program with the given sender slot; return (exit_reason,
+/// exit_arg). The published instance's root cnode holds a `kernel:mint_yield`
+/// YieldSender at `SENDER_SLOT`.
+fn run(nub: &mut Nub, sender_slot: u8) -> (u32, u32) {
+    // The kernel:mint_yield YieldSender (a Cap::Instance), placed in the root
+    // cnode so it reaches the guest.
+    let mint = Cap::Instance(yield_sender(&Key::from(&YK_MINT_YIELD[..])));
+    let mint_h = nub.put_cap(&mint).expect("put mint_yield sender");
+
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(&Key::from(SENDER_SLOT), Some(CapHashOrRef::Hash(mint_h)))
+        .expect("set sender slot");
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put root cnode");
+
+    let img = prog_image();
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    let args = [
+        sender_slot as u64,
+        NEW_KEY as u64,
+        SENDER_DST as u64,
+        RECEIVER_DST as u64,
+    ];
+    let result = nub
+        .invoke_cached(inst_h, 0, args, GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+#[test]
+fn host_yield_mint_yield_via_kernel_root() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Positive: yielding the kernel:mint_yield sender runs the syscall inline;
+    // the guest resumes and halts cleanly (reason 4, arg 0 — the trailing
+    // REPLY). A trap or unhandled error here would change the reason.
+    let (reason, arg) = run(&mut nub, SENDER_SLOT);
+    assert_eq!(
+        (reason, arg),
+        (4, 0),
+        "kernel:mint_yield must be handled inline and resume (clean halt), got reason={reason} arg={arg}",
+    );
+
+    // Negative: an empty sender slot makes host_yield trap (reason 7) —
+    // confirms the op validates its YieldSender, so the positive isn't a false
+    // pass.
+    let (reason, _) = run(&mut nub, EMPTY_SLOT);
+    assert_eq!(
+        reason, 7,
+        "host_yield with an empty sender slot must trap (7), got reason={reason}",
+    );
+}

--- a/rust/javm-guest-tests/tests/jit_cache.rs
+++ b/rust/javm-guest-tests/tests/jit_cache.rs
@@ -1,0 +1,72 @@
+//! Smoke test for the resident per-Image JIT cache: a compiled Image can be
+//! evicted from its `CachedCap` and rebuilt on the next invoke.
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{Cap, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const GAS_BUDGET: u64 = 1_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn reply_image() -> Image {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    Image {
+        code: ecalli(OP_REPLY).to_le_bytes().to_vec(),
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+#[test]
+fn evict_jit_cache_then_reinvoke_rebuilds_image_cache() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let img = reply_image();
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+    let cnode_h = nub.put_cap(&Cap::empty_cnode()).expect("put cnode");
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            img.instance_mem_backing(),
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    let first = nub
+        .invoke_cached(inst_h, 0, [0; 4], GAS_BUDGET)
+        .expect("first invoke");
+    assert_eq!((first.exit_reason, first.exit_arg), (4, 0));
+
+    nub.evict_jit_all().expect("evict jit cache");
+
+    let second = nub
+        .invoke_cached(inst_h, 0, [0; 4], GAS_BUDGET)
+        .expect("second invoke after eviction");
+    assert_eq!((second.exit_reason, second.exit_arg), (4, 0));
+}

--- a/rust/javm-guest-tests/tests/mint_gas.rs
+++ b/rust/javm-guest-tests/tests/mint_gas.rs
@@ -1,0 +1,145 @@
+//! `kernel:mint_gas` / `kernel:mint_quota` inline syscalls (via `host_yield`):
+//! a guest places a `kernel:mint_gas` (or `kernel:mint_quota`) YieldSender in a
+//! slot and yields it; the kernel, as the implicit ROOT receiver, mints a
+//! `Gas{meter_key}` (or `Quota{quota_key}`) unit handle into the requested slot
+//! INLINE and the guest resumes — pure-cap syscalls in the same family as
+//! `kernel:mint_yield`.
+//!
+//! Positive: a `kernel:mint_gas` / `kernel:mint_quota` yield into a free slot
+//! runs and the guest halts cleanly (reason 4). Negative: minting into a PINNED
+//! slot traps (reason 7) — confirms the op validates its dst.
+//!
+//! The mint_gas/mint_quota YieldSenders are `Cap::Instance`s, so they reach the
+//! guest via the instance's root cnode (see `root_cnode_seeding`). Gated to the
+//! nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image, PinnedCap};
+use javm_cap::yield_cap::{YK_MINT_GAS, YK_MINT_QUOTA};
+use javm_cap::{yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_HOST_YIELD: u32 = 16;
+const OP_REPLY: u32 = 0;
+/// Root-cnode slot holding the mint_gas / mint_quota YieldSender.
+const SENDER_SLOT: u8 = 5;
+/// The meter_key / quota_key byte the guest asks the kernel to name.
+const KEY_BYTE: u8 = 7;
+/// A free dst slot for the minted handle (the positive case).
+const FREE_DST: u8 = 6;
+/// A pinned dst slot (holds a `Cap::Data`) — the negative case.
+const PINNED_DST: u8 = 66;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// Image: `host_yield(φ7=sender, φ8=key, φ9=dst); reply`, with a pinned
+/// `Cap::Data` at PINNED_DST so the negative run targets a read-only slot.
+fn prog_image() -> Image {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    let mut pinned_slots = BTreeMap::new();
+    pinned_slots.insert(
+        Key::from(PINNED_DST),
+        PinnedCap::Data {
+            content: vec![0xAB; 16],
+            size: 4096,
+        },
+    );
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    Image {
+        code,
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots,
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Invoke the program: `mint_key` selects mint_gas vs mint_quota; `dst` is the
+/// handle destination slot. Returns `(exit_reason, exit_arg)`.
+fn run(nub: &mut Nub, mint_key: &[u8], dst: u8) -> (u32, u32) {
+    let sender = Cap::Instance(yield_sender(&Key::from(mint_key)));
+    let sender_h = nub.put_cap(&sender).expect("put mint sender");
+
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(&Key::from(SENDER_SLOT), Some(CapHashOrRef::Hash(sender_h)))
+        .expect("set sender slot");
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put root cnode");
+
+    let img = prog_image();
+    let data_h = nub
+        .put_cap(&Cap::data_inline_with_size(&[0xAB; 16], 4096))
+        .expect("put pinned data");
+    let image_h = nub
+        .put_cap(
+            &Cap::image_with_slots(&img, &[(Key::from(PINNED_DST), data_h)], &[]).expect("image"),
+        )
+        .expect("put image");
+
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    let args = [SENDER_SLOT as u64, KEY_BYTE as u64, dst as u64, 0];
+    let result = nub
+        .invoke_cached(inst_h, 0, args, GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+#[test]
+fn mint_gas_and_quota_via_kernel_root() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Positive: kernel:mint_gas into a free slot is handled inline and resumes
+    // → clean halt (reason 4, arg 0 — the trailing REPLY).
+    let (reason, arg) = run(&mut nub, &YK_MINT_GAS[..], FREE_DST);
+    assert_eq!(
+        (reason, arg),
+        (4, 0),
+        "kernel:mint_gas must mint inline and resume, got reason={reason} arg={arg}",
+    );
+
+    // kernel:mint_quota into a free slot — same inline path, different handle.
+    let (reason, arg) = run(&mut nub, &YK_MINT_QUOTA[..], FREE_DST);
+    assert_eq!(
+        (reason, arg),
+        (4, 0),
+        "kernel:mint_quota must mint inline and resume, got reason={reason} arg={arg}",
+    );
+
+    // Negative: minting into a PINNED slot traps (reason 7) — confirms the op
+    // rejects a read-only dst, so the positives aren't false passes.
+    let (reason, _) = run(&mut nub, &YK_MINT_GAS[..], PINNED_DST);
+    assert_eq!(
+        reason, 7,
+        "kernel:mint_gas into a pinned dst must trap (7), got reason={reason}",
+    );
+}

--- a/rust/javm-guest-tests/tests/oog_yield.rs
+++ b/rust/javm-guest-tests/tests/oog_yield.rs
@@ -1,0 +1,186 @@
+//! OOG-as-yield (the lazy-load OOG-catch pattern): a metered child that runs out
+//! of gas does NOT bubble a fault — the kernel injects a `kernel:oog` yield
+//! (payload = the child's `Gas{meter_key}`) routed to a registered receiver. A
+//! chain that catches `kernel:oog` tops up the meter via `set_gas_meter` and
+//! `CALL_RESUME`s the child, which re-reads its meter and completes.
+//!
+//! The chain registers `kernel:oog` in its YieldReceiver, funds the child's
+//! meter at 0, then CALLs it. With the handler registered the child OOGs, routes
+//! to the chain, gets topped up, and the whole thing halts cleanly (reason 4).
+//! WITHOUT the registration (the receiver holds a different key) the OOG finds no
+//! catcher and bubbles (reason 2) — the host-stub root catch.
+//!
+//! The chain is straight-line: it unconditionally tops up + resumes (the
+//! resumable-CALL handler shape). It threads the topup amount through φ10 (a
+//! register, dodging addi's 12-bit immediate limit) and uses addi to reset the
+//! syscall operand registers after the CALL. φ7→x10, φ8→x11, φ9→x12, φ10→x13.
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::{YK_OOG, YK_SET_GAS_METER};
+use javm_cap::{
+    gas_handle, yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS,
+};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+
+const SENDER_SLOT: u8 = 5; // kernel:set_gas_meter YieldSender
+const CHILD_SLOT: u8 = 6; // the metered child
+const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — child's gas_slots[0]
+const RECEIVER_SLOT: u8 = 9; // chain's YieldReceiver (catches kernel:oog)
+const METER_KEY: u8 = 0; // child meter_key == child endpoint == 0
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// `addi rd, rs1, imm` (RV opcode 0x13).
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    e.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    e
+}
+
+fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots,
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Run the OOG-catch scenario. `catch_oog` controls whether the chain's
+/// YieldReceiver registers `kernel:oog`. Returns the top-level `exit_reason`.
+fn run(nub: &mut Nub, catch_oog: bool) -> u32 {
+    let sender = Cap::Instance(yield_sender(&Key::from(&YK_SET_GAS_METER[..])));
+    let sender_h = nub.put_cap(&sender).expect("put sgm sender");
+    let gas = Cap::Instance(gas_handle(&Key::from(METER_KEY)));
+    let gas_h = nub.put_cap(&gas).expect("put gas handle");
+
+    // The chain's catch-set: kernel:oog (handler present) or a decoy key (absent).
+    let recv_key = if catch_oog {
+        Key::from(&YK_OOG[..])
+    } else {
+        Key::from(99u8)
+    };
+    let receiver = Cap::Instance(yield_receiver(&[recv_key]));
+    let receiver_h = nub.put_cap(&receiver).expect("put receiver");
+
+    // The metered child: a bare `reply`, gas_slots[0] = CHILD_GAS_SLOT.
+    let child_img = image(
+        ecalli(OP_REPLY).to_le_bytes().to_vec(),
+        vec![Key::from(CHILD_GAS_SLOT)],
+        None,
+    );
+    let child_image_h = nub
+        .put_cap(&Cap::image_with_slots(&child_img, &[], &[]).expect("child image"))
+        .expect("put child image");
+    let child_mem = child_img.instance_mem_backing();
+    let child_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            child_image_h,
+            [0u8; 32],
+            child_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put child");
+
+    let mut cnode = CNodeCap::new();
+    for (slot, h) in [
+        (SENDER_SLOT, sender_h),
+        (CHILD_SLOT, child_h),
+        (CHILD_GAS_SLOT, gas_h),
+        (RECEIVER_SLOT, receiver_h),
+    ] {
+        cnode
+            .set(&Key::from(slot), Some(CapHashOrRef::Hash(h)))
+            .unwrap();
+    }
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put chain cnode");
+
+    // Chain: fund child at 0; CALL it (it OOGs -> kernel:oog -> resume here);
+    // reset φ7/φ8/φ9 for the topup; set_gas_meter(more); resume; reply.
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes()); // set_gas_meter(0,0)
+    code.extend_from_slice(&addi(10, 0, CHILD_SLOT as i32).to_le_bytes()); // φ7=child slot
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL child
+    code.extend_from_slice(&addi(10, 0, SENDER_SLOT as i32).to_le_bytes()); // φ7=sgm sender
+    code.extend_from_slice(&addi(11, 0, METER_KEY as i32).to_le_bytes()); // φ8=meter_key (was YIELDED)
+    code.extend_from_slice(&addi(12, 13, 0).to_le_bytes()); // φ9=φ10 (topup amount)
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes()); // set_gas_meter(more)
+    code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes()); // resume child
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes()); // chain halts
+    let chain_img = image(code, Vec::new(), Some(Key::from(RECEIVER_SLOT)));
+    let chain_image_h = nub
+        .put_cap(&Cap::image_with_slots(&chain_img, &[], &[]).expect("chain image"))
+        .expect("put chain image");
+    let chain_mem = chain_img.instance_mem_backing();
+    let chain_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            chain_image_h,
+            cnode_h,
+            chain_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put chain");
+
+    // φ7=SENDER, φ8=0 (meter_key + child ep), φ9=0 (initial fund), φ10=topup.
+    let args = [SENDER_SLOT as u64, 0, 0, 1_000_000];
+    nub.invoke_cached(chain_h, 0, args, GAS_BUDGET)
+        .expect("invoke chain")
+        .exit_reason
+}
+
+#[test]
+fn oog_routes_to_chain_handler_and_resumes() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // With the chain catching kernel:oog: the child OOGs at meter 0, routes to
+    // the chain, the chain tops up + resumes, the child completes, and the chain
+    // halts cleanly (reason 4). Requires the whole OOG-yield + per-frame-metering
+    // + resume-re-reads-meter loop to work.
+    assert_eq!(
+        run(&mut nub, true),
+        4,
+        "kernel:oog caught by the chain must top up and resume to a clean halt",
+    );
+
+    // Without the registration: the OOG finds no catcher and bubbles (reason 2,
+    // the host-stub root catch). Confirms the clean halt above was the routed
+    // topup, not the child silently completing.
+    assert_eq!(
+        run(&mut nub, false),
+        2,
+        "an uncaught OOG must bubble EXIT_OOG (host-stub root catch)",
+    );
+}

--- a/rust/javm-guest-tests/tests/oog_yield.rs
+++ b/rust/javm-guest-tests/tests/oog_yield.rs
@@ -32,7 +32,7 @@ const OP_CALL_RESUME: u32 = 27;
 
 const SENDER_SLOT: u8 = 5; // kernel:set_gas_meter YieldSender
 const CHILD_SLOT: u8 = 6; // the metered child
-const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — child's gas_slots[0]
+const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — child's primary gas slot
 const RECEIVER_SLOT: u8 = 9; // chain's YieldReceiver (catches kernel:oog)
 const METER_KEY: u8 = 0; // child meter_key == child endpoint == 0
 const GAS_BUDGET: u64 = 10_000_000_000;
@@ -90,7 +90,7 @@ fn run(nub: &mut Nub, catch_oog: bool) -> u32 {
     let receiver = Cap::Instance(yield_receiver(&[recv_key]));
     let receiver_h = nub.put_cap(&receiver).expect("put receiver");
 
-    // The metered child: a bare `reply`, gas_slots[0] = CHILD_GAS_SLOT.
+    // The metered child: a bare `reply`, primary gas slot = CHILD_GAS_SLOT.
     let child_img = image(
         ecalli(OP_REPLY).to_le_bytes().to_vec(),
         vec![Key::from(CHILD_GAS_SLOT)],

--- a/rust/javm-guest-tests/tests/pending_origin.rs
+++ b/rust/javm-guest-tests/tests/pending_origin.rs
@@ -1,0 +1,213 @@
+//! Empty-reserved origin slots for running Instances. CALL moves the callee
+//! into a KernelFrame and leaves the origin cnode slot empty but reserved until
+//! the callee returns or is discarded.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::YK_MINT_GAS;
+use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_IMAGE_HASH_CHAIN: u32 = 20;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+const OP_DROP_RESUME: u32 = 28;
+
+const SENDER_SLOT: u8 = 5;
+const B_SLOT: u8 = 6;
+const RECEIVER_SLOT: u8 = 9;
+const MINT_GAS_SENDER_SLOT: u8 = 10;
+const TYPE_DST_SLOT: u8 = 11;
+const METER_KEY: u8 = 3;
+const YIELD_KEY: u8 = 0x42;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    endpoints
+}
+
+fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        mem,
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+fn b_image() -> Image {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    image(code, None)
+}
+
+fn run_a(a_code: Vec<u8>) -> (u32, u32) {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    let sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))
+        .expect("put sender");
+    let receiver_h = nub
+        .put_cap(&Cap::Instance(yield_receiver(&[Key::from(YIELD_KEY)])))
+        .expect("put receiver");
+    let mint_gas_sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(&YK_MINT_GAS[..]))))
+        .expect("put mint_gas sender");
+    let b_h = put_instance(&mut nub, &b_image(), [0u8; 32]);
+
+    let mut cnode = CNodeCap::new();
+    for (slot, h) in [
+        (SENDER_SLOT, sender_h),
+        (B_SLOT, b_h),
+        (RECEIVER_SLOT, receiver_h),
+        (MINT_GAS_SENDER_SLOT, mint_gas_sender_h),
+    ] {
+        cnode
+            .set(&Key::from(slot), Some(CapHashOrRef::Hash(h)))
+            .expect("set slot");
+    }
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put A cnode");
+    let a_h = put_instance(
+        &mut nub,
+        &image(a_code, Some(Key::from(RECEIVER_SLOT))),
+        cnode_h,
+    );
+    let r = nub
+        .invoke_cached(
+            a_h,
+            0,
+            [B_SLOT as u64, 0, SENDER_SLOT as u64, 0],
+            GAS_BUDGET,
+        )
+        .expect("invoke A");
+    (r.exit_reason, r.exit_arg)
+}
+
+#[test]
+fn call_running_instance_origin_traps() {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B; B yields.
+    code.extend_from_slice(&addi(10, 0, B_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, 0).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B again.
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    assert_eq!(
+        run_a(code),
+        (7, 0),
+        "CALL against B's empty-reserved origin slot must trap",
+    );
+}
+
+#[test]
+fn writing_running_instance_origin_traps() {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B; B yields.
+    code.extend_from_slice(&addi(10, 0, MINT_GAS_SENDER_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, METER_KEY as i32).to_le_bytes());
+    code.extend_from_slice(&addi(12, 0, B_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes()); // mint into B slot.
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    assert_eq!(
+        run_a(code),
+        (7, 0),
+        "writing a cap into B's empty-reserved origin slot must trap",
+    );
+}
+
+#[test]
+fn reading_running_instance_origin_traps() {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B; B yields.
+    code.extend_from_slice(&addi(10, 0, B_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, TYPE_DST_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_IMAGE_HASH_CHAIN).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    assert_eq!(
+        run_a(code),
+        (7, 0),
+        "reading/type-querying B's empty-reserved origin slot must trap",
+    );
+}
+
+#[test]
+fn returned_hash_target_can_be_called_again_as_owned() {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // Hash target B yields.
+    code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes()); // B replies and restores as Owned.
+    code.extend_from_slice(&addi(10, 0, B_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, 0).to_le_bytes());
+    code.extend_from_slice(&addi(12, 0, SENDER_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // Re-CALL returned B.
+    code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    assert_eq!(
+        run_a(code).0,
+        4,
+        "a hash target must return as an updated owned Instance and be callable again",
+    );
+}
+
+#[test]
+fn drop_resume_clears_reservation_and_leaves_slot_empty() {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B; B yields.
+    code.extend_from_slice(&ecalli(OP_DROP_RESUME).to_le_bytes()); // Discard B.
+    code.extend_from_slice(&addi(10, 0, MINT_GAS_SENDER_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&addi(11, 0, METER_KEY as i32).to_le_bytes());
+    code.extend_from_slice(&addi(12, 0, B_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes()); // Slot is no longer reserved.
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    assert_eq!(
+        run_a(code).0,
+        4,
+        "DROP_RESUME must clear B's reservation while leaving the origin slot empty",
+    );
+}

--- a/rust/javm-guest-tests/tests/pending_origin.rs
+++ b/rust/javm-guest-tests/tests/pending_origin.rs
@@ -8,6 +8,7 @@ use javm_cap::yield_cap::YK_MINT_GAS;
 use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -24,6 +25,14 @@ const TYPE_DST_SLOT: u8 = 11;
 const METER_KEY: u8 = 3;
 const YIELD_KEY: u8 = 0x42;
 const GAS_BUDGET: u64 = 10_000_000_000;
+
+static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
+    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
+    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    (guard, nub)
+}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -85,7 +94,7 @@ fn b_image() -> Image {
 }
 
 fn run_a(a_code: Vec<u8>) -> (u32, u32) {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
 
     let sender_h = nub
         .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))

--- a/rust/javm-guest-tests/tests/root_cnode_seeding.rs
+++ b/rust/javm-guest-tests/tests/root_cnode_seeding.rs
@@ -1,0 +1,132 @@
+//! The guest `frame.cnode` is seeded from the instance's **root cnode**, so a
+//! `Cap::Instance` — which cannot be pinned (pinned slots are Data/Image only)
+//! — flows into a guest slot. This is the prerequisite for cap-flow of
+//! YieldSenders / sub-VM handles / authority caps into running instances.
+//!
+//! Validated via `host_image_hash_chain` (op 20): it reads the cap at a slot,
+//! so a clean halt on a slot holding a root-cnode `Cap::Instance` proves the
+//! cap was visible; an empty slot traps (negative control — the op traps on an
+//! absent src).
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{CNodeCap, Cap, CapHashOrRef, DataCap, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_IMAGE_HASH_CHAIN: u32 = 20;
+const OP_REPLY: u32 = 0;
+/// Root-cnode slot holding a `Cap::Instance` (a non-pinnable cap).
+const INSTANCE_SLOT: u8 = 5;
+/// An empty (unseeded) slot — the negative control.
+const EMPTY_SLOT: u8 = 7;
+/// Destination for the minted identity DataCap.
+const DST_SLOT: u8 = 6;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// Image: `host_image_hash_chain(φ7=src, φ8=dst)` then `REPLY`.
+fn prog_image() -> Image {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_IMAGE_HASH_CHAIN).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    Image {
+        code,
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Invoke the program with the given src slot; return (exit_reason, exit_arg).
+/// The published instance's root cnode holds a `Cap::Instance` at
+/// `INSTANCE_SLOT`.
+fn run(nub: &mut Nub, src: u8) -> (u32, u32) {
+    // A payload Cap::Instance to live in the root cnode (any instance; its
+    // identity is what host_image_hash_chain reads).
+    let payload = Cap::instance_with_mem(
+        [0xAA; 32],
+        [0u8; 32],
+        [0u8; 32],
+        DataCap::empty(),
+        [0u64; NUM_REGS],
+        0,
+        0,
+    );
+    let payload_h = nub.put_cap(&payload).expect("put payload instance");
+
+    // Root cnode: the payload instance at INSTANCE_SLOT (a non-pinnable cap).
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(
+            &Key::from(INSTANCE_SLOT),
+            Some(CapHashOrRef::Hash(payload_h)),
+        )
+        .expect("set root cnode slot");
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put root cnode");
+
+    let img = prog_image();
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    let result = nub
+        .invoke_cached(inst_h, 0, [src as u64, DST_SLOT as u64, 0, 0], GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+#[test]
+fn root_cnode_instance_is_visible_to_guest() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Positive: the root-cnode Cap::Instance at INSTANCE_SLOT is visible, so
+    // host_image_hash_chain reads it and the guest halts cleanly (reason 4,
+    // arg 0 — the trailing REPLY).
+    let (reason, arg) = run(&mut nub, INSTANCE_SLOT);
+    assert_eq!(
+        (reason, arg),
+        (4, 0),
+        "root-cnode Cap::Instance must be visible (clean halt), got reason={reason} arg={arg}",
+    );
+
+    // Negative control: an empty slot traps (reason 7) — confirms the op does
+    // fault on an absent src, so the positive result isn't a false pass.
+    let (reason, _) = run(&mut nub, EMPTY_SLOT);
+    assert_eq!(
+        reason, 7,
+        "host_image_hash_chain on an empty slot must trap (7), got reason={reason}",
+    );
+}

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -1,0 +1,120 @@
+//! The TOP-level frame's own gas meter (its `gas_slots[0]` → `Gas{root_meter}`)
+//! is a first-class meter: `kernel:set_gas_meter` on it reads/writes the LIVE
+//! balance, so a chain can self-harvest its root meter (`set_gas_meter(root, 0)`
+//! returns the remaining and zeroes it), exactly like a child meter.
+//!
+//! Regression for the validation finding "the top frame's own meter cannot be
+//! read/written via set_gas_meter" (it was stamped active=None and never seeded).
+//! With the fix the guest resolves and seeds the root meter from the host budget.
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::YK_SET_GAS_METER;
+use javm_cap::{gas_handle, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const SENDER_SLOT: u8 = 5; // kernel:set_gas_meter YieldSender
+const GAS_SLOT: u8 = 8; // the top's gas_slots[0] → Gas{ROOT_METER}
+const ROOT_METER: u8 = 3; // the top's meter_key
+const BUDGET: u64 = 1_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+#[test]
+fn root_meter_self_harvest_via_set_gas_meter() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // The set_gas_meter YieldSender + the top's Gas{ROOT_METER} handle.
+    let sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(
+            &YK_SET_GAS_METER[..],
+        ))))
+        .expect("put sender");
+    let gas_h = nub
+        .put_cap(&Cap::Instance(gas_handle(&Key::from(ROOT_METER))))
+        .expect("put gas handle");
+
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(&Key::from(SENDER_SLOT), Some(CapHashOrRef::Hash(sender_h)))
+        .unwrap();
+    cnode
+        .set(&Key::from(GAS_SLOT), Some(CapHashOrRef::Hash(gas_h)))
+        .unwrap();
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put cnode");
+
+    // Top image: gas_slots[0] = GAS_SLOT; code = `set_gas_meter(ROOT_METER, 0);
+    // reply` — harvest-and-zero, returning the previous balance in φ7.
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let img = Image {
+        code,
+        endpoints,
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots: vec![Key::from(GAS_SLOT)],
+        quota_slots: Vec::new(),
+    };
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            cnode_h,
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+
+    // Fund the root meter host-side; invoke_cached seeds the run from it.
+    nub.set_meter(Key::from(ROOT_METER), BUDGET);
+
+    // φ7=SENDER_SLOT, φ8=ROOT_METER, φ9=0 (the harvest value).
+    let r = nub
+        .invoke_cached(
+            inst_h,
+            0,
+            [SENDER_SLOT as u64, ROOT_METER as u64, 0, 0],
+            BUDGET,
+        )
+        .expect("invoke");
+
+    // set_gas_meter(root, 0) returned the LIVE remaining (most of BUDGET, minus a
+    // little for the one ecall) in φ7 — NOT 0, which is what the bug returned.
+    assert!(
+        r.return_value > BUDGET / 2 && r.return_value < BUDGET,
+        "set_gas_meter(root,0) must return the live remaining, got {}",
+        r.return_value,
+    );
+    // It zeroed the meter: the harvested run leaves the root meter at 0.
+    assert_eq!(
+        nub.get_meter(&Key::from(ROOT_METER)),
+        0,
+        "set_gas_meter(root,0) must zero the root meter",
+    );
+}

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -1,4 +1,4 @@
-//! The TOP-level frame's own gas meter (its `gas_slots[0]` → `Gas{root_meter}`)
+//! The TOP-level frame's own primary gas meter (`gas_slots` → `Gas{root_meter}`)
 //! is a first-class meter: `kernel:set_gas_meter` on it reads/writes the LIVE
 //! balance, so a chain can self-harvest its root meter (`set_gas_meter(root, 0)`
 //! returns the remaining and zeroes it), exactly like a child meter.
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
 const SENDER_SLOT: u8 = 5; // kernel:set_gas_meter YieldSender
-const GAS_SLOT: u8 = 8; // the top's gas_slots[0] → Gas{ROOT_METER}
+const GAS_SLOT: u8 = 8; // the top's primary gas slot → Gas{ROOT_METER}
 const ROOT_METER: u8 = 3; // the top's meter_key
 const BUDGET: u64 = 1_000_000;
 
@@ -50,7 +50,7 @@ fn root_meter_self_harvest_via_set_gas_meter() {
         .unwrap();
     let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put cnode");
 
-    // Top image: gas_slots[0] = GAS_SLOT; code = `set_gas_meter(ROOT_METER, 0);
+    // Top image: primary gas slot = GAS_SLOT; code = `set_gas_meter(ROOT_METER, 0);
     // reply` — harvest-and-zero, returning the previous balance in φ7.
     let mut endpoints = BTreeMap::new();
     endpoints.insert(

--- a/rust/javm-guest-tests/tests/set_gas_meter.rs
+++ b/rust/javm-guest-tests/tests/set_gas_meter.rs
@@ -1,6 +1,6 @@
 //! `kernel:set_gas_meter` + per-frame metering: a chain funds a guest meter via
-//! the `set_gas_meter` syscall, then CALLs a child whose `gas_slots[0]` names
-//! that meter — the child runs on the FUNDED balance, not the chain's pool.
+//! the `set_gas_meter` syscall, then CALLs a child whose primary usable gas slot
+//! names that meter — the child runs on the FUNDED balance, not the chain's pool.
 //!
 //! This is the observable proof of per-frame metering: with the child's meter
 //! set to 0 the child OOGs (reason 2) even though the chain's pool is large; if
@@ -28,7 +28,7 @@ const OP_HOST_CALL: u32 = 26;
 /// Chain root-cnode slots.
 const SENDER_SLOT: u8 = 5; // the kernel:set_gas_meter YieldSender
 const CHILD_SLOT: u8 = 6; // the metered child (a published Cap::Instance)
-const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — the child's gas_slots[0]
+const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — the child's primary gas slot
 /// The meter_key (= 0) the child's Gas handle names. Also the child endpoint and
 /// the set_gas_meter meter_key operand, so chain φ8 = 0 serves all three.
 const METER_KEY: u8 = 0;
@@ -102,12 +102,12 @@ fn run_metered(nub: &mut Nub, meter_value: u64) -> u32 {
     let sender = Cap::Instance(yield_sender(&Key::from(&YK_SET_GAS_METER[..])));
     let sender_h = nub.put_cap(&sender).expect("put set_gas_meter sender");
 
-    // The Gas{meter_key=0} handle the child's gas_slots[0] resolves to (the child
-    // inherits it from the chain's cnode at CALL).
+    // The Gas{meter_key=0} handle the child's primary gas slot resolves to (the
+    // child inherits it from the chain's cnode at CALL).
     let gas = Cap::Instance(gas_handle(&Key::from(METER_KEY)));
     let gas_h = nub.put_cap(&gas).expect("put gas handle");
 
-    // The metered child: a bare `reply`, with gas_slots[0] = CHILD_GAS_SLOT.
+    // The metered child: a bare `reply`, with primary gas slot = CHILD_GAS_SLOT.
     let child_img = image(
         ecalli(OP_REPLY).to_le_bytes().to_vec(),
         vec![Key::from(CHILD_GAS_SLOT)],

--- a/rust/javm-guest-tests/tests/set_gas_meter.rs
+++ b/rust/javm-guest-tests/tests/set_gas_meter.rs
@@ -1,0 +1,214 @@
+//! `kernel:set_gas_meter` + per-frame metering: a chain funds a guest meter via
+//! the `set_gas_meter` syscall, then CALLs a child whose `gas_slots[0]` names
+//! that meter — the child runs on the FUNDED balance, not the chain's pool.
+//!
+//! This is the observable proof of per-frame metering: with the child's meter
+//! set to 0 the child OOGs (reason 2) even though the chain's pool is large; if
+//! the child instead loaned the chain's pool (the old one-pool model) the
+//! 0-meter would be irrelevant and the child would complete. With the meter
+//! funded large, the child completes and the chain halts cleanly (reason 4).
+//!
+//! The chain is `host_yield(set_gas_meter); addi φ7=child_slot; host_call;
+//! reply`. `set_gas_meter` returns the previous balance in φ7 (the sender slot),
+//! so an `addi` resets φ7 to the child slot before the CALL — exercising real
+//! in-guest register setup. φ8=0 serves as both the meter_key and the child
+//! endpoint. Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::YK_SET_GAS_METER;
+use javm_cap::{gas_handle, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+
+/// Chain root-cnode slots.
+const SENDER_SLOT: u8 = 5; // the kernel:set_gas_meter YieldSender
+const CHILD_SLOT: u8 = 6; // the metered child (a published Cap::Instance)
+const CHILD_GAS_SLOT: u8 = 8; // Gas{meter_key=0} — the child's gas_slots[0]
+/// The meter_key (= 0) the child's Gas handle names. Also the child endpoint and
+/// the set_gas_meter meter_key operand, so chain φ8 = 0 serves all three.
+const METER_KEY: u8 = 0;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// `addi rd, rs1, imm` (RV opcode 0x13). φ[7] maps to RV x10, so `addi(10, 0,
+/// n)` sets φ[7] = n (rs1 = x0 = zero).
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    endpoints
+}
+
+fn image(code: Vec<u8>, gas_slots: Vec<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots,
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Invoke a standalone image and return its `(exit_reason, return_value)`.
+fn run_image(nub: &mut Nub, code: Vec<u8>, args: [u64; 4]) -> (u32, u64) {
+    let img = image(code, Vec::new());
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            [0u8; 32],
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+    let r = nub
+        .invoke_cached(inst_h, 0, args, GAS_BUDGET)
+        .expect("invoke");
+    (r.exit_reason, r.return_value)
+}
+
+/// Run the chain: `set_gas_meter(meter_key=0, meter_value)` then CALL the metered
+/// child. Returns the top-level `exit_reason`.
+fn run_metered(nub: &mut Nub, meter_value: u64) -> u32 {
+    // kernel:set_gas_meter YieldSender, in the chain's root cnode.
+    let sender = Cap::Instance(yield_sender(&Key::from(&YK_SET_GAS_METER[..])));
+    let sender_h = nub.put_cap(&sender).expect("put set_gas_meter sender");
+
+    // The Gas{meter_key=0} handle the child's gas_slots[0] resolves to (the child
+    // inherits it from the chain's cnode at CALL).
+    let gas = Cap::Instance(gas_handle(&Key::from(METER_KEY)));
+    let gas_h = nub.put_cap(&gas).expect("put gas handle");
+
+    // The metered child: a bare `reply`, with gas_slots[0] = CHILD_GAS_SLOT.
+    let child_img = image(
+        ecalli(OP_REPLY).to_le_bytes().to_vec(),
+        vec![Key::from(CHILD_GAS_SLOT)],
+    );
+    let child_image_h = nub
+        .put_cap(&Cap::image_with_slots(&child_img, &[], &[]).expect("child image"))
+        .expect("put child image");
+    let child_mem = child_img.instance_mem_backing();
+    let child_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            child_image_h,
+            [0u8; 32],
+            child_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put child instance");
+
+    // Chain root cnode: the set_gas_meter sender, the child, and the Gas handle.
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(&Key::from(SENDER_SLOT), Some(CapHashOrRef::Hash(sender_h)))
+        .unwrap();
+    cnode
+        .set(&Key::from(CHILD_SLOT), Some(CapHashOrRef::Hash(child_h)))
+        .unwrap();
+    cnode
+        .set(&Key::from(CHILD_GAS_SLOT), Some(CapHashOrRef::Hash(gas_h)))
+        .unwrap();
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put chain cnode");
+
+    // Chain: host_yield(set_gas_meter); addi φ7=CHILD_SLOT; host_call; reply.
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&addi(10, 0, CHILD_SLOT as i32).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let chain_img = image(code, Vec::new());
+    let chain_image_h = nub
+        .put_cap(&Cap::image_with_slots(&chain_img, &[], &[]).expect("chain image"))
+        .expect("put chain image");
+    let chain_mem = chain_img.instance_mem_backing();
+    let chain_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            chain_image_h,
+            cnode_h,
+            chain_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put chain instance");
+
+    // φ7=SENDER_SLOT, φ8=0 (meter_key + child ep), φ9=meter_value, φ10=0.
+    let args = [SENDER_SLOT as u64, 0, meter_value, 0];
+    let r = nub
+        .invoke_cached(chain_h, 0, args, GAS_BUDGET)
+        .expect("invoke chain");
+    r.exit_reason
+}
+
+#[test]
+fn set_gas_meter_funds_per_frame_metering() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Probe the φ7→x10 register mapping the chain relies on: `addi(10,0,55);
+    // reply` must return 55 in φ7. A wrong mapping here would silently corrupt
+    // the chain's host_call slot operand below.
+    let (reason, ret) = run_image(
+        &mut nub,
+        {
+            let mut c = Vec::new();
+            c.extend_from_slice(&addi(10, 0, 55).to_le_bytes());
+            c.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+            c
+        },
+        [0; 4],
+    );
+    assert_eq!(
+        (reason, ret),
+        (4, 55),
+        "φ7 == x10: addi(10,0,55) must set φ7=55"
+    );
+
+    // Funded large: the child runs on its own (ample) meter and completes; the
+    // chain resumes and halts cleanly (reason 4).
+    assert_eq!(
+        run_metered(&mut nub, 1_000_000),
+        4,
+        "a child with a well-funded meter completes; chain halts cleanly",
+    );
+
+    // Funded ZERO: the child runs on its own empty meter and OOGs (reason 2) —
+    // even though the chain's pool is large. This is the per-frame-metering
+    // proof: a loaned child would ignore the 0-meter and complete.
+    assert_eq!(
+        run_metered(&mut nub, 0),
+        2,
+        "a child metered at 0 must OOG on its own meter, not loan the chain pool",
+    );
+}

--- a/rust/javm-guest-tests/tests/unfunded_meter.rs
+++ b/rust/javm-guest-tests/tests/unfunded_meter.rs
@@ -1,4 +1,4 @@
-//! A child that DECLARES a gas meter (`gas_slots[0]` → `Gas{k}`) but whose meter
+//! A child that DECLARES a primary gas meter (`gas_slots` → `Gas{k}`) but whose meter
 //! `k` was never funded (no `set_gas_meter`) runs metered on an EFFECTIVE-ZERO
 //! balance and OOGs immediately — it must NOT silently loan and spend the
 //! caller's pool. (Spec: an absent meter entry == balance 0; only an instance
@@ -54,7 +54,7 @@ fn image(code: Vec<u8>, gas_slots: Vec<Key>) -> Image {
 }
 
 /// Run a chain (top frame, host-budgeted) that CALLs a `reply` child. If
-/// `declare_meter` the child declares `gas_slots[0]` → an UNFUNDED `Gas{0}`;
+/// `declare_meter` the child declares a primary gas slot → an UNFUNDED `Gas{0}`;
 /// otherwise it declares no gas slot. Returns the top-level `exit_reason`.
 fn run(nub: &mut Nub, declare_meter: bool) -> u32 {
     let gas_slots = if declare_meter {

--- a/rust/javm-guest-tests/tests/unfunded_meter.rs
+++ b/rust/javm-guest-tests/tests/unfunded_meter.rs
@@ -1,0 +1,146 @@
+//! A child that DECLARES a gas meter (`gas_slots[0]` → `Gas{k}`) but whose meter
+//! `k` was never funded (no `set_gas_meter`) runs metered on an EFFECTIVE-ZERO
+//! balance and OOGs immediately — it must NOT silently loan and spend the
+//! caller's pool. (Spec: an absent meter entry == balance 0; only an instance
+//! with NO gas slot loans the caller's pool.)
+//!
+//! Regression for the validation finding "never-funded meter loans the caller
+//! pool". Control: the same child with NO gas slot loans and completes.
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{gas_handle, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_CALL: u32 = 26;
+const CHILD_SLOT: u8 = 6;
+const CHILD_GAS_SLOT: u8 = 8;
+const METER_KEY: u8 = 0;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    e.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    e
+}
+
+fn image(code: Vec<u8>, gas_slots: Vec<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot: None,
+        gas_slots,
+        quota_slots: Vec::new(),
+    }
+}
+
+/// Run a chain (top frame, host-budgeted) that CALLs a `reply` child. If
+/// `declare_meter` the child declares `gas_slots[0]` → an UNFUNDED `Gas{0}`;
+/// otherwise it declares no gas slot. Returns the top-level `exit_reason`.
+fn run(nub: &mut Nub, declare_meter: bool) -> u32 {
+    let gas_slots = if declare_meter {
+        vec![Key::from(CHILD_GAS_SLOT)]
+    } else {
+        Vec::new()
+    };
+    let child_img = image(ecalli(OP_REPLY).to_le_bytes().to_vec(), gas_slots);
+    let child_image_h = nub
+        .put_cap(&Cap::image_with_slots(&child_img, &[], &[]).expect("child image"))
+        .expect("put child image");
+    let child_mem = child_img.instance_mem_backing();
+    let child_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            child_image_h,
+            [0u8; 32],
+            child_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put child");
+
+    // Chain cnode: the child + (when declared) an UNFUNDED Gas{0} handle the
+    // child inherits at CALL. No set_gas_meter is ever emitted.
+    let mut cnode = CNodeCap::new();
+    cnode
+        .set(&Key::from(CHILD_SLOT), Some(CapHashOrRef::Hash(child_h)))
+        .unwrap();
+    if declare_meter {
+        let gas_h = nub
+            .put_cap(&Cap::Instance(gas_handle(&Key::from(METER_KEY))))
+            .expect("put gas handle");
+        cnode
+            .set(&Key::from(CHILD_GAS_SLOT), Some(CapHashOrRef::Hash(gas_h)))
+            .unwrap();
+    }
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put chain cnode");
+
+    // Chain: host_call(child); reply.
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let chain_img = image(code, Vec::new());
+    let chain_image_h = nub
+        .put_cap(&Cap::image_with_slots(&chain_img, &[], &[]).expect("chain image"))
+        .expect("put chain image");
+    let chain_mem = chain_img.instance_mem_backing();
+    let chain_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            chain_image_h,
+            cnode_h,
+            chain_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put chain");
+
+    // φ7=child slot, φ8=endpoint 0.
+    nub.invoke_cached(chain_h, 0, [CHILD_SLOT as u64, 0, 0, 0], GAS_BUDGET)
+        .expect("invoke chain")
+        .exit_reason
+}
+
+#[test]
+fn unfunded_declared_meter_oogs_not_loans() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Declared-but-unfunded meter: the child runs metered@0 and OOGs; with no
+    // kernel:oog receiver it bubbles (reason 2). If it had instead loaned the
+    // chain's (large) pool it would complete (reason 4) — that is the bug.
+    assert_eq!(
+        run(&mut nub, true),
+        2,
+        "a declared-but-unfunded meter must run @0 and OOG, not loan the caller pool",
+    );
+
+    // Control: NO gas slot → the child loans the chain's pool and completes
+    // (reason 4). Confirms the OOG above is specifically the metered-@0 behavior,
+    // not the child failing for an unrelated reason.
+    assert_eq!(
+        run(&mut nub, false),
+        4,
+        "a child with no gas slot loans the caller pool and completes",
+    );
+}

--- a/rust/javm-guest-tests/tests/yield_owner_edge.rs
+++ b/rust/javm-guest-tests/tests/yield_owner_edge.rs
@@ -15,6 +15,7 @@ use javm_cap::{
 };
 use nub::Nub;
 use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -35,6 +36,14 @@ const ROOT_METER: u8 = 3;
 const B_KEY: u8 = 0x42;
 const C_KEY: u8 = 0x43;
 const GAS_BUDGET: u64 = 10_000_000_000;
+
+static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
+    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
+    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    (guard, nub)
+}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -182,7 +191,7 @@ fn run_c_yield(nub: &mut Nub, a_catches_c: bool) -> (u32, u32) {
 
 #[test]
 fn yielded_owner_call_uses_owner_edge_not_waiting_b() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
 
     let (reason, arg) = run_c_yield(&mut nub, false);
     assert_eq!(
@@ -200,7 +209,7 @@ fn yielded_owner_call_uses_owner_edge_not_waiting_b() {
 
 #[test]
 fn yielded_owner_oog_is_not_caught_by_waiting_b() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let (_guard, mut nub) = new_serial_nub();
 
     let set_gas_sender_h = nub
         .put_cap(&Cap::Instance(yield_sender(&Key::from(

--- a/rust/javm-guest-tests/tests/yield_owner_edge.rs
+++ b/rust/javm-guest-tests/tests/yield_owner_edge.rs
@@ -1,0 +1,241 @@
+//! Owner-edge yield routing. A CALLs B; B first CALLs D so the old physical
+//! router would leave a receiver snapshot on B, then B yields to A. While B is
+//! still waiting, A runs as `ref[A]` and CALLs C:
+//!
+//!   physical stack: A -> B -> ref[A] -> C
+//!   owner edges:    A -> B, A -> C
+//!
+//! C's yield must consult the A->C owner edge and never be caught by B.
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::yield_cap::{YK_OOG, YK_SET_GAS_METER};
+use javm_cap::{
+    gas_handle, yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS,
+};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+
+const D_SLOT: u8 = 4;
+const B_SENDER_SLOT: u8 = 5;
+const B_SLOT: u8 = 6;
+const C_SLOT: u8 = 7;
+const C_SENDER_SLOT: u8 = 8;
+const A_RECEIVER_SLOT: u8 = 9;
+const B_RECEIVER_SLOT: u8 = 10;
+const SET_GAS_SENDER_SLOT: u8 = 11;
+const ROOT_GAS_SLOT: u8 = 12;
+const ROOT_METER: u8 = 3;
+
+const B_KEY: u8 = 0x42;
+const C_KEY: u8 = 0x43;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    e.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    e
+}
+
+fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots,
+        quota_slots: Vec::new(),
+    }
+}
+
+fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        mem,
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+fn setup_graph(
+    nub: &mut Nub,
+    a_keys: &[Key],
+    b_keys: &[Key],
+    a_code: Vec<u8>,
+    a_gas_slots: Vec<Key>,
+    extra_caps: &[(u8, [u8; 32])],
+) -> [u8; 32] {
+    let b_sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(B_KEY))))
+        .expect("put B sender");
+    let c_sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(C_KEY))))
+        .expect("put C sender");
+    let a_receiver_h = nub
+        .put_cap(&Cap::Instance(yield_receiver(a_keys)))
+        .expect("put A receiver");
+    let b_receiver_h = nub
+        .put_cap(&Cap::Instance(yield_receiver(b_keys)))
+        .expect("put B receiver");
+
+    let d_h = put_instance(
+        nub,
+        &image(ecalli(OP_REPLY).to_le_bytes().to_vec(), Vec::new(), None),
+        [0u8; 32],
+    );
+
+    let mut b_code = Vec::new();
+    b_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    b_code.extend_from_slice(&addi(10, 0, B_SENDER_SLOT as i32).to_le_bytes());
+    b_code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    b_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let b_h = put_instance(
+        nub,
+        &image(b_code, Vec::new(), Some(Key::from(B_RECEIVER_SLOT))),
+        [0u8; 32],
+    );
+
+    let mut c_code = Vec::new();
+    c_code.extend_from_slice(&addi(10, 0, C_SENDER_SLOT as i32).to_le_bytes());
+    c_code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    c_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let c_h = put_instance(nub, &image(c_code, Vec::new(), None), [0u8; 32]);
+
+    let mut cnode = CNodeCap::new();
+    for (slot, h) in [
+        (D_SLOT, d_h),
+        (B_SENDER_SLOT, b_sender_h),
+        (B_SLOT, b_h),
+        (C_SLOT, c_h),
+        (C_SENDER_SLOT, c_sender_h),
+        (A_RECEIVER_SLOT, a_receiver_h),
+        (B_RECEIVER_SLOT, b_receiver_h),
+    ] {
+        cnode
+            .set(&Key::from(slot), Some(CapHashOrRef::Hash(h)))
+            .unwrap();
+    }
+    for (slot, h) in extra_caps {
+        cnode
+            .set(&Key::from(*slot), Some(CapHashOrRef::Hash(*h)))
+            .unwrap();
+    }
+    let cnode_h = nub.put_cap(&Cap::CNode(cnode)).expect("put A cnode");
+    put_instance(
+        nub,
+        &image(a_code, a_gas_slots, Some(Key::from(A_RECEIVER_SLOT))),
+        cnode_h,
+    )
+}
+
+fn run_c_yield(nub: &mut Nub, a_catches_c: bool) -> (u32, u32) {
+    let mut a_code = Vec::new();
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B
+    a_code.extend_from_slice(&addi(10, 0, C_SLOT as i32).to_le_bytes());
+    a_code.extend_from_slice(&addi(11, 0, 0).to_le_bytes());
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL C as ref[A]
+    a_code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    a_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    let a_keys = if a_catches_c {
+        vec![Key::from(B_KEY), Key::from(C_KEY)]
+    } else {
+        vec![Key::from(B_KEY)]
+    };
+    let a_h = setup_graph(nub, &a_keys, &[Key::from(C_KEY)], a_code, Vec::new(), &[]);
+    let r = nub
+        .invoke_cached(a_h, 0, [B_SLOT as u64, 0, D_SLOT as u64, 0], GAS_BUDGET)
+        .expect("invoke A");
+    (r.exit_reason, r.exit_arg)
+}
+
+#[test]
+fn yielded_owner_call_uses_owner_edge_not_waiting_b() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    let (reason, arg) = run_c_yield(&mut nub, false);
+    assert_eq!(
+        (reason, arg),
+        (7, 70),
+        "C's yield must not be caught by waiting B; without A catching it, it is unhandled",
+    );
+
+    let (reason, _) = run_c_yield(&mut nub, true);
+    assert_eq!(
+        reason, 4,
+        "when A catches C's key on the A->C owner edge, C resumes and the run halts cleanly",
+    );
+}
+
+#[test]
+fn yielded_owner_oog_is_not_caught_by_waiting_b() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    let set_gas_sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(
+            &YK_SET_GAS_METER[..],
+        ))))
+        .expect("put set_gas sender");
+    let root_gas_h = nub
+        .put_cap(&Cap::Instance(gas_handle(&Key::from(ROOT_METER))))
+        .expect("put root gas");
+
+    let mut a_code = Vec::new();
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes()); // CALL B
+    a_code.extend_from_slice(&addi(10, 0, SET_GAS_SENDER_SLOT as i32).to_le_bytes());
+    a_code.extend_from_slice(&addi(11, 0, ROOT_METER as i32).to_le_bytes());
+    a_code.extend_from_slice(&addi(12, 0, 0).to_le_bytes());
+    a_code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes()); // root meter := 0
+    a_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes()); // OOG before reply
+
+    let a_h = setup_graph(
+        &mut nub,
+        &[Key::from(B_KEY)],
+        &[Key::from(&YK_OOG[..])],
+        a_code,
+        vec![Key::from(ROOT_GAS_SLOT)],
+        &[
+            (SET_GAS_SENDER_SLOT, set_gas_sender_h),
+            (ROOT_GAS_SLOT, root_gas_h),
+        ],
+    );
+
+    let r = nub
+        .invoke_cached(a_h, 0, [B_SLOT as u64, 0, D_SLOT as u64, 0], GAS_BUDGET)
+        .expect("invoke A");
+    assert_eq!(
+        r.exit_reason, 2,
+        "A's OOG while running as ref[A] must start from A's owner edge, so waiting B cannot catch it",
+    );
+}

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -1,0 +1,238 @@
+//! User-key `host_yield` routing + `CALL_RESUME` — the in-flight suspension
+//! core. A (top-level) CALLs B (a sub-VM); B `host_yield`s a user-key
+//! `YieldSender`; the kernel walks the call stack, skips B's own frames
+//! (emitter-exclusion), and routes the yield to the nearest ancestor whose
+//! per-CALL snapshotted `YieldReceiver` contains the key — here A. A resumes at
+//! its post-CALL continuation, `CALL_RESUME`s B, B halts, and A halts cleanly.
+//!
+//! A is deliberately STRAIGHT-LINE — `host_call; call_resume; reply` — which is
+//! exactly the resumable-CALL handler shape: when B yields, control lands on the
+//! instruction *after* A's `host_call` (its `call_resume`), so no PVM-level
+//! branching is needed to drive the resume.
+//!
+//! Positive: A's `YieldReceiver` catches B's key → routed, resumed, clean halt
+//! (reason 4). Negative: A's receiver holds a DIFFERENT key → no ancestor
+//! catches → the emitter faults (reason 7) — confirms routing actually consults
+//! the catch-set rather than blindly resuming.
+//!
+//! Gated to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+
+/// A's root-cnode slots.
+const B_SLOT: u8 = 6; // the sub-VM B (a published `Cap::Instance`)
+const SENDER_SLOT: u8 = 5; // the user-key `YieldSender` (B inherits it)
+const RECEIVER_SLOT: u8 = 9; // A's `YieldReceiver` (A.image.yield_receiver_slot)
+
+/// The user yield_key B emits (single byte; first byte != 0xCE so it is NOT a
+/// kernel key and routes to an ancestor receiver).
+const YIELD_KEY: u8 = 0x42;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut endpoints = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    endpoints
+}
+
+fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+/// A: `host_call(φ7=B slot, φ8=endpoint); [call_resume();] reply`. The slot/
+/// endpoint operands arrive via the invoke args (φ7..φ10). When `resume` is
+/// false A omits the `call_resume` — so when B's yield routes to A, A's handler
+/// continuation runs straight to REPLY, exercising the handler-halt guard.
+fn a_image(resume: bool) -> Image {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    if resume {
+        code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    }
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    image(code, Some(Key::from(RECEIVER_SLOT)))
+}
+
+/// B: `host_yield(φ7=sender slot); reply`. φ7 is threaded from A's φ9 by the
+/// CALL arg-passing convention.
+fn b_image() -> Image {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    image(code, None)
+}
+
+/// Run the routing scenario with A's receiver registering `receiver_key` and A
+/// resuming B iff `resume`. Returns A's `(exit_reason, exit_arg)`.
+fn run(nub: &mut Nub, receiver_key: u8, resume: bool) -> (u32, u32) {
+    // The user-key YieldSender B will emit, and A's YieldReceiver.
+    let sender = Cap::Instance(yield_sender(&Key::from(YIELD_KEY)));
+    let sender_h = nub.put_cap(&sender).expect("put sender");
+    let receiver = Cap::Instance(yield_receiver(&[Key::from(receiver_key)]));
+    let receiver_h = nub.put_cap(&receiver).expect("put receiver");
+
+    // B: a published sub-VM with an empty root cnode (it inherits A's cnode
+    // entries — including the YieldSender at SENDER_SLOT — at CALL).
+    let b_img = b_image();
+    let b_image_h = nub
+        .put_cap(&Cap::image_with_slots(&b_img, &[], &[]).expect("b image"))
+        .expect("put b image");
+    let b_mem = b_img.instance_mem_backing();
+    let b_inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            b_image_h,
+            [0u8; 32],
+            b_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put b instance");
+
+    // A's root cnode: B at B_SLOT, the YieldSender at SENDER_SLOT, A's
+    // YieldReceiver at RECEIVER_SLOT (named by A's image yield_receiver_slot).
+    let mut a_cnode = CNodeCap::new();
+    a_cnode
+        .set(&Key::from(B_SLOT), Some(CapHashOrRef::Hash(b_inst_h)))
+        .expect("set B");
+    a_cnode
+        .set(&Key::from(SENDER_SLOT), Some(CapHashOrRef::Hash(sender_h)))
+        .expect("set sender");
+    a_cnode
+        .set(
+            &Key::from(RECEIVER_SLOT),
+            Some(CapHashOrRef::Hash(receiver_h)),
+        )
+        .expect("set receiver");
+    let a_cnode_h = nub.put_cap(&Cap::CNode(a_cnode)).expect("put A cnode");
+
+    let a_img = a_image(resume);
+    let a_image_h = nub
+        .put_cap(&Cap::image_with_slots(&a_img, &[], &[]).expect("a image"))
+        .expect("put a image");
+    let a_mem = a_img.instance_mem_backing();
+    let a_inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            a_image_h,
+            a_cnode_h,
+            a_mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put a instance");
+
+    // Invoke args → A.φ7..φ10: φ7=B slot, φ8=B endpoint, φ9=sender slot
+    // (becomes B.φ7), φ10 unused.
+    let args = [B_SLOT as u64, 0, SENDER_SLOT as u64, 0];
+    let result = nub
+        .invoke_cached(a_inst_h, 0, args, GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+/// A top-level instance that does `call_resume; reply` with no outstanding
+/// yield — exercises the CALL_RESUME guard (the top is an InstanceEntry, not a
+/// handler activation). Returns `(exit_reason, exit_arg)`.
+fn run_bare_call_resume(nub: &mut Nub) -> (u32, u32) {
+    let mut code = Vec::new();
+    code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let img = image(code, None);
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    let inst_h = nub
+        .put_cap(&Cap::instance_with_mem(
+            [0u8; 32],
+            image_h,
+            [0u8; 32],
+            mem,
+            [0u64; NUM_REGS],
+            0,
+            0,
+        ))
+        .expect("put instance");
+    let result = nub
+        .invoke_cached(inst_h, 0, [0; 4], GAS_BUDGET)
+        .expect("invoke_cached");
+    (result.exit_reason, result.exit_arg)
+}
+
+/// Error code the call loop packs into `exit_arg` when a handler activation
+/// HALTs/REPLYs without resuming its yielder (the deferred multi-frame unwind).
+const ERR_HANDLER_HALT: u32 = 72;
+
+#[test]
+fn user_key_yield_routes_to_ancestor_and_resumes() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // Positive: A's receiver registers YIELD_KEY, so B's yield routes to A
+    // (skipping B's frames), A resumes B, B halts, A halts cleanly (reason 4 —
+    // the trailing REPLY). A trap/unhandled here would change the reason.
+    let (reason, _) = run(&mut nub, YIELD_KEY, true);
+    assert_eq!(
+        reason, 4,
+        "a user-key yield caught by an ancestor must route, resume, and halt cleanly, got reason={reason}",
+    );
+
+    // Negative: A's receiver registers a DIFFERENT key, so no ancestor catches
+    // B's yield → the emitter faults (reason 7). Confirms routing consults the
+    // snapshotted catch-set, so the positive isn't a false pass.
+    let (reason, _) = run(&mut nub, YIELD_KEY.wrapping_add(1), true);
+    assert_eq!(
+        reason, 7,
+        "a user-key yield no ancestor catches must fault the emitter (7), got reason={reason}",
+    );
+
+    // Handler-halt guard: A catches B's yield but REPLYs without `call_resume`.
+    // Folding A's HALT up while B waits is the deferred multi-frame unwind → a
+    // clean trap (reason 7, exit_arg = ERR_HANDLER_HALT) rather than a panic.
+    let (reason, arg) = run(&mut nub, YIELD_KEY, false);
+    assert_eq!(
+        (reason, arg),
+        (7, ERR_HANDLER_HALT),
+        "a handler that halts without resuming must trap with ERR_HANDLER_HALT, got reason={reason} arg={arg}",
+    );
+
+    // CALL_RESUME guard: a top-level instance with no outstanding yield faults
+    // (the top is an InstanceEntry, not a handler activation).
+    let (reason, _) = run_bare_call_resume(&mut nub);
+    assert_eq!(
+        reason, 7,
+        "call_resume with no outstanding yield must fault (7), got reason={reason}",
+    );
+}

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -27,6 +27,7 @@ const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
 const OP_HOST_CALL: u32 = 26;
 const OP_CALL_RESUME: u32 = 27;
+const OP_DROP_PAUSED: u32 = 28;
 
 /// A's root-cnode slots.
 const B_SLOT: u8 = 6; // the sub-VM B (a published `Cap::Instance`)
@@ -69,15 +70,16 @@ fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
     }
 }
 
-/// A: `host_call(φ7=B slot, φ8=endpoint); [call_resume();] reply`. The slot/
-/// endpoint operands arrive via the invoke args (φ7..φ10). When `resume` is
-/// false A omits the `call_resume` — so when B's yield routes to A, A's handler
-/// continuation runs straight to REPLY, exercising the handler-halt guard.
-fn a_image(resume: bool) -> Image {
+/// A: `host_call(φ7=B slot, φ8=endpoint); [mid_op;] reply`. The slot/endpoint
+/// operands arrive via the invoke args (φ7..φ10). When B's yield routes to A, A
+/// resumes at the instruction after its `host_call`: `mid_op` is the handler's
+/// action — `Some(OP_CALL_RESUME)` resumes B, `Some(OP_DROP_PAUSED)` discards B,
+/// `None` runs straight to REPLY (the handler-halt unwind path).
+fn a_image(mid_op: Option<u32>) -> Image {
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
-    if resume {
-        code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    if let Some(op) = mid_op {
+        code.extend_from_slice(&ecalli(op).to_le_bytes());
     }
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
     image(code, Some(Key::from(RECEIVER_SLOT)))
@@ -92,9 +94,9 @@ fn b_image() -> Image {
     image(code, None)
 }
 
-/// Run the routing scenario with A's receiver registering `receiver_key` and A
-/// resuming B iff `resume`. Returns A's `(exit_reason, exit_arg)`.
-fn run(nub: &mut Nub, receiver_key: u8, resume: bool) -> (u32, u32) {
+/// Run the routing scenario with A's receiver registering `receiver_key` and A's
+/// handler action `mid_op`. Returns A's `(exit_reason, exit_arg)`.
+fn run(nub: &mut Nub, receiver_key: u8, mid_op: Option<u32>) -> (u32, u32) {
     // The user-key YieldSender B will emit, and A's YieldReceiver.
     let sender = Cap::Instance(yield_sender(&Key::from(YIELD_KEY)));
     let sender_h = nub.put_cap(&sender).expect("put sender");
@@ -137,7 +139,7 @@ fn run(nub: &mut Nub, receiver_key: u8, resume: bool) -> (u32, u32) {
         .expect("set receiver");
     let a_cnode_h = nub.put_cap(&Cap::CNode(a_cnode)).expect("put A cnode");
 
-    let a_img = a_image(resume);
+    let a_img = a_image(mid_op);
     let a_image_h = nub
         .put_cap(&Cap::image_with_slots(&a_img, &[], &[]).expect("a image"))
         .expect("put a image");
@@ -163,12 +165,12 @@ fn run(nub: &mut Nub, receiver_key: u8, resume: bool) -> (u32, u32) {
     (result.exit_reason, result.exit_arg)
 }
 
-/// A top-level instance that does `call_resume; reply` with no outstanding
-/// yield — exercises the CALL_RESUME guard (the top is an InstanceEntry, not a
-/// handler activation). Returns `(exit_reason, exit_arg)`.
-fn run_bare_call_resume(nub: &mut Nub) -> (u32, u32) {
+/// A top-level instance that does `op; reply` with no outstanding yield —
+/// exercises the CALL_RESUME / DROP_PAUSED guards (the top is an InstanceEntry,
+/// not a handler activation). Returns `(exit_reason, exit_arg)`.
+fn run_bare(nub: &mut Nub, op: u32) -> (u32, u32) {
     let mut code = Vec::new();
-    code.extend_from_slice(&ecalli(OP_CALL_RESUME).to_le_bytes());
+    code.extend_from_slice(&ecalli(op).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
     let img = image(code, None);
     let image_h = nub
@@ -192,10 +194,6 @@ fn run_bare_call_resume(nub: &mut Nub) -> (u32, u32) {
     (result.exit_reason, result.exit_arg)
 }
 
-/// Error code the call loop packs into `exit_arg` when a handler activation
-/// HALTs/REPLYs without resuming its yielder (the deferred multi-frame unwind).
-const ERR_HANDLER_HALT: u32 = 72;
-
 #[test]
 fn user_key_yield_routes_to_ancestor_and_resumes() {
     let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
@@ -203,7 +201,7 @@ fn user_key_yield_routes_to_ancestor_and_resumes() {
     // Positive: A's receiver registers YIELD_KEY, so B's yield routes to A
     // (skipping B's frames), A resumes B, B halts, A halts cleanly (reason 4 —
     // the trailing REPLY). A trap/unhandled here would change the reason.
-    let (reason, _) = run(&mut nub, YIELD_KEY, true);
+    let (reason, _) = run(&mut nub, YIELD_KEY, Some(OP_CALL_RESUME));
     assert_eq!(
         reason, 4,
         "a user-key yield caught by an ancestor must route, resume, and halt cleanly, got reason={reason}",
@@ -212,27 +210,41 @@ fn user_key_yield_routes_to_ancestor_and_resumes() {
     // Negative: A's receiver registers a DIFFERENT key, so no ancestor catches
     // B's yield → the emitter faults (reason 7). Confirms routing consults the
     // snapshotted catch-set, so the positive isn't a false pass.
-    let (reason, _) = run(&mut nub, YIELD_KEY.wrapping_add(1), true);
+    let (reason, _) = run(&mut nub, YIELD_KEY.wrapping_add(1), Some(OP_CALL_RESUME));
     assert_eq!(
         reason, 7,
         "a user-key yield no ancestor catches must fault the emitter (7), got reason={reason}",
     );
 
-    // Handler-halt guard: A catches B's yield but REPLYs without `call_resume`.
-    // Folding A's HALT up while B waits is the deferred multi-frame unwind → a
-    // clean trap (reason 7, exit_arg = ERR_HANDLER_HALT) rather than a panic.
-    let (reason, arg) = run(&mut nub, YIELD_KEY, false);
+    // DROP_PAUSED: A catches B's yield, discards B with `drop_paused`, then
+    // continues to REPLY — the handler keeps running after dropping its yielder,
+    // so the run halts cleanly (reason 4).
+    let (reason, _) = run(&mut nub, YIELD_KEY, Some(OP_DROP_PAUSED));
     assert_eq!(
-        (reason, arg),
-        (7, ERR_HANDLER_HALT),
-        "a handler that halts without resuming must trap with ERR_HANDLER_HALT, got reason={reason} arg={arg}",
+        reason, 4,
+        "drop_paused must discard the yielder and let the handler continue to a clean halt (4), got reason={reason}",
     );
 
-    // CALL_RESUME guard: a top-level instance with no outstanding yield faults
-    // (the top is an InstanceEntry, not a handler activation).
-    let (reason, _) = run_bare_call_resume(&mut nub);
+    // Handler-halt unwind: A catches B's yield but REPLYs without resuming or
+    // dropping. Per sub-tree atomicity A's HALT discards the abandoned yielder B
+    // and folds A's own HALT up to its caller — A is top-level, so the run drains
+    // to a clean halt (reason 4), NOT a fault.
+    let (reason, _) = run(&mut nub, YIELD_KEY, None);
     assert_eq!(
-        reason, 7,
-        "call_resume with no outstanding yield must fault (7), got reason={reason}",
+        reason, 4,
+        "a handler that halts without resuming must discard its yielder and halt cleanly (4), got reason={reason}",
+    );
+
+    // CALL_RESUME / DROP_PAUSED guards: at top level (no outstanding yield) both
+    // fault — the top is an InstanceEntry, not a handler activation.
+    assert_eq!(
+        run_bare(&mut nub, OP_CALL_RESUME).0,
+        7,
+        "call_resume with no outstanding yield must fault (7)",
+    );
+    assert_eq!(
+        run_bare(&mut nub, OP_DROP_PAUSED).0,
+        7,
+        "drop_paused with no outstanding yield must fault (7)",
     );
 }

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -27,7 +27,7 @@ const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
 const OP_HOST_CALL: u32 = 26;
 const OP_CALL_RESUME: u32 = 27;
-const OP_DROP_PAUSED: u32 = 28;
+const OP_DROP_RESUME: u32 = 28;
 
 /// A's root-cnode slots.
 const B_SLOT: u8 = 6; // the sub-VM B (a published `Cap::Instance`)
@@ -73,7 +73,7 @@ fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
 /// A: `host_call(φ7=B slot, φ8=endpoint); [mid_op;] reply`. The slot/endpoint
 /// operands arrive via the invoke args (φ7..φ10). When B's yield routes to A, A
 /// resumes at the instruction after its `host_call`: `mid_op` is the handler's
-/// action — `Some(OP_CALL_RESUME)` resumes B, `Some(OP_DROP_PAUSED)` discards B,
+/// action — `Some(OP_CALL_RESUME)` resumes B, `Some(OP_DROP_RESUME)` discards B,
 /// `None` runs straight to REPLY (the handler-halt unwind path).
 fn a_image(mid_op: Option<u32>) -> Image {
     let mut code = Vec::new();
@@ -166,7 +166,7 @@ fn run(nub: &mut Nub, receiver_key: u8, mid_op: Option<u32>) -> (u32, u32) {
 }
 
 /// A top-level instance that does `op; reply` with no outstanding yield —
-/// exercises the CALL_RESUME / DROP_PAUSED guards (the top is an InstanceEntry,
+/// exercises the CALL_RESUME / DROP_RESUME guards (the top is an InstanceEntry,
 /// not a handler activation). Returns `(exit_reason, exit_arg)`.
 fn run_bare(nub: &mut Nub, op: u32) -> (u32, u32) {
     let mut code = Vec::new();
@@ -216,13 +216,13 @@ fn user_key_yield_routes_to_ancestor_and_resumes() {
         "a user-key yield no ancestor catches must fault the emitter (7), got reason={reason}",
     );
 
-    // DROP_PAUSED: A catches B's yield, discards B with `drop_paused`, then
+    // DROP_RESUME: A catches B's yield, discards B with `drop_resume`, then
     // continues to REPLY — the handler keeps running after dropping its yielder,
     // so the run halts cleanly (reason 4).
-    let (reason, _) = run(&mut nub, YIELD_KEY, Some(OP_DROP_PAUSED));
+    let (reason, _) = run(&mut nub, YIELD_KEY, Some(OP_DROP_RESUME));
     assert_eq!(
         reason, 4,
-        "drop_paused must discard the yielder and let the handler continue to a clean halt (4), got reason={reason}",
+        "drop_resume must discard the yielder and let the handler continue to a clean halt (4), got reason={reason}",
     );
 
     // Handler-halt unwind: A catches B's yield but REPLYs without resuming or
@@ -235,7 +235,7 @@ fn user_key_yield_routes_to_ancestor_and_resumes() {
         "a handler that halts without resuming must discard its yielder and halt cleanly (4), got reason={reason}",
     );
 
-    // CALL_RESUME / DROP_PAUSED guards: at top level (no outstanding yield) both
+    // CALL_RESUME / DROP_RESUME guards: at top level (no outstanding yield) both
     // fault — the top is an InstanceEntry, not a handler activation.
     assert_eq!(
         run_bare(&mut nub, OP_CALL_RESUME).0,
@@ -243,8 +243,8 @@ fn user_key_yield_routes_to_ancestor_and_resumes() {
         "call_resume with no outstanding yield must fault (7)",
     );
     assert_eq!(
-        run_bare(&mut nub, OP_DROP_PAUSED).0,
+        run_bare(&mut nub, OP_DROP_RESUME).0,
         7,
-        "drop_paused with no outstanding yield must fault (7)",
+        "drop_resume with no outstanding yield must fault (7)",
     );
 }

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -1,8 +1,8 @@
 //! User-key `host_yield` routing + `CALL_RESUME` — the in-flight suspension
 //! core. A (top-level) CALLs B (a sub-VM); B `host_yield`s a user-key
-//! `YieldSender`; the kernel walks the call stack, skips B's own frames
-//! (emitter-exclusion), and routes the yield to the nearest ancestor whose
-//! per-CALL snapshotted `YieldReceiver` contains the key — here A. A resumes at
+//! `YieldSender`; the kernel follows B's owner edge and routes the yield to the
+//! nearest owner whose per-CALL snapshotted `YieldReceiver` contains the key —
+//! here A. A resumes at
 //! its post-CALL continuation, `CALL_RESUME`s B, B halts, and A halts cleanly.
 //!
 //! A is deliberately STRAIGHT-LINE — `host_call; call_resume; reply` — which is

--- a/rust/javm-guest-tests/tests/yield_walk_past.rs
+++ b/rust/javm-guest-tests/tests/yield_walk_past.rs
@@ -6,7 +6,7 @@
 //!   B); C completes, returns up through B to A → clean halt (reason 4). This
 //!   exercises the routing walk's skip-and-continue + the correct multi-frame
 //!   resume (the depth-2 tests can't reach a walked-past frame).
-//! - DROP_PAUSED then CALL_RESUME: drop_paused must discard the WHOLE caught
+//! - DROP_RESUME then CALL_RESUME: drop_resume must discard the WHOLE caught
 //!   subtree (B and C), leaving A a plain InstanceEntry — so the following
 //!   call_resume faults (reason 7). With the buggy single-entry remove, B stays
 //!   wedged and the call_resume would resume B instead (reason 4).
@@ -25,7 +25,7 @@ const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
 const OP_HOST_CALL: u32 = 26;
 const OP_CALL_RESUME: u32 = 27;
-const OP_DROP_PAUSED: u32 = 28;
+const OP_DROP_RESUME: u32 = 28;
 
 const B_SLOT: u8 = 6; // B in A's cnode
 const C_SLOT: u8 = 4; // C in A's cnode (inherited by B)
@@ -158,13 +158,13 @@ fn walk_past_intermediate_routing() {
         "a yield routed past a non-catching intermediate must resume the actual yielder and halt cleanly",
     );
 
-    // DROP_PAUSED then CALL_RESUME: drop_paused discards the whole caught subtree
+    // DROP_RESUME then CALL_RESUME: drop_resume discards the whole caught subtree
     // (B and C), leaving A a plain InstanceEntry, so the trailing call_resume has
     // no outstanding yield and faults (reason 7). A single-entry remove would
     // leave B wedged and resume it here → reason 4.
     assert_eq!(
-        run(&mut nub, &[OP_DROP_PAUSED, OP_CALL_RESUME]),
+        run(&mut nub, &[OP_DROP_RESUME, OP_CALL_RESUME]),
         7,
-        "drop_paused must discard the routed-past subtree so a following call_resume faults",
+        "drop_resume must discard the routed-past subtree so a following call_resume faults",
     );
 }

--- a/rust/javm-guest-tests/tests/yield_walk_past.rs
+++ b/rust/javm-guest-tests/tests/yield_walk_past.rs
@@ -1,0 +1,170 @@
+//! Depth-3 yield routing that walks PAST a non-catching intermediate frame, plus
+//! the handler verbs on a routed-past subtree. A (catcher, registers K) CALLs B;
+//! B (catches nothing) CALLs C; C host_yields K, which routes past B to A.
+//!
+//! - CALL_RESUME: A resumes the actual yielder C (not the wedged intermediate
+//!   B); C completes, returns up through B to A → clean halt (reason 4). This
+//!   exercises the routing walk's skip-and-continue + the correct multi-frame
+//!   resume (the depth-2 tests can't reach a walked-past frame).
+//! - DROP_PAUSED then CALL_RESUME: drop_paused must discard the WHOLE caught
+//!   subtree (B and C), leaving A a plain InstanceEntry — so the following
+//!   call_resume faults (reason 7). With the buggy single-entry remove, B stays
+//!   wedged and the call_resume would resume B instead (reason 4).
+//!
+//! B threads C's sender slot into φ9 with an `addi` before its host_call
+//! (φ9→x12), since the CALL arg convention only forwards φ7/φ8 to a child. Gated
+//! to the nub Hyperlight host (linux-x86_64).
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
+use nub::Nub;
+use std::collections::BTreeMap;
+
+const OP_REPLY: u32 = 0;
+const OP_HOST_YIELD: u32 = 16;
+const OP_HOST_CALL: u32 = 26;
+const OP_CALL_RESUME: u32 = 27;
+const OP_DROP_PAUSED: u32 = 28;
+
+const B_SLOT: u8 = 6; // B in A's cnode
+const C_SLOT: u8 = 4; // C in A's cnode (inherited by B)
+const SENDER_SLOT: u8 = 5; // YieldSender{K} (inherited A→B→C)
+const RECEIVER_SLOT: u8 = 9; // A's YieldReceiver (A.yield_receiver_slot)
+const YIELD_KEY: u8 = 0x42;
+const GAS_BUDGET: u64 = 10_000_000_000;
+
+fn ecalli(imm: u32) -> u32 {
+    ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
+}
+
+/// `addi rd, rs1, imm`. φ9 maps to RV x12.
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn endpoint0() -> BTreeMap<Key, EndpointDef> {
+    let mut e = BTreeMap::new();
+    e.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    e
+}
+
+fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
+    Image {
+        code,
+        endpoints: endpoint0(),
+        memory_mappings: Vec::new(),
+        pinned_slots: BTreeMap::new(),
+        initial_slots: BTreeMap::new(),
+        yield_receiver_slot,
+        gas_slots: Vec::new(),
+        quota_slots: Vec::new(),
+    }
+}
+
+fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(img, &[], &[]).expect("image"))
+        .expect("put image");
+    let mem = img.instance_mem_backing();
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        mem,
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+/// Run the depth-3 walk-past scenario; `handler_ops` are A's handler-continuation
+/// ecalls after its `host_call`. Returns the top-level `exit_reason`.
+fn run(nub: &mut Nub, handler_ops: &[u32]) -> u32 {
+    let sender_h = nub
+        .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))
+        .expect("put sender");
+    let receiver_h = nub
+        .put_cap(&Cap::Instance(yield_receiver(&[Key::from(YIELD_KEY)])))
+        .expect("put receiver");
+
+    // C: host_yield(φ7=sender); reply. Empty root cnode (inherits sender from B).
+    let mut c_code = Vec::new();
+    c_code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
+    c_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    let c_h = put_instance(nub, &image(c_code, None), [0u8; 32]);
+
+    // B: addi φ9=SENDER_SLOT; host_call(φ7=C slot, φ8=ep); reply. Catches nothing.
+    let mut b_code = Vec::new();
+    b_code.extend_from_slice(&addi(12, 0, SENDER_SLOT as i32).to_le_bytes());
+    b_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    b_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+    // B's root cnode: C (inherited by C's CALL) — B also inherits A's cnode, but
+    // C and the sender live in A's cnode, so an empty B cnode suffices; B inherits
+    // C + sender from A at the A→B CALL.
+    let b_h = put_instance(nub, &image(b_code, None), [0u8; 32]);
+
+    // A: host_call(φ7=B slot, φ8=ep); <handler_ops>; reply. Catches K.
+    let mut a_code = Vec::new();
+    a_code.extend_from_slice(&ecalli(OP_HOST_CALL).to_le_bytes());
+    for op in handler_ops {
+        a_code.extend_from_slice(&ecalli(*op).to_le_bytes());
+    }
+    a_code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
+
+    let mut a_cnode = CNodeCap::new();
+    for (slot, h) in [
+        (B_SLOT, b_h),
+        (C_SLOT, c_h),
+        (SENDER_SLOT, sender_h),
+        (RECEIVER_SLOT, receiver_h),
+    ] {
+        a_cnode
+            .set(&Key::from(slot), Some(CapHashOrRef::Hash(h)))
+            .unwrap();
+    }
+    let a_cnode_h = nub.put_cap(&Cap::CNode(a_cnode)).expect("put A cnode");
+    let a_h = put_instance(
+        nub,
+        &image(a_code, Some(Key::from(RECEIVER_SLOT))),
+        a_cnode_h,
+    );
+
+    // φ7=B slot, φ8=ep, φ9=C slot (→ B.φ7), φ10=ep (→ B.φ8).
+    let args = [B_SLOT as u64, 0, C_SLOT as u64, 0];
+    nub.invoke_cached(a_h, 0, args, GAS_BUDGET)
+        .expect("invoke A")
+        .exit_reason
+}
+
+#[test]
+fn walk_past_intermediate_routing() {
+    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+
+    // CALL_RESUME: C's yield routes past B to A; A resumes C (the real yielder),
+    // C completes and unwinds C→B→A → clean halt (reason 4).
+    assert_eq!(
+        run(&mut nub, &[OP_CALL_RESUME]),
+        4,
+        "a yield routed past a non-catching intermediate must resume the actual yielder and halt cleanly",
+    );
+
+    // DROP_PAUSED then CALL_RESUME: drop_paused discards the whole caught subtree
+    // (B and C), leaving A a plain InstanceEntry, so the trailing call_resume has
+    // no outstanding yield and faults (reason 7). A single-entry remove would
+    // leave B wedged and resume it here → reason 4.
+    assert_eq!(
+        run(&mut nub, &[OP_DROP_PAUSED, OP_CALL_RESUME]),
+        7,
+        "drop_paused must discard the routed-past subtree so a following call_resume faults",
+    );
+}

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -900,10 +900,12 @@ fn read_subsoil_endpoints_rv(
     elf_data: &[u8],
     base_vaddr: u64,
     code_len: usize,
-) -> Result<BTreeMap<u8, EndpointDef>, TranspileError> {
+) -> Result<BTreeMap<Key, EndpointDef>, TranspileError> {
     let sections = crate::elf::find_all_section_bytes(elf_data, ".subsoil.endpoints")?;
     const DESCRIPTOR_SIZE: usize = 16;
-    let mut endpoints: BTreeMap<u8, EndpointDef> = BTreeMap::new();
+    // Endpoints are keyed by a Key selector (the V1 single-byte ABI maps the
+    // descriptor's u8 index to the one-byte key `[index]`).
+    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     for section_bytes in &sections {
         if section_bytes.len() % DESCRIPTOR_SIZE != 0 {
             return Err(TranspileError::InvalidSection(format!(
@@ -926,7 +928,7 @@ fn read_subsoil_endpoints_rv(
             let rv_pc = fn_ptr - base_vaddr;
             if endpoints
                 .insert(
-                    index,
+                    Key::from(index),
                     EndpointDef {
                         entry_pc: rv_pc,
                         arg_registers,

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -38,7 +38,7 @@ use crate::layout::{
     RO_CAP_INDEX, RW_CAP_INDEX, STACK_CAP_INDEX,
 };
 use javm_cap::Key;
-use javm_cap::abi::BARE_YIELD_CATCHER_SLOT;
+use javm_cap::abi::BARE_YIELD_RECEIVER_SLOT;
 use javm_cap::image::{EndpointDef, Image, InitialDataCap, MemoryMapping, PinnedCap};
 use javm_cap::slot::SlotPath;
 use std::collections::BTreeMap;
@@ -537,7 +537,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         memory_mappings,
         pinned_slots,
         initial_slots,
-        yield_marker_slot: Some(Key::from(BARE_YIELD_CATCHER_SLOT)),
+        yield_receiver_slot: Some(Key::from(BARE_YIELD_RECEIVER_SLOT)),
         gas_slots: Vec::new(),
         quota_slots: Vec::new(),
     })

--- a/rust/nub-arch-local/src/lib.rs
+++ b/rust/nub-arch-local/src/lib.rs
@@ -113,10 +113,14 @@ pub fn run_instance(
         }
     }
 
-    let endpoint = image
+    // V1 single-byte ABI: the endpoint selector is a single-byte Key into the
+    // sparse endpoint list.
+    let target = javm_cap::Key::from(endpoint_idx);
+    let (_, endpoint) = image
         .endpoints
-        .get(endpoint_idx as usize)
-        .expect("endpoint index out of range");
+        .iter()
+        .find(|(k, _)| *k == target)
+        .expect("endpoint key not defined");
 
     let mut regs = Regs::new();
     regs.pc = endpoint.entry_pc;

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -29,8 +29,9 @@ pub const FN_ID_NUB_INVOKE_CACHED: u32 = 3;
 /// Payload: rkyv-archived `javm_cap::Cap`. Guest validates and
 /// materialises via [`rkyv::access`] + [`rkyv::deserialize`], computes
 /// the cap's content hash, inserts into the guest-resident `CACHE`
-/// (a `CacheDirectory<FixedState>` holding `HashMap<CapHash, Arc<Cap>>`
-/// in talc heap), and replies with the rkyv-archived [`CapHash`] (raw
+/// (a resident `CacheDirectory<FixedState, CachedCap>` holding
+/// `HashMap<CapHash, Arc<CachedCap>>` in talc heap), and replies with the
+/// rkyv-archived [`CapHash`] (raw
 /// 32 bytes). The host's `MultiUseSandbox::put_cap` propagates a
 /// `CapHasRefError` from `javm_cap` if any slot still holds a Ref.
 pub const FN_ID_NUB_PUT_CAP: u32 = 4;
@@ -59,11 +60,10 @@ pub const FN_ID_NUB_EVICT_JIT_ALL: u32 = 6;
 ///
 /// `magic` is checked first as a sanity guard against reading a
 /// stale or wrong-binary boot region. `directory_va` is the address
-/// of the guest's `CacheDirectory<FixedState>`, which the host reader
-/// (`GuestCacheReader`) dereferences and indexes by `CapHash`.
+/// of the guest's resident cap directory.
 /// `directory_type_id` lets future protocol upgrades reject a
 /// mismatched layout (today: opaque sentinel matching
-/// `CacheDirectory<FixedState>` — bumped when any field is added or
+/// `CacheDirectory<FixedState, CachedCap>` — bumped when any field is added or
 /// its type changes).
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]

--- a/rust/nub-arch-x86/src/cached_cap.rs
+++ b/rust/nub-arch-x86/src/cached_cap.rs
@@ -6,7 +6,7 @@
 //! cache belongs **with the cap**: `cache lifetime == cap lifetime`. A running
 //! frame's cnode is a [`CNodeCap<Box<CachedCap>>`](javm_cap::CNodeCap), and a
 //! `derive_spawn`'d instance lives in it as `CapHashOrRef::Owned(Box<CachedCap>)`
-//! — its parked page table riding in [`CacheSlot`], dropped automatically when
+//! — its parked page table riding in [`CapCache`], dropped automatically when
 //! the slot is overwritten or the frame pops. This replaces the parent-side
 //! `child_runtimes` side-table: no slot-keying, no manual `derive_spawn`
 //! invalidation, no per-frame `BTreeMap` allocation, and the cache follows the
@@ -22,8 +22,15 @@
 use alloc::boxed::Box;
 
 use javm_cap::cap::Cap;
+use javm_cap::cap::instance::InstanceCap;
+use javm_cap::{CNodeCap, ResidentCap};
+use spin::Mutex as SpinMutex;
 
+use crate::jit_cache::CompiledImage;
 use crate::jit_run::FrameRuntime;
+
+pub type ResidentCNode = CNodeCap<Box<CachedCap>>;
+pub type ResidentInstance = InstanceCap<Box<CachedCap>>;
 
 /// A cap paired with the derived runtime cache that rides with it inside a
 /// running frame's cnode (`CapHashOrRef::Owned(Box<CachedCap>)`).
@@ -40,16 +47,29 @@ pub struct CachedCap {
     /// moved scratchpad slot).
     pub cap: Cap,
     /// The engine-private derived cache attached to this cap.
-    pub cache: CacheSlot,
+    pub cache: SpinMutex<CapCache>,
 }
+
+/// SAFETY: Hyperlight serialises guest execution and RPCs; these resident
+/// caches never move across concurrently-running threads. The impl only lets
+/// them live behind the static directory mutex.
+unsafe impl Send for CachedCap {}
+/// SAFETY: same single-threaded guest invariant as the `Send` impl above.
+unsafe impl Sync for CachedCap {}
 
 /// The derived runtime cache attached to a resident cap. `None` for a cap with
 /// no cached runtime (freshly spawned, or a non-instance scratchpad cap).
 #[derive(Default)]
-pub enum CacheSlot {
+pub enum CapCache {
     /// No cached runtime.
     #[default]
     None,
+    /// A resident CNode's cache-carrying sparse slot map. The `cap` field keeps
+    /// the public wire shape; this variant is authoritative while the CNode is
+    /// resident in the guest.
+    CNode(Box<ResidentCNode>),
+    /// A published Image's compiled code arena and page-table template.
+    Image(Box<CompiledImage>),
     /// A resident sub-VM instance's ring-3 page table, parked (re-armed for
     /// CoW) between CALLs so the next CALL of this same instance reuses the
     /// whole page table instead of rebuilding it.
@@ -62,7 +82,15 @@ impl CachedCap {
     pub fn new(cap: Cap) -> Self {
         Self {
             cap,
-            cache: CacheSlot::None,
+            cache: SpinMutex::new(CapCache::None),
+        }
+    }
+
+    /// Wrap a CNode with a resident cache-carrying slot map.
+    pub fn cnode(cnode: ResidentCNode) -> Self {
+        Self {
+            cap: Cap::empty_cnode(),
+            cache: SpinMutex::new(CapCache::CNode(Box::new(cnode))),
         }
     }
 
@@ -71,6 +99,11 @@ impl CachedCap {
     pub fn boxed(cap: Cap) -> Box<Self> {
         Box::new(Self::new(cap))
     }
+
+    /// Box a resident CNode, ready for an Instance's live `root_cnode`.
+    pub fn boxed_cnode(cnode: ResidentCNode) -> Box<Self> {
+        Box::new(Self::cnode(cnode))
+    }
 }
 
 impl Clone for CachedCap {
@@ -78,18 +111,38 @@ impl Clone for CachedCap {
         // A clone is a distinct instance → fresh, empty cache.
         Self {
             cap: self.cap.clone(),
-            cache: CacheSlot::None,
+            cache: SpinMutex::new(CapCache::None),
         }
+    }
+}
+
+impl ResidentCap for CachedCap {
+    fn from_cap(cap: Cap) -> Self {
+        Self::new(cap)
+    }
+
+    fn as_cap(&self) -> &Cap {
+        &self.cap
+    }
+
+    fn into_cap(self) -> Cap {
+        self.cap
     }
 }
 
 impl core::fmt::Debug for CachedCap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // `FrameRuntime` is not `Debug`; report only cache presence.
-        let cached = !matches!(self.cache, CacheSlot::None);
+        // `FrameRuntime` / `CompiledImage` are not `Debug`; report only the
+        // cache variant.
+        let cache = match &*self.cache.lock() {
+            CapCache::None => "None",
+            CapCache::CNode(_) => "CNode",
+            CapCache::Image(_) => "Image",
+            CapCache::Instance(_) => "Instance",
+        };
         f.debug_struct("CachedCap")
             .field("cap", &self.cap)
-            .field("cached_runtime", &cached)
+            .field("cache", &cache)
             .finish()
     }
 }

--- a/rust/nub-arch-x86/src/cached_cap.rs
+++ b/rust/nub-arch-x86/src/cached_cap.rs
@@ -23,7 +23,7 @@ use alloc::boxed::Box;
 
 use javm_cap::cap::Cap;
 use javm_cap::cap::instance::InstanceCap;
-use javm_cap::{CNodeCap, ResidentCap};
+use javm_cap::{CNodeCap, CapHashOrRef, MissingOr, ResidentCap};
 use spin::Mutex as SpinMutex;
 
 use crate::jit_cache::CompiledImage;
@@ -70,10 +70,26 @@ pub enum CapCache {
     CNode(Box<ResidentCNode>),
     /// A published Image's compiled code arena and page-table template.
     Image(Box<CompiledImage>),
-    /// A resident sub-VM instance's ring-3 page table, parked (re-armed for
-    /// CoW) between CALLs so the next CALL of this same instance reuses the
-    /// whole page table instead of rebuilding it.
-    Instance(FrameRuntime),
+    /// A resident sub-VM instance's parked execution state. The root CNode is
+    /// kept resident between internal CALL/HALT edges so unwinding a deep
+    /// sub-VM tree does not repeatedly fold it into wire form; the optional
+    /// page table is re-armed for CoW and reused on the next CALL of the same
+    /// instance.
+    Instance(InstanceCache),
+}
+
+pub struct InstanceCache {
+    pub runtime: Option<FrameRuntime>,
+    pub root_cnode: Option<Box<ResidentCNode>>,
+}
+
+impl InstanceCache {
+    pub fn new(runtime: Option<FrameRuntime>, root_cnode: Option<Box<ResidentCNode>>) -> Self {
+        Self {
+            runtime,
+            root_cnode,
+        }
+    }
 }
 
 impl CachedCap {
@@ -104,6 +120,58 @@ impl CachedCap {
     pub fn boxed_cnode(cnode: ResidentCNode) -> Box<Self> {
         Box::new(Self::cnode(cnode))
     }
+
+    /// Fold this resident cached cap back to the public wire shape. Internal
+    /// CALL/HALT edges keep root CNodes resident in [`CapCache::Instance`] and
+    /// only pay this recursive fold at a real wire/persistence boundary.
+    pub fn to_wire_cap(&self) -> Cap {
+        match &self.cap {
+            Cap::CNode(_) => {
+                let cache = self.cache.lock();
+                match &*cache {
+                    CapCache::CNode(cnode) => Cap::CNode(fold_cnode_to_wire(cnode)),
+                    CapCache::None | CapCache::Image(_) | CapCache::Instance(_) => self.cap.clone(),
+                }
+            }
+            Cap::Instance(inst) => {
+                let cache = self.cache.lock();
+                match &*cache {
+                    CapCache::Instance(instance_cache) => {
+                        if let Some(root_cnode) = &instance_cache.root_cnode {
+                            let mut inst = inst.clone();
+                            inst.root_cnode = CapHashOrRef::Owned(Box::new(Cap::CNode(
+                                fold_cnode_to_wire(root_cnode),
+                            )));
+                            Cap::Instance(inst)
+                        } else {
+                            self.cap.clone()
+                        }
+                    }
+                    CapCache::None | CapCache::CNode(_) | CapCache::Image(_) => self.cap.clone(),
+                }
+            }
+            _ => self.cap.clone(),
+        }
+    }
+}
+
+fn target_to_wire(target: &CapHashOrRef<Box<CachedCap>>) -> CapHashOrRef<Box<Cap>> {
+    match target {
+        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
+        CapHashOrRef::Owned(boxed) => CapHashOrRef::Owned(Box::new(boxed.to_wire_cap())),
+    }
+}
+
+fn fold_cnode_to_wire(cnode: &ResidentCNode) -> CNodeCap<Box<Cap>> {
+    let mut out = CNodeCap::new();
+    for (k, mo) in cnode.slots.iter() {
+        let conv = match mo {
+            MissingOr::Materialized(t) => MissingOr::Materialized(target_to_wire(t)),
+            MissingOr::Missing(h) => MissingOr::Missing(*h),
+        };
+        out.slots.insert(k.clone(), conv);
+    }
+    out
 }
 
 impl Clone for CachedCap {
@@ -126,7 +194,7 @@ impl ResidentCap for CachedCap {
     }
 
     fn into_cap(self) -> Cap {
-        self.cap
+        self.to_wire_cap()
     }
 }
 

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -120,6 +120,13 @@ const EXIT_TRAP: u32 = 7;
 
 const OP_REPLY: u32 = 0;
 const OP_DERIVE_SPAWN: u32 = 18;
+/// `host_image_hash_chain(src_slot=φ[7], dst_slot=φ[8])` — read the cap's
+/// kernel-attested type identity (an Instance's cumulative `image_hash_chain`,
+/// or an Image's content hash) and place a `Cap::Data` of its 32 raw bytes at
+/// `dst`. Reclaims the old `HOST_TYPE_OF`/`HOST_SAME_TYPE` ABI slots (20/21):
+/// type identity is now read as plain bytes and compared in userspace
+/// (memcmp), so there is no separate `Cap::Type` kind or same-type host op.
+const OP_IMAGE_HASH_CHAIN: u32 = 20;
 const OP_HOST_CALL: u32 = 26;
 
 /// Hard ceiling on the in-kernel call-stack depth. NOTE: with runtime eviction
@@ -405,6 +412,22 @@ pub fn run_top(
                         };
                         if trapped {
                             // Pinned dst → guest trap, mirroring the interpreter.
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: gas,
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
+                    }
+                    OP_IMAGE_HASH_CHAIN => {
+                        let trapped = {
+                            let frame = stack.last_mut().expect("non-empty");
+                            dispatch_image_hash_chain(frame)?
+                        };
+                        if trapped {
+                            // Pinned/empty dst or wrong src kind → guest trap.
                             break LoopOutcome {
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
@@ -898,6 +921,63 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
     // moves it. Overwriting the slot drops any previous occupant's `CachedCap`
     // (and its parked page table), so a stale cache for that slot is
     // invalidated automatically — no separate side-table to maintain.
+    frame
+        .cnode
+        .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
+        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+    Ok(false)
+}
+
+/// `host_image_hash_chain(src_slot=φ[7], dst_slot=φ[8])`. Reads the type
+/// identity of the cap at `src_slot` — an `Cap::Instance`'s cumulative
+/// `image_hash_chain`, or a `Cap::Image`'s content hash (which *is* its
+/// identity) — and places a `Cap::Data` holding those 32 raw bytes
+/// (page-padded) at `dst_slot`. The result is freely readable/comparable:
+/// same-type is a userspace `memcmp` of two such DataCaps; there is no
+/// `Cap::Type` kind and no same-type host op (see [`OP_IMAGE_HASH_CHAIN`]).
+///
+/// Returns `Ok(true)` to TRAP (pinned/empty dst, or a src that is neither an
+/// Instance nor an Image), mirroring `dispatch_derive_spawn`'s trap discipline.
+fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
+    // V1 single-byte ABI: φ[7] = src slot, φ[8] = dst slot.
+    let src_slot = Key::from((frame.regs[7] & 0xFF) as u8);
+    let dst_slot = Key::from((frame.regs[8] & 0xFF) as u8);
+
+    // Writing into a pinned (read-only) slot traps, mirroring the
+    // derive_spawn pinned-dst rejection.
+    if frame.pinned.binary_search(&dst_slot).is_ok() {
+        return Ok(true);
+    }
+
+    // Read the source cap's type identity. `peek_key` borrows (no clone, so
+    // an Owned instance's parked page-table cache is untouched). Hash targets
+    // resolve through the blob cache; an inline Owned instance reads its field
+    // directly (no hash needed).
+    let chain: CapHash = match frame.cnode.peek_key(src_slot.as_slice()) {
+        Some(CapHashOrRef::Hash(h)) => {
+            let h = *h;
+            let arc = CACHE
+                .get(CapHashOrRef::Hash(h))
+                .ok_or(ERR_INSTANCE_NOT_FOUND)?;
+            match &*arc {
+                Cap::Instance(i) => i.image_hash_chain,
+                // An Image is content-addressed: its hash IS its identity.
+                Cap::Image(_) => h,
+                _ => return Ok(true),
+            }
+        }
+        Some(CapHashOrRef::Owned(cc)) => match &cc.cap {
+            Cap::Instance(i) => i.image_hash_chain,
+            Cap::Image(_) => cc.cap.cap_hash(),
+            _ => return Ok(true),
+        },
+        None => return Ok(true),
+    };
+
+    // Mint a Cap::Data of the 32 identity bytes (padded to a page) and place
+    // it at dst as an inline Owned cap, settled at termination — same
+    // placement convention as derive_spawn's child instance.
+    let cap = Cap::data_inline(&chain);
     frame
         .cnode
         .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -21,7 +21,7 @@
 //! ## V1 simplifications
 //!
 //! - **The frame owns its mem.** Each [`KernelFrame`] holds its
-//!   read-write memory as an owned [`DataCap`] (`frame.instance.cap.mem`), cloned
+//!   read-write memory as an owned [`DataCap`] (`frame.instance.mem`), cloned
 //!   from the running Instance at build. The CoW #PF handler writes
 //!   dirtied pages straight into the cap's `overlay`, so the cap is
 //!   the source of truth: a runtime rebuilt after a future reclamation
@@ -103,7 +103,7 @@ use javm_cap::slot::Key;
 use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
-use crate::cached_cap::{CacheSlot, CachedCap};
+use crate::cached_cap::{CachedCap, CapCache, ResidentCNode, ResidentInstance};
 use crate::jit_run::{self, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
@@ -207,15 +207,16 @@ const ERR_GAS_SLOT_INVALID: u32 = 73;
 /// bookkeeping invariant, not a guest-visible trap.
 const ERR_PENDING_ORIGIN_INVARIANT: u32 = 74;
 
+type ResidentSlotTarget = CapHashOrRef<Box<CachedCap>>;
+type ResidentSlotEntry = ([u8; 32], MissingOr<ResidentSlotTarget>);
+
 /// One stack frame on the in-kernel call stack. Holds the running Instance
 /// value, the origin reservation metadata for the owner slot it came from, and
 /// the ring-3 resource cache. The Image cap is resolved from the heap-resident
 /// [`CACHE`] on access (blobs never evict mid-RPC); the running Instance's
-/// memory is owned outright by [`RunningInstance::cap`], not re-resolved from
-/// the cache.
 pub struct KernelFrame {
     /// Runtime form of the Instance this frame owns.
-    instance: RunningInstance,
+    instance: ResidentInstance,
     /// The owner frame + cnode slot this running Instance was moved out of.
     /// While this frame is on the kernel stack that origin slot is physically
     /// empty and recorded in the owner's [`Self::pending_origins`], so ordinary
@@ -269,20 +270,6 @@ pub struct KernelFrame {
     /// page tables match the no-cache case (one per stack frame, plus the
     /// just-popped child).
     runtime: Option<FrameRuntime>,
-}
-
-struct RunningInstance {
-    /// The public Instance payload, kept whole while the frame runs. Its
-    /// `root_cnode` field is a placeholder while live because the actual
-    /// runtime cnode needs `CachedCap` entries and is carried in [`Self::cnode`].
-    cap: InstanceCap,
-    /// Runtime root cnode: the radix kv-map (`Hasher(Key) ->
-    /// CapHashOrRef<Box<CachedCap>>`) seeded from `cap.root_cnode` and grown by
-    /// cnode operations. The payload is [`CachedCap`] — a cap plus its
-    /// engine-private page-table cache — so a resident sub-VM's runtime rides
-    /// with the cap in its slot. This cnode is deliberately non-wire-
-    /// serialisable and is folded back into `cap.root_cnode` on frame return.
-    cnode: CNodeCap<Box<CachedCap>>,
 }
 
 #[derive(Clone, Debug)]
@@ -417,9 +404,9 @@ impl FrameGas {
 /// is also invalid: there is no primary Gas cap to carry in an OOG payload.
 fn resolve_frame_gas(frame: &KernelFrame) -> Result<Option<FrameGas>, u32> {
     let img_arc = CACHE
-        .get(CapHashOrRef::Hash(frame.instance.cap.image_hash))
+        .get(CapHashOrRef::Hash(frame.instance.image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
-    let slots = match &*img_arc {
+    let slots = match &img_arc.cap {
         Cap::Image(i) => i.gas_slots.clone(),
         _ => return Err(ERR_IMAGE_KIND),
     };
@@ -432,10 +419,13 @@ fn resolve_frame_gas(frame: &KernelFrame) -> Result<Option<FrameGas>, u32> {
         if slot_is_pending(frame, &slot) {
             return Err(ERR_GAS_SLOT_INVALID);
         }
-        let Some(cap_ref) = frame.instance.cnode.peek_key(slot.as_slice()) else {
+        let meter = with_cnode_peek(frame, &slot, |cap_ref| match cap_ref {
+            Some(cap_ref) => gas_meter_key_from_ref(cap_ref).map(Some),
+            None => Ok(None),
+        })?;
+        let Some(meter) = meter else {
             continue;
         };
-        let meter = gas_meter_key_from_ref(cap_ref)?;
         if !meters.contains(&meter) {
             meters.push(meter);
         }
@@ -453,7 +443,7 @@ fn gas_meter_key_from_ref(cap_ref: &CapHashOrRef<Box<CachedCap>>) -> Result<Key,
             let arc = CACHE
                 .get(CapHashOrRef::Hash(*h))
                 .ok_or(ERR_GAS_SLOT_INVALID)?;
-            match &*arc {
+            match &arc.cap {
                 Cap::Instance(i) => i.clone(),
                 _ => return Err(ERR_GAS_SLOT_INVALID),
             }
@@ -546,14 +536,68 @@ fn slot_write_blocked(frame: &KernelFrame, slot: &Key) -> bool {
     frame.pinned.binary_search(slot).is_ok() || slot_is_pending(frame, slot)
 }
 
-fn cnode_peek_guest<'a>(
-    frame: &'a KernelFrame,
+fn with_root_cnode<R>(frame: &KernelFrame, f: impl FnOnce(&ResidentCNode) -> R) -> R {
+    let CapHashOrRef::Owned(root) = &frame.instance.root_cnode else {
+        panic!("running frame root_cnode must be resident-owned")
+    };
+    let cache = root.cache.lock();
+    let CapCache::CNode(cnode) = &*cache else {
+        panic!("running frame root_cnode cache must hold a CNode")
+    };
+    f(cnode)
+}
+
+fn with_root_cnode_mut<R>(frame: &mut KernelFrame, f: impl FnOnce(&mut ResidentCNode) -> R) -> R {
+    let CapHashOrRef::Owned(root) = &mut frame.instance.root_cnode else {
+        panic!("running frame root_cnode must be resident-owned")
+    };
+    let mut cache = root.cache.lock();
+    let CapCache::CNode(cnode) = &mut *cache else {
+        panic!("running frame root_cnode cache must hold a CNode")
+    };
+    f(cnode)
+}
+
+fn frame_cnode_set(
+    frame: &mut KernelFrame,
     slot: &Key,
-) -> Result<Option<&'a CapHashOrRef<Box<CachedCap>>>, u32> {
+    target: Option<CapHashOrRef<Box<CachedCap>>>,
+) -> Result<Option<CapHashOrRef<Box<CachedCap>>>, javm_cap::error::CapError> {
+    with_root_cnode_mut(frame, |cnode| cnode.set(slot, target))
+}
+
+fn frame_cnode_set_key(
+    frame: &mut KernelFrame,
+    key: &[u8],
+    target: Option<CapHashOrRef<Box<CachedCap>>>,
+) -> Option<CapHashOrRef<Box<CachedCap>>> {
+    with_root_cnode_mut(frame, |cnode| cnode.set_key(key, target))
+}
+
+fn frame_cnode_take_key(
+    frame: &mut KernelFrame,
+    key: &[u8],
+) -> Option<CapHashOrRef<Box<CachedCap>>> {
+    with_root_cnode_mut(frame, |cnode| cnode.take_key(key))
+}
+
+fn with_cnode_peek<R>(
+    frame: &KernelFrame,
+    slot: &Key,
+    f: impl FnOnce(Option<&CapHashOrRef<Box<CachedCap>>>) -> R,
+) -> R {
+    with_root_cnode(frame, |cnode| f(cnode.peek_key(slot.as_slice())))
+}
+
+fn with_cnode_peek_guest<R>(
+    frame: &KernelFrame,
+    slot: &Key,
+    f: impl FnOnce(Option<&CapHashOrRef<Box<CachedCap>>>) -> R,
+) -> Result<R, u32> {
     if slot_is_pending(frame, slot) {
         return Err(EXIT_TRAP);
     }
-    Ok(frame.instance.cnode.peek_key(slot.as_slice()))
+    Ok(with_cnode_peek(frame, slot, f))
 }
 
 /// Snapshot a frame's Instance `yield_receiver_slot` YieldReceiver as a sorted,
@@ -562,10 +606,10 @@ fn cnode_peek_guest<'a>(
 /// receiver slot, the slot is empty, or it doesn't hold a YieldReceiver
 /// (catches nothing). Reads only; never mutates.
 fn snapshot_catch_set(frame: &KernelFrame) -> Result<Vec<Key>, u32> {
-    let Some(img_arc) = CACHE.get(CapHashOrRef::Hash(frame.instance.cap.image_hash)) else {
+    let Some(img_arc) = CACHE.get(CapHashOrRef::Hash(frame.instance.image_hash)) else {
         return Ok(Vec::new());
     };
-    let slot = match &*img_arc {
+    let slot = match &img_arc.cap {
         Cap::Image(i) => match &i.yield_receiver_slot {
             Some(s) => s.clone(),
             None => return Ok(Vec::new()),
@@ -626,8 +670,8 @@ pub struct LoopOutcome {
 /// (`Empty` → zero). Byte offset 0 of `mem` is guest VA `DATA_BASE`.
 fn read_scratchpad_head(frame: &KernelFrame) -> [u8; SCRATCHPAD_HEAD_LEN] {
     let mut out = [0u8; SCRATCHPAD_HEAD_LEN];
-    if frame.instance.cap.mem.content_len() as usize >= SCRATCHPAD_HEAD_LEN {
-        frame.instance.cap.mem.copy_into(0, &mut out);
+    if frame.instance.mem.content_len() as usize >= SCRATCHPAD_HEAD_LEN {
+        frame.instance.mem.copy_into(0, &mut out);
     }
     out
 }
@@ -703,8 +747,8 @@ pub fn run_top(
         // Mirror the JIT's post-exit state back into the running frame.
         {
             let frame = frame_at_mut(&mut stack, top_idx);
-            frame.instance.cap.regs = info.regs;
-            frame.instance.cap.pc = info.pc as u64;
+            frame.instance.regs = info.regs;
+            frame.instance.pc = info.pc as u64;
         }
 
         // Phase 2: classify the exit. Borrow scopes are kept tight so
@@ -964,23 +1008,21 @@ pub fn run_top(
                         // yielder's loads (picking up a kernel:oog topup).
                         let response = {
                             let handler = frame_at_mut(&mut stack, top_idx);
-                            handler
-                                .instance
-                                .cnode
-                                .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
+                            frame_cnode_take_key(handler, &[javm_cap::abi::SCRATCHPAD_SLOT])
                         };
                         stack.pop();
                         let yielder_idx = stack.len() - 1;
                         let yielder = frame_at_mut(&mut stack, yielder_idx);
                         if let Some(cap) = response {
-                            yielder
-                                .instance
-                                .cnode
-                                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+                            frame_cnode_set_key(
+                                yielder,
+                                &[javm_cap::abi::SCRATCHPAD_SLOT],
+                                Some(cap),
+                            );
                         }
                         // Spec §4: a resumed yielder sees φ[8] = Ok (the handler's
                         // response status) — its host_yield "returns" here.
-                        yielder.instance.cap.regs[8] = STATUS_OK;
+                        yielder.instance.regs[8] = STATUS_OK;
                     }
                     OP_DROP_RESUME => {
                         // Give up on the Waiting yielder: discard the WHOLE caught
@@ -1095,15 +1137,14 @@ pub fn run_top(
                         // overwritten by the caller-provided scratchpad.
                         {
                             let parent = frame_at_mut(&mut stack, top_idx);
-                            if let Some(cap) = parent
-                                .instance
-                                .cnode
-                                .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
+                            if let Some(cap) =
+                                frame_cnode_take_key(parent, &[javm_cap::abi::SCRATCHPAD_SLOT])
                             {
-                                child
-                                    .instance
-                                    .cnode
-                                    .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+                                frame_cnode_set_key(
+                                    &mut child,
+                                    &[javm_cap::abi::SCRATCHPAD_SLOT],
+                                    Some(cap),
+                                );
                             }
                         }
                         // No runtime eviction: every live frame keeps its page
@@ -1194,14 +1235,14 @@ fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
         let rt = build_runtime(frame)?;
         frame.runtime = Some(rt);
     }
-    let pc = frame.instance.cap.pc as u32;
-    let regs = frame.instance.cap.regs;
+    let pc = frame.instance.pc as u32;
+    let regs = frame.instance.regs;
     // Split borrow of disjoint fields: while the JIT runs against
-    // `frame.runtime`'s PT, the #PF handler CoWs guest writes into `frame.instance.cap.mem`'s
+    // `frame.runtime`'s PT, the #PF handler CoWs guest writes into `frame.instance.mem`'s
     // overlay and advances `frame.mat_state` / `frame.ro_units` in place. The
     // raw-pointer casts end those `&mut` borrows immediately, so the subsequent
     // `frame.runtime` borrow does not conflict.
-    let overlay_sink: *mut DataCap = &mut frame.instance.cap.mem;
+    let overlay_sink: *mut DataCap = &mut frame.instance.mem;
     let mat_state_ptr = frame.mat_state.as_mut_ptr();
     let mat_state_len = frame.mat_state.len() as u64;
     let ro_units: *mut Vec<u32> = &mut frame.ro_units;
@@ -1233,15 +1274,15 @@ fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
 /// RPC) even after this function returns and the guard is dropped.
 fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // CacheDirectory is interior-mutable; each `get` takes the inner
-    // spin::Mutex briefly and returns an `Arc<Cap>`. We keep the Arc
+    // spin::Mutex briefly and returns an `Arc<CachedCap>`. We keep the Arc
     // locals alive for the duration of the function so any borrowed
     // slices (used to compute PAs for direct PT mapping) stay valid.
     // Blobs are never evicted in V0, so the PAs remain valid for the
     // frame's lifetime past return.
     let img_arc = CACHE
-        .get(CapHashOrRef::Hash(frame.instance.cap.image_hash))
+        .get(CapHashOrRef::Hash(frame.instance.image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
-    let img = match &*img_arc {
+    let img = match &img_arc.cap {
         Cap::Image(i) => i,
         _ => return Err(ERR_IMAGE_KIND),
     };
@@ -1259,7 +1300,7 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     let (code_base, code_bytes) = img.code_mapping().ok_or(ERR_IMAGE_KIND)?;
     let code_pa = paging::va_to_pa(code_bytes.as_ptr() as u64).ok_or(ERR_MAP_BAD_KIND)?;
 
-    // The frame's RW memory is its **owned** dense `DataCap` (`frame.instance.cap.mem`)
+    // The frame's RW memory is its **owned** dense `DataCap` (`frame.instance.mem`)
     // covering the whole data extent, holding both initial and pinned content
     // at their VAs with page-aligned slabs. Source every data page from it
     // (overlay-then-backing, so a rebuilt runtime picks up prior CoW writes):
@@ -1268,14 +1309,14 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // `UnpinnedCapCow` range. The slabs are owned by the frame, so their PAs
     // stay valid for the frame's life past this function's return.
     let data_base = javm_cap::layout::DATA_BASE;
-    let mem = &frame.instance.cap.mem;
+    let mem = &frame.instance.mem;
     let extent = mem.content_len() as u32;
     let mem_size = data_base.saturating_add(extent);
     let pages = (extent / paging::PAGE_SIZE as u32) as usize;
 
     // Pinned mappings → PinnedCapRo ranges (pushed first → precedence). Bounds +
     // kind only; the #PF handler resolves each page's source PA lazily from
-    // `frame.instance.cap.mem` (`jit_run::mem_source_pa`).
+    // `frame.instance.mem` (`jit_run::mem_source_pa`).
     for m in img.mappings.iter() {
         if m.path().is_empty() || !img.mapping_is_pinned(m.start as u32) {
             continue;
@@ -1310,7 +1351,8 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // the no-eviction V1 invariant.
     unsafe {
         jit_run::build_frame_runtime(
-            &frame.instance.cap.image_hash,
+            &img_arc,
+            &frame.instance.image_hash,
             code_bytes,
             code_base,
             code_pa,
@@ -1358,12 +1400,13 @@ fn route_yield(
     {
         let catcher_frame = frame_at_mut(stack, owner);
         if let Some(inst) = payload {
-            catcher_frame.instance.cnode.set_key(
+            frame_cnode_set_key(
+                catcher_frame,
                 &[javm_cap::abi::SCRATCHPAD_SLOT],
                 Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(inst)))),
             );
         }
-        catcher_frame.instance.cap.regs[8] = STATUS_YIELDED;
+        catcher_frame.instance.regs[8] = STATUS_YIELDED;
     }
     stack.push(StackEntry {
         kind: EntryKind::Reference,
@@ -1393,7 +1436,7 @@ fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32)
     if active_meter(stack, top_idx).is_none() {
         return false;
     }
-    frame_at_mut(stack, top_idx).instance.cap.pc = reattempt_pc as u64;
+    frame_at_mut(stack, top_idx).instance.pc = reattempt_pc as u64;
     if stack[top_idx].gas.advance() {
         return true;
     }
@@ -1435,14 +1478,15 @@ fn restore_instance_to_origin(
         return Err(ERR_PENDING_ORIGIN_INVARIANT);
     }
     let cache = match runtime {
-        Some(rt) => CacheSlot::Instance(rt),
-        None => CacheSlot::None,
+        Some(rt) => CapCache::Instance(rt),
+        None => CapCache::None,
     };
-    owner.instance.cnode.set_key(
+    frame_cnode_set_key(
+        owner,
         origin.slot.as_slice(),
         Some(CapHashOrRef::Owned(Box::new(CachedCap {
             cap: Cap::Instance(inst),
-            cache,
+            cache: spin::Mutex::new(cache),
         }))),
     );
     Ok(())
@@ -1502,10 +1546,7 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
     }
 
     // Move the callee's scratchpad (slot[0]) back to the caller.
-    let scratch = popped
-        .instance
-        .cnode
-        .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT]);
+    let scratch = frame_cnode_take_key(&mut popped, &[javm_cap::abi::SCRATCHPAD_SLOT]);
 
     // If the child was a moved-in instance, reconstruct its
     // `InstanceCap` from this frame's final state so the parent's slot gets the
@@ -1520,13 +1561,10 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
             // CoW (gas-neutral — the page is reused, only the W bit toggles).
             let runtime = popped.runtime.take();
             if let Some(rt) = &runtime {
-                rt.rearm_cow(popped.instance.cap.mem.overlay.keys().copied());
+                rt.rearm_cow(popped.instance.mem.overlay.keys().copied());
             }
-            let RunningInstance { mut cap, cnode } = popped.instance;
-            cap.root_cnode =
-                CapHashOrRef::Owned(Box::new(Cap::CNode(fold_frame_cnode_to_wire(cnode))));
-            cap.gas_remaining = 0;
-            let inst = cap;
+            popped.instance.gas_remaining = 0;
+            let inst = resident_instance_to_wire(popped.instance)?;
             Some((origin, inst, runtime))
         }
         None => {
@@ -1541,15 +1579,12 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
     let parent_idx = stack.len() - 1;
     {
         let parent = frame_at_mut(stack, parent_idx);
-        parent.instance.cap.regs[7] = return_value;
+        parent.instance.regs[7] = return_value;
         // Spec §4: the caller's φ[8] reflects the termination status — Ok for a normal
         // HALT/REPLY return (resetting any stale YIELDED a prior catch left there).
-        parent.instance.cap.regs[8] = STATUS_OK;
+        parent.instance.regs[8] = STATUS_OK;
         if let Some(cap) = scratch {
-            parent
-                .instance
-                .cnode
-                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+            frame_cnode_set_key(parent, &[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
         }
     }
     if let Some((origin, inst, runtime)) = owned_back {
@@ -1654,7 +1689,7 @@ fn compose_instance_mem(img: &ImageCap) -> DataCap {
         let Some(src_arc) = CACHE.get(CapHashOrRef::Hash(src_hash)) else {
             continue;
         };
-        if let Cap::Data(d) = &*src_arc {
+        if let Cap::Data(d) = &src_arc.cap {
             mem.place_shared(m.start.saturating_sub(data_base), d);
         }
     }
@@ -1674,9 +1709,9 @@ fn compose_instance_mem(img: &ImageCap) -> DataCap {
 /// `OpError::SlotPinned → ExitReason::Trap`. `Ok(false)` on a normal spawn.
 fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
     // V1 single-byte ABI: each slot is the 1-byte key `gpr & 0xFF`.
-    let image_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
-    let _cnode_slot = (frame.instance.cap.regs[8] & 0xFF) as u8;
-    let dst_slot = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
+    let image_slot = Key::from((frame.instance.regs[7] & 0xFF) as u8);
+    let _cnode_slot = (frame.instance.regs[8] & 0xFF) as u8;
+    let dst_slot = Key::from((frame.instance.regs[9] & 0xFF) as u8);
 
     // Reject a write to a pinned (read-only) slot — the interpreter rejects
     // this and traps (javm/src/ecall.rs); the recompiler must agree or the
@@ -1685,12 +1720,14 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
         return Ok(true);
     }
 
-    let image_hash = match cnode_peek_guest(frame, &image_slot) {
+    let image_hash = match with_cnode_peek_guest(frame, &image_slot, |cap_ref| match cap_ref {
+        Some(CapHashOrRef::Hash(h)) => *h,
+        Some(CapHashOrRef::Owned(_)) | None => frame.instance.image_hash,
+    }) {
         Err(_) => return Ok(true),
-        Ok(Some(CapHashOrRef::Hash(h))) => *h,
-        Ok(Some(CapHashOrRef::Owned(_))) | Ok(None) => frame.instance.cap.image_hash,
+        Ok(h) => h,
     };
-    let child_chain = Blake2b256::hash_pair(&frame.instance.cap.image_hash_chain, &image_hash);
+    let child_chain = Blake2b256::hash_pair(&frame.instance.image_hash_chain, &image_hash);
 
     // Build the child's initial memory from its Image (pinned RO + initial RW
     // sources folded at their VAs, source pages Arc-shared) — like the top-
@@ -1700,7 +1737,7 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
         let img_arc = CACHE
             .get(CapHashOrRef::Hash(image_hash))
             .ok_or(ERR_IMAGE_NOT_FOUND)?;
-        match &*img_arc {
+        match &img_arc.cap {
             Cap::Image(img) => build_instance_mem(&image_hash, img),
             _ => return Err(ERR_IMAGE_KIND),
         }
@@ -1721,11 +1758,12 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
     // moves it. Overwriting the slot drops any previous occupant's `CachedCap`
     // (and its parked page table), so a stale cache for that slot is
     // invalidated automatically — no separate side-table to maintain.
-    frame
-        .instance
-        .cnode
-        .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
-        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+    frame_cnode_set(
+        frame,
+        &dst_slot,
+        Some(CapHashOrRef::Owned(CachedCap::boxed(cap))),
+    )
+    .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
     Ok(false)
 }
 
@@ -1741,8 +1779,8 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
 /// Instance nor an Image), mirroring `dispatch_derive_spawn`'s trap discipline.
 fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
     // V1 single-byte ABI: φ[7] = src slot, φ[8] = dst slot.
-    let src_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
-    let dst_slot = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
+    let src_slot = Key::from((frame.instance.regs[7] & 0xFF) as u8);
+    let dst_slot = Key::from((frame.instance.regs[8] & 0xFF) as u8);
 
     // Writing into a pinned (read-only) slot traps, mirroring the
     // derive_spawn pinned-dst rejection.
@@ -1754,37 +1792,46 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
     // an Owned instance's parked page-table cache is untouched). Hash targets
     // resolve through the blob cache; an inline Owned instance reads its field
     // directly (no hash needed).
-    let chain: CapHash = match cnode_peek_guest(frame, &src_slot) {
-        Err(_) => return Ok(true),
-        Ok(Some(CapHashOrRef::Hash(h))) => {
-            let h = *h;
-            let arc = CACHE
-                .get(CapHashOrRef::Hash(h))
-                .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-            match &*arc {
-                Cap::Instance(i) => i.image_hash_chain,
-                // An Image is content-addressed: its hash IS its identity.
-                Cap::Image(_) => h,
-                _ => return Ok(true),
+    let chain: CapHash = match with_cnode_peek_guest(frame, &src_slot, |cap_ref| {
+        let chain = match cap_ref {
+            Some(CapHashOrRef::Hash(h)) => {
+                let h = *h;
+                let arc = match CACHE.get(CapHashOrRef::Hash(h)) {
+                    Some(arc) => arc,
+                    None => return Err(ERR_INSTANCE_NOT_FOUND),
+                };
+                match &arc.cap {
+                    Cap::Instance(i) => i.image_hash_chain,
+                    // An Image is content-addressed: its hash IS its identity.
+                    Cap::Image(_) => h,
+                    _ => return Ok(None),
+                }
             }
-        }
-        Ok(Some(CapHashOrRef::Owned(cc))) => match &cc.cap {
-            Cap::Instance(i) => i.image_hash_chain,
-            Cap::Image(_) => cc.cap.cap_hash(),
-            _ => return Ok(true),
-        },
-        Ok(None) => return Ok(true),
+            Some(CapHashOrRef::Owned(cc)) => match &cc.cap {
+                Cap::Instance(i) => i.image_hash_chain,
+                Cap::Image(_) => cc.cap.cap_hash(),
+                _ => return Ok(None),
+            },
+            None => return Ok(None),
+        };
+        Ok(Some(chain))
+    }) {
+        Err(_) => return Ok(true),
+        Ok(Err(e)) => return Err(e),
+        Ok(Ok(Some(chain))) => chain,
+        Ok(Ok(None)) => return Ok(true),
     };
 
     // Mint a Cap::Data of the 32 identity bytes (padded to a page) and place
     // it at dst as an inline Owned cap, settled at termination — same
     // placement convention as derive_spawn's child instance.
     let cap = Cap::data_inline(&chain);
-    frame
-        .instance
-        .cnode
-        .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
-        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+    frame_cnode_set(
+        frame,
+        &dst_slot,
+        Some(CapHashOrRef::Owned(CachedCap::boxed(cap))),
+    )
+    .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
     Ok(false)
 }
 
@@ -1794,10 +1841,10 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
 /// kernel-assisted handles this is used for (YieldSender / YieldReceiver) are
 /// tiny (a few registers + a small mem).
 fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
-    match frame.instance.cnode.peek_key(slot.as_slice())? {
+    with_cnode_peek(frame, slot, |cap_ref| match cap_ref? {
         CapHashOrRef::Hash(h) => {
             let arc = CACHE.get(CapHashOrRef::Hash(*h))?;
-            match &*arc {
+            match &arc.cap {
                 Cap::Instance(i) => Some(i.clone()),
                 _ => None,
             }
@@ -1806,7 +1853,7 @@ fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
             Cap::Instance(i) => Some(i.clone()),
             _ => None,
         },
-    }
+    })
 }
 
 fn read_instance_cap_guest(frame: &KernelFrame, slot: &Key) -> Result<Option<InstanceCap>, u32> {
@@ -1853,7 +1900,7 @@ fn dispatch_host_yield(
     gas: &mut i64,
     active: &Option<Key>,
 ) -> Result<YieldOutcome, u32> {
-    let sender_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
+    let sender_slot = Key::from((frame.instance.regs[7] & 0xFF) as u8);
     let yield_key = match read_instance_cap_guest(frame, &sender_slot) {
         Err(_) => return Ok(YieldOutcome::Trap),
         Ok(Some(inst)) => match javm_cap::yield_sender_key(&inst) {
@@ -1874,35 +1921,31 @@ fn dispatch_host_yield(
     let k = yield_key.as_slice();
 
     if k == javm_cap::yield_cap::YK_MINT_YIELD {
-        let new_key = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
-        let sender_dst = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
-        let receiver_dst = Key::from((frame.instance.cap.regs[10] & 0xFF) as u8);
+        let new_key = Key::from((frame.instance.regs[8] & 0xFF) as u8);
+        let sender_dst = Key::from((frame.instance.regs[9] & 0xFF) as u8);
+        let receiver_dst = Key::from((frame.instance.regs[10] & 0xFF) as u8);
         if slot_write_blocked(frame, &sender_dst) || slot_write_blocked(frame, &receiver_dst) {
             return Ok(YieldOutcome::Trap);
         }
         let sender = Cap::Instance(javm_cap::yield_sender(&new_key));
         let receiver = Cap::Instance(javm_cap::yield_receiver(&[new_key]));
-        frame
-            .instance
-            .cnode
-            .set(
-                &sender_dst,
-                Some(CapHashOrRef::Owned(CachedCap::boxed(sender))),
-            )
-            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
-        frame
-            .instance
-            .cnode
-            .set(
-                &receiver_dst,
-                Some(CapHashOrRef::Owned(CachedCap::boxed(receiver))),
-            )
-            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        frame_cnode_set(
+            frame,
+            &sender_dst,
+            Some(CapHashOrRef::Owned(CachedCap::boxed(sender))),
+        )
+        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        frame_cnode_set(
+            frame,
+            &receiver_dst,
+            Some(CapHashOrRef::Owned(CachedCap::boxed(receiver))),
+        )
+        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
         Ok(YieldOutcome::Inline)
     } else if k == javm_cap::yield_cap::YK_MERGE_YIELD_RECEIVER {
-        let a_slot = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
-        let b_slot = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
-        let dst = Key::from((frame.instance.cap.regs[10] & 0xFF) as u8);
+        let a_slot = Key::from((frame.instance.regs[8] & 0xFF) as u8);
+        let b_slot = Key::from((frame.instance.regs[9] & 0xFF) as u8);
+        let dst = Key::from((frame.instance.regs[10] & 0xFF) as u8);
         if slot_write_blocked(frame, &dst) {
             return Ok(YieldOutcome::Trap);
         }
@@ -1920,14 +1963,12 @@ fn dispatch_host_yield(
             Some(m) => m,
             None => return Ok(YieldOutcome::Trap), // operands not both receivers
         };
-        frame
-            .instance
-            .cnode
-            .set(
-                &dst,
-                Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(merged)))),
-            )
-            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        frame_cnode_set(
+            frame,
+            &dst,
+            Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(merged)))),
+        )
+        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
         Ok(YieldOutcome::Inline)
     } else if k == javm_cap::yield_cap::YK_MINT_GAS {
         // kernel:mint_gas(φ8=meter_key byte, φ9=dst): mint a Gas{meter_key}
@@ -1935,14 +1976,14 @@ fn dispatch_host_yield(
         // managed separately (set_gas_meter / the host meter table).
         mint_unit_handle(
             frame,
-            javm_cap::gas_handle(&Key::from((frame.instance.cap.regs[8] & 0xFF) as u8)),
+            javm_cap::gas_handle(&Key::from((frame.instance.regs[8] & 0xFF) as u8)),
         )
     } else if k == javm_cap::yield_cap::YK_MINT_QUOTA {
         // kernel:mint_quota(φ8=quota_key byte, φ9=dst): the storage-quota
         // analogue of mint_gas.
         mint_unit_handle(
             frame,
-            javm_cap::quota_handle(&Key::from((frame.instance.cap.regs[8] & 0xFF) as u8)),
+            javm_cap::quota_handle(&Key::from((frame.instance.regs[8] & 0xFF) as u8)),
         )
     } else if k == javm_cap::yield_cap::YK_SET_GAS_METER {
         // kernel:set_gas_meter(φ8=meter_key byte, φ9=value) -> previous (φ7).
@@ -1951,8 +1992,8 @@ fn dispatch_host_yield(
         // (e.g. a frame topping up the pool it itself loans from), the live `gas`
         // is authoritative, so set it directly and return its value; otherwise the
         // table entry is authoritative.
-        let meter_key = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
-        let value = frame.instance.cap.regs[9] as i64;
+        let meter_key = Key::from((frame.instance.regs[8] & 0xFF) as u8);
+        let value = frame.instance.regs[9] as i64;
         let previous = if active.as_ref() == Some(&meter_key) {
             let p = *gas;
             *gas = value;
@@ -1960,7 +2001,7 @@ fn dispatch_host_yield(
         } else {
             meters.insert(meter_key, value).unwrap_or(0)
         };
-        frame.instance.cap.regs[7] = previous as u64;
+        frame.instance.regs[7] = previous as u64;
         Ok(YieldOutcome::Inline)
     } else {
         // A kernel:* key not wired inline (oog / storage_exhausted / …): route it.
@@ -1978,18 +2019,16 @@ fn dispatch_host_yield(
 /// named by φ[9] (V1 single-byte ABI). Traps on a pinned dst. Shared by
 /// `kernel:mint_gas` / `kernel:mint_quota`.
 fn mint_unit_handle(frame: &mut KernelFrame, handle: InstanceCap) -> Result<YieldOutcome, u32> {
-    let dst = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
+    let dst = Key::from((frame.instance.regs[9] & 0xFF) as u8);
     if slot_write_blocked(frame, &dst) {
         return Ok(YieldOutcome::Trap);
     }
-    frame
-        .instance
-        .cnode
-        .set(
-            &dst,
-            Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(handle)))),
-        )
-        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+    frame_cnode_set(
+        frame,
+        &dst,
+        Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(handle)))),
+    )
+    .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
     Ok(YieldOutcome::Inline)
 }
 
@@ -2009,24 +2048,16 @@ fn dispatch_host_call(
     parent: &mut KernelFrame,
     logical_owner: usize,
 ) -> Result<Option<KernelFrame>, u32> {
-    let instance_slot = Key::from((parent.instance.cap.regs[7] & 0xFF) as u8);
-    let endpoint_idx = (parent.instance.cap.regs[8] & 0xFF) as u32;
-    let args = [
-        parent.instance.cap.regs[9],
-        parent.instance.cap.regs[10],
-        0,
-        0,
-    ];
+    let instance_slot = Key::from((parent.instance.regs[7] & 0xFF) as u8);
+    let endpoint_idx = (parent.instance.regs[8] & 0xFF) as u32;
+    let args = [parent.instance.regs[9], parent.instance.regs[10], 0, 0];
     if slot_is_pending(parent, &instance_slot) {
         return Ok(None);
     }
 
     // MOVE the target out of the parent cnode (zero-copy for `Owned`).
-    let target = parent
-        .instance
-        .cnode
-        .take_key(instance_slot.as_slice())
-        .ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
+    let target =
+        frame_cnode_take_key(parent, instance_slot.as_slice()).ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
     let origin = FrameOrigin {
         owner: logical_owner,
         slot: instance_slot.clone(),
@@ -2038,15 +2069,16 @@ fn dispatch_host_call(
         // instance back.
         CapHashOrRef::Owned(boxed) => {
             let CachedCap { cap, cache } = *boxed;
+            let cache = cache.into_inner();
             let mut child = build_frame_from_owned(cap, origin, endpoint_idx, args)?;
             // Page-table reuse: if this resident instance carries a parked
             // runtime (re-armed at its last HALT), move it into the child frame
             // instead of rebuilding the page table. The data extent is fixed
             // per image (immutable), so the parked extent must match.
-            if let CacheSlot::Instance(rt) = cache {
+            if let CapCache::Instance(rt) = cache {
                 debug_assert_eq!(
                     rt.data_extent(),
-                    child.instance.cap.mem.content_len(),
+                    child.instance.mem.content_len(),
                     "parked runtime extent must match the resident instance's mem",
                 );
                 child.runtime = Some(rt);
@@ -2060,7 +2092,7 @@ fn dispatch_host_call(
             let arc = CACHE
                 .get(CapHashOrRef::Hash(h))
                 .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-            let inst = match &*arc {
+            let inst = match &arc.cap {
                 Cap::Instance(i) => i.clone(),
                 _ => return Err(ERR_INSTANCE_KIND),
             };
@@ -2082,17 +2114,28 @@ fn dispatch_host_call(
     // `key_of` is payload-independent (it hashes the logical key); annotate
     // the generic so it resolves, matching the parent frame's cnode payload.
     let scratch_phys = CNodeCap::<Box<CachedCap>>::key_of(&[javm_cap::abi::SCRATCHPAD_SLOT]);
-    for (phys_key, val) in parent.instance.cnode.slots.iter() {
-        if *phys_key == scratch_phys {
-            continue;
+    let inherited: Vec<ResidentSlotEntry> = with_root_cnode(parent, |parent_cnode| {
+        parent_cnode
+            .slots
+            .iter()
+            .filter_map(|(phys_key, val)| {
+                if *phys_key == scratch_phys {
+                    return None;
+                }
+                if let MissingOr::Materialized(CapHashOrRef::Owned(_)) = val {
+                    return None;
+                }
+                Some((*phys_key, val.clone()))
+            })
+            .collect()
+    });
+    with_root_cnode_mut(&mut child, |child_cnode| {
+        for (phys_key, val) in inherited {
+            if child_cnode.slots.get(&phys_key).is_none() {
+                child_cnode.slots.insert(phys_key, val);
+            }
         }
-        if let MissingOr::Materialized(CapHashOrRef::Owned(_)) = val {
-            continue;
-        }
-        if child.instance.cnode.slots.get(phys_key).is_none() {
-            child.instance.cnode.slots.insert(*phys_key, val.clone());
-        }
-    }
+    });
     Ok(Some(child))
 }
 
@@ -2109,7 +2152,7 @@ fn call_frame_cost_for(image_hash: &CapHash) -> Result<i64, u32> {
     let img_arc = CACHE
         .get(CapHashOrRef::Hash(*image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
-    let img = match &*img_arc {
+    let img = match &img_arc.cap {
         Cap::Image(i) => i,
         _ => return Err(ERR_IMAGE_KIND),
     };
@@ -2138,26 +2181,26 @@ fn call_frame_cost_for(image_hash: &CapHash) -> Result<i64, u32> {
 /// `dispatch_host_call` will (same slot, same `Owned`/`Hash` handling), so
 /// the cost gated here equals the cost the built child would have.
 fn host_call_frame_cost(parent: &KernelFrame) -> Result<Option<i64>, u32> {
-    let instance_slot = Key::from((parent.instance.cap.regs[7] & 0xFF) as u8);
+    let instance_slot = Key::from((parent.instance.regs[7] & 0xFF) as u8);
     if slot_is_pending(parent, &instance_slot) {
         return Ok(None);
     }
-    let image_hash = match parent.instance.cnode.peek_key(instance_slot.as_slice()) {
+    let image_hash = with_cnode_peek(parent, &instance_slot, |cap_ref| match cap_ref {
         Some(CapHashOrRef::Owned(boxed)) => match &boxed.cap {
-            Cap::Instance(i) => i.image_hash,
-            _ => return Err(ERR_INSTANCE_KIND),
+            Cap::Instance(i) => Ok(i.image_hash),
+            _ => Err(ERR_INSTANCE_KIND),
         },
         Some(CapHashOrRef::Hash(h)) => {
             let arc = CACHE
                 .get(CapHashOrRef::Hash(*h))
                 .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-            match &*arc {
-                Cap::Instance(i) => i.image_hash,
-                _ => return Err(ERR_INSTANCE_KIND),
+            match &arc.cap {
+                Cap::Instance(i) => Ok(i.image_hash),
+                _ => Err(ERR_INSTANCE_KIND),
             }
         }
-        None => return Err(ERR_HOST_CALL_SLOT_EMPTY),
-    };
+        None => Err(ERR_HOST_CALL_SLOT_EMPTY),
+    })?;
     call_frame_cost_for(&image_hash).map(Some)
 }
 
@@ -2173,7 +2216,7 @@ fn build_frame_from_published(
     let arc = CACHE
         .get(CapHashOrRef::Hash(*instance_hash))
         .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-    let inst = match &*arc {
+    let inst = match &arc.cap {
         Cap::Instance(i) => i.clone(),
         _ => return Err(ERR_INSTANCE_KIND),
     };
@@ -2208,28 +2251,26 @@ fn build_frame_from_instance(
     build_frame_inner(inst, origin, endpoint_idx, args)
 }
 
-fn seed_cnode_from_root(
-    root_cnode: &CapHashOrRef,
-    cnode: &mut CNodeCap<Box<CachedCap>>,
-) -> Result<(), u32> {
+fn materialize_root_cnode(root_cnode: &CapHashOrRef) -> Result<ResidentCNode, u32> {
+    let mut cnode = ResidentCNode::new();
     match root_cnode {
-        CapHashOrRef::Hash(h) if *h == [0u8; 32] => Ok(()),
+        CapHashOrRef::Hash(h) if *h == [0u8; 32] => Ok(cnode),
         CapHashOrRef::Hash(h) => {
             let rc_arc = CACHE
                 .get(CapHashOrRef::Hash(*h))
                 .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-            let Cap::CNode(cn) = &*rc_arc else {
+            let Cap::CNode(cn) = &rc_arc.cap else {
                 return Err(ERR_INSTANCE_KIND);
             };
-            copy_wire_cnode_into_cached(cn, cnode);
-            Ok(())
+            copy_wire_cnode_into_cached(cn, &mut cnode);
+            Ok(cnode)
         }
         CapHashOrRef::Owned(boxed) => {
             let Cap::CNode(cn) = &**boxed else {
                 return Err(ERR_INSTANCE_KIND);
             };
-            copy_wire_cnode_into_cached(cn, cnode);
-            Ok(())
+            copy_wire_cnode_into_cached(cn, &mut cnode);
+            Ok(cnode)
         }
     }
 }
@@ -2247,27 +2288,64 @@ fn copy_wire_cnode_into_cached(src: &CNodeCap<Box<Cap>>, dst: &mut CNodeCap<Box<
 fn wire_target_to_cached(target: &CapHashOrRef<Box<Cap>>) -> CapHashOrRef<Box<CachedCap>> {
     match target {
         CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
-        CapHashOrRef::Owned(b) => CapHashOrRef::Owned(CachedCap::boxed((**b).clone())),
+        CapHashOrRef::Owned(b) => match &**b {
+            Cap::CNode(cn) => {
+                let mut cnode = ResidentCNode::new();
+                copy_wire_cnode_into_cached(cn, &mut cnode);
+                CapHashOrRef::Owned(CachedCap::boxed_cnode(cnode))
+            }
+            other => CapHashOrRef::Owned(CachedCap::boxed(other.clone())),
+        },
     }
 }
 
-fn cached_target_to_wire(target: &CapHashOrRef<Box<CachedCap>>) -> CapHashOrRef<Box<Cap>> {
+fn cached_target_to_wire_ref(target: &CapHashOrRef<Box<CachedCap>>) -> CapHashOrRef<Box<Cap>> {
     match target {
         CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
-        CapHashOrRef::Owned(boxed) => CapHashOrRef::Owned(Box::new(boxed.cap.clone())),
+        CapHashOrRef::Owned(boxed) => CapHashOrRef::Owned(Box::new(cached_cap_to_wire_ref(boxed))),
     }
 }
 
-fn fold_frame_cnode_to_wire(cnode: CNodeCap<Box<CachedCap>>) -> CNodeCap<Box<Cap>> {
+fn cached_cap_to_wire_ref(cap: &CachedCap) -> Cap {
+    let cache = cap.cache.lock();
+    match &*cache {
+        CapCache::CNode(cnode) => Cap::CNode(fold_frame_cnode_to_wire_ref(cnode)),
+        CapCache::None | CapCache::Image(_) | CapCache::Instance(_) => cap.cap.clone(),
+    }
+}
+
+fn fold_frame_cnode_to_wire_ref(cnode: &ResidentCNode) -> CNodeCap<Box<Cap>> {
     let mut out = CNodeCap::new();
     for (k, mo) in cnode.slots.iter() {
         let conv = match mo {
-            MissingOr::Materialized(t) => MissingOr::Materialized(cached_target_to_wire(t)),
+            MissingOr::Materialized(t) => MissingOr::Materialized(cached_target_to_wire_ref(t)),
             MissingOr::Missing(h) => MissingOr::Missing(*h),
         };
         out.slots.insert(*k, conv);
     }
     out
+}
+
+fn resident_instance_to_wire(inst: ResidentInstance) -> Result<InstanceCap, u32> {
+    let root_cnode = match &inst.root_cnode {
+        CapHashOrRef::Owned(root) => {
+            let cache = root.cache.lock();
+            let CapCache::CNode(cnode) = &*cache else {
+                return Err(ERR_INSTANCE_KIND);
+            };
+            CapHashOrRef::Owned(Box::new(Cap::CNode(fold_frame_cnode_to_wire_ref(cnode))))
+        }
+        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
+    };
+    Ok(InstanceCap {
+        image_hash_chain: inst.image_hash_chain,
+        image_hash: inst.image_hash,
+        root_cnode,
+        mem: inst.mem,
+        regs: inst.regs,
+        pc: inst.pc,
+        gas_remaining: inst.gas_remaining,
+    })
 }
 
 // `build_frame_from_instance_ref` / `build_frame_from_cap` were removed: a
@@ -2290,7 +2368,7 @@ fn build_frame_inner(
     let img_arc = CACHE
         .get(CapHashOrRef::Hash(image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
-    let img = match &*img_arc {
+    let img = match &img_arc.cap {
         Cap::Image(i) => i,
         _ => return Err(ERR_IMAGE_KIND),
     };
@@ -2320,15 +2398,10 @@ fn build_frame_inner(
     cap.pc = ep.entry_pc;
     cap.gas_remaining = 0;
 
-    let mut cnode: CNodeCap<Box<CachedCap>> = CNodeCap::new();
-    // Seed the persistent state from the instance's root cnode first. This is
-    // how arbitrary caps — `Cap::Instance` (YieldSenders, sub-VM handles) that
-    // can't be pinned, plus carried-over mutable slots — flow to the guest. A
-    // published root cnode holds only `Hash` entries; an inline `Owned` (in
-    // principle) deep-clones into the frame's `CachedCap` form. Entries are
-    // copied by raw radix key (the cnode is keyed by `Hasher(Key)`, so the
-    // logical key isn't recoverable to re-`set`).
-    seed_cnode_from_root(&root_cnode, &mut cnode)?;
+    let mut cnode = materialize_root_cnode(&root_cnode)?;
+    // The persistent root cnode is now resident in `cap.root_cnode` itself:
+    // arbitrary caps flow through this cache-carrying CNode, while image pinned
+    // and initial slots overlay/fill it below.
     // Image pinned slots overlay the root-cnode state (image-authoritative:
     // pinned content is swapped as a unit at set_image), then initial slots
     // fill only still-empty slots (bootstrap-only).
@@ -2360,8 +2433,17 @@ fn build_frame_inner(
     // The cap-backed mappings (their PAs + pinned/initial kind) are
     // resolved in `build_runtime` when the per-frame runtime is built;
     // nothing mapping-related is needed on the frame itself.
+    let instance = ResidentInstance {
+        image_hash_chain: cap.image_hash_chain,
+        image_hash: cap.image_hash,
+        root_cnode: CapHashOrRef::Owned(CachedCap::boxed_cnode(cnode)),
+        mem: cap.mem,
+        regs: cap.regs,
+        pc: cap.pc,
+        gas_remaining: cap.gas_remaining,
+    };
     Ok(KernelFrame {
-        instance: RunningInstance { cap, cnode },
+        instance,
         origin,
         pending_origins: BTreeSet::new(),
         pinned,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1214,11 +1214,16 @@ fn build_frame_inner(
         _ => return Err(ERR_IMAGE_KIND),
     };
 
-    let endpoint = endpoint_idx as usize;
-    if endpoint >= img.endpoints.len() {
-        return Err(ERR_ENDPOINT_OOB);
-    }
-    let ep = &img.endpoints[endpoint];
+    // V1 single-byte ABI: the endpoint selector is the low byte of
+    // `endpoint_idx`, looked up as a Key in the sparse endpoint list. An absent
+    // key is an undefined endpoint.
+    let target = Key::from((endpoint_idx & 0xFF) as u8);
+    let ep = img
+        .endpoints
+        .iter()
+        .find(|(k, _)| *k == target)
+        .map(|(_, ep)| ep)
+        .ok_or(ERR_ENDPOINT_OOB)?;
 
     let mut regs = ep.initial_regs;
     if let Some(inst_regs) = inst_regs {

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -336,6 +336,18 @@ struct StackEntry {
     /// sub-call — a frame cannot shrink its catch-set mid-flight to dodge a
     /// descendant's yield (spec §3 "frozen for the sub-call").
     catch_set: Vec<Key>,
+    /// This frame's gas meter, when it runs on its OWN balance drawn from the
+    /// guest meter table (its `gas_slots[0]` → `Gas{meter_key}` had a funded
+    /// entry at CALL). `None` = the frame *loans* the caller's pool — it debits
+    /// the threaded `gas` directly and returns the remainder to the caller at
+    /// HALT (the one-pool subtree model, the default for non-metered sub-VMs and
+    /// the host-budgeted top frame). `Some(k)` = metered: the live `gas` was
+    /// swapped to `meters[k]` at CALL and is written back to `meters[k]` at HALT.
+    meter: Option<Key>,
+    /// The caller's pool, saved when this frame swapped the live `gas` to its own
+    /// meter balance at CALL; restored into `gas` when this frame pops. `Some`
+    /// iff [`Self::meter`] is `Some`.
+    saved_gas: Option<i64>,
 }
 
 impl StackEntry {
@@ -348,8 +360,23 @@ impl StackEntry {
             target: index,
             instance_id,
             catch_set: Vec::new(),
+            meter: None,
+            saved_gas: None,
         }
     }
+}
+
+/// Resolve a frame's active gas meter: read its Image's `gas_slots[0]`, look that
+/// slot up in the frame's cnode, and decode the `Gas{meter_key}` handle there.
+/// `None` if the Image declares no gas slot, the slot is empty, or it doesn't
+/// hold a `Gas` handle (the frame then loans its caller's pool).
+fn resolve_frame_meter(frame: &KernelFrame) -> Option<Key> {
+    let img_arc = CACHE.get(CapHashOrRef::Hash(frame.image_hash))?;
+    let slot = match &*img_arc {
+        Cap::Image(i) => i.gas_slots.first()?.clone(),
+        _ => return None,
+    };
+    javm_cap::gas_meter_key(&read_instance_cap(frame, &slot)?)
 }
 
 /// `&mut` to the [`KernelFrame`] the entry at `idx` runs, following a
@@ -468,7 +495,14 @@ pub fn run_top(
     let mut next_iid: u64 = 0;
     stack.push(StackEntry::instance(top, 0, next_iid));
     next_iid += 1;
+    // The threaded `gas` is the RUNNING frame's live balance: the host-budgeted
+    // top pool, a loaned caller pool, or a metered frame's own balance. The guest
+    // meter table holds balances NAMED by `Gas{meter_key}` and funded via
+    // `kernel:set_gas_meter`; a metered frame draws its balance here at CALL and
+    // writes the remainder back at HALT. Per-RPC (a block-spanning table is the
+    // deferred lazy-load piece); the top frame's meter stays host-owned.
     let mut gas = initial_gas;
+    let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
 
     let outcome = loop {
         let top_idx = stack.len() - 1;
@@ -510,7 +544,7 @@ pub fn run_top(
                 } else {
                     [0u8; SCRATCHPAD_HEAD_LEN]
                 };
-                if pop_and_reflect(&mut stack, info.regs[7]) {
+                if pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters) {
                     break LoopOutcome {
                         exit_reason: info.exit_reason,
                         exit_arg: info.exit_arg,
@@ -567,7 +601,7 @@ pub fn run_top(
                         } else {
                             [0u8; SCRATCHPAD_HEAD_LEN]
                         };
-                        if pop_and_reflect(&mut stack, info.regs[7]) {
+                        if pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters) {
                             // Preserve the JIT exit shape so the host bench
                             // harness (which asserts `(reason=4, arg=0)` for the
                             // subsoil trampoline halt) doesn't trip.
@@ -617,7 +651,7 @@ pub fn run_top(
                     OP_HOST_YIELD => {
                         let outcome = {
                             let frame = frame_at_mut(&mut stack, top_idx);
-                            dispatch_host_yield(frame)?
+                            dispatch_host_yield(frame, &mut meters)?
                         };
                         match outcome {
                             // A kernel-root pure-cap syscall handled inline; the
@@ -694,6 +728,8 @@ pub fn run_top(
                                     target,
                                     instance_id: recv_iid,
                                     catch_set: Vec::new(),
+                                    meter: None,
+                                    saved_gas: None,
                                 });
                             }
                         }
@@ -795,6 +831,20 @@ pub fn run_top(
                         let child_idx = stack.len();
                         stack.push(StackEntry::instance(child, child_idx, next_iid));
                         next_iid += 1;
+                        // Per-frame metering: if the child names a gas meter
+                        // (`gas_slots[0]` → `Gas{meter_key}`) that the guest table
+                        // funds, it runs on THAT balance — save the caller's pool
+                        // to restore at the child's HALT, swap the live `gas` to
+                        // the meter balance. Otherwise the child loans the caller's
+                        // pool (the live `gas` threads in unchanged), preserving
+                        // the one-pool subtree model for non-metered sub-VMs.
+                        if let Some(k) = resolve_frame_meter(frame_at(&stack, child_idx))
+                            && let Some(&balance) = meters.get(&k)
+                        {
+                            stack[child_idx].meter = Some(k);
+                            stack[child_idx].saved_gas = Some(gas);
+                            gas = balance;
+                        }
                     }
                     // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
                     // arbitrary `ecalli imm`, …) is not in-kernel-
@@ -980,11 +1030,30 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
 /// move it back into the parent's origin slot (the single-owner round trip).
 /// Returns `true` when the stack has been drained (the RPC caller hands a
 /// result back to the host).
-fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
+///
+/// Gas: when the popped frame was metered ([`StackEntry::meter`] = `Some(k)`),
+/// its remaining `gas` is written back to `meters[k]` and the caller's pool is
+/// restored from `saved_gas`. A loaned frame (`meter` = `None`) leaves `gas`
+/// threaded as-is (its remainder flows to the caller — the one-pool model).
+fn pop_and_reflect(
+    stack: &mut Vec<StackEntry>,
+    return_value: u64,
+    gas: &mut i64,
+    meters: &mut BTreeMap<Key, i64>,
+) -> bool {
     // A HALT/REPLY only pops an InstanceEntry — a ReferenceEntry (handler
     // activation) is removed by CALL_RESUME, and a handler that HALTs without
     // resuming is caught by the EXIT_HALT/OP_REPLY guards before this point.
-    let mut popped = match stack.pop().expect("non-empty").kind {
+    let popped_entry = stack.pop().expect("non-empty");
+    // Metered frame: write the remaining balance back to its meter and restore
+    // the caller's pool (done before reflection — independent of the cap moves).
+    if let Some(k) = &popped_entry.meter {
+        meters.insert(k.clone(), *gas);
+        if let Some(saved) = popped_entry.saved_gas {
+            *gas = saved;
+        }
+    }
+    let mut popped = match popped_entry.kind {
         EntryKind::Instance(boxed) => *boxed,
         EntryKind::Reference => unreachable!("pop_and_reflect on a ReferenceEntry"),
     };
@@ -1349,7 +1418,12 @@ enum YieldOutcome {
 /// φ[10] = YieldReceiver dst. `kernel:merge_yield_receiver`: φ[8] = receiver A
 /// slot, φ[9] = receiver B slot, φ[10] = dst slot. `kernel:mint_gas` /
 /// `kernel:mint_quota`: φ[8] = meter_key / quota_key byte, φ[9] = handle dst.
-fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<YieldOutcome, u32> {
+/// `kernel:set_gas_meter`: φ[8] = meter_key byte, φ[9] = value; returns the
+/// previous balance in φ[7].
+fn dispatch_host_yield(
+    frame: &mut KernelFrame,
+    meters: &mut BTreeMap<Key, i64>,
+) -> Result<YieldOutcome, u32> {
     let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
     let yield_key = match read_instance_cap(frame, &sender_slot) {
         Some(inst) => match javm_cap::yield_sender_key(&inst) {
@@ -1431,8 +1505,20 @@ fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<YieldOutcome, u32> {
             frame,
             javm_cap::quota_handle(&Key::from((frame.regs[8] & 0xFF) as u8)),
         )
+    } else if k == javm_cap::yield_cap::YK_SET_GAS_METER {
+        // kernel:set_gas_meter(φ8=meter_key byte, φ9=value) -> previous (φ7).
+        // Atomically set the guest meter balance and return the previous (0 if
+        // absent) — the chain's topup / harvest primitive. The new balance takes
+        // effect when a frame next READS this meter (a CALL or CALL_RESUME of an
+        // instance whose gas_slots[0] names it), per the frame-entry metering
+        // model — it does not retroactively change a live pool.
+        let meter_key = Key::from((frame.regs[8] & 0xFF) as u8);
+        let value = frame.regs[9] as i64;
+        let previous = meters.insert(meter_key, value).unwrap_or(0);
+        frame.regs[7] = previous as u64;
+        Ok(YieldOutcome::Inline)
     } else {
-        // A kernel:* key not wired inline (set_gas_meter / oog / …): route it.
+        // A kernel:* key not wired inline (oog / storage_exhausted / …): route it.
         // The kernel root catches kernel:* keys the chain registered in its
         // YieldReceiver (e.g. kernel:oog); an unregistered key finds no catcher
         // and the emitter faults.

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -119,6 +119,15 @@ const EXIT_ECALL: u32 = 6;
 const EXIT_TRAP: u32 = 7;
 
 const OP_REPLY: u32 = 0;
+/// `host_yield(sender_slot=φ[7], …)` — emit the yield_key carried by the
+/// YieldSender at `sender_slot`. `kernel:*` keys are caught by the kernel as
+/// the implicit ROOT receiver and handled INLINE (the guest resumes at the next
+/// instruction, like a hostcall — the "syscalls conceptually push a kernel
+/// frame but we don't actually push" model). Wired today: the pure-cap syscalls
+/// `kernel:mint_yield` / `kernel:merge_yield_receiver`. Gas/quota syscalls (need
+/// the meter table) and user-key routing to an ancestor YieldReceiver (needs
+/// suspension) are later stages.
+const OP_HOST_YIELD: u32 = 16;
 const OP_DERIVE_SPAWN: u32 = 18;
 /// `host_image_hash_chain(src_slot=φ[7], dst_slot=φ[8])` — read the cap's
 /// kernel-attested type identity (an Instance's cumulative `image_hash_chain`,
@@ -159,6 +168,13 @@ const ERR_HOST_CALL_SLOT_EMPTY: u32 = 40;
 const ERR_JIT_FAILED: u32 = 50;
 const ERR_DEPTH_LIMIT: u32 = 51;
 const ERR_MAP_BAD_KIND: u32 = 60;
+/// `host_yield` carried a yield_key the kernel does not (yet) handle as root
+/// receiver — a non-`kernel:*` user key (ancestor routing is a later stage) or
+/// a `kernel:*` syscall not yet wired (gas/quota/oog).
+const ERR_YIELD_UNHANDLED: u32 = 70;
+/// A `host_yield` operand slot did not hold the expected kernel-assisted
+/// Instance (YieldSender / YieldReceiver).
+const ERR_YIELD_BAD_SENDER: u32 = 71;
 
 /// One stack frame on the in-kernel call stack. Holds the running Image's
 /// identity hashes, the frame's **owned** `mem` DataCap + PVM register/PC
@@ -428,6 +444,22 @@ pub fn run_top(
                         };
                         if trapped {
                             // Pinned/empty dst or wrong src kind → guest trap.
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: gas,
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
+                    }
+                    OP_HOST_YIELD => {
+                        let trapped = {
+                            let frame = stack.last_mut().expect("non-empty");
+                            dispatch_host_yield(frame)?
+                        };
+                        if trapped {
+                            // Bad/empty sender slot or pinned dst → guest trap.
                             break LoopOutcome {
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
@@ -983,6 +1015,110 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
         .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
         .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
     Ok(false)
+}
+
+/// Read an owned `InstanceCap` from a frame cnode slot — a `Hash` resolves
+/// through the blob cache, an inline `Owned` reads its boxed cap. `None` if the
+/// slot is empty or doesn't hold a `Cap::Instance`. Clones, but the
+/// kernel-assisted handles this is used for (YieldSender / YieldReceiver) are
+/// tiny (a few registers + a small mem).
+fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
+    match frame.cnode.peek_key(slot.as_slice())? {
+        CapHashOrRef::Hash(h) => {
+            let arc = CACHE.get(CapHashOrRef::Hash(*h))?;
+            match &*arc {
+                Cap::Instance(i) => Some(i.clone()),
+                _ => None,
+            }
+        }
+        CapHashOrRef::Owned(cc) => match &cc.cap {
+            Cap::Instance(i) => Some(i.clone()),
+            _ => None,
+        },
+    }
+}
+
+/// `host_yield(sender_slot=φ[7], …)`. Reads the `YieldSender` at `sender_slot`,
+/// extracts its yield_key, and — for a `kernel:*` key the kernel handles as the
+/// implicit root receiver — performs the syscall INLINE and resumes the guest
+/// (`Ok(false)`, like derive_spawn). Returns `Ok(true)` to TRAP (bad/empty
+/// sender, pinned dst, malformed operand); `Err(code)` for a yield_key not yet
+/// handled here (user keys, or kernel:* syscalls deferred to later stages).
+///
+/// V1 single-byte ABI: all slot operands are the low byte of their φ register.
+/// `kernel:mint_yield`: φ[8] = new yield_key byte, φ[9] = YieldSender dst,
+/// φ[10] = YieldReceiver dst. `kernel:merge_yield_receiver`: φ[8] = receiver A
+/// slot, φ[9] = receiver B slot, φ[10] = dst slot.
+fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<bool, u32> {
+    let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
+    let yield_key = match read_instance_cap(frame, &sender_slot) {
+        Some(inst) => match javm_cap::yield_sender_key(&inst) {
+            Some(k) => k,
+            None => return Ok(true), // not a YieldSender → trap
+        },
+        None => return Ok(true), // empty / non-Instance sender slot → trap
+    };
+
+    // Only kernel:* keys are caught here (kernel = implicit root receiver).
+    // Routing a user key to an ancestor YieldReceiver needs the suspension
+    // mechanism — a later stage.
+    if !javm_cap::is_kernel_yield_key(&yield_key) {
+        return Err(ERR_YIELD_UNHANDLED);
+    }
+    let k = yield_key.as_slice();
+
+    if k == javm_cap::yield_cap::YK_MINT_YIELD {
+        let new_key = Key::from((frame.regs[8] & 0xFF) as u8);
+        let sender_dst = Key::from((frame.regs[9] & 0xFF) as u8);
+        let receiver_dst = Key::from((frame.regs[10] & 0xFF) as u8);
+        if frame.pinned.binary_search(&sender_dst).is_ok()
+            || frame.pinned.binary_search(&receiver_dst).is_ok()
+        {
+            return Ok(true);
+        }
+        let sender = Cap::Instance(javm_cap::yield_sender(&new_key));
+        let receiver = Cap::Instance(javm_cap::yield_receiver(&[new_key]));
+        frame
+            .cnode
+            .set(
+                &sender_dst,
+                Some(CapHashOrRef::Owned(CachedCap::boxed(sender))),
+            )
+            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        frame
+            .cnode
+            .set(
+                &receiver_dst,
+                Some(CapHashOrRef::Owned(CachedCap::boxed(receiver))),
+            )
+            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        Ok(false)
+    } else if k == javm_cap::yield_cap::YK_MERGE_YIELD_RECEIVER {
+        let a_slot = Key::from((frame.regs[8] & 0xFF) as u8);
+        let b_slot = Key::from((frame.regs[9] & 0xFF) as u8);
+        let dst = Key::from((frame.regs[10] & 0xFF) as u8);
+        if frame.pinned.binary_search(&dst).is_ok() {
+            return Ok(true);
+        }
+        let a = read_instance_cap(frame, &a_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
+        let b = read_instance_cap(frame, &b_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
+        let merged = match javm_cap::merge_yield_receivers(&a, &b) {
+            Some(m) => m,
+            None => return Ok(true), // operands not both YieldReceivers → trap
+        };
+        frame
+            .cnode
+            .set(
+                &dst,
+                Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(merged)))),
+            )
+            .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+        Ok(false)
+    } else {
+        // kernel:set_gas_meter / mint_gas / oog / … need the (guest-side) meter
+        // table or the suspension mechanism — later stages.
+        Err(ERR_YIELD_UNHANDLED)
+    }
 }
 
 /// `host_call(instance_slot=φ[7], endpoint_idx=φ[8])`. **Moves** the target

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -21,7 +21,7 @@
 //! ## V1 simplifications
 //!
 //! - **The frame owns its mem.** Each [`KernelFrame`] holds its
-//!   read-write memory as an owned [`DataCap`] (`frame.mem`), cloned
+//!   read-write memory as an owned [`DataCap`] (`frame.instance.cap.mem`), cloned
 //!   from the running Instance at build. The CoW #PF handler writes
 //!   dirtied pages straight into the cap's `overlay`, so the cap is
 //!   the source of truth: a runtime rebuilt after a future reclamation
@@ -30,25 +30,24 @@
 //!   pop (Phase 2 does not yet propagate it upward — see the data-flow
 //!   section).
 //!
-//! - **Sub-VM instances are inline `Owned` caps.** `derive_spawn`
-//!   builds a fresh `Cap::Instance` and stores it directly in the
-//!   parent's cnode slot as [`CapHashOrRef::Owned`] — no cache publish,
-//!   no `CapRef`. `host_call` then **moves** that instance out of the
-//!   slot (`take_key`, zero copy) into the child frame; at HALT the
-//!   frame's final mem/regs/pc fold back into the instance and it moves
-//!   back into the parent's slot. The instance has exactly one owner at
-//!   every instant (parent slot → child frame → parent slot). A
-//!   host-published `Hash` instance is the only `host_call` target that
-//!   is *not* consumed (the hash is reinserted; the blob is read-only).
+//! - **CALL moves the Instance into a frame.** `derive_spawn` builds a
+//!   fresh `Cap::Instance` and stores it directly in the parent's cnode
+//!   slot as [`CapHashOrRef::Owned`] — no cache publish, no `CapRef`.
+//!   `host_call` moves either an inline `Owned` instance or a
+//!   host-published `Hash` instance out of the caller's slot into the
+//!   child frame. The caller's origin slot stays physically empty and
+//!   kernel-reserved until HALT restores the updated instance or a V1
+//!   discard clears the reservation and leaves it empty. The instance
+//!   has exactly one live owner at every instant (owner slot → child
+//!   frame → owner slot, or owner slot → child frame → discarded).
 //!
 //! - **Per-frame cnode snapshot.** Top frame's cnode is seeded from
 //!   the running `Cap::Instance`'s `root_cnode` (now walkable from
 //!   the guest after the SSZ `SparseList` allocator-genericity
 //!   change); child frames inherit the parent's cnode entries. The
-//!   in-frame cnode is mutable (slot writes via `derive_spawn`); the
-//!   underlying `Cap::CNode` in the cache is read-only. A follow-up
-//!   commit will migrate writes into the cache via `cap_make_mut` so
-//!   the cnode lives entirely in cache.instances.
+//!   in-frame cnode is mutable (slot writes via `derive_spawn`); on
+//!   HALT it is folded back into the returned `InstanceCap.root_cnode`
+//!   with nested runtime caches stripped.
 //!
 //! ## Data-flow principle and dirty pages
 //!
@@ -91,7 +90,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 
@@ -203,57 +202,32 @@ const ERR_YIELD_BAD_SENDER: u32 = 71;
 const ERR_GAS_SLOT_EMPTY: u32 = 72;
 /// A declared gas slot was present but did not resolve to a Gas handle.
 const ERR_GAS_SLOT_INVALID: u32 = 73;
+/// A frame attempted to persist while it still owns running children, or a
+/// private restore found no matching origin reservation. This is a kernel
+/// bookkeeping invariant, not a guest-visible trap.
+const ERR_PENDING_ORIGIN_INVARIANT: u32 = 74;
 
-/// One stack frame on the in-kernel call stack. Holds the running Image's
-/// identity hashes, the frame's **owned** `mem` DataCap + PVM register/PC
-/// state, its cnode snapshot, and the ring-3 resource cache. The Image cap
-/// is resolved from the heap-resident [`CACHE`] on access (blobs never evict
-/// mid-RPC); the running Instance's memory is owned outright (`mem`), not
-/// re-resolved from the cache.
+/// One stack frame on the in-kernel call stack. Holds the running Instance
+/// value, the origin reservation metadata for the owner slot it came from, and
+/// the ring-3 resource cache. The Image cap is resolved from the heap-resident
+/// [`CACHE`] on access (blobs never evict mid-RPC); the running Instance's
+/// memory is owned outright by [`RunningInstance::cap`], not re-resolved from
+/// the cache.
 pub struct KernelFrame {
-    /// Content hash of the Image cap this frame runs. Resolved via
-    /// `CACHE.lock().get(CapHashOrRef::Hash(image_hash))` at each access.
-    image_hash: CapHash,
-    /// Image's chain hash. Used by `derive_spawn` to compute the
-    /// child's chain. Cached locally to avoid a cap deref per
-    /// derive.
-    image_hash_chain: CapHash,
-    /// The parent cnode slot to return this instance to, set when the frame was
-    /// built by moving an `Owned` sub-VM out of that slot (`host_call` of a
-    /// `derive_spawn`'d instance). The instance is fully **decomposed** into
-    /// this frame's own fields — `image_hash` / `image_hash_chain` (identity),
-    /// [`Self::mem`], [`Self::regs`], [`Self::pc`] — so only the return slot
-    /// needs remembering; at HALT [`pop_and_reflect`] reconstructs the
-    /// `InstanceCap` from those fields, boxes it `Owned`, and moves it back into
-    /// the slot — the single-owner round trip. `None` for a top-level /
-    /// host-published (`Hash`) frame (nothing to return).
-    owned_origin: Option<Key>,
-    /// The frame's **owned** read-write memory: a [`DataCap`] cloned from the
-    /// running Instance at frame build (Arc-backing bump + empty overlay). The
-    /// #PF handler copy-on-writes guest writes straight into its `overlay`
-    /// (via `jit_run::OVERLAY_SINK`), so the cap is the source of truth — a
-    /// runtime rebuilt after a future reclamation (host-backed swap) sources the
-    /// overlay page, not the immutable backing, so writes are never lost.
-    /// Dropped at frame pop (Phase 2 does not yet propagate it to the parent or
-    /// persist it — see the module doc).
-    mem: DataCap,
-    /// Live PVM register file. Written by the JIT on every entry/
-    /// exit.
-    regs: [u64; NUM_REGS],
-    /// Current PVM PC. Same lifecycle as `regs`.
-    pc: u32,
-    /// Per-frame cnode snapshot: the radix kv-map (`Hasher(Key) ->
-    /// CapHashOrRef<Box<CachedCap>>`) seeded from the running `Cap::Instance`'s
-    /// image (pinned/initial, as `Hash` entries) and grown by `derive_spawn`
-    /// (as inline `Owned(CachedCap)`). No fixed slot count — a normal
-    /// `CNodeCap`. The payload is [`CachedCap`] — a cap plus its engine-private
-    /// page-table cache — so a resident sub-VM's runtime rides *with* the cap
-    /// in its slot (no parent-side side-table). CNode ops run only in the
-    /// call-loop dispatch (ring 0 after the JIT context switch), so the
-    /// kernel-heap `RadixMap` is live; the JIT-compiled guest code never
-    /// touches this directly. The `CachedCap` payload is deliberately
-    /// non-wire-serialisable, so this cnode cannot be hashed or shipped.
-    cnode: CNodeCap<Box<CachedCap>>,
+    /// Runtime form of the Instance this frame owns.
+    instance: RunningInstance,
+    /// The owner frame + cnode slot this running Instance was moved out of.
+    /// While this frame is on the kernel stack that origin slot is physically
+    /// empty and recorded in the owner's [`Self::pending_origins`], so ordinary
+    /// guest reads/writes/CALLs against it trap like pinned-slot misuse.
+    /// `None` only for the top-level invocation.
+    origin: Option<FrameOrigin>,
+    /// Direct cnode slots whose Instance caps are currently running in child
+    /// frames. The slots are empty in `cnode`; this side metadata reserves them
+    /// until the child returns (private restore path) or is discarded (clear and
+    /// leave empty). V1 uses direct byte slots; future nested cnode paths should
+    /// replace `Key` with a `SlotPath`.
+    pending_origins: BTreeSet<Key>,
     /// Slot keys this frame's image declares pinned (read-only), sorted —
     /// the recompiler's mirror of the interpreter's
     /// `InstanceEntry.pinned_slots`. A write to one of these (e.g. a
@@ -295,6 +269,26 @@ pub struct KernelFrame {
     /// page tables match the no-cache case (one per stack frame, plus the
     /// just-popped child).
     runtime: Option<FrameRuntime>,
+}
+
+struct RunningInstance {
+    /// The public Instance payload, kept whole while the frame runs. Its
+    /// `root_cnode` field is a placeholder while live because the actual
+    /// runtime cnode needs `CachedCap` entries and is carried in [`Self::cnode`].
+    cap: InstanceCap,
+    /// Runtime root cnode: the radix kv-map (`Hasher(Key) ->
+    /// CapHashOrRef<Box<CachedCap>>`) seeded from `cap.root_cnode` and grown by
+    /// cnode operations. The payload is [`CachedCap`] — a cap plus its
+    /// engine-private page-table cache — so a resident sub-VM's runtime rides
+    /// with the cap in its slot. This cnode is deliberately non-wire-
+    /// serialisable and is folded back into `cap.root_cnode` on frame return.
+    cnode: CNodeCap<Box<CachedCap>>,
+}
+
+#[derive(Clone, Debug)]
+struct FrameOrigin {
+    owner: usize,
+    slot: Key,
 }
 
 /// What a kernel call-stack entry runs.
@@ -423,7 +417,7 @@ impl FrameGas {
 /// is also invalid: there is no primary Gas cap to carry in an OOG payload.
 fn resolve_frame_gas(frame: &KernelFrame) -> Result<Option<FrameGas>, u32> {
     let img_arc = CACHE
-        .get(CapHashOrRef::Hash(frame.image_hash))
+        .get(CapHashOrRef::Hash(frame.instance.cap.image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
     let slots = match &*img_arc {
         Cap::Image(i) => i.gas_slots.clone(),
@@ -435,7 +429,10 @@ fn resolve_frame_gas(frame: &KernelFrame) -> Result<Option<FrameGas>, u32> {
 
     let mut meters = Vec::new();
     for slot in slots {
-        let Some(cap_ref) = frame.cnode.peek_key(slot.as_slice()) else {
+        if slot_is_pending(frame, &slot) {
+            return Err(ERR_GAS_SLOT_INVALID);
+        }
+        let Some(cap_ref) = frame.instance.cnode.peek_key(slot.as_slice()) else {
             continue;
         };
         let meter = gas_meter_key_from_ref(cap_ref)?;
@@ -539,30 +536,51 @@ fn frame_at(stack: &[StackEntry], idx: usize) -> &KernelFrame {
     }
 }
 
+#[inline]
+fn slot_is_pending(frame: &KernelFrame, slot: &Key) -> bool {
+    frame.pending_origins.contains(slot)
+}
+
+#[inline]
+fn slot_write_blocked(frame: &KernelFrame, slot: &Key) -> bool {
+    frame.pinned.binary_search(slot).is_ok() || slot_is_pending(frame, slot)
+}
+
+fn cnode_peek_guest<'a>(
+    frame: &'a KernelFrame,
+    slot: &Key,
+) -> Result<Option<&'a CapHashOrRef<Box<CachedCap>>>, u32> {
+    if slot_is_pending(frame, slot) {
+        return Err(EXIT_TRAP);
+    }
+    Ok(frame.instance.cnode.peek_key(slot.as_slice()))
+}
+
 /// Snapshot a frame's Instance `yield_receiver_slot` YieldReceiver as a sorted,
 /// deduped catch-set — the keys it will catch from the subtree of its *next*
 /// downward CALL (spec §3 per-CALL snapshot). Empty when the Image declares no
 /// receiver slot, the slot is empty, or it doesn't hold a YieldReceiver
 /// (catches nothing). Reads only; never mutates.
-fn snapshot_catch_set(frame: &KernelFrame) -> Vec<Key> {
-    let Some(img_arc) = CACHE.get(CapHashOrRef::Hash(frame.image_hash)) else {
-        return Vec::new();
+fn snapshot_catch_set(frame: &KernelFrame) -> Result<Vec<Key>, u32> {
+    let Some(img_arc) = CACHE.get(CapHashOrRef::Hash(frame.instance.cap.image_hash)) else {
+        return Ok(Vec::new());
     };
     let slot = match &*img_arc {
         Cap::Image(i) => match &i.yield_receiver_slot {
             Some(s) => s.clone(),
-            None => return Vec::new(),
+            None => return Ok(Vec::new()),
         },
-        _ => return Vec::new(),
+        _ => return Ok(Vec::new()),
     };
-    match read_instance_cap(frame, &slot) {
-        Some(inst) => {
+    match read_instance_cap_guest(frame, &slot) {
+        Err(_) => Err(EXIT_TRAP),
+        Ok(Some(inst)) => {
             let mut keys = javm_cap::yield_receiver_keys(&inst).unwrap_or_default();
             keys.sort();
             keys.dedup();
-            keys
+            Ok(keys)
         }
-        None => Vec::new(),
+        Ok(None) => Ok(Vec::new()),
     }
 }
 
@@ -608,8 +626,8 @@ pub struct LoopOutcome {
 /// (`Empty` → zero). Byte offset 0 of `mem` is guest VA `DATA_BASE`.
 fn read_scratchpad_head(frame: &KernelFrame) -> [u8; SCRATCHPAD_HEAD_LEN] {
     let mut out = [0u8; SCRATCHPAD_HEAD_LEN];
-    if frame.mem.content_len() as usize >= SCRATCHPAD_HEAD_LEN {
-        frame.mem.copy_into(0, &mut out);
+    if frame.instance.cap.mem.content_len() as usize >= SCRATCHPAD_HEAD_LEN {
+        frame.instance.cap.mem.copy_into(0, &mut out);
     }
     out
 }
@@ -685,8 +703,8 @@ pub fn run_top(
         // Mirror the JIT's post-exit state back into the running frame.
         {
             let frame = frame_at_mut(&mut stack, top_idx);
-            frame.regs = info.regs;
-            frame.pc = info.pc;
+            frame.instance.cap.regs = info.regs;
+            frame.instance.cap.pc = info.pc as u64;
         }
 
         // Phase 2: classify the exit. Borrow scopes are kept tight so
@@ -707,9 +725,9 @@ pub fn run_top(
                 // resuming/dropping its yielder triggers the sub-tree-atomic
                 // unwind; an ordinary InstanceEntry pops and reflects.
                 let drained = if stack[top_idx].target != top_idx {
-                    unwind_to_handler(&mut stack, top_idx, info.regs[7])
+                    unwind_to_handler(&mut stack, top_idx, info.regs[7])?
                 } else {
-                    pop_and_reflect(&mut stack, info.regs[7])
+                    pop_and_reflect(&mut stack, info.regs[7])?
                 };
                 if drained {
                     break LoopOutcome {
@@ -748,12 +766,19 @@ pub fn run_top(
                 // Image and billed to the caller; resolved BEFORE charging so it
                 // joins the floor in one atomic gate. Depth-limit is a hard Err,
                 // not an OOG.
+                let mut host_call_pending = false;
                 let frame_cost = if op == OP_HOST_CALL {
                     if stack.len() >= MAX_DEPTH {
                         return Err(ERR_DEPTH_LIMIT);
                     }
                     let parent = frame_at(&stack, top_idx);
-                    host_call_frame_cost(parent)?
+                    match host_call_frame_cost(parent)? {
+                        Some(cost) => cost,
+                        None => {
+                            host_call_pending = true;
+                            0
+                        }
+                    }
                 } else {
                     0
                 };
@@ -792,9 +817,9 @@ pub fn run_top(
                         // A handler REPLYing without resuming/dropping → sub-tree
                         // unwind; an ordinary InstanceEntry pops and reflects.
                         let drained = if stack[top_idx].target != top_idx {
-                            unwind_to_handler(&mut stack, top_idx, info.regs[7])
+                            unwind_to_handler(&mut stack, top_idx, info.regs[7])?
                         } else {
-                            pop_and_reflect(&mut stack, info.regs[7])
+                            pop_and_reflect(&mut stack, info.regs[7])?
                         };
                         if drained {
                             // Preserve the JIT exit shape so the host bench
@@ -939,19 +964,23 @@ pub fn run_top(
                         // yielder's loads (picking up a kernel:oog topup).
                         let response = {
                             let handler = frame_at_mut(&mut stack, top_idx);
-                            handler.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
+                            handler
+                                .instance
+                                .cnode
+                                .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
                         };
                         stack.pop();
                         let yielder_idx = stack.len() - 1;
                         let yielder = frame_at_mut(&mut stack, yielder_idx);
                         if let Some(cap) = response {
                             yielder
+                                .instance
                                 .cnode
                                 .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                         }
                         // Spec §4: a resumed yielder sees φ[8] = Ok (the handler's
                         // response status) — its host_yield "returns" here.
-                        yielder.regs[8] = STATUS_OK;
+                        yielder.instance.cap.regs[8] = STATUS_OK;
                     }
                     OP_DROP_RESUME => {
                         // Give up on the Waiting yielder: discard the WHOLE caught
@@ -987,9 +1016,25 @@ pub fn run_top(
                         // CALL_RESUME/DROP_RESUME sound — there is no longer a stale
                         // handler with a wedged intermediate below it.
                         let handler_inst = stack[top_idx].target;
+                        release_pending_origins_for_dropped(&mut stack, handler_inst + 1);
                         stack.truncate(handler_inst + 1);
                     }
                     OP_HOST_CALL => {
+                        if host_call_pending {
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
                         // The ecall floor + this CALL's frame_cost were charged
                         // atomically at the top of the arm (check-before-charge,
                         // before `dispatch_host_call` moves any instance, so an
@@ -1001,13 +1046,48 @@ pub fn run_top(
                         // the keys on the owner edge `owner -> child`. When A is
                         // running via `ref[A]`, the physical caller is the
                         // ReferenceEntry but the logical owner is A itself.
-                        let catch_set = {
+                        let logical_owner = stack[top_idx].target;
+                        let catch_result = {
                             let parent = frame_at(&stack, top_idx);
                             snapshot_catch_set(parent)
                         };
-                        let mut child = {
+                        let catch_set = match catch_result {
+                            Ok(set) => set,
+                            Err(EXIT_TRAP) => {
+                                break LoopOutcome {
+                                    exit_reason: EXIT_TRAP,
+                                    exit_arg: 0,
+                                    return_value: info.regs[7],
+                                    gas_remaining: root_remaining(
+                                        &root_active,
+                                        &current_active,
+                                        gas,
+                                        host_budget,
+                                        &meters,
+                                    ),
+                                    scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                                };
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        let child_result = {
                             let parent = frame_at_mut(&mut stack, top_idx);
-                            dispatch_host_call(parent)?
+                            dispatch_host_call(parent, logical_owner)?
+                        };
+                        let Some(mut child) = child_result else {
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
                         };
                         // Scratchpad: MOVE the caller's slot[0] into the
                         // callee. `take_key` empties the parent (one owner);
@@ -1015,10 +1095,13 @@ pub fn run_top(
                         // overwritten by the caller-provided scratchpad.
                         {
                             let parent = frame_at_mut(&mut stack, top_idx);
-                            if let Some(cap) =
-                                parent.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
+                            if let Some(cap) = parent
+                                .instance
+                                .cnode
+                                .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
                             {
                                 child
+                                    .instance
                                     .cnode
                                     .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                             }
@@ -1034,7 +1117,6 @@ pub fn run_top(
                         // Stamp owner-edge routing and funding. The child owns
                         // its declared gas scope if it has one; otherwise it
                         // loans the caller/catcher's current gas scope.
-                        let logical_owner = stack[top_idx].target;
                         stack[child_idx].owner = Some(logical_owner);
                         stack[child_idx].owner_catch_set = catch_set;
                         let inherited_gas = stack[top_idx].gas.clone();
@@ -1112,14 +1194,14 @@ fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
         let rt = build_runtime(frame)?;
         frame.runtime = Some(rt);
     }
-    let pc = frame.pc;
-    let regs = frame.regs;
+    let pc = frame.instance.cap.pc as u32;
+    let regs = frame.instance.cap.regs;
     // Split borrow of disjoint fields: while the JIT runs against
-    // `frame.runtime`'s PT, the #PF handler CoWs guest writes into `frame.mem`'s
+    // `frame.runtime`'s PT, the #PF handler CoWs guest writes into `frame.instance.cap.mem`'s
     // overlay and advances `frame.mat_state` / `frame.ro_units` in place. The
     // raw-pointer casts end those `&mut` borrows immediately, so the subsequent
     // `frame.runtime` borrow does not conflict.
-    let overlay_sink: *mut DataCap = &mut frame.mem;
+    let overlay_sink: *mut DataCap = &mut frame.instance.cap.mem;
     let mat_state_ptr = frame.mat_state.as_mut_ptr();
     let mat_state_len = frame.mat_state.len() as u64;
     let ro_units: *mut Vec<u32> = &mut frame.ro_units;
@@ -1157,7 +1239,7 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // Blobs are never evicted in V0, so the PAs remain valid for the
     // frame's lifetime past return.
     let img_arc = CACHE
-        .get(CapHashOrRef::Hash(frame.image_hash))
+        .get(CapHashOrRef::Hash(frame.instance.cap.image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
     let img = match &*img_arc {
         Cap::Image(i) => i,
@@ -1177,7 +1259,7 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     let (code_base, code_bytes) = img.code_mapping().ok_or(ERR_IMAGE_KIND)?;
     let code_pa = paging::va_to_pa(code_bytes.as_ptr() as u64).ok_or(ERR_MAP_BAD_KIND)?;
 
-    // The frame's RW memory is its **owned** dense `DataCap` (`frame.mem`)
+    // The frame's RW memory is its **owned** dense `DataCap` (`frame.instance.cap.mem`)
     // covering the whole data extent, holding both initial and pinned content
     // at their VAs with page-aligned slabs. Source every data page from it
     // (overlay-then-backing, so a rebuilt runtime picks up prior CoW writes):
@@ -1186,14 +1268,14 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // `UnpinnedCapCow` range. The slabs are owned by the frame, so their PAs
     // stay valid for the frame's life past this function's return.
     let data_base = javm_cap::layout::DATA_BASE;
-    let mem = &frame.mem;
+    let mem = &frame.instance.cap.mem;
     let extent = mem.content_len() as u32;
     let mem_size = data_base.saturating_add(extent);
     let pages = (extent / paging::PAGE_SIZE as u32) as usize;
 
     // Pinned mappings → PinnedCapRo ranges (pushed first → precedence). Bounds +
     // kind only; the #PF handler resolves each page's source PA lazily from
-    // `frame.mem` (`jit_run::mem_source_pa`).
+    // `frame.instance.cap.mem` (`jit_run::mem_source_pa`).
     for m in img.mappings.iter() {
         if m.path().is_empty() || !img.mapping_is_pinned(m.start as u32) {
             continue;
@@ -1228,7 +1310,7 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // the no-eviction V1 invariant.
     unsafe {
         jit_run::build_frame_runtime(
-            &frame.image_hash,
+            &frame.instance.cap.image_hash,
             code_bytes,
             code_base,
             code_pa,
@@ -1276,12 +1358,12 @@ fn route_yield(
     {
         let catcher_frame = frame_at_mut(stack, owner);
         if let Some(inst) = payload {
-            catcher_frame.cnode.set_key(
+            catcher_frame.instance.cnode.set_key(
                 &[javm_cap::abi::SCRATCHPAD_SLOT],
                 Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(inst)))),
             );
         }
-        catcher_frame.regs[8] = STATUS_YIELDED;
+        catcher_frame.instance.cap.regs[8] = STATUS_YIELDED;
     }
     stack.push(StackEntry {
         kind: EntryKind::Reference,
@@ -1311,7 +1393,7 @@ fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32)
     if active_meter(stack, top_idx).is_none() {
         return false;
     }
-    frame_at_mut(stack, top_idx).pc = reattempt_pc;
+    frame_at_mut(stack, top_idx).instance.cap.pc = reattempt_pc as u64;
     if stack[top_idx].gas.advance() {
         return true;
     }
@@ -1324,6 +1406,48 @@ fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32)
     route_yield(stack, top_idx, &oog_key, payload)
 }
 
+fn entry_origin(entry: &StackEntry) -> Option<FrameOrigin> {
+    match &entry.kind {
+        EntryKind::Instance(frame) => frame.origin.clone(),
+        EntryKind::Reference => None,
+    }
+}
+
+fn release_pending_origins_for_dropped(stack: &mut [StackEntry], start: usize) {
+    let origins: Vec<FrameOrigin> = stack[start..].iter().filter_map(entry_origin).collect();
+    for origin in origins {
+        if origin.owner < start {
+            frame_at_mut(stack, origin.owner)
+                .pending_origins
+                .remove(&origin.slot);
+        }
+    }
+}
+
+fn restore_instance_to_origin(
+    stack: &mut [StackEntry],
+    origin: FrameOrigin,
+    inst: InstanceCap,
+    runtime: Option<FrameRuntime>,
+) -> Result<(), u32> {
+    let owner = frame_at_mut(stack, origin.owner);
+    if !owner.pending_origins.remove(&origin.slot) {
+        return Err(ERR_PENDING_ORIGIN_INVARIANT);
+    }
+    let cache = match runtime {
+        Some(rt) => CacheSlot::Instance(rt),
+        None => CacheSlot::None,
+    };
+    owner.instance.cnode.set_key(
+        origin.slot.as_slice(),
+        Some(CapHashOrRef::Owned(Box::new(CachedCap {
+            cap: Cap::Instance(inst),
+            cache,
+        }))),
+    );
+    Ok(())
+}
+
 /// A yield handler (a ReferenceEntry activation) HALTed/REPLYed without resuming
 /// or dropping its yielder. Per sub-tree atomicity (spec §10) the handler
 /// Instance's HALT commits/discards its WHOLE caught subtree — the abandoned
@@ -1332,12 +1456,17 @@ fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32)
 /// handler's InstanceEntry (their frames, banked meters kept), then reflects that
 /// InstanceEntry's HALT exactly as a normal pop. Returns `true` when the stack
 /// drains.
-fn unwind_to_handler(stack: &mut Vec<StackEntry>, top_idx: usize, return_value: u64) -> bool {
+fn unwind_to_handler(
+    stack: &mut Vec<StackEntry>,
+    top_idx: usize,
+    return_value: u64,
+) -> Result<bool, u32> {
     let h_inst = stack[top_idx].target;
     // Drop the handler activation + the abandoned subtree above the handler's
     // own frame; the handler's InstanceEntry becomes the top. Gas is reconciled
     // at the next loop top (the discarded metered frames bank naturally as the
     // active meter changes back to the handler's).
+    release_pending_origins_for_dropped(stack, h_inst + 1);
     stack.truncate(h_inst + 1);
     pop_and_reflect(stack, return_value)
 }
@@ -1351,7 +1480,7 @@ fn unwind_to_handler(stack: &mut Vec<StackEntry>, top_idx: usize, return_value: 
 /// result back to the host). Gas is NOT touched here — the loop-top
 /// [`reconcile_active`] banks the popped frame's meter and loads the parent's on
 /// the next iteration.
-fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
+fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<bool, u32> {
     // A HALT/REPLY only pops an InstanceEntry — a ReferenceEntry (handler
     // activation) is removed by CALL_RESUME, and a handler that HALTs without
     // resuming is caught by the EXIT_HALT/OP_REPLY guards before this point.
@@ -1359,6 +1488,9 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
         EntryKind::Instance(boxed) => *boxed,
         EntryKind::Reference => unreachable!("pop_and_reflect on a ReferenceEntry"),
     };
+    if !popped.pending_origins.is_empty() {
+        return Err(ERR_PENDING_ORIGIN_INVARIANT);
+    }
 
     if stack.is_empty() {
         // Top-level HALT: no parent to park the runtime in, so drop it (its
@@ -1366,45 +1498,36 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
         // return path surfaces slot[0] / `scratchpad_head` as the result. The
         // frame is dropped at scope end (top-level mem persistence deferred).
         popped.runtime = None;
-        return true;
+        return Ok(true);
     }
 
     // Move the callee's scratchpad (slot[0]) back to the caller.
-    let scratch = popped.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT]);
+    let scratch = popped
+        .instance
+        .cnode
+        .take_key(&[javm_cap::abi::SCRATCHPAD_SLOT]);
 
-    // If the child was a moved-in `Owned` instance, reconstruct its
+    // If the child was a moved-in instance, reconstruct its
     // `InstanceCap` from this frame's final state so the parent's slot gets the
     // *updated* instance — sub-VM state persists across calls — AND carry its
     // re-armed page table back so the parent can park it for the next CALL. The
     // page table travels **paired** with the cap (their overlay pages stay
-    // mapped): no PT references a cap whose PT it doesn't own. A non-`Owned`
-    // (host-published `Hash`) child is not resident, so its runtime is dropped
-    // (the next CALL rebuilds it from the blob).
-    let owned_back = match popped.owned_origin.take() {
-        Some(slot) => {
+    // mapped): no PT references a cap whose PT it doesn't own.
+    let owned_back = match popped.origin.take() {
+        Some(origin) => {
             // Re-arm BEFORE the mem moves into the cap: clear W on every CoW'd
             // leaf so the next CALL re-faults on first write and re-charges its
             // CoW (gas-neutral — the page is reused, only the W bit toggles).
             let runtime = popped.runtime.take();
             if let Some(rt) = &runtime {
-                rt.rearm_cow(popped.mem.overlay.keys().copied());
+                rt.rearm_cow(popped.instance.cap.mem.overlay.keys().copied());
             }
-            // Reconstruct from the frame's authoritative running state: identity
-            // (`image_hash` / `image_hash_chain`) is carried on the frame, and
-            // the final `mem` / `regs` / `pc` are the frame's. `root_cnode` and
-            // `gas_remaining` stay spawn-time placeholders — V1 persists neither
-            // the running cnode nor residual gas into the cap (the exact values
-            // the parked shell used to carry).
-            let inst = InstanceCap {
-                image_hash_chain: popped.image_hash_chain,
-                image_hash: popped.image_hash,
-                root_cnode: CapHashOrRef::Hash([0u8; 32]),
-                mem: popped.mem, // the (overlaid) mem
-                regs: popped.regs,
-                pc: popped.pc as u64,
-                gas_remaining: 0,
-            };
-            Some((slot, inst, runtime))
+            let RunningInstance { mut cap, cnode } = popped.instance;
+            cap.root_cnode =
+                CapHashOrRef::Owned(Box::new(Cap::CNode(fold_frame_cnode_to_wire(cnode))));
+            cap.gas_remaining = 0;
+            let inst = cap;
+            Some((origin, inst, runtime))
         }
         None => {
             popped.runtime = None;
@@ -1416,35 +1539,23 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
     // referent frame so a child of a handler activation reflects into the
     // handler's Instance (which spawned/called it).
     let parent_idx = stack.len() - 1;
-    let parent = frame_at_mut(stack, parent_idx);
-    parent.regs[7] = return_value;
-    // Spec §4: the caller's φ[8] reflects the termination status — Ok for a normal
-    // HALT/REPLY return (resetting any stale YIELDED a prior catch left there).
-    parent.regs[8] = STATUS_OK;
-    if let Some(cap) = scratch {
-        parent
-            .cnode
-            .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+    {
+        let parent = frame_at_mut(stack, parent_idx);
+        parent.instance.cap.regs[7] = return_value;
+        // Spec §4: the caller's φ[8] reflects the termination status — Ok for a normal
+        // HALT/REPLY return (resetting any stale YIELDED a prior catch left there).
+        parent.instance.cap.regs[8] = STATUS_OK;
+        if let Some(cap) = scratch {
+            parent
+                .instance
+                .cnode
+                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+        }
     }
-    if let Some((slot, inst, runtime)) = owned_back {
-        // Re-attach the (re-armed) page table to the returning instance's
-        // `CachedCap` cache slot, so the next `host_call` of this instance
-        // reuses it. The cache rides *with* the cap in the parent's cnode slot
-        // — no side-table, freed automatically when the slot is overwritten or
-        // the parent frame pops.
-        let cache = match runtime {
-            Some(rt) => CacheSlot::Instance(rt),
-            None => CacheSlot::None,
-        };
-        parent.cnode.set_key(
-            slot.as_slice(),
-            Some(CapHashOrRef::Owned(Box::new(CachedCap {
-                cap: Cap::Instance(inst),
-                cache,
-            }))),
-        );
+    if let Some((origin, inst, runtime)) = owned_back {
+        restore_instance_to_origin(stack, origin, inst, runtime)?;
     }
-    false
+    Ok(false)
 }
 
 /// Per-`image_hash` cache of the **clean** composed instance-memory backing.
@@ -1563,22 +1674,23 @@ fn compose_instance_mem(img: &ImageCap) -> DataCap {
 /// `OpError::SlotPinned → ExitReason::Trap`. `Ok(false)` on a normal spawn.
 fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
     // V1 single-byte ABI: each slot is the 1-byte key `gpr & 0xFF`.
-    let image_slot = Key::from((frame.regs[7] & 0xFF) as u8);
-    let _cnode_slot = (frame.regs[8] & 0xFF) as u8;
-    let dst_slot = Key::from((frame.regs[9] & 0xFF) as u8);
+    let image_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
+    let _cnode_slot = (frame.instance.cap.regs[8] & 0xFF) as u8;
+    let dst_slot = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
 
     // Reject a write to a pinned (read-only) slot — the interpreter rejects
     // this and traps (javm/src/ecall.rs); the recompiler must agree or the
     // engines fork on `derive_spawn(dst=<pinned>)`.
-    if frame.pinned.binary_search(&dst_slot).is_ok() {
+    if slot_write_blocked(frame, &dst_slot) {
         return Ok(true);
     }
 
-    let image_hash = match frame.cnode.get(&image_slot) {
-        Some(CapHashOrRef::Hash(h)) => h,
-        Some(CapHashOrRef::Owned(_)) | None => frame.image_hash,
+    let image_hash = match cnode_peek_guest(frame, &image_slot) {
+        Err(_) => return Ok(true),
+        Ok(Some(CapHashOrRef::Hash(h))) => *h,
+        Ok(Some(CapHashOrRef::Owned(_))) | Ok(None) => frame.instance.cap.image_hash,
     };
-    let child_chain = Blake2b256::hash_pair(&frame.image_hash_chain, &image_hash);
+    let child_chain = Blake2b256::hash_pair(&frame.instance.cap.image_hash_chain, &image_hash);
 
     // Build the child's initial memory from its Image (pinned RO + initial RW
     // sources folded at their VAs, source pages Arc-shared) — like the top-
@@ -1610,6 +1722,7 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
     // (and its parked page table), so a stale cache for that slot is
     // invalidated automatically — no separate side-table to maintain.
     frame
+        .instance
         .cnode
         .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
         .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
@@ -1628,12 +1741,12 @@ fn dispatch_derive_spawn(frame: &mut KernelFrame) -> Result<bool, u32> {
 /// Instance nor an Image), mirroring `dispatch_derive_spawn`'s trap discipline.
 fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
     // V1 single-byte ABI: φ[7] = src slot, φ[8] = dst slot.
-    let src_slot = Key::from((frame.regs[7] & 0xFF) as u8);
-    let dst_slot = Key::from((frame.regs[8] & 0xFF) as u8);
+    let src_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
+    let dst_slot = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
 
     // Writing into a pinned (read-only) slot traps, mirroring the
     // derive_spawn pinned-dst rejection.
-    if frame.pinned.binary_search(&dst_slot).is_ok() {
+    if slot_write_blocked(frame, &dst_slot) {
         return Ok(true);
     }
 
@@ -1641,8 +1754,9 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
     // an Owned instance's parked page-table cache is untouched). Hash targets
     // resolve through the blob cache; an inline Owned instance reads its field
     // directly (no hash needed).
-    let chain: CapHash = match frame.cnode.peek_key(src_slot.as_slice()) {
-        Some(CapHashOrRef::Hash(h)) => {
+    let chain: CapHash = match cnode_peek_guest(frame, &src_slot) {
+        Err(_) => return Ok(true),
+        Ok(Some(CapHashOrRef::Hash(h))) => {
             let h = *h;
             let arc = CACHE
                 .get(CapHashOrRef::Hash(h))
@@ -1654,12 +1768,12 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
                 _ => return Ok(true),
             }
         }
-        Some(CapHashOrRef::Owned(cc)) => match &cc.cap {
+        Ok(Some(CapHashOrRef::Owned(cc))) => match &cc.cap {
             Cap::Instance(i) => i.image_hash_chain,
             Cap::Image(_) => cc.cap.cap_hash(),
             _ => return Ok(true),
         },
-        None => return Ok(true),
+        Ok(None) => return Ok(true),
     };
 
     // Mint a Cap::Data of the 32 identity bytes (padded to a page) and place
@@ -1667,6 +1781,7 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
     // placement convention as derive_spawn's child instance.
     let cap = Cap::data_inline(&chain);
     frame
+        .instance
         .cnode
         .set(&dst_slot, Some(CapHashOrRef::Owned(CachedCap::boxed(cap))))
         .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
@@ -1679,7 +1794,7 @@ fn dispatch_image_hash_chain(frame: &mut KernelFrame) -> Result<bool, u32> {
 /// kernel-assisted handles this is used for (YieldSender / YieldReceiver) are
 /// tiny (a few registers + a small mem).
 fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
-    match frame.cnode.peek_key(slot.as_slice())? {
+    match frame.instance.cnode.peek_key(slot.as_slice())? {
         CapHashOrRef::Hash(h) => {
             let arc = CACHE.get(CapHashOrRef::Hash(*h))?;
             match &*arc {
@@ -1692,6 +1807,13 @@ fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
             _ => None,
         },
     }
+}
+
+fn read_instance_cap_guest(frame: &KernelFrame, slot: &Key) -> Result<Option<InstanceCap>, u32> {
+    if slot_is_pending(frame, slot) {
+        return Err(EXIT_TRAP);
+    }
+    Ok(read_instance_cap(frame, slot))
 }
 
 /// Outcome of a `host_yield`, classified by [`dispatch_host_yield`] for the
@@ -1731,13 +1853,14 @@ fn dispatch_host_yield(
     gas: &mut i64,
     active: &Option<Key>,
 ) -> Result<YieldOutcome, u32> {
-    let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
-    let yield_key = match read_instance_cap(frame, &sender_slot) {
-        Some(inst) => match javm_cap::yield_sender_key(&inst) {
+    let sender_slot = Key::from((frame.instance.cap.regs[7] & 0xFF) as u8);
+    let yield_key = match read_instance_cap_guest(frame, &sender_slot) {
+        Err(_) => return Ok(YieldOutcome::Trap),
+        Ok(Some(inst)) => match javm_cap::yield_sender_key(&inst) {
             Some(k) => k,
             None => return Ok(YieldOutcome::Trap), // not a YieldSender → trap
         },
-        None => return Ok(YieldOutcome::Trap), // empty / non-Instance sender → trap
+        Ok(None) => return Ok(YieldOutcome::Trap), // empty / non-Instance sender → trap
     };
 
     // User keys (and any kernel:* key not wired inline below) route to an owner
@@ -1751,17 +1874,16 @@ fn dispatch_host_yield(
     let k = yield_key.as_slice();
 
     if k == javm_cap::yield_cap::YK_MINT_YIELD {
-        let new_key = Key::from((frame.regs[8] & 0xFF) as u8);
-        let sender_dst = Key::from((frame.regs[9] & 0xFF) as u8);
-        let receiver_dst = Key::from((frame.regs[10] & 0xFF) as u8);
-        if frame.pinned.binary_search(&sender_dst).is_ok()
-            || frame.pinned.binary_search(&receiver_dst).is_ok()
-        {
+        let new_key = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
+        let sender_dst = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
+        let receiver_dst = Key::from((frame.instance.cap.regs[10] & 0xFF) as u8);
+        if slot_write_blocked(frame, &sender_dst) || slot_write_blocked(frame, &receiver_dst) {
             return Ok(YieldOutcome::Trap);
         }
         let sender = Cap::Instance(javm_cap::yield_sender(&new_key));
         let receiver = Cap::Instance(javm_cap::yield_receiver(&[new_key]));
         frame
+            .instance
             .cnode
             .set(
                 &sender_dst,
@@ -1769,6 +1891,7 @@ fn dispatch_host_yield(
             )
             .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
         frame
+            .instance
             .cnode
             .set(
                 &receiver_dst,
@@ -1777,19 +1900,28 @@ fn dispatch_host_yield(
             .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
         Ok(YieldOutcome::Inline)
     } else if k == javm_cap::yield_cap::YK_MERGE_YIELD_RECEIVER {
-        let a_slot = Key::from((frame.regs[8] & 0xFF) as u8);
-        let b_slot = Key::from((frame.regs[9] & 0xFF) as u8);
-        let dst = Key::from((frame.regs[10] & 0xFF) as u8);
-        if frame.pinned.binary_search(&dst).is_ok() {
+        let a_slot = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
+        let b_slot = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
+        let dst = Key::from((frame.instance.cap.regs[10] & 0xFF) as u8);
+        if slot_write_blocked(frame, &dst) {
             return Ok(YieldOutcome::Trap);
         }
-        let a = read_instance_cap(frame, &a_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
-        let b = read_instance_cap(frame, &b_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
+        let a = match read_instance_cap_guest(frame, &a_slot) {
+            Err(_) => return Ok(YieldOutcome::Trap),
+            Ok(Some(inst)) => inst,
+            Ok(None) => return Err(ERR_YIELD_BAD_SENDER),
+        };
+        let b = match read_instance_cap_guest(frame, &b_slot) {
+            Err(_) => return Ok(YieldOutcome::Trap),
+            Ok(Some(inst)) => inst,
+            Ok(None) => return Err(ERR_YIELD_BAD_SENDER),
+        };
         let merged = match javm_cap::merge_yield_receivers(&a, &b) {
             Some(m) => m,
             None => return Ok(YieldOutcome::Trap), // operands not both receivers
         };
         frame
+            .instance
             .cnode
             .set(
                 &dst,
@@ -1803,14 +1935,14 @@ fn dispatch_host_yield(
         // managed separately (set_gas_meter / the host meter table).
         mint_unit_handle(
             frame,
-            javm_cap::gas_handle(&Key::from((frame.regs[8] & 0xFF) as u8)),
+            javm_cap::gas_handle(&Key::from((frame.instance.cap.regs[8] & 0xFF) as u8)),
         )
     } else if k == javm_cap::yield_cap::YK_MINT_QUOTA {
         // kernel:mint_quota(φ8=quota_key byte, φ9=dst): the storage-quota
         // analogue of mint_gas.
         mint_unit_handle(
             frame,
-            javm_cap::quota_handle(&Key::from((frame.regs[8] & 0xFF) as u8)),
+            javm_cap::quota_handle(&Key::from((frame.instance.cap.regs[8] & 0xFF) as u8)),
         )
     } else if k == javm_cap::yield_cap::YK_SET_GAS_METER {
         // kernel:set_gas_meter(φ8=meter_key byte, φ9=value) -> previous (φ7).
@@ -1819,8 +1951,8 @@ fn dispatch_host_yield(
         // (e.g. a frame topping up the pool it itself loans from), the live `gas`
         // is authoritative, so set it directly and return its value; otherwise the
         // table entry is authoritative.
-        let meter_key = Key::from((frame.regs[8] & 0xFF) as u8);
-        let value = frame.regs[9] as i64;
+        let meter_key = Key::from((frame.instance.cap.regs[8] & 0xFF) as u8);
+        let value = frame.instance.cap.regs[9] as i64;
         let previous = if active.as_ref() == Some(&meter_key) {
             let p = *gas;
             *gas = value;
@@ -1828,7 +1960,7 @@ fn dispatch_host_yield(
         } else {
             meters.insert(meter_key, value).unwrap_or(0)
         };
-        frame.regs[7] = previous as u64;
+        frame.instance.cap.regs[7] = previous as u64;
         Ok(YieldOutcome::Inline)
     } else {
         // A kernel:* key not wired inline (oog / storage_exhausted / …): route it.
@@ -1846,11 +1978,12 @@ fn dispatch_host_yield(
 /// named by φ[9] (V1 single-byte ABI). Traps on a pinned dst. Shared by
 /// `kernel:mint_gas` / `kernel:mint_quota`.
 fn mint_unit_handle(frame: &mut KernelFrame, handle: InstanceCap) -> Result<YieldOutcome, u32> {
-    let dst = Key::from((frame.regs[9] & 0xFF) as u8);
-    if frame.pinned.binary_search(&dst).is_ok() {
+    let dst = Key::from((frame.instance.cap.regs[9] & 0xFF) as u8);
+    if slot_write_blocked(frame, &dst) {
         return Ok(YieldOutcome::Trap);
     }
     frame
+        .instance
         .cnode
         .set(
             &dst,
@@ -1866,21 +1999,38 @@ fn mint_unit_handle(frame: &mut KernelFrame, handle: InstanceCap) -> Result<Yiel
 /// (arg-passing convention — the recursive-spawn bench threads the remaining
 /// depth through φ[9]).
 ///
-/// - `Owned` (a `derive_spawn`'d sub-VM): moved into the child frame with
-///   zero copy; the parent's slot is left empty and HALT moves the updated
-///   instance back ([`KernelFrame::owned_origin`] → [`pop_and_reflect`]).
-/// - `Hash` (a host-published instance): NOT consumed — the hash is
-///   reinserted and the frame built read-only from the blob.
-fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
-    let instance_slot = Key::from((parent.regs[7] & 0xFF) as u8);
-    let endpoint_idx = (parent.regs[8] & 0xFF) as u32;
-    let args = [parent.regs[9], parent.regs[10], 0, 0];
+/// - `Owned` (a `derive_spawn`'d or previously returned sub-VM): moved into
+///   the child frame with zero copy.
+/// - `Hash` (a host-published instance): materialized into the child frame.
+///
+/// In both cases the parent's slot is left empty and reserved; HALT moves the
+/// updated instance back ([`KernelFrame::origin`] → [`pop_and_reflect`]).
+fn dispatch_host_call(
+    parent: &mut KernelFrame,
+    logical_owner: usize,
+) -> Result<Option<KernelFrame>, u32> {
+    let instance_slot = Key::from((parent.instance.cap.regs[7] & 0xFF) as u8);
+    let endpoint_idx = (parent.instance.cap.regs[8] & 0xFF) as u32;
+    let args = [
+        parent.instance.cap.regs[9],
+        parent.instance.cap.regs[10],
+        0,
+        0,
+    ];
+    if slot_is_pending(parent, &instance_slot) {
+        return Ok(None);
+    }
 
     // MOVE the target out of the parent cnode (zero-copy for `Owned`).
     let target = parent
+        .instance
         .cnode
         .take_key(instance_slot.as_slice())
         .ok_or(ERR_HOST_CALL_SLOT_EMPTY)?;
+    let origin = FrameOrigin {
+        owner: logical_owner,
+        slot: instance_slot.clone(),
+    };
 
     let mut child = match target {
         // Single-owner instance: move it (and its parked page table) into the
@@ -1888,7 +2038,7 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
         // instance back.
         CapHashOrRef::Owned(boxed) => {
             let CachedCap { cap, cache } = *boxed;
-            let mut child = build_frame_from_owned(cap, instance_slot.clone(), endpoint_idx, args)?;
+            let mut child = build_frame_from_owned(cap, origin, endpoint_idx, args)?;
             // Page-table reuse: if this resident instance carries a parked
             // runtime (re-armed at its last HALT), move it into the child frame
             // instead of rebuilding the page table. The data extent is fixed
@@ -1896,22 +2046,28 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
             if let CacheSlot::Instance(rt) = cache {
                 debug_assert_eq!(
                     rt.data_extent(),
-                    child.mem.content_len(),
+                    child.instance.cap.mem.content_len(),
                     "parked runtime extent must match the resident instance's mem",
                 );
                 child.runtime = Some(rt);
             }
             child
         }
-        // Host-published instance: not consumed by host_call — put the hash
-        // back and build read-only from the blob.
+        // Host-published instance: materialize the immutable blob into this
+        // call's live frame, but still consume the origin slot. The slot returns
+        // as an updated Owned instance when the child HALTs.
         CapHashOrRef::Hash(h) => {
-            parent
-                .cnode
-                .set_key(instance_slot.as_slice(), Some(CapHashOrRef::Hash(h)));
-            build_frame_from_published(&h, endpoint_idx, args)?
+            let arc = CACHE
+                .get(CapHashOrRef::Hash(h))
+                .ok_or(ERR_INSTANCE_NOT_FOUND)?;
+            let inst = match &*arc {
+                Cap::Instance(i) => i.clone(),
+                _ => return Err(ERR_INSTANCE_KIND),
+            };
+            build_frame_from_instance(inst, Some(origin), endpoint_idx, args)?
         }
     };
+    parent.pending_origins.insert(instance_slot.clone());
 
     // The child inherits the parent's cnode entries its image didn't
     // pre-populate. Per the data-flow principle every inherited entry is a
@@ -1919,25 +2075,25 @@ fn dispatch_host_call(parent: &mut KernelFrame) -> Result<KernelFrame, u32> {
     // entries are **skipped** — they are single-owner and move-only, so
     // copying one would create two owners (same rule as the scratchpad
     // slot[0] below). The moved-out `instance_slot` is already gone from the
-    // parent (for `Owned`) so it is naturally not inherited.
+    // parent, so it is naturally not inherited.
     //
     // The scratchpad slot (slot[0]) is EXCLUDED here: it is not inherited by
     // copy but *moved* by the caller (the `OP_HOST_CALL` arm).
     // `key_of` is payload-independent (it hashes the logical key); annotate
     // the generic so it resolves, matching the parent frame's cnode payload.
     let scratch_phys = CNodeCap::<Box<CachedCap>>::key_of(&[javm_cap::abi::SCRATCHPAD_SLOT]);
-    for (phys_key, val) in parent.cnode.slots.iter() {
+    for (phys_key, val) in parent.instance.cnode.slots.iter() {
         if *phys_key == scratch_phys {
             continue;
         }
         if let MissingOr::Materialized(CapHashOrRef::Owned(_)) = val {
             continue;
         }
-        if child.cnode.slots.get(phys_key).is_none() {
-            child.cnode.slots.insert(*phys_key, val.clone());
+        if child.instance.cnode.slots.get(phys_key).is_none() {
+            child.instance.cnode.slots.insert(*phys_key, val.clone());
         }
     }
-    Ok(child)
+    Ok(Some(child))
 }
 
 /// Category-#3 call-frame cost for materializing the callee `image_hash`,
@@ -1981,9 +2137,12 @@ fn call_frame_cost_for(image_hash: &CapHash) -> Result<i64, u32> {
 /// pristine state. Resolves the callee `image_hash` exactly as
 /// `dispatch_host_call` will (same slot, same `Owned`/`Hash` handling), so
 /// the cost gated here equals the cost the built child would have.
-fn host_call_frame_cost(parent: &KernelFrame) -> Result<i64, u32> {
-    let instance_slot = Key::from((parent.regs[7] & 0xFF) as u8);
-    let image_hash = match parent.cnode.peek_key(instance_slot.as_slice()) {
+fn host_call_frame_cost(parent: &KernelFrame) -> Result<Option<i64>, u32> {
+    let instance_slot = Key::from((parent.instance.cap.regs[7] & 0xFF) as u8);
+    if slot_is_pending(parent, &instance_slot) {
+        return Ok(None);
+    }
+    let image_hash = match parent.instance.cnode.peek_key(instance_slot.as_slice()) {
         Some(CapHashOrRef::Owned(boxed)) => match &boxed.cap {
             Cap::Instance(i) => i.image_hash,
             _ => return Err(ERR_INSTANCE_KIND),
@@ -1999,7 +2158,7 @@ fn host_call_frame_cost(parent: &KernelFrame) -> Result<i64, u32> {
         }
         None => return Err(ERR_HOST_CALL_SLOT_EMPTY),
     };
-    call_frame_cost_for(&image_hash)
+    call_frame_cost_for(&image_hash).map(Some)
 }
 
 /// Build a frame from a `Cap::Instance` published in the heap-
@@ -2014,69 +2173,101 @@ fn build_frame_from_published(
     let arc = CACHE
         .get(CapHashOrRef::Hash(*instance_hash))
         .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-    let (image_hash, image_hash_chain, mem, root_cnode) = match &*arc {
-        Cap::Instance(i) => (
-            i.image_hash,
-            i.image_hash_chain,
-            i.mem.clone(),
-            root_cnode_hash(&i.root_cnode),
-        ),
+    let inst = match &*arc {
+        Cap::Instance(i) => i.clone(),
         _ => return Err(ERR_INSTANCE_KIND),
     };
-    build_frame_inner(
-        image_hash,
-        image_hash_chain,
-        None,
-        endpoint_idx,
-        args,
-        mem,
-        root_cnode,
-    )
-}
-
-/// The root-cnode content hash to seed a frame from, or `None` when there is no
-/// persistent cnode to load: an inline `Owned` root cnode (mid-mutation — not a
-/// published instance) or the all-zero spawn-time placeholder a `derive_spawn`'d
-/// sub-VM carries (see [`dispatch_derive_spawn`] / [`pop_and_reflect`]).
-fn root_cnode_hash(root_cnode: &CapHashOrRef) -> Option<CapHash> {
-    match root_cnode {
-        CapHashOrRef::Hash(h) if *h != [0u8; 32] => Some(*h),
-        _ => None,
-    }
+    build_frame_from_instance(inst, None, endpoint_idx, args)
 }
 
 /// Build a frame by **moving** an `Owned` `Cap::Instance` into it: the
-/// instance is fully decomposed — its `mem` becomes the frame's owned memory
-/// and its identity (`image_hash` / `image_hash_chain`) + `regs` seed the
-/// frame. `root_cnode`, `pc`, and `gas_remaining` are not needed at build (the
-/// frame starts at the endpoint's entry-pc with a freshly-seeded cnode). Only
-/// `origin_slot` is remembered in [`KernelFrame::owned_origin`] so HALT can
-/// reconstruct the instance from the frame's final state and return it.
+/// instance is fully decomposed — its `mem` becomes the frame's owned memory,
+/// and its identity (`image_hash` / `image_hash_chain`) plus `root_cnode` seed
+/// the frame. CALL starts at the endpoint entry PC; saved regs/pc are restored
+/// only by CALL_RESUME. `origin` is remembered in [`KernelFrame::origin`] so
+/// HALT can reconstruct the instance from the frame's final state and return
+/// it.
 fn build_frame_from_owned(
     cap: Cap,
-    origin_slot: Key,
+    origin: FrameOrigin,
     endpoint_idx: u32,
     args: [u64; 4],
 ) -> Result<KernelFrame, u32> {
     let Cap::Instance(inst) = cap else {
         return Err(ERR_INSTANCE_KIND);
     };
-    let InstanceCap {
-        image_hash,
-        image_hash_chain,
-        mem,
-        root_cnode,
-        ..
-    } = inst;
-    build_frame_inner(
-        image_hash,
-        image_hash_chain,
-        Some(origin_slot),
-        endpoint_idx,
-        args,
-        mem,
-        root_cnode_hash(&root_cnode),
-    )
+    build_frame_from_instance(inst, Some(origin), endpoint_idx, args)
+}
+
+fn build_frame_from_instance(
+    inst: InstanceCap,
+    origin: Option<FrameOrigin>,
+    endpoint_idx: u32,
+    args: [u64; 4],
+) -> Result<KernelFrame, u32> {
+    build_frame_inner(inst, origin, endpoint_idx, args)
+}
+
+fn seed_cnode_from_root(
+    root_cnode: &CapHashOrRef,
+    cnode: &mut CNodeCap<Box<CachedCap>>,
+) -> Result<(), u32> {
+    match root_cnode {
+        CapHashOrRef::Hash(h) if *h == [0u8; 32] => Ok(()),
+        CapHashOrRef::Hash(h) => {
+            let rc_arc = CACHE
+                .get(CapHashOrRef::Hash(*h))
+                .ok_or(ERR_INSTANCE_NOT_FOUND)?;
+            let Cap::CNode(cn) = &*rc_arc else {
+                return Err(ERR_INSTANCE_KIND);
+            };
+            copy_wire_cnode_into_cached(cn, cnode);
+            Ok(())
+        }
+        CapHashOrRef::Owned(boxed) => {
+            let Cap::CNode(cn) = &**boxed else {
+                return Err(ERR_INSTANCE_KIND);
+            };
+            copy_wire_cnode_into_cached(cn, cnode);
+            Ok(())
+        }
+    }
+}
+
+fn copy_wire_cnode_into_cached(src: &CNodeCap<Box<Cap>>, dst: &mut CNodeCap<Box<CachedCap>>) {
+    for (k, mo) in src.slots.iter() {
+        let conv = match mo {
+            MissingOr::Materialized(t) => MissingOr::Materialized(wire_target_to_cached(t)),
+            MissingOr::Missing(h) => MissingOr::Missing(*h),
+        };
+        dst.slots.insert(*k, conv);
+    }
+}
+
+fn wire_target_to_cached(target: &CapHashOrRef<Box<Cap>>) -> CapHashOrRef<Box<CachedCap>> {
+    match target {
+        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
+        CapHashOrRef::Owned(b) => CapHashOrRef::Owned(CachedCap::boxed((**b).clone())),
+    }
+}
+
+fn cached_target_to_wire(target: &CapHashOrRef<Box<CachedCap>>) -> CapHashOrRef<Box<Cap>> {
+    match target {
+        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
+        CapHashOrRef::Owned(boxed) => CapHashOrRef::Owned(Box::new(boxed.cap.clone())),
+    }
+}
+
+fn fold_frame_cnode_to_wire(cnode: CNodeCap<Box<CachedCap>>) -> CNodeCap<Box<Cap>> {
+    let mut out = CNodeCap::new();
+    for (k, mo) in cnode.slots.iter() {
+        let conv = match mo {
+            MissingOr::Materialized(t) => MissingOr::Materialized(cached_target_to_wire(t)),
+            MissingOr::Missing(h) => MissingOr::Missing(*h),
+        };
+        out.slots.insert(*k, conv);
+    }
+    out
 }
 
 // `build_frame_from_instance_ref` / `build_frame_from_cap` were removed: a
@@ -2085,18 +2276,17 @@ fn build_frame_from_owned(
 
 /// Core frame builder: reads the image cap to seed regs/pc/cnode +
 /// CoW ranges, stores only IDs on the frame (no `CapHandle` pins).
-/// `owned_origin` is the parent return slot for a moved-in `Owned` sub-VM
-/// (`None` for a top-level / `Hash` frame).
+/// `origin` is the owner return slot for a moved-in sub-VM (`None` only for the
+/// top-level frame).
 #[allow(clippy::too_many_arguments)]
 fn build_frame_inner(
-    image_hash: CapHash,
-    image_hash_chain: CapHash,
-    owned_origin: Option<Key>,
+    mut cap: InstanceCap,
+    origin: Option<FrameOrigin>,
     endpoint_idx: u32,
     args: [u64; 4],
-    mem: DataCap,
-    root_cnode: Option<CapHash>,
 ) -> Result<KernelFrame, u32> {
+    let image_hash = cap.image_hash;
+    let root_cnode = core::mem::replace(&mut cap.root_cnode, CapHashOrRef::Hash([0u8; 32]));
     let img_arc = CACHE
         .get(CapHashOrRef::Hash(image_hash))
         .ok_or(ERR_IMAGE_NOT_FOUND)?;
@@ -2126,7 +2316,9 @@ fn build_frame_inner(
     for (i, v) in args.iter().enumerate() {
         regs[7 + i] = *v;
     }
-    let pc = ep.entry_pc as u32;
+    cap.regs = regs;
+    cap.pc = ep.entry_pc;
+    cap.gas_remaining = 0;
 
     let mut cnode: CNodeCap<Box<CachedCap>> = CNodeCap::new();
     // Seed the persistent state from the instance's root cnode first. This is
@@ -2136,23 +2328,7 @@ fn build_frame_inner(
     // principle) deep-clones into the frame's `CachedCap` form. Entries are
     // copied by raw radix key (the cnode is keyed by `Hasher(Key)`, so the
     // logical key isn't recoverable to re-`set`).
-    if let Some(rc) = root_cnode {
-        let rc_arc = CACHE
-            .get(CapHashOrRef::Hash(rc))
-            .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-        let Cap::CNode(cn) = &*rc_arc else {
-            return Err(ERR_INSTANCE_KIND);
-        };
-        for (k, mo) in cn.slots.iter() {
-            if let MissingOr::Materialized(t) = mo {
-                let conv = match t {
-                    CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
-                    CapHashOrRef::Owned(b) => CapHashOrRef::Owned(CachedCap::boxed((**b).clone())),
-                };
-                cnode.slots.insert(*k, MissingOr::Materialized(conv));
-            }
-        }
-    }
+    seed_cnode_from_root(&root_cnode, &mut cnode)?;
     // Image pinned slots overlay the root-cnode state (image-authoritative:
     // pinned content is swapped as a unit at set_image), then initial slots
     // fill only still-empty slots (bootstrap-only).
@@ -2179,19 +2355,15 @@ fn build_frame_inner(
     // `FrameRuntime`'s `mem_top - data_base` extent. Lives here, on the
     // `KernelFrame`, not the runtime, so it survives any future runtime
     // reclamation (host-backed swap) — see the field doc.
-    let mat_state_pages = (mem.content_len() / paging::PAGE_SIZE as u64) as usize;
+    let mat_state_pages = (cap.mem.content_len() / paging::PAGE_SIZE as u64) as usize;
 
     // The cap-backed mappings (their PAs + pinned/initial kind) are
     // resolved in `build_runtime` when the per-frame runtime is built;
     // nothing mapping-related is needed on the frame itself.
     Ok(KernelFrame {
-        image_hash,
-        image_hash_chain,
-        owned_origin,
-        mem,
-        regs,
-        pc,
-        cnode,
+        instance: RunningInstance { cap, cnode },
+        origin,
+        pending_origins: BTreeSet::new(),
         pinned,
         mat_state: alloc::vec![0u8; mat_state_pages],
         ro_units: Vec::new(),

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1337,8 +1337,8 @@ enum YieldOutcome {
 
 /// `host_yield(sender_slot=φ[7], …)`. Reads the `YieldSender` at `sender_slot`
 /// and classifies the yield: a `kernel:*` pure-cap syscall (mint_yield,
-/// merge_yield_receiver) is performed INLINE as the implicit root receiver
-/// ([`YieldOutcome::Inline`]); a malformed operand traps
+/// merge_yield_receiver, mint_gas, mint_quota) is performed INLINE as the
+/// implicit root receiver ([`YieldOutcome::Inline`]); a malformed operand traps
 /// ([`YieldOutcome::Trap`]); anything else — a user key, or a `kernel:*` key not
 /// handled inline — is routed to an ancestor YieldReceiver by the call loop
 /// ([`YieldOutcome::Route`]). `Err(code)` is reserved for an internal cnode
@@ -1347,7 +1347,8 @@ enum YieldOutcome {
 /// V1 single-byte ABI: all slot operands are the low byte of their φ register.
 /// `kernel:mint_yield`: φ[8] = new yield_key byte, φ[9] = YieldSender dst,
 /// φ[10] = YieldReceiver dst. `kernel:merge_yield_receiver`: φ[8] = receiver A
-/// slot, φ[9] = receiver B slot, φ[10] = dst slot.
+/// slot, φ[9] = receiver B slot, φ[10] = dst slot. `kernel:mint_gas` /
+/// `kernel:mint_quota`: φ[8] = meter_key / quota_key byte, φ[9] = handle dst.
 fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<YieldOutcome, u32> {
     let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
     let yield_key = match read_instance_cap(frame, &sender_slot) {
@@ -1415,16 +1416,49 @@ fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<YieldOutcome, u32> {
             )
             .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
         Ok(YieldOutcome::Inline)
+    } else if k == javm_cap::yield_cap::YK_MINT_GAS {
+        // kernel:mint_gas(φ8=meter_key byte, φ9=dst): mint a Gas{meter_key}
+        // handle (pure-cap, like mint_yield). The meter mapping it indexes is
+        // managed separately (set_gas_meter / the host meter table).
+        mint_unit_handle(
+            frame,
+            javm_cap::gas_handle(&Key::from((frame.regs[8] & 0xFF) as u8)),
+        )
+    } else if k == javm_cap::yield_cap::YK_MINT_QUOTA {
+        // kernel:mint_quota(φ8=quota_key byte, φ9=dst): the storage-quota
+        // analogue of mint_gas.
+        mint_unit_handle(
+            frame,
+            javm_cap::quota_handle(&Key::from((frame.regs[8] & 0xFF) as u8)),
+        )
     } else {
-        // A kernel:* key not wired inline (set_gas_meter / mint_gas / oog / …):
-        // route it. The kernel root catches kernel:* keys the chain registered
-        // in its YieldReceiver (e.g. kernel:oog); an unregistered key finds no
-        // catcher and the emitter faults.
+        // A kernel:* key not wired inline (set_gas_meter / oog / …): route it.
+        // The kernel root catches kernel:* keys the chain registered in its
+        // YieldReceiver (e.g. kernel:oog); an unregistered key finds no catcher
+        // and the emitter faults.
         Ok(YieldOutcome::Route {
             key: yield_key,
             sender_slot,
         })
     }
+}
+
+/// Place a freshly-minted kernel unit handle (`Gas` / `Quota`) into the dst slot
+/// named by φ[9] (V1 single-byte ABI). Traps on a pinned dst. Shared by
+/// `kernel:mint_gas` / `kernel:mint_quota`.
+fn mint_unit_handle(frame: &mut KernelFrame, handle: InstanceCap) -> Result<YieldOutcome, u32> {
+    let dst = Key::from((frame.regs[9] & 0xFF) as u8);
+    if frame.pinned.binary_search(&dst).is_ok() {
+        return Ok(YieldOutcome::Trap);
+    }
+    frame
+        .cnode
+        .set(
+            &dst,
+            Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(handle)))),
+        )
+        .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
+    Ok(YieldOutcome::Inline)
 }
 
 /// `host_call(instance_slot=φ[7], endpoint_idx=φ[8])`. **Moves** the target

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -149,6 +149,11 @@ const OP_HOST_CALL: u32 = 26;
 /// guest-kernel op number — needs no recompiler change (the recompiler surfaces
 /// `ecalli imm` → EXIT_HOST_CALL(imm) generically; dispatched here).
 const OP_CALL_RESUME: u32 = 27;
+/// `drop_paused()` — a yield handler gives up on its Waiting yielder (spec §4
+/// DROP_PAUSED): discard the entry directly below this handler's ReferenceEntry
+/// (its frame + state) WITHOUT resuming it; the handler keeps running. Faults if
+/// the top is not a handler activation. New guest-kernel op number.
+const OP_DROP_PAUSED: u32 = 28;
 
 /// φ[8] status a catcher sees when it resumes as a yield handler (vs. a normal
 /// CALL return). Forward-looking — a straight-line handler that unconditionally
@@ -192,12 +197,6 @@ const ERR_YIELD_UNHANDLED: u32 = 70;
 /// A `host_yield` operand slot did not hold the expected kernel-assisted
 /// Instance (YieldSender / YieldReceiver).
 const ERR_YIELD_BAD_SENDER: u32 = 71;
-/// A yield **handler** (a ReferenceEntry activation) ran to HALT/REPLY without
-/// `CALL_RESUME`-ing its Waiting yielder. Per sub-tree atomicity this should
-/// discard the abandoned yielder and fold the handler's HALT up to the
-/// referent's caller — a multi-frame unwind deferred to the DROP_PAUSED/Paused
-/// step. Until then it is a clean trap rather than a panic.
-const ERR_HANDLER_HALT: u32 = 72;
 
 /// One stack frame on the in-kernel call stack. Holds the running Image's
 /// identity hashes, the frame's **owned** `mem` DataCap + PVM register/PC
@@ -525,26 +524,25 @@ pub fn run_top(
         // we can mutate `stack` (push/pop) inside each arm.
         match info.exit_reason {
             EXIT_HALT => {
-                // A handler activation (ReferenceEntry) that HALTs without
-                // resuming its yielder needs the deferred multi-frame unwind →
-                // clean trap for now (never reflected by pop_and_reflect).
-                if stack[top_idx].target != top_idx {
-                    break LoopOutcome {
-                        exit_reason: EXIT_TRAP,
-                        exit_arg: ERR_HANDLER_HALT,
-                        return_value: info.regs[7],
-                        gas_remaining: gas,
-                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                    };
-                }
-                // Read the scratchpad head from the top frame BEFORE it is
-                // popped (and dropped) — only meaningful at the top-level HALT.
-                let head = if stack.len() == 1 {
+                // Read the scratchpad head from the InstanceEntry that will drain
+                // (its `target` reaches stack[0]) BEFORE it is popped — meaningful
+                // only at the top-level HALT. `frame_at(top_idx)` resolves the
+                // running frame whether the top is an InstanceEntry or a handler
+                // ReferenceEntry.
+                let head = if stack[top_idx].target == 0 {
                     read_scratchpad_head(frame_at(&stack, top_idx))
                 } else {
                     [0u8; SCRATCHPAD_HEAD_LEN]
                 };
-                if pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters) {
+                // A handler activation (ReferenceEntry) that HALTs without
+                // resuming/dropping its yielder triggers the sub-tree-atomic
+                // unwind; an ordinary InstanceEntry pops and reflects.
+                let drained = if stack[top_idx].target != top_idx {
+                    unwind_to_handler(&mut stack, top_idx, info.regs[7], &mut gas, &mut meters)
+                } else {
+                    pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters)
+                };
+                if drained {
                     break LoopOutcome {
                         exit_reason: info.exit_reason,
                         exit_arg: info.exit_arg,
@@ -595,26 +593,27 @@ pub fn run_top(
                 };
                 match op {
                     OP_REPLY => {
-                        // A handler activation (ReferenceEntry) that REPLYs
-                        // without resuming its yielder → deferred unwind, clean
-                        // trap (see EXIT_HALT).
-                        if stack[top_idx].target != top_idx {
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: ERR_HANDLER_HALT,
-                                return_value: info.regs[7],
-                                gas_remaining: gas,
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
-                        }
-                        // Read the scratchpad head from the top frame before the
-                        // pop (only meaningful at the top-level trampoline HALT).
-                        let head = if stack.len() == 1 {
+                        // Read the scratchpad head from the InstanceEntry that
+                        // will drain before the pop (see EXIT_HALT).
+                        let head = if stack[top_idx].target == 0 {
                             read_scratchpad_head(frame_at(&stack, top_idx))
                         } else {
                             [0u8; SCRATCHPAD_HEAD_LEN]
                         };
-                        if pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters) {
+                        // A handler REPLYing without resuming/dropping → sub-tree
+                        // unwind; an ordinary InstanceEntry pops and reflects.
+                        let drained = if stack[top_idx].target != top_idx {
+                            unwind_to_handler(
+                                &mut stack,
+                                top_idx,
+                                info.regs[7],
+                                &mut gas,
+                                &mut meters,
+                            )
+                        } else {
+                            pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters)
+                        };
+                        if drained {
                             // Preserve the JIT exit shape so the host bench
                             // harness (which asserts `(reason=4, arg=0)` for the
                             // subsoil trampoline halt) doesn't trip.
@@ -747,6 +746,27 @@ pub fn run_top(
                             stack[yielder_idx].saved_gas = Some(gas);
                             gas = *meters.get(&k).unwrap_or(&0);
                         }
+                    }
+                    OP_DROP_PAUSED => {
+                        // Give up on the Waiting yielder directly below this
+                        // handler activation: discard its entry (frame + state);
+                        // the handler keeps running (it does NOT resume the
+                        // yielder). The top must be a handler ReferenceEntry — an
+                        // InstanceEntry top has no outstanding yield → trap.
+                        if stack[top_idx].target == top_idx {
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: 0,
+                                return_value: info.regs[7],
+                                gas_remaining: gas,
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
+                        // Remove the yielder (top_idx - 1); the handler
+                        // ReferenceEntry shifts down to become the running top and
+                        // continues at its post-drop PC. Its `target` (a lower
+                        // index) is unaffected by the removal.
+                        stack.remove(top_idx - 1);
                     }
                     OP_HOST_CALL => {
                         if stack.len() >= MAX_DEPTH {
@@ -1117,6 +1137,28 @@ fn try_oog_yield(
     let oog_key = Key::from(&javm_cap::yield_cap::YK_OOG[..]);
     let payload = Some(javm_cap::gas_handle(&meter));
     route_yield(stack, top_idx, &oog_key, payload, gas, meters)
+}
+
+/// A yield handler (a ReferenceEntry activation) HALTed/REPLYed without resuming
+/// or dropping its yielder. Per sub-tree atomicity (spec §10) the handler
+/// Instance's HALT commits/discards its WHOLE caught subtree — the abandoned
+/// yielder plus any intermediate frames a descendant's yield routed past — and
+/// reflects to the handler Instance's own caller. Discards every entry above the
+/// handler's InstanceEntry (their frames, banked meters kept), then reflects that
+/// InstanceEntry's HALT exactly as a normal pop. Returns `true` when the stack
+/// drains.
+fn unwind_to_handler(
+    stack: &mut Vec<StackEntry>,
+    top_idx: usize,
+    return_value: u64,
+    gas: &mut i64,
+    meters: &mut BTreeMap<Key, i64>,
+) -> bool {
+    let h_inst = stack[top_idx].target;
+    // Drop the handler activation + the abandoned subtree above the handler's
+    // own frame; the handler's InstanceEntry becomes the top.
+    stack.truncate(h_inst + 1);
+    pop_and_reflect(stack, return_value, gas, meters)
 }
 
 /// Pop the top frame; if a parent exists, reflect the popped child's

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1139,8 +1139,14 @@ fn build_frame_from_published(
     let arc = CACHE
         .get(CapHashOrRef::Hash(*instance_hash))
         .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-    let (image_hash, image_hash_chain, inst_regs, mem) = match &*arc {
-        Cap::Instance(i) => (i.image_hash, i.image_hash_chain, i.regs, i.mem.clone()),
+    let (image_hash, image_hash_chain, inst_regs, mem, root_cnode) = match &*arc {
+        Cap::Instance(i) => (
+            i.image_hash,
+            i.image_hash_chain,
+            i.regs,
+            i.mem.clone(),
+            root_cnode_hash(&i.root_cnode),
+        ),
         _ => return Err(ERR_INSTANCE_KIND),
     };
     build_frame_inner(
@@ -1151,7 +1157,19 @@ fn build_frame_from_published(
         args,
         Some(&inst_regs),
         mem,
+        root_cnode,
     )
+}
+
+/// The root-cnode content hash to seed a frame from, or `None` when there is no
+/// persistent cnode to load: an inline `Owned` root cnode (mid-mutation — not a
+/// published instance) or the all-zero spawn-time placeholder a `derive_spawn`'d
+/// sub-VM carries (see [`dispatch_derive_spawn`] / [`pop_and_reflect`]).
+fn root_cnode_hash(root_cnode: &CapHashOrRef) -> Option<CapHash> {
+    match root_cnode {
+        CapHashOrRef::Hash(h) if *h != [0u8; 32] => Some(*h),
+        _ => None,
+    }
 }
 
 /// Build a frame by **moving** an `Owned` `Cap::Instance` into it: the
@@ -1175,6 +1193,7 @@ fn build_frame_from_owned(
         image_hash_chain,
         regs,
         mem,
+        root_cnode,
         ..
     } = inst;
     build_frame_inner(
@@ -1185,6 +1204,7 @@ fn build_frame_from_owned(
         args,
         Some(&regs),
         mem,
+        root_cnode_hash(&root_cnode),
     )
 }
 
@@ -1205,6 +1225,7 @@ fn build_frame_inner(
     args: [u64; 4],
     inst_regs: Option<&[u64; NUM_REGS]>,
     mem: DataCap,
+    root_cnode: Option<CapHash>,
 ) -> Result<KernelFrame, u32> {
     let img_arc = CACHE
         .get(CapHashOrRef::Hash(image_hash))
@@ -1238,7 +1259,34 @@ fn build_frame_inner(
     }
     let pc = ep.entry_pc as u32;
 
-    let mut cnode = CNodeCap::new();
+    let mut cnode: CNodeCap<Box<CachedCap>> = CNodeCap::new();
+    // Seed the persistent state from the instance's root cnode first. This is
+    // how arbitrary caps — `Cap::Instance` (YieldSenders, sub-VM handles) that
+    // can't be pinned, plus carried-over mutable slots — flow to the guest. A
+    // published root cnode holds only `Hash` entries; an inline `Owned` (in
+    // principle) deep-clones into the frame's `CachedCap` form. Entries are
+    // copied by raw radix key (the cnode is keyed by `Hasher(Key)`, so the
+    // logical key isn't recoverable to re-`set`).
+    if let Some(rc) = root_cnode {
+        let rc_arc = CACHE
+            .get(CapHashOrRef::Hash(rc))
+            .ok_or(ERR_INSTANCE_NOT_FOUND)?;
+        let Cap::CNode(cn) = &*rc_arc else {
+            return Err(ERR_INSTANCE_KIND);
+        };
+        for (k, mo) in cn.slots.iter() {
+            if let MissingOr::Materialized(t) = mo {
+                let conv = match t {
+                    CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
+                    CapHashOrRef::Owned(b) => CapHashOrRef::Owned(CachedCap::boxed((**b).clone())),
+                };
+                cnode.slots.insert(*k, MissingOr::Materialized(conv));
+            }
+        }
+    }
+    // Image pinned slots overlay the root-cnode state (image-authoritative:
+    // pinned content is swapped as a unit at set_image), then initial slots
+    // fill only still-empty slots (bootstrap-only).
     for e in img.pinned.iter() {
         cnode
             .set(&e.slot, Some(CapHashOrRef::Hash(e.cap_hash)))

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -120,13 +120,17 @@ const EXIT_TRAP: u32 = 7;
 
 const OP_REPLY: u32 = 0;
 /// `host_yield(sender_slot=φ[7], …)` — emit the yield_key carried by the
-/// YieldSender at `sender_slot`. `kernel:*` keys are caught by the kernel as
-/// the implicit ROOT receiver and handled INLINE (the guest resumes at the next
-/// instruction, like a hostcall — the "syscalls conceptually push a kernel
-/// frame but we don't actually push" model). Wired today: the pure-cap syscalls
-/// `kernel:mint_yield` / `kernel:merge_yield_receiver`. Gas/quota syscalls (need
-/// the meter table) and user-key routing to an ancestor YieldReceiver (needs
-/// suspension) are later stages.
+/// YieldSender at `sender_slot`. Pure-cap `kernel:*` syscalls
+/// (`kernel:mint_yield` / `kernel:merge_yield_receiver`) are caught by the
+/// kernel as the implicit ROOT receiver and handled INLINE — the guest resumes
+/// at the next instruction (the "syscalls conceptually push a kernel frame but
+/// we don't actually push" model). Everything else — a user key, or a
+/// `kernel:*` key not wired inline — is ROUTED: the loop walks the call stack
+/// from the emitter toward the root (skipping the emitter instance's own
+/// frames) and the nearest ancestor whose per-CALL snapshotted YieldReceiver
+/// contains the key catches it (push a ReferenceEntry, suspend the yielder;
+/// resumed by [`OP_CALL_RESUME`]). Gas/quota `kernel:*` syscalls (need the meter
+/// table) remain a later stage.
 const OP_HOST_YIELD: u32 = 16;
 const OP_DERIVE_SPAWN: u32 = 18;
 /// `host_image_hash_chain(src_slot=φ[7], dst_slot=φ[8])` — read the cap's
@@ -137,6 +141,19 @@ const OP_DERIVE_SPAWN: u32 = 18;
 /// (memcmp), so there is no separate `Cap::Type` kind or same-type host op.
 const OP_IMAGE_HASH_CHAIN: u32 = 20;
 const OP_HOST_CALL: u32 = 26;
+/// `call_resume()` — resume the Waiting yielder directly below this handler's
+/// ReferenceEntry (spec §4 CALL_RESUME). The handler's scratchpad (`slot[0]`)
+/// reflects to the yielder as its response; the ReferenceEntry pops; the yielder
+/// becomes the running top and continues at its post-yield PC. Faults if the top
+/// is not a handler activation (no outstanding yield to resume). New
+/// guest-kernel op number — needs no recompiler change (the recompiler surfaces
+/// `ecalli imm` → EXIT_HOST_CALL(imm) generically; dispatched here).
+const OP_CALL_RESUME: u32 = 27;
+
+/// φ[8] status a catcher sees when it resumes as a yield handler (vs. a normal
+/// CALL return). Forward-looking — a straight-line handler that unconditionally
+/// `call_resume`s ignores it; a discriminating handler branches on it.
+const STATUS_YIELDED: u64 = 1;
 
 /// Hard ceiling on the in-kernel call-stack depth. NOTE: with runtime eviction
 /// removed, every live frame keeps its ~24 KiB page table resident, so
@@ -175,6 +192,12 @@ const ERR_YIELD_UNHANDLED: u32 = 70;
 /// A `host_yield` operand slot did not hold the expected kernel-assisted
 /// Instance (YieldSender / YieldReceiver).
 const ERR_YIELD_BAD_SENDER: u32 = 71;
+/// A yield **handler** (a ReferenceEntry activation) ran to HALT/REPLY without
+/// `CALL_RESUME`-ing its Waiting yielder. Per sub-tree atomicity this should
+/// discard the abandoned yielder and fold the handler's HALT up to the
+/// referent's caller — a multi-frame unwind deferred to the DROP_PAUSED/Paused
+/// step. Until then it is a clean trap rather than a panic.
+const ERR_HANDLER_HALT: u32 = 72;
 
 /// One stack frame on the in-kernel call stack. Holds the running Image's
 /// identity hashes, the frame's **owned** `mem` DataCap + PVM register/PC
@@ -269,6 +292,113 @@ pub struct KernelFrame {
     runtime: Option<FrameRuntime>,
 }
 
+/// What a kernel call-stack entry runs.
+enum EntryKind {
+    /// A fresh invocation of an Instance — owns the running [`KernelFrame`].
+    /// Pushed by CALL; popped (and reflected) by HALT. Boxed so the stack `Vec`
+    /// element stays pointer-sized: a [`KernelFrame`] is large (~500 B) and a
+    /// `Reference` carries no frame, so an inline variant would bloat every
+    /// stack slot. One alloc per CALL is negligible beside the per-frame page
+    /// table build.
+    Instance(Box<KernelFrame>),
+    /// A **yield activation**: re-runs an earlier [`EntryKind::Instance`] (the
+    /// one at [`StackEntry::target`]) at its post-CALL continuation, with the
+    /// yield payload reflected into its scratchpad. It carries no frame of its
+    /// own — running the top of the stack runs the *referent's* frame — so one
+    /// Instance shares a single PC/regs/mem across its InstanceEntry and every
+    /// ReferenceEntry (spec §3 "same-instance entries share PC"). Pushed by a
+    /// routed `host_yield`; popped by `CALL_RESUME`.
+    Reference,
+}
+
+/// One entry on the in-kernel call stack. The stack drives control transfer:
+/// CALL pushes an [`EntryKind::Instance`], a routed `host_yield` pushes an
+/// [`EntryKind::Reference`], and HALT / `CALL_RESUME` pop. Exactly one entry —
+/// the top — is *Running*; every entry below it is *Waiting* (kernel-internal
+/// accounting, not a σ-visible Instance state).
+struct StackEntry {
+    kind: EntryKind,
+    /// Index of the [`EntryKind::Instance`] whose [`KernelFrame`] this entry
+    /// runs: its **own** index for an InstanceEntry, the **referent's** index
+    /// for a ReferenceEntry. Lower-or-equal to the entry's own index and stable
+    /// (entries below the top never move while the top exists).
+    target: usize,
+    /// Canonical Instance identity for **emitter-exclusion**: an InstanceEntry
+    /// gets a fresh id at CALL; a ReferenceEntry copies its referent's id, so
+    /// every stack entry of one Instance compares equal. Yield routing skips all
+    /// entries whose `instance_id` matches the emitter's (spec §3 "skip ALL
+    /// frames belonging to the emitting instance").
+    instance_id: u64,
+    /// The catch-list this entry offers to the subtree currently below it: a
+    /// **snapshot** of its Instance's `yield_receiver_slot` YieldReceiver taken
+    /// at this entry's most recent DOWNWARD CALL (a sorted, deduped key set;
+    /// empty until/unless this entry has called down). Static for the in-flight
+    /// sub-call — a frame cannot shrink its catch-set mid-flight to dodge a
+    /// descendant's yield (spec §3 "frozen for the sub-call").
+    catch_set: Vec<Key>,
+}
+
+impl StackEntry {
+    /// A fresh InstanceEntry at stack position `index` carrying a new
+    /// `instance_id`. `target` is its own index (it runs its own frame); the
+    /// catch-set is empty until its first downward CALL.
+    fn instance(frame: KernelFrame, index: usize, instance_id: u64) -> Self {
+        StackEntry {
+            kind: EntryKind::Instance(Box::new(frame)),
+            target: index,
+            instance_id,
+            catch_set: Vec::new(),
+        }
+    }
+}
+
+/// `&mut` to the [`KernelFrame`] the entry at `idx` runs, following a
+/// ReferenceEntry to its referent InstanceEntry. The referent is always an
+/// `Instance` (a Reference's `target` only ever names an InstanceEntry).
+fn frame_at_mut(stack: &mut [StackEntry], idx: usize) -> &mut KernelFrame {
+    let target = stack[idx].target;
+    match &mut stack[target].kind {
+        EntryKind::Instance(f) => f,
+        EntryKind::Reference => unreachable!("ReferenceEntry.target must be an InstanceEntry"),
+    }
+}
+
+/// Shared-borrow companion of [`frame_at_mut`].
+fn frame_at(stack: &[StackEntry], idx: usize) -> &KernelFrame {
+    let target = stack[idx].target;
+    match &stack[target].kind {
+        EntryKind::Instance(f) => f,
+        EntryKind::Reference => unreachable!("ReferenceEntry.target must be an InstanceEntry"),
+    }
+}
+
+/// Snapshot a frame's Instance `yield_receiver_slot` YieldReceiver as a sorted,
+/// deduped catch-set — the keys it will catch from the subtree of its *next*
+/// downward CALL (spec §3 per-CALL snapshot). Empty when the Image declares no
+/// receiver slot, the slot is empty, or it doesn't hold a YieldReceiver
+/// (catches nothing). Reads only; never mutates.
+fn snapshot_catch_set(frame: &KernelFrame) -> Vec<Key> {
+    let Some(img_arc) = CACHE.get(CapHashOrRef::Hash(frame.image_hash)) else {
+        return Vec::new();
+    };
+    let slot = match &*img_arc {
+        Cap::Image(i) => match &i.yield_receiver_slot {
+            Some(s) => s.clone(),
+            None => return Vec::new(),
+        },
+        _ => return Vec::new(),
+    };
+    match read_instance_cap(frame, &slot) {
+        Some(inst) => {
+            let mut keys = javm_cap::yield_receiver_keys(&inst).unwrap_or_default();
+            keys.sort();
+            keys.dedup();
+            keys
+        }
+        None => Vec::new(),
+    }
+}
+
 /// One cap-backed data mapping projected into the guest address space,
 /// lazily materialized (category #3). The #PF handler scans this list when a
 /// guest access faults inside ring 3; a hit identifies the page's **kind**
@@ -332,20 +462,27 @@ pub fn run_top(
     initial_gas: i64,
 ) -> Result<LoopOutcome, u32> {
     let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
-    let mut stack: Vec<KernelFrame> = Vec::with_capacity(8);
-    stack.push(top);
+    let mut stack: Vec<StackEntry> = Vec::with_capacity(8);
+    // Monotonic Instance identity for emitter-exclusion (§3). The top-level
+    // invocation is instance 0; every CALL mints the next id.
+    let mut next_iid: u64 = 0;
+    stack.push(StackEntry::instance(top, 0, next_iid));
+    next_iid += 1;
     let mut gas = initial_gas;
 
     let outcome = loop {
-        // Phase 1: run one ring-3 entry on the top frame.
+        let top_idx = stack.len() - 1;
+        // Phase 1: run one ring-3 entry on the top entry's frame (an
+        // InstanceEntry runs its own frame; a ReferenceEntry runs its
+        // referent's — the same Instance, sharing one PC/regs/mem).
         let info = {
-            let frame = stack.last_mut().expect("stack non-empty");
+            let frame = frame_at_mut(&mut stack, top_idx);
             run_one_entry(frame, gas)?
         };
         gas = info.gas_remaining;
-        // Mirror the JIT's post-exit state back into the top frame.
+        // Mirror the JIT's post-exit state back into the running frame.
         {
-            let frame = stack.last_mut().expect("stack non-empty");
+            let frame = frame_at_mut(&mut stack, top_idx);
             frame.regs = info.regs;
             frame.pc = info.pc;
         }
@@ -354,10 +491,22 @@ pub fn run_top(
         // we can mutate `stack` (push/pop) inside each arm.
         match info.exit_reason {
             EXIT_HALT => {
+                // A handler activation (ReferenceEntry) that HALTs without
+                // resuming its yielder needs the deferred multi-frame unwind →
+                // clean trap for now (never reflected by pop_and_reflect).
+                if stack[top_idx].target != top_idx {
+                    break LoopOutcome {
+                        exit_reason: EXIT_TRAP,
+                        exit_arg: ERR_HANDLER_HALT,
+                        return_value: info.regs[7],
+                        gas_remaining: gas,
+                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                    };
+                }
                 // Read the scratchpad head from the top frame BEFORE it is
                 // popped (and dropped) — only meaningful at the top-level HALT.
                 let head = if stack.len() == 1 {
-                    read_scratchpad_head(stack.last().expect("stack non-empty"))
+                    read_scratchpad_head(frame_at(&stack, top_idx))
                 } else {
                     [0u8; SCRATCHPAD_HEAD_LEN]
                 };
@@ -399,10 +548,22 @@ pub fn run_top(
                 };
                 match op {
                     OP_REPLY => {
+                        // A handler activation (ReferenceEntry) that REPLYs
+                        // without resuming its yielder → deferred unwind, clean
+                        // trap (see EXIT_HALT).
+                        if stack[top_idx].target != top_idx {
+                            break LoopOutcome {
+                                exit_reason: EXIT_TRAP,
+                                exit_arg: ERR_HANDLER_HALT,
+                                return_value: info.regs[7],
+                                gas_remaining: gas,
+                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                            };
+                        }
                         // Read the scratchpad head from the top frame before the
                         // pop (only meaningful at the top-level trampoline HALT).
                         let head = if stack.len() == 1 {
-                            read_scratchpad_head(stack.last().expect("stack non-empty"))
+                            read_scratchpad_head(frame_at(&stack, top_idx))
                         } else {
                             [0u8; SCRATCHPAD_HEAD_LEN]
                         };
@@ -423,7 +584,7 @@ pub fn run_top(
                     }
                     OP_DERIVE_SPAWN => {
                         let trapped = {
-                            let frame = stack.last_mut().expect("non-empty");
+                            let frame = frame_at_mut(&mut stack, top_idx);
                             dispatch_derive_spawn(frame)?
                         };
                         if trapped {
@@ -439,7 +600,7 @@ pub fn run_top(
                     }
                     OP_IMAGE_HASH_CHAIN => {
                         let trapped = {
-                            let frame = stack.last_mut().expect("non-empty");
+                            let frame = frame_at_mut(&mut stack, top_idx);
                             dispatch_image_hash_chain(frame)?
                         };
                         if trapped {
@@ -454,12 +615,95 @@ pub fn run_top(
                         }
                     }
                     OP_HOST_YIELD => {
-                        let trapped = {
-                            let frame = stack.last_mut().expect("non-empty");
+                        let outcome = {
+                            let frame = frame_at_mut(&mut stack, top_idx);
                             dispatch_host_yield(frame)?
                         };
-                        if trapped {
+                        match outcome {
+                            // A kernel-root pure-cap syscall handled inline; the
+                            // guest resumes at the next instruction (the
+                            // "conceptually push a kernel frame but don't" path).
+                            YieldOutcome::Inline => {}
                             // Bad/empty sender slot or pinned dst → guest trap.
+                            YieldOutcome::Trap => {
+                                break LoopOutcome {
+                                    exit_reason: EXIT_TRAP,
+                                    exit_arg: 0,
+                                    return_value: info.regs[7],
+                                    gas_remaining: gas,
+                                    scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                                };
+                            }
+                            // Route `key` to an ancestor YieldReceiver: walk from
+                            // just below the emitter toward the root, SKIPPING all
+                            // frames of the emitting instance (§3
+                            // emitter-exclusion via `instance_id`); the nearest
+                            // entry whose SNAPSHOTTED catch-set contains `key`
+                            // catches it (single-resumer).
+                            YieldOutcome::Route { key, sender_slot } => {
+                                let emitter_iid = stack[top_idx].instance_id;
+                                let mut catcher = None;
+                                for j in (0..top_idx).rev() {
+                                    if stack[j].instance_id == emitter_iid {
+                                        continue;
+                                    }
+                                    if stack[j].catch_set.binary_search(&key).is_ok() {
+                                        catcher = Some(j);
+                                        break;
+                                    }
+                                }
+                                let Some(j) = catcher else {
+                                    // No ancestor catches and the kernel root has
+                                    // no handler for this key → the emitter faults
+                                    // ("unhandled yield_key").
+                                    break LoopOutcome {
+                                        exit_reason: EXIT_TRAP,
+                                        exit_arg: ERR_YIELD_UNHANDLED,
+                                        return_value: info.regs[7],
+                                        gas_remaining: gas,
+                                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                                    };
+                                };
+                                // Reflect a copy of the YieldSender into the
+                                // catcher's scratchpad slot[0] as the payload, and
+                                // flag φ[8] = YIELDED so a discriminating handler
+                                // can tell a yield from a plain CALL return.
+                                let payload = {
+                                    let emitter = frame_at(&stack, top_idx);
+                                    read_instance_cap(emitter, &sender_slot)
+                                };
+                                let target = stack[j].target;
+                                let recv_iid = stack[j].instance_id;
+                                {
+                                    let catcher_frame = frame_at_mut(&mut stack, j);
+                                    if let Some(inst) = payload {
+                                        catcher_frame.cnode.set_key(
+                                            &[javm_cap::abi::SCRATCHPAD_SLOT],
+                                            Some(CapHashOrRef::Owned(CachedCap::boxed(
+                                                Cap::Instance(inst),
+                                            ))),
+                                        );
+                                    }
+                                    catcher_frame.regs[8] = STATUS_YIELDED;
+                                }
+                                // Push the handler activation (a ReferenceEntry to
+                                // the catcher); the yielder stays on the stack
+                                // below as Waiting until the handler CALL_RESUMEs.
+                                stack.push(StackEntry {
+                                    kind: EntryKind::Reference,
+                                    target,
+                                    instance_id: recv_iid,
+                                    catch_set: Vec::new(),
+                                });
+                            }
+                        }
+                    }
+                    OP_CALL_RESUME => {
+                        // Resume the Waiting yielder directly below this handler
+                        // activation. The top MUST be a ReferenceEntry (we are
+                        // running as a yield handler); an InstanceEntry top has no
+                        // outstanding yield to resume → trap.
+                        if stack[top_idx].target == top_idx {
                             break LoopOutcome {
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
@@ -467,6 +711,22 @@ pub fn run_top(
                                 gas_remaining: gas,
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
+                        }
+                        // Reflect the handler's scratchpad slot[0] (its response)
+                        // to the yielder, pop the ReferenceEntry, and let the
+                        // yielder become the running top (it continues at its
+                        // post-yield PC next iteration).
+                        let response = {
+                            let handler = frame_at_mut(&mut stack, top_idx);
+                            handler.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
+                        };
+                        stack.pop();
+                        let yielder_idx = stack.len() - 1;
+                        let yielder = frame_at_mut(&mut stack, yielder_idx);
+                        if let Some(cap) = response {
+                            yielder
+                                .cnode
+                                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                         }
                     }
                     OP_HOST_CALL => {
@@ -486,7 +746,7 @@ pub fn run_top(
                         // never a gas discount — so gas is independent of the
                         // node-local compile/PT cache (gas_const::call_frame_cost).
                         let frame_cost = {
-                            let parent = stack.last().expect("non-empty");
+                            let parent = frame_at(&stack, top_idx);
                             host_call_frame_cost(parent)?
                         };
                         if gas < frame_cost {
@@ -499,8 +759,17 @@ pub fn run_top(
                             };
                         }
                         gas -= frame_cost;
+                        // Snapshot the caller's catch-set at this downward CALL
+                        // (§3): the keys it will catch from the callee's whole
+                        // subtree. Captured from the caller's CURRENT
+                        // `yield_receiver_slot`, stored on the caller entry, and
+                        // frozen for the sub-call — yield routing consults it.
+                        let catch_set = {
+                            let parent = frame_at(&stack, top_idx);
+                            snapshot_catch_set(parent)
+                        };
                         let mut child = {
-                            let parent = stack.last_mut().expect("non-empty");
+                            let parent = frame_at_mut(&mut stack, top_idx);
                             dispatch_host_call(parent)?
                         };
                         // Scratchpad: MOVE the caller's slot[0] into the
@@ -508,7 +777,7 @@ pub fn run_top(
                         // the callee's image-default slot[0], if any, is
                         // overwritten by the caller-provided scratchpad.
                         {
-                            let parent = stack.last_mut().expect("non-empty");
+                            let parent = frame_at_mut(&mut stack, top_idx);
                             if let Some(cap) =
                                 parent.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
                             {
@@ -522,7 +791,10 @@ pub fn run_top(
                         // `MAX_DEPTH` (interim) / the cnode nesting limit
                         // (target), so the resident page-table set is bounded
                         // structurally rather than by an LRU cap.
-                        stack.push(child);
+                        stack[top_idx].catch_set = catch_set;
+                        let child_idx = stack.len();
+                        stack.push(StackEntry::instance(child, child_idx, next_iid));
+                        next_iid += 1;
                     }
                     // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
                     // arbitrary `ecalli imm`, …) is not in-kernel-
@@ -708,8 +980,14 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
 /// move it back into the parent's origin slot (the single-owner round trip).
 /// Returns `true` when the stack has been drained (the RPC caller hands a
 /// result back to the host).
-fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
-    let mut popped = stack.pop().expect("non-empty");
+fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
+    // A HALT/REPLY only pops an InstanceEntry — a ReferenceEntry (handler
+    // activation) is removed by CALL_RESUME, and a handler that HALTs without
+    // resuming is caught by the EXIT_HALT/OP_REPLY guards before this point.
+    let mut popped = match stack.pop().expect("non-empty").kind {
+        EntryKind::Instance(boxed) => *boxed,
+        EntryKind::Reference => unreachable!("pop_and_reflect on a ReferenceEntry"),
+    };
 
     if stack.is_empty() {
         // Top-level HALT: no parent to park the runtime in, so drop it (its
@@ -763,7 +1041,11 @@ fn pop_and_reflect(stack: &mut Vec<KernelFrame>, return_value: u64) -> bool {
         }
     };
 
-    let parent = stack.last_mut().unwrap();
+    // The parent is the entry directly below; follow a ReferenceEntry to the
+    // referent frame so a child of a handler activation reflects into the
+    // handler's Instance (which spawned/called it).
+    let parent_idx = stack.len() - 1;
+    let parent = frame_at_mut(stack, parent_idx);
     parent.regs[7] = return_value;
     if let Some(cap) = scratch {
         parent
@@ -1038,32 +1320,51 @@ fn read_instance_cap(frame: &KernelFrame, slot: &Key) -> Option<InstanceCap> {
     }
 }
 
-/// `host_yield(sender_slot=φ[7], …)`. Reads the `YieldSender` at `sender_slot`,
-/// extracts its yield_key, and — for a `kernel:*` key the kernel handles as the
-/// implicit root receiver — performs the syscall INLINE and resumes the guest
-/// (`Ok(false)`, like derive_spawn). Returns `Ok(true)` to TRAP (bad/empty
-/// sender, pinned dst, malformed operand); `Err(code)` for a yield_key not yet
-/// handled here (user keys, or kernel:* syscalls deferred to later stages).
+/// Outcome of a `host_yield`, classified by [`dispatch_host_yield`] for the
+/// call loop to act on.
+enum YieldOutcome {
+    /// A `kernel:*` pure-cap syscall the kernel handled inline as the implicit
+    /// root receiver (no stack push); the guest resumes at the next instruction.
+    Inline,
+    /// The operand was malformed (bad/empty sender, pinned dst, wrong cap kind)
+    /// → trap the emitter.
+    Trap,
+    /// Not handled inline → route `key` to an ancestor YieldReceiver. `key` is
+    /// the YieldSender's yield_key; `sender_slot` names the YieldSender so the
+    /// loop can reflect a copy of it to the catcher as the yield payload.
+    Route { key: Key, sender_slot: Key },
+}
+
+/// `host_yield(sender_slot=φ[7], …)`. Reads the `YieldSender` at `sender_slot`
+/// and classifies the yield: a `kernel:*` pure-cap syscall (mint_yield,
+/// merge_yield_receiver) is performed INLINE as the implicit root receiver
+/// ([`YieldOutcome::Inline`]); a malformed operand traps
+/// ([`YieldOutcome::Trap`]); anything else — a user key, or a `kernel:*` key not
+/// handled inline — is routed to an ancestor YieldReceiver by the call loop
+/// ([`YieldOutcome::Route`]). `Err(code)` is reserved for an internal cnode
+/// failure (loud, not a guest-visible trap).
 ///
 /// V1 single-byte ABI: all slot operands are the low byte of their φ register.
 /// `kernel:mint_yield`: φ[8] = new yield_key byte, φ[9] = YieldSender dst,
 /// φ[10] = YieldReceiver dst. `kernel:merge_yield_receiver`: φ[8] = receiver A
 /// slot, φ[9] = receiver B slot, φ[10] = dst slot.
-fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<bool, u32> {
+fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<YieldOutcome, u32> {
     let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
     let yield_key = match read_instance_cap(frame, &sender_slot) {
         Some(inst) => match javm_cap::yield_sender_key(&inst) {
             Some(k) => k,
-            None => return Ok(true), // not a YieldSender → trap
+            None => return Ok(YieldOutcome::Trap), // not a YieldSender → trap
         },
-        None => return Ok(true), // empty / non-Instance sender slot → trap
+        None => return Ok(YieldOutcome::Trap), // empty / non-Instance sender → trap
     };
 
-    // Only kernel:* keys are caught here (kernel = implicit root receiver).
-    // Routing a user key to an ancestor YieldReceiver needs the suspension
-    // mechanism — a later stage.
+    // User keys (and any kernel:* key not wired inline below) route to an
+    // ancestor YieldReceiver; the loop walks the stack and suspends the emitter.
     if !javm_cap::is_kernel_yield_key(&yield_key) {
-        return Err(ERR_YIELD_UNHANDLED);
+        return Ok(YieldOutcome::Route {
+            key: yield_key,
+            sender_slot,
+        });
     }
     let k = yield_key.as_slice();
 
@@ -1074,7 +1375,7 @@ fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<bool, u32> {
         if frame.pinned.binary_search(&sender_dst).is_ok()
             || frame.pinned.binary_search(&receiver_dst).is_ok()
         {
-            return Ok(true);
+            return Ok(YieldOutcome::Trap);
         }
         let sender = Cap::Instance(javm_cap::yield_sender(&new_key));
         let receiver = Cap::Instance(javm_cap::yield_receiver(&[new_key]));
@@ -1092,19 +1393,19 @@ fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<bool, u32> {
                 Some(CapHashOrRef::Owned(CachedCap::boxed(receiver))),
             )
             .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
-        Ok(false)
+        Ok(YieldOutcome::Inline)
     } else if k == javm_cap::yield_cap::YK_MERGE_YIELD_RECEIVER {
         let a_slot = Key::from((frame.regs[8] & 0xFF) as u8);
         let b_slot = Key::from((frame.regs[9] & 0xFF) as u8);
         let dst = Key::from((frame.regs[10] & 0xFF) as u8);
         if frame.pinned.binary_search(&dst).is_ok() {
-            return Ok(true);
+            return Ok(YieldOutcome::Trap);
         }
         let a = read_instance_cap(frame, &a_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
         let b = read_instance_cap(frame, &b_slot).ok_or(ERR_YIELD_BAD_SENDER)?;
         let merged = match javm_cap::merge_yield_receivers(&a, &b) {
             Some(m) => m,
-            None => return Ok(true), // operands not both YieldReceivers → trap
+            None => return Ok(YieldOutcome::Trap), // operands not both receivers
         };
         frame
             .cnode
@@ -1113,11 +1414,16 @@ fn dispatch_host_yield(frame: &mut KernelFrame) -> Result<bool, u32> {
                 Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(merged)))),
             )
             .map_err(|_| ERR_DERIVE_SLOT_OOB)?;
-        Ok(false)
+        Ok(YieldOutcome::Inline)
     } else {
-        // kernel:set_gas_meter / mint_gas / oog / … need the (guest-side) meter
-        // table or the suspension mechanism — later stages.
-        Err(ERR_YIELD_UNHANDLED)
+        // A kernel:* key not wired inline (set_gas_meter / mint_gas / oog / …):
+        // route it. The kernel root catches kernel:* keys the chain registered
+        // in its YieldReceiver (e.g. kernel:oog); an unregistered key finds no
+        // catcher and the emitter faults.
+        Ok(YieldOutcome::Route {
+            key: yield_key,
+            sender_slot,
+        })
     }
 }
 

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -149,11 +149,11 @@ const OP_HOST_CALL: u32 = 26;
 /// guest-kernel op number — needs no recompiler change (the recompiler surfaces
 /// `ecalli imm` → EXIT_HOST_CALL(imm) generically; dispatched here).
 const OP_CALL_RESUME: u32 = 27;
-/// `drop_paused()` — a yield handler gives up on its Waiting yielder (spec §4
-/// DROP_PAUSED): discard the entry directly below this handler's ReferenceEntry
-/// (its frame + state) WITHOUT resuming it; the handler keeps running. Faults if
-/// the top is not a handler activation. New guest-kernel op number.
-const OP_DROP_PAUSED: u32 = 28;
+/// `drop_resume()` — a yield handler gives up on its Waiting yielder (spec §4
+/// DROP_RESUME). V1 discards the caught in-flight subtree WITHOUT resuming it;
+/// materializing a sigma-resident Paused cap is a later stage. The handler keeps
+/// running. Faults if the top is not a handler activation.
+const OP_DROP_RESUME: u32 = 28;
 
 /// φ[8] status the kernel writes into the caller on apply termination (spec §4
 /// calling convention): `Ok` on a normal HALT/REPLY return and on a CALL_RESUME
@@ -863,13 +863,15 @@ pub fn run_top(
                         // response status) — its host_yield "returns" here.
                         yielder.regs[8] = STATUS_OK;
                     }
-                    OP_DROP_PAUSED => {
+                    OP_DROP_RESUME => {
                         // Give up on the Waiting yielder: discard the WHOLE caught
                         // subtree (the yielder + any intermediates a descendant
                         // routed past — same scope as a handler HALT, §10), but
-                        // keep the handler running. The top must be a handler
-                        // ReferenceEntry — an InstanceEntry top has no outstanding
-                        // yield → trap.
+                        // keep the handler running. Full DROP_RESUME will detach
+                        // the yielder as sigma-resident Paused; this V1 path only
+                        // implements the discard behavior. The top must be a
+                        // handler ReferenceEntry — an InstanceEntry top has no
+                        // outstanding yield → trap.
                         if stack[top_idx].target == top_idx {
                             break LoopOutcome {
                                 exit_reason: EXIT_TRAP,
@@ -892,7 +894,7 @@ pub fn run_top(
                         // route_yield, so the meter table stays consistent — gas is
                         // STM-exempt: a dropped subtree's spend is NOT refunded.)
                         // Using `target+1` (not `top_idx-1`) keeps subsequent
-                        // CALL_RESUME/DROP_PAUSED sound — there is no longer a stale
+                        // CALL_RESUME/DROP_RESUME sound — there is no longer a stale
                         // handler with a wedged intermediate below it.
                         let handler_inst = stack[top_idx].target;
                         stack.truncate(handler_inst + 1);

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -125,12 +125,10 @@ const OP_REPLY: u32 = 0;
 /// kernel as the implicit ROOT receiver and handled INLINE — the guest resumes
 /// at the next instruction (the "syscalls conceptually push a kernel frame but
 /// we don't actually push" model). Everything else — a user key, or a
-/// `kernel:*` key not wired inline — is ROUTED: the loop walks the call stack
-/// from the emitter toward the root (skipping the emitter instance's own
-/// frames) and the nearest ancestor whose per-CALL snapshotted YieldReceiver
+/// `kernel:*` key not wired inline — is ROUTED: the loop follows logical owner
+/// edges, and the nearest owner edge whose per-CALL snapshotted YieldReceiver
 /// contains the key catches it (push a ReferenceEntry, suspend the yielder;
-/// resumed by [`OP_CALL_RESUME`]). Gas/quota `kernel:*` syscalls (need the meter
-/// table) remain a later stage.
+/// resumed by [`OP_CALL_RESUME`]).
 const OP_HOST_YIELD: u32 = 16;
 const OP_DERIVE_SPAWN: u32 = 18;
 /// `host_image_hash_chain(src_slot=φ[7], dst_slot=φ[8])` — read the cap's
@@ -193,13 +191,18 @@ const ERR_HOST_CALL_SLOT_EMPTY: u32 = 40;
 const ERR_JIT_FAILED: u32 = 50;
 const ERR_DEPTH_LIMIT: u32 = 51;
 const ERR_MAP_BAD_KIND: u32 = 60;
-/// `host_yield` carried a yield_key the kernel does not (yet) handle as root
-/// receiver — a non-`kernel:*` user key (ancestor routing is a later stage) or
-/// a `kernel:*` syscall not yet wired (gas/quota/oog).
+/// `host_yield` carried a yield_key no owner receiver caught, or a `kernel:*`
+/// syscall not yet wired inline.
 const ERR_YIELD_UNHANDLED: u32 = 70;
 /// A `host_yield` operand slot did not hold the expected kernel-assisted
 /// Instance (YieldSender / YieldReceiver).
 const ERR_YIELD_BAD_SENDER: u32 = 71;
+/// An Image declared gas slots, but every declared slot was empty. Empty slots
+/// are skipped individually; an all-empty declaration is a malformed funding
+/// interface.
+const ERR_GAS_SLOT_EMPTY: u32 = 72;
+/// A declared gas slot was present but did not resolve to a Gas handle.
+const ERR_GAS_SLOT_INVALID: u32 = 73;
 
 /// One stack frame on the in-kernel call stack. Holds the running Image's
 /// identity hashes, the frame's **owned** `mem` DataCap + PVM register/PC
@@ -325,60 +328,145 @@ struct StackEntry {
     /// for a ReferenceEntry. Lower-or-equal to the entry's own index and stable
     /// (entries below the top never move while the top exists).
     target: usize,
-    /// Canonical Instance identity for **emitter-exclusion**: an InstanceEntry
-    /// gets a fresh id at CALL; a ReferenceEntry copies its referent's id, so
-    /// every stack entry of one Instance compares equal. Yield routing skips all
-    /// entries whose `instance_id` matches the emitter's (spec §3 "skip ALL
-    /// frames belonging to the emitting instance").
+    /// Canonical Instance identity: an InstanceEntry gets a fresh id at CALL; a
+    /// ReferenceEntry copies its referent's id, so every stack entry of one
+    /// Instance compares equal. Kept for status/debug accounting; yield routing
+    /// follows owner edges, not instance-id skipping.
     instance_id: u64,
-    /// The catch-list this entry offers to the subtree currently below it: a
-    /// **snapshot** of its Instance's `yield_receiver_slot` YieldReceiver taken
-    /// at this entry's most recent DOWNWARD CALL (a sorted, deduped key set;
-    /// empty until/unless this entry has called down). Static for the in-flight
-    /// sub-call — a frame cannot shrink its catch-set mid-flight to dodge a
-    /// descendant's yield (spec §3 "frozen for the sub-call").
-    catch_set: Vec<Key>,
-    /// The gas meter that funds this entry's frame — computed ONCE at push time
-    /// as `own_meter.or(parent_or_catcher.active)`: the frame's own
-    /// `gas_slots[0]` → `Gas{meter_key}` if it declares one, else (loaned) it
-    /// inherits its caller's active meter; a handler `ReferenceEntry` inherits the
-    /// CATCHER's active meter. `None` = host-budgeted (the top frame and its
-    /// loaned descendants). The loop reconciles `gas` to this on each iteration
-    /// (see [`reconcile_active`]). Storing it (vs. a stack walk) is unambiguous in
-    /// the presence of yields, where the entries between a handler Reference and
-    /// its referent are a *suspended* subtree, NOT the running frame's ancestry.
-    /// Aliasing falls out: a child naming the same meter as a live ancestor gets
-    /// the SAME `active`, so no reconcile/swap — it shares the one balance.
-    active: Option<Key>,
+    /// Logical data-flow owner of this InstanceEntry. For a normal CALL from a
+    /// handler ReferenceEntry this points to the handler's referent InstanceEntry
+    /// (so `A -> B -> ref[A] -> C` records `owner(C)=A`). Root has no owner.
+    /// ReferenceEntries carry this only for diagnostics; routing starts at
+    /// `target`, the logical frame being run.
+    owner: Option<usize>,
+    /// Snapshot of the owner's YieldReceiver at the CALL that created this
+    /// entry: the catch-list on the owner edge `owner -> this`. Yield routing
+    /// consults this edge snapshot, then walks to the owner and repeats. Static
+    /// for the in-flight sub-call.
+    owner_catch_set: Vec<Key>,
+    /// Gas sources funding this entry's frame. A frame with declared gas slots
+    /// owns an ordered list of usable Gas handles; OOG consults each before
+    /// routing `kernel:oog`. A frame with no declaration loans its caller's gas
+    /// scope. A handler ReferenceEntry inherits the catcher's gas scope.
+    gas: FrameGas,
 }
 
 impl StackEntry {
     /// A fresh InstanceEntry at stack position `index` carrying a new
-    /// `instance_id`. `target` is its own index (it runs its own frame); the
-    /// catch-set is empty until its first downward CALL; `active` is stamped by
-    /// the CALL site (`own_meter.or(parent.active)`).
+    /// `instance_id`. `target` is its own index (it runs its own frame); owner
+    /// and gas scope are stamped by the CALL site.
     fn instance(frame: KernelFrame, index: usize, instance_id: u64) -> Self {
         StackEntry {
             kind: EntryKind::Instance(Box::new(frame)),
             target: index,
             instance_id,
-            catch_set: Vec::new(),
-            active: None,
+            owner: None,
+            owner_catch_set: Vec::new(),
+            gas: FrameGas::host_budgeted(),
         }
     }
 }
 
-/// Resolve a frame's own gas meter: read its Image's `gas_slots[0]`, look that
-/// slot up in the frame's cnode, and decode the `Gas{meter_key}` handle there.
-/// `None` if the Image declares no gas slot, the slot is empty, or it doesn't
-/// hold a `Gas` handle (the frame then loans its caller's active meter).
-fn resolve_frame_meter(frame: &KernelFrame) -> Option<Key> {
-    let img_arc = CACHE.get(CapHashOrRef::Hash(frame.image_hash))?;
-    let slot = match &*img_arc {
-        Cap::Image(i) => i.gas_slots.first()?.clone(),
-        _ => return None,
+#[derive(Clone, Debug, Default)]
+struct FrameGas {
+    meters: Vec<Key>,
+    active: Option<usize>,
+}
+
+impl FrameGas {
+    fn host_budgeted() -> Self {
+        Self {
+            meters: Vec::new(),
+            active: None,
+        }
+    }
+
+    fn declared(meters: Vec<Key>) -> Self {
+        debug_assert!(!meters.is_empty());
+        Self {
+            meters,
+            active: Some(0),
+        }
+    }
+
+    fn active_key(&self) -> Option<Key> {
+        self.active.and_then(|idx| self.meters.get(idx).cloned())
+    }
+
+    fn primary_key(&self) -> Option<Key> {
+        self.meters.first().cloned()
+    }
+
+    fn advance(&mut self) -> bool {
+        let Some(idx) = self.active else {
+            return false;
+        };
+        let next = idx + 1;
+        if next < self.meters.len() {
+            self.active = Some(next);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn reset_to_primary(&mut self) {
+        if !self.meters.is_empty() {
+            self.active = Some(0);
+        }
+    }
+}
+
+/// Resolve a frame's declared gas sources. No declaration means the frame loans
+/// its caller's gas scope. Individual empty slots are skipped. A present slot
+/// that is not a Gas handle is a hard kernel error, and an all-empty declaration
+/// is also invalid: there is no primary Gas cap to carry in an OOG payload.
+fn resolve_frame_gas(frame: &KernelFrame) -> Result<Option<FrameGas>, u32> {
+    let img_arc = CACHE
+        .get(CapHashOrRef::Hash(frame.image_hash))
+        .ok_or(ERR_IMAGE_NOT_FOUND)?;
+    let slots = match &*img_arc {
+        Cap::Image(i) => i.gas_slots.clone(),
+        _ => return Err(ERR_IMAGE_KIND),
     };
-    javm_cap::gas_meter_key(&read_instance_cap(frame, &slot)?)
+    if slots.is_empty() {
+        return Ok(None);
+    }
+
+    let mut meters = Vec::new();
+    for slot in slots {
+        let Some(cap_ref) = frame.cnode.peek_key(slot.as_slice()) else {
+            continue;
+        };
+        let meter = gas_meter_key_from_ref(cap_ref)?;
+        if !meters.contains(&meter) {
+            meters.push(meter);
+        }
+    }
+    if meters.is_empty() {
+        Err(ERR_GAS_SLOT_EMPTY)
+    } else {
+        Ok(Some(FrameGas::declared(meters)))
+    }
+}
+
+fn gas_meter_key_from_ref(cap_ref: &CapHashOrRef<Box<CachedCap>>) -> Result<Key, u32> {
+    let inst = match cap_ref {
+        CapHashOrRef::Hash(h) => {
+            let arc = CACHE
+                .get(CapHashOrRef::Hash(*h))
+                .ok_or(ERR_GAS_SLOT_INVALID)?;
+            match &*arc {
+                Cap::Instance(i) => i.clone(),
+                _ => return Err(ERR_GAS_SLOT_INVALID),
+            }
+        }
+        CapHashOrRef::Owned(cc) => match &cc.cap {
+            Cap::Instance(i) => i.clone(),
+            _ => return Err(ERR_GAS_SLOT_INVALID),
+        },
+    };
+    javm_cap::gas_meter_key(&inst).ok_or(ERR_GAS_SLOT_INVALID)
 }
 
 /// Reconcile the threaded `gas` (the live balance of the running frame's active
@@ -542,14 +630,15 @@ pub fn run_top(
 ) -> Result<LoopOutcome, u32> {
     let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
     let mut stack: Vec<StackEntry> = Vec::with_capacity(8);
-    // Monotonic Instance identity for emitter-exclusion (§3). The top-level
-    // invocation is instance 0; every CALL mints the next id.
+    // Monotonic Instance identity. The top-level invocation is instance 0; every
+    // CALL mints the next id.
     let mut next_iid: u64 = 0;
     stack.push(StackEntry::instance(top, 0, next_iid));
     next_iid += 1;
     // GAS MODEL (single reconciliation point). The threaded `gas` always holds
     // the LIVE balance of the running frame's ACTIVE meter — `active_meter(top)`,
-    // the frame's stored `active` (its own meter, or its caller/catcher's).
+    // the frame's stored gas scope (its own declared meter list, or its
+    // caller/catcher's loaned scope).
     // `meters[k]` is authoritative for every non-active meter. At the top of each
     // iteration we reconcile: if the top's active meter changed since last
     // iteration, bank the old scope + load the new. Every CALL/HALT/yield/resume/
@@ -557,14 +646,15 @@ pub fn run_top(
     // gas bookkeeping. The guest meter table is per-RPC (a block-spanning table is
     // the deferred lazy-load piece).
     let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
-    // The TOP frame's own meter (its `gas_slots[0]` → `Gas{root_meter_key}`, if
-    // any) is the RPC's ROOT scope: stamp it like any frame and seed the table
-    // from the host-supplied budget, so `set_gas_meter` on the root meter (a chain
-    // self-harvesting, or a child aliasing the root) goes through the SAME table as
-    // sub-meters. A top with NO gas slot is host-budgeted (`root_active == None`,
-    // tracked in `host_budget`).
-    let root_active = resolve_frame_meter(frame_at(&stack, 0));
-    stack[0].active = root_active.clone();
+    // The TOP frame's primary usable meter, if declared, is the RPC's ROOT
+    // scope: stamp it like any frame and seed the table from the host-supplied
+    // budget, so `set_gas_meter` on the root meter goes through the SAME table
+    // as sub-meters. A top with NO gas slot is host-budgeted
+    // (`root_active == None`, tracked in `host_budget`). The host ABI still
+    // supplies one budget; secondary root gas slots are usable if a guest-side
+    // syscall funds them during the run.
+    stack[0].gas = resolve_frame_gas(frame_at(&stack, 0))?.unwrap_or_else(FrameGas::host_budgeted);
+    let root_active = stack[0].gas.active_key();
     if let Some(k) = &root_active {
         meters.insert(k.clone(), initial_gas);
     }
@@ -797,9 +887,9 @@ pub fn run_top(
                                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                 };
                             }
-                            // Route `key` to an ancestor YieldReceiver (the
-                            // payload is a copy of the emitted YieldSender). No
-                            // catcher → the emitter faults ("unhandled yield_key").
+                            // Route `key` to an owner YieldReceiver (the payload
+                            // is a copy of the emitted YieldSender). No catcher
+                            // → the emitter faults ("unhandled yield_key").
                             YieldOutcome::Route { key, sender_slot } => {
                                 let payload =
                                     read_instance_cap(frame_at(&stack, top_idx), &sender_slot);
@@ -907,11 +997,10 @@ pub fn run_top(
                         // every CALL — compile/PT memoization is for *work*, never
                         // a gas discount — so gas is independent of the cache.
                         //
-                        // Snapshot the caller's catch-set at this downward CALL
-                        // (§3): the keys it will catch from the callee's whole
-                        // subtree. Captured from the caller's CURRENT
-                        // `yield_receiver_slot`, stored on the caller entry, and
-                        // frozen for the sub-call — yield routing consults it.
+                        // Snapshot the logical owner's catch-set at this CALL:
+                        // the keys on the owner edge `owner -> child`. When A is
+                        // running via `ref[A]`, the physical caller is the
+                        // ReferenceEntry but the logical owner is A itself.
                         let catch_set = {
                             let parent = frame_at(&stack, top_idx);
                             snapshot_catch_set(parent)
@@ -939,21 +1028,18 @@ pub fn run_top(
                         // `MAX_DEPTH` (interim) / the cnode nesting limit
                         // (target), so the resident page-table set is bounded
                         // structurally rather than by an LRU cap.
-                        stack[top_idx].catch_set = catch_set;
                         let child_idx = stack.len();
                         stack.push(StackEntry::instance(child, child_idx, next_iid));
                         next_iid += 1;
-                        // Stamp the child's active (funding) meter: its own
-                        // `gas_slots[0]` meter, else (loaned) the caller's active
-                        // meter. The loop-top reconcile then swaps `gas` only when
-                        // the active meter actually changes — a child naming a NEW
-                        // meter becomes the active scope (gas := meters[k],
-                        // effective-0 if unfunded → OOG-routes on first debit); a
-                        // child naming the SAME meter as a live ancestor keeps the
-                        // shared scope (no swap, no double-spend).
-                        let parent_active = stack[top_idx].active.clone();
-                        stack[child_idx].active =
-                            resolve_frame_meter(frame_at(&stack, child_idx)).or(parent_active);
+                        // Stamp owner-edge routing and funding. The child owns
+                        // its declared gas scope if it has one; otherwise it
+                        // loans the caller/catcher's current gas scope.
+                        let logical_owner = stack[top_idx].target;
+                        stack[child_idx].owner = Some(logical_owner);
+                        stack[child_idx].owner_catch_set = catch_set;
+                        let inherited_gas = stack[top_idx].gas.clone();
+                        stack[child_idx].gas = resolve_frame_gas(frame_at(&stack, child_idx))?
+                            .unwrap_or(inherited_gas);
                     }
                     // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
                     // arbitrary `ecalli imm`, …) is not in-kernel-
@@ -1153,44 +1239,42 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     .ok_or(ERR_JIT_FAILED)
 }
 
-/// Walk the kernel stack for a catcher of `key` (emitter-exclusion: skip every
-/// frame whose instance matches the top emitter's) and, if one is found, suspend
-/// the emitter and transfer control to the catcher as a yield handler: reflect
+/// Walk owner edges for a catcher of `key` and, if one is found, suspend the
+/// emitter and transfer control to the owner as a yield handler: reflect
 /// `payload` (a YieldSender / `Gas` cap copy) into the catcher's scratchpad
 /// slot[0], flag φ[8] = YIELDED, and push a ReferenceEntry to the catcher (the
 /// yielder stays Waiting below, resumed later by `CALL_RESUME`). Gas is NOT
 /// handled here — the loop-top [`reconcile_active`] banks the emitter's active
 /// meter and loads the catcher's on the next iteration.
 ///
-/// Returns `true` if routed, `false` if no ancestor catches `key` — the caller
-/// decides (fault the emitter for a user key, or bubble EXIT_OOG for kernel:oog).
+/// Returns `true` if routed, `false` if no owner ancestor catches `key` — the
+/// caller decides (fault the emitter for a user key, or bubble EXIT_OOG for
+/// kernel:oog).
 fn route_yield(
     stack: &mut Vec<StackEntry>,
     top_idx: usize,
     key: &Key,
     payload: Option<InstanceCap>,
 ) -> bool {
-    let emitter_iid = stack[top_idx].instance_id;
+    let mut node = stack[top_idx].target;
     let mut catcher = None;
-    for j in (0..top_idx).rev() {
-        if stack[j].instance_id == emitter_iid {
-            continue;
-        }
-        if stack[j].catch_set.binary_search(key).is_ok() {
-            catcher = Some(j);
+    while let Some(owner) = stack[node].owner {
+        if stack[node].owner_catch_set.binary_search(key).is_ok() {
+            catcher = Some(owner);
             break;
         }
+        node = owner;
     }
-    let Some(j) = catcher else {
+    let Some(owner) = catcher else {
         return false;
     };
-    let target = stack[j].target;
-    let recv_iid = stack[j].instance_id;
+    let target = owner;
+    let recv_iid = stack[owner].instance_id;
     // The handler runs the catcher's frame, so it is funded by the catcher's
-    // active meter (NOT the emitter's).
-    let recv_active = stack[j].active.clone();
+    // gas scope (NOT the emitter's).
+    let recv_gas = stack[owner].gas.clone();
     {
-        let catcher_frame = frame_at_mut(stack, j);
+        let catcher_frame = frame_at_mut(stack, owner);
         if let Some(inst) = payload {
             catcher_frame.cnode.set_key(
                 &[javm_cap::abi::SCRATCHPAD_SLOT],
@@ -1203,34 +1287,38 @@ fn route_yield(
         kind: EntryKind::Reference,
         target,
         instance_id: recv_iid,
-        catch_set: Vec::new(),
-        active: recv_active,
+        owner: stack[target].owner,
+        owner_catch_set: Vec::new(),
+        gas: recv_gas,
     });
     true
 }
 
 /// The gas meter funding the frame run by the entry at `idx` — the precomputed
-/// [`StackEntry::active`] (own meter, or inherited from the caller/catcher at
-/// push). O(1), unambiguous under yields.
+/// active key from its gas scope (own declared meter list, or inherited from the
+/// caller/catcher at push). O(1), unambiguous under yields.
 fn active_meter(stack: &[StackEntry], idx: usize) -> Option<Key> {
-    stack[idx].active.clone()
+    stack[idx].gas.active_key()
 }
 
-/// On gas exhaustion, inject a routed `kernel:oog` yield (payload =
-/// `Gas{meter_key}` of the meter funding the depleted pool) so a registered
-/// receiver (the chain) can top up the meter and `CALL_RESUME` — the frame then
-/// re-runs from `reattempt_pc` (a bb_start: the failing block's start, or the
-/// ecall's own pc). The depleted pool belongs to the ACTIVE meter (nearest
-/// metered ancestor), which may live below a loaned frame or on a handler
-/// ReferenceEntry's referent — not necessarily on the top entry. Returns `true`
-/// if routed; `false` if the pool is host-budgeted (no metered frame) or no
-/// receiver caught `kernel:oog` (the caller bubbles EXIT_OOG — host-stub root
-/// catch).
+/// On gas exhaustion, first consult the frame's remaining declared gas slots by
+/// advancing to the next usable meter and re-attempting `reattempt_pc`. Only
+/// after all usable meters are exhausted do we inject a routed `kernel:oog`
+/// yield. The OOG payload is the primary usable Gas handle so the receiver can
+/// top up that meter and `CALL_RESUME`; before routing, the frame resets to the
+/// primary so resume deterministically re-reads the top-up.
 fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32) -> bool {
-    let Some(meter) = active_meter(stack, top_idx) else {
+    if active_meter(stack, top_idx).is_none() {
+        return false;
+    }
+    frame_at_mut(stack, top_idx).pc = reattempt_pc;
+    if stack[top_idx].gas.advance() {
+        return true;
+    }
+    let Some(meter) = stack[top_idx].gas.primary_key() else {
         return false;
     };
-    frame_at_mut(stack, top_idx).pc = reattempt_pc;
+    stack[top_idx].gas.reset_to_primary();
     let oog_key = Key::from(&javm_cap::yield_cap::YK_OOG[..]);
     let payload = Some(javm_cap::gas_handle(&meter));
     route_yield(stack, top_idx, &oog_key, payload)
@@ -1615,7 +1703,7 @@ enum YieldOutcome {
     /// The operand was malformed (bad/empty sender, pinned dst, wrong cap kind)
     /// → trap the emitter.
     Trap,
-    /// Not handled inline → route `key` to an ancestor YieldReceiver. `key` is
+    /// Not handled inline → route `key` to an owner YieldReceiver. `key` is
     /// the YieldSender's yield_key; `sender_slot` names the YieldSender so the
     /// loop can reflect a copy of it to the catcher as the yield payload.
     Route { key: Key, sender_slot: Key },
@@ -1626,7 +1714,7 @@ enum YieldOutcome {
 /// merge_yield_receiver, mint_gas, mint_quota) is performed INLINE as the
 /// implicit root receiver ([`YieldOutcome::Inline`]); a malformed operand traps
 /// ([`YieldOutcome::Trap`]); anything else — a user key, or a `kernel:*` key not
-/// handled inline — is routed to an ancestor YieldReceiver by the call loop
+/// handled inline — is routed to an owner YieldReceiver by the call loop
 /// ([`YieldOutcome::Route`]). `Err(code)` is reserved for an internal cnode
 /// failure (loud, not a guest-visible trap).
 ///
@@ -1652,8 +1740,8 @@ fn dispatch_host_yield(
         None => return Ok(YieldOutcome::Trap), // empty / non-Instance sender → trap
     };
 
-    // User keys (and any kernel:* key not wired inline below) route to an
-    // ancestor YieldReceiver; the loop walks the stack and suspends the emitter.
+    // User keys (and any kernel:* key not wired inline below) route to an owner
+    // YieldReceiver; the loop suspends the emitter.
     if !javm_cap::is_kernel_yield_key(&yield_key) {
         return Ok(YieldOutcome::Route {
             key: yield_key,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -155,9 +155,12 @@ const OP_CALL_RESUME: u32 = 27;
 /// the top is not a handler activation. New guest-kernel op number.
 const OP_DROP_PAUSED: u32 = 28;
 
-/// φ[8] status a catcher sees when it resumes as a yield handler (vs. a normal
-/// CALL return). Forward-looking — a straight-line handler that unconditionally
-/// `call_resume`s ignores it; a discriminating handler branches on it.
+/// φ[8] status the kernel writes into the caller on apply termination (spec §4
+/// calling convention): `Ok` on a normal HALT/REPLY return and on a CALL_RESUME
+/// response, `YIELDED` when a routed yield hands control to a catcher. A
+/// discriminating handler branches on φ[8] to tell a yield from a plain return;
+/// a straight-line one ignores it.
+const STATUS_OK: u64 = 0;
 const STATUS_YIELDED: u64 = 1;
 
 /// Hard ceiling on the in-kernel call-stack depth. NOTE: with runtime eviction
@@ -856,6 +859,9 @@ pub fn run_top(
                                 .cnode
                                 .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                         }
+                        // Spec §4: a resumed yielder sees φ[8] = Ok (the handler's
+                        // response status) — its host_yield "returns" here.
+                        yielder.regs[8] = STATUS_OK;
                     }
                     OP_DROP_PAUSED => {
                         // Give up on the Waiting yielder: discard the WHOLE caught
@@ -1322,6 +1328,9 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
     let parent_idx = stack.len() - 1;
     let parent = frame_at_mut(stack, parent_idx);
     parent.regs[7] = return_value;
+    // Spec §4: the caller's φ[8] reflects the termination status — Ok for a normal
+    // HALT/REPLY return (resetting any stale YIELDED a prior catch left there).
+    parent.regs[8] = STATUS_OK;
     if let Some(cap) = scratch {
         parent
             .cnode

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -565,6 +565,19 @@ pub fn run_top(
                 let is_ecalli = info.exit_reason == EXIT_HOST_CALL;
                 let ecall_cost = javm_exec::gas_const::ecall_dynamic_cost(is_ecalli) as i64;
                 if gas < ecall_cost {
+                    // A metered frame re-attempts THIS ecall after a kernel:oog
+                    // topup (the ecall is a forced bb_start; `info.pc` is the
+                    // next instruction and custom-0 is 4 bytes). Unmetered /
+                    // uncaught → bubble EXIT_OOG.
+                    if try_oog_yield(
+                        &mut stack,
+                        top_idx,
+                        &mut gas,
+                        &mut meters,
+                        info.pc.saturating_sub(4),
+                    ) {
+                        continue;
+                    }
                     break LoopOutcome {
                         exit_reason: EXIT_OOG,
                         exit_arg: 0,
@@ -668,28 +681,20 @@ pub fn run_top(
                                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                 };
                             }
-                            // Route `key` to an ancestor YieldReceiver: walk from
-                            // just below the emitter toward the root, SKIPPING all
-                            // frames of the emitting instance (§3
-                            // emitter-exclusion via `instance_id`); the nearest
-                            // entry whose SNAPSHOTTED catch-set contains `key`
-                            // catches it (single-resumer).
+                            // Route `key` to an ancestor YieldReceiver (the
+                            // payload is a copy of the emitted YieldSender). No
+                            // catcher → the emitter faults ("unhandled yield_key").
                             YieldOutcome::Route { key, sender_slot } => {
-                                let emitter_iid = stack[top_idx].instance_id;
-                                let mut catcher = None;
-                                for j in (0..top_idx).rev() {
-                                    if stack[j].instance_id == emitter_iid {
-                                        continue;
-                                    }
-                                    if stack[j].catch_set.binary_search(&key).is_ok() {
-                                        catcher = Some(j);
-                                        break;
-                                    }
-                                }
-                                let Some(j) = catcher else {
-                                    // No ancestor catches and the kernel root has
-                                    // no handler for this key → the emitter faults
-                                    // ("unhandled yield_key").
+                                let payload =
+                                    read_instance_cap(frame_at(&stack, top_idx), &sender_slot);
+                                if !route_yield(
+                                    &mut stack,
+                                    top_idx,
+                                    &key,
+                                    payload,
+                                    &mut gas,
+                                    &mut meters,
+                                ) {
                                     break LoopOutcome {
                                         exit_reason: EXIT_TRAP,
                                         exit_arg: ERR_YIELD_UNHANDLED,
@@ -697,40 +702,7 @@ pub fn run_top(
                                         gas_remaining: gas,
                                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                     };
-                                };
-                                // Reflect a copy of the YieldSender into the
-                                // catcher's scratchpad slot[0] as the payload, and
-                                // flag φ[8] = YIELDED so a discriminating handler
-                                // can tell a yield from a plain CALL return.
-                                let payload = {
-                                    let emitter = frame_at(&stack, top_idx);
-                                    read_instance_cap(emitter, &sender_slot)
-                                };
-                                let target = stack[j].target;
-                                let recv_iid = stack[j].instance_id;
-                                {
-                                    let catcher_frame = frame_at_mut(&mut stack, j);
-                                    if let Some(inst) = payload {
-                                        catcher_frame.cnode.set_key(
-                                            &[javm_cap::abi::SCRATCHPAD_SLOT],
-                                            Some(CapHashOrRef::Owned(CachedCap::boxed(
-                                                Cap::Instance(inst),
-                                            ))),
-                                        );
-                                    }
-                                    catcher_frame.regs[8] = STATUS_YIELDED;
                                 }
-                                // Push the handler activation (a ReferenceEntry to
-                                // the catcher); the yielder stays on the stack
-                                // below as Waiting until the handler CALL_RESUMEs.
-                                stack.push(StackEntry {
-                                    kind: EntryKind::Reference,
-                                    target,
-                                    instance_id: recv_iid,
-                                    catch_set: Vec::new(),
-                                    meter: None,
-                                    saved_gas: None,
-                                });
                             }
                         }
                     }
@@ -758,11 +730,22 @@ pub fn run_top(
                         };
                         stack.pop();
                         let yielder_idx = stack.len() - 1;
-                        let yielder = frame_at_mut(&mut stack, yielder_idx);
-                        if let Some(cap) = response {
-                            yielder
-                                .cnode
-                                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+                        {
+                            let yielder = frame_at_mut(&mut stack, yielder_idx);
+                            if let Some(cap) = response {
+                                yielder
+                                    .cnode
+                                    .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
+                            }
+                        }
+                        // A metered yielder resumes on its meter's CURRENT balance
+                        // (a kernel:oog handler may have topped it up via
+                        // set_gas_meter); the handler's pool is saved to restore at
+                        // the yielder's HALT. A non-metered yielder keeps the
+                        // threaded pool (the loaned-pool / shared-subtree case).
+                        if let Some(k) = stack[yielder_idx].meter.clone() {
+                            stack[yielder_idx].saved_gas = Some(gas);
+                            gas = *meters.get(&k).unwrap_or(&0);
                         }
                     }
                     OP_HOST_CALL => {
@@ -786,6 +769,19 @@ pub fn run_top(
                             host_call_frame_cost(parent)?
                         };
                         if gas < frame_cost {
+                            // Metered caller re-attempts THIS host_call after a
+                            // kernel:oog topup (gated before any instance move, so
+                            // the re-attempt is clean). Unmetered / uncaught →
+                            // bubble EXIT_OOG.
+                            if try_oog_yield(
+                                &mut stack,
+                                top_idx,
+                                &mut gas,
+                                &mut meters,
+                                info.pc.saturating_sub(4),
+                            ) {
+                                continue;
+                            }
                             break LoopOutcome {
                                 exit_reason: EXIT_OOG,
                                 exit_arg: 0,
@@ -866,6 +862,17 @@ pub fn run_top(
             }
             _ => {
                 // PageFault (3), Panic (1), OOG (2), Trap (7), …
+                // An in-block OOG (the JIT's per-block gas gate) on a metered
+                // frame re-attempts the SAME block after a kernel:oog topup —
+                // `info.pc` is that block's bb_start (the gate is a pre-charge:
+                // the block was not entered and no gas was charged). Unmetered /
+                // uncaught OOG, and every other exit (fault/panic/trap), bubble
+                // verbatim.
+                if info.exit_reason == EXIT_OOG
+                    && try_oog_yield(&mut stack, top_idx, &mut gas, &mut meters, info.pc)
+                {
+                    continue;
+                }
                 break LoopOutcome {
                     exit_reason: info.exit_reason,
                     exit_arg: info.exit_arg,
@@ -1021,6 +1028,95 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
         )
     }
     .ok_or(ERR_JIT_FAILED)
+}
+
+/// Walk the kernel stack for a catcher of `key` (emitter-exclusion: skip every
+/// frame whose instance matches the top emitter's) and, if one is found, suspend
+/// the emitter and transfer control to the catcher as a yield handler:
+/// - a metered emitter banks its remaining balance to its meter and the catcher
+///   resumes on the emitter's saved caller-pool (a non-metered emitter loans its
+///   pool, which threads to the catcher unchanged);
+/// - `payload` (a YieldSender / `Gas` cap copy) reflects into the catcher's
+///   scratchpad slot[0] and φ[8] is flagged YIELDED;
+/// - a ReferenceEntry to the catcher is pushed (the yielder stays Waiting below,
+///   resumed later by `CALL_RESUME`).
+///
+/// Returns `true` if routed, `false` if no ancestor catches `key` — the caller
+/// decides (fault the emitter for a user key, or bubble EXIT_OOG for kernel:oog).
+fn route_yield(
+    stack: &mut Vec<StackEntry>,
+    top_idx: usize,
+    key: &Key,
+    payload: Option<InstanceCap>,
+    gas: &mut i64,
+    meters: &mut BTreeMap<Key, i64>,
+) -> bool {
+    let emitter_iid = stack[top_idx].instance_id;
+    let mut catcher = None;
+    for j in (0..top_idx).rev() {
+        if stack[j].instance_id == emitter_iid {
+            continue;
+        }
+        if stack[j].catch_set.binary_search(key).is_ok() {
+            catcher = Some(j);
+            break;
+        }
+    }
+    let Some(j) = catcher else {
+        return false;
+    };
+    // Suspend the emitter: a metered emitter banks its remaining balance, and the
+    // catcher resumes on the pool the emitter saved at its own CALL.
+    if let Some(k) = stack[top_idx].meter.clone() {
+        meters.insert(k, *gas);
+        if let Some(saved) = stack[top_idx].saved_gas {
+            *gas = saved;
+        }
+    }
+    let target = stack[j].target;
+    let recv_iid = stack[j].instance_id;
+    {
+        let catcher_frame = frame_at_mut(stack, j);
+        if let Some(inst) = payload {
+            catcher_frame.cnode.set_key(
+                &[javm_cap::abi::SCRATCHPAD_SLOT],
+                Some(CapHashOrRef::Owned(CachedCap::boxed(Cap::Instance(inst)))),
+            );
+        }
+        catcher_frame.regs[8] = STATUS_YIELDED;
+    }
+    stack.push(StackEntry {
+        kind: EntryKind::Reference,
+        target,
+        instance_id: recv_iid,
+        catch_set: Vec::new(),
+        meter: None,
+        saved_gas: None,
+    });
+    true
+}
+
+/// On gas exhaustion of a **metered** top frame, inject a routed `kernel:oog`
+/// yield (payload = its `Gas{meter_key}`) so a registered receiver (the chain)
+/// can top up the meter and `CALL_RESUME` — the frame then re-runs from
+/// `reattempt_pc` (a bb_start: the failing block's start, or the ecall's own
+/// pc). Returns `true` if routed (the catcher runs next iteration); `false` if
+/// the frame is unmetered or no receiver caught `kernel:oog` (the caller bubbles
+/// EXIT_OOG — the host-stub root catch).
+fn try_oog_yield(
+    stack: &mut Vec<StackEntry>,
+    top_idx: usize,
+    gas: &mut i64,
+    meters: &mut BTreeMap<Key, i64>,
+    reattempt_pc: u32,
+) -> bool {
+    let Some(meter) = stack[top_idx].meter.clone() else {
+        return false;
+    };
+    frame_at_mut(stack, top_idx).pc = reattempt_pc;
+    let oog_key = Key::from(&javm_cap::yield_cap::YK_OOG[..]);
+    let payload = Some(javm_cap::gas_handle(&meter));
+    route_yield(stack, top_idx, &oog_key, payload, gas, meters)
 }
 
 /// Pop the top frame; if a parent exists, reflect the popped child's

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1862,11 +1862,10 @@ fn build_frame_from_published(
     let arc = CACHE
         .get(CapHashOrRef::Hash(*instance_hash))
         .ok_or(ERR_INSTANCE_NOT_FOUND)?;
-    let (image_hash, image_hash_chain, inst_regs, mem, root_cnode) = match &*arc {
+    let (image_hash, image_hash_chain, mem, root_cnode) = match &*arc {
         Cap::Instance(i) => (
             i.image_hash,
             i.image_hash_chain,
-            i.regs,
             i.mem.clone(),
             root_cnode_hash(&i.root_cnode),
         ),
@@ -1878,7 +1877,6 @@ fn build_frame_from_published(
         None,
         endpoint_idx,
         args,
-        Some(&inst_regs),
         mem,
         root_cnode,
     )
@@ -1914,7 +1912,6 @@ fn build_frame_from_owned(
     let InstanceCap {
         image_hash,
         image_hash_chain,
-        regs,
         mem,
         root_cnode,
         ..
@@ -1925,7 +1922,6 @@ fn build_frame_from_owned(
         Some(origin_slot),
         endpoint_idx,
         args,
-        Some(&regs),
         mem,
         root_cnode_hash(&root_cnode),
     )
@@ -1946,7 +1942,6 @@ fn build_frame_inner(
     owned_origin: Option<Key>,
     endpoint_idx: u32,
     args: [u64; 4],
-    inst_regs: Option<&[u64; NUM_REGS]>,
     mem: DataCap,
     root_cnode: Option<CapHash>,
 ) -> Result<KernelFrame, u32> {
@@ -1969,14 +1964,13 @@ fn build_frame_inner(
         .map(|(_, ep)| ep)
         .ok_or(ERR_ENDPOINT_OOB)?;
 
+    // Spec CALL convention (_index.md §4): φ = endpoint.initial_regs, then
+    // φ[7..11] = args, all other φ = 0. A CALL is a fresh per-invocation register
+    // file — the Instance's SAVED regs do NOT seed it (a sub-VM persists across
+    // CALLs via its memory/CoW overlay, not its registers). CALL_RESUME, which
+    // does restore saved regs, runs the live Waiting frame in place and never
+    // reaches this builder.
     let mut regs = ep.initial_regs;
-    if let Some(inst_regs) = inst_regs {
-        for (i, v) in inst_regs.iter().enumerate() {
-            if *v != 0 {
-                regs[i] = *v;
-            }
-        }
-    }
     for (i, v) in args.iter().enumerate() {
         regs[7 + i] = *v;
     }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -553,20 +553,39 @@ pub fn run_top(
                 }
             }
             EXIT_HOST_CALL | EXIT_ECALL => {
-                // ecall block: charge its dynamic cost (check-before-
-                // charge) BEFORE doing the work, matching the interpreter's
-                // per-ecall charge. On OOG the block is not done and gas is
-                // unchanged; the resume point is the ecall's OWN pc
-                // (info.pc is the next instruction; custom-0 is 4-byte) —
-                // surfacing that pc rides on the deferred recoverable-yield
-                // layer, like the in-code block OOG (gas-cost.md §3).
+                // ecall block: charge its dynamic cost (check-before-charge)
+                // BEFORE doing the work. The cost is the ecall floor PLUS, for an
+                // in-kernel CALL (OP_HOST_CALL), the callee's call_frame_cost —
+                // and these are charged ATOMICALLY as one `actual` (gas-cost.md
+                // §3): a single gate, so an OOG leaves gas UNCHANGED and the
+                // re-attempt from the ecall's OWN pc (info.pc is the next
+                // instruction; custom-0 is 4 bytes) is clean. Splitting the gate
+                // would double-charge the floor across an OOG+resume.
                 let is_ecalli = info.exit_reason == EXIT_HOST_CALL;
                 let ecall_cost = javm_exec::gas_const::ecall_dynamic_cost(is_ecalli) as i64;
-                if gas < ecall_cost {
+                let op = if info.exit_reason == EXIT_HOST_CALL {
+                    info.exit_arg
+                } else {
+                    info.regs[11] as u32
+                };
+                // The CALL frame-materialization cost (JIT compile + eager RO
+                // page-in + setup base), computed statically from the callee
+                // Image and billed to the caller; resolved BEFORE charging so it
+                // joins the floor in one atomic gate. Depth-limit is a hard Err,
+                // not an OOG.
+                let frame_cost = if op == OP_HOST_CALL {
+                    if stack.len() >= MAX_DEPTH {
+                        return Err(ERR_DEPTH_LIMIT);
+                    }
+                    let parent = frame_at(&stack, top_idx);
+                    host_call_frame_cost(parent)?
+                } else {
+                    0
+                };
+                let total_cost = ecall_cost + frame_cost;
+                if gas < total_cost {
                     // A metered frame re-attempts THIS ecall after a kernel:oog
-                    // topup (the ecall is a forced bb_start; `info.pc` is the
-                    // next instruction and custom-0 is 4 bytes). Unmetered /
-                    // uncaught → bubble EXIT_OOG.
+                    // topup; unmetered / uncaught → bubble EXIT_OOG.
                     if try_oog_yield(
                         &mut stack,
                         top_idx,
@@ -584,13 +603,8 @@ pub fn run_top(
                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                     };
                 }
-                gas -= ecall_cost;
+                gas -= total_cost;
 
-                let op = if info.exit_reason == EXIT_HOST_CALL {
-                    info.exit_arg
-                } else {
-                    info.regs[11] as u32
-                };
                 match op {
                     OP_REPLY => {
                         // Read the scratchpad head from the InstanceEntry that
@@ -723,6 +737,7 @@ pub fn run_top(
                         // to the yielder, pop the ReferenceEntry, and let the
                         // yielder become the running top (it continues at its
                         // post-yield PC next iteration).
+                        let catcher_idx = stack[top_idx].target;
                         let response = {
                             let handler = frame_at_mut(&mut stack, top_idx);
                             handler.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
@@ -737,22 +752,30 @@ pub fn run_top(
                                     .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                             }
                         }
-                        // A metered yielder resumes on its meter's CURRENT balance
-                        // (a kernel:oog handler may have topped it up via
-                        // set_gas_meter); the handler's pool is saved to restore at
-                        // the yielder's HALT. A non-metered yielder keeps the
-                        // threaded pool (the loaned-pool / shared-subtree case).
+                        // Gas: the handler's pool must be restored when control
+                        // eventually returns to the catcher — i.e. when the
+                        // catcher's DIRECT child (the bottom of the routed-past
+                        // subtree, == the yielder in the common single-level case)
+                        // HALTs back up. Stash the handler's pool on that child if
+                        // it is metered (its `saved_gas` is what its HALT restores).
+                        let catcher_child = catcher_idx + 1;
+                        if stack[catcher_child].meter.is_some() {
+                            stack[catcher_child].saved_gas = Some(gas);
+                        }
+                        // The yielder resumes on its meter's CURRENT balance (a
+                        // kernel:oog handler may have topped it up). A non-metered
+                        // yielder keeps the threaded pool (loaned / shared subtree).
                         if let Some(k) = stack[yielder_idx].meter.clone() {
-                            stack[yielder_idx].saved_gas = Some(gas);
                             gas = *meters.get(&k).unwrap_or(&0);
                         }
                     }
                     OP_DROP_PAUSED => {
-                        // Give up on the Waiting yielder directly below this
-                        // handler activation: discard its entry (frame + state);
-                        // the handler keeps running (it does NOT resume the
-                        // yielder). The top must be a handler ReferenceEntry — an
-                        // InstanceEntry top has no outstanding yield → trap.
+                        // Give up on the Waiting yielder: discard the WHOLE caught
+                        // subtree (the yielder + any intermediates a descendant
+                        // routed past — same scope as a handler HALT, §10), but
+                        // keep the handler running. The top must be a handler
+                        // ReferenceEntry — an InstanceEntry top has no outstanding
+                        // yield → trap.
                         if stack[top_idx].target == top_idx {
                             break LoopOutcome {
                                 exit_reason: EXIT_TRAP,
@@ -762,55 +785,26 @@ pub fn run_top(
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
-                        // Remove the yielder (top_idx - 1); the handler
-                        // ReferenceEntry shifts down to become the running top and
-                        // continues at its post-drop PC. Its `target` (a lower
-                        // index) is unaffected by the removal.
-                        stack.remove(top_idx - 1);
+                        // Truncate everything above the handler's InstanceEntry
+                        // (the ReferenceEntry + the discarded subtree); the handler
+                        // becomes a plain InstanceEntry again and continues at its
+                        // post-drop pc. (Discarded metered frames were banked at
+                        // route_yield, so the meter table stays consistent — gas is
+                        // STM-exempt: a dropped subtree's spend is NOT refunded.)
+                        // Using `target+1` (not `top_idx-1`) keeps subsequent
+                        // CALL_RESUME/DROP_PAUSED sound — there is no longer a stale
+                        // handler with a wedged intermediate below it.
+                        let handler_inst = stack[top_idx].target;
+                        stack.truncate(handler_inst + 1);
                     }
                     OP_HOST_CALL => {
-                        if stack.len() >= MAX_DEPTH {
-                            return Err(ERR_DEPTH_LIMIT);
-                        }
-                        // Charge the call-frame materialization — JIT compile
-                        // (O(code)) + eager read-only page-in (per declared
-                        // 2 MiB unit) + frame-setup base — computed statically
-                        // from the callee Image and billed to the CALLER (on
-                        // top of the ecall floor above). Check-before-charge,
-                        // gated **before** `dispatch_host_call` moves the
-                        // instance, so an OOG here leaves the parent slot
-                        // untouched and the re-attempt is clean (gas-cost.md
-                        // §3). Charged in full on every CALL — the compiled
-                        // image + page table are memoized for *work* only,
-                        // never a gas discount — so gas is independent of the
-                        // node-local compile/PT cache (gas_const::call_frame_cost).
-                        let frame_cost = {
-                            let parent = frame_at(&stack, top_idx);
-                            host_call_frame_cost(parent)?
-                        };
-                        if gas < frame_cost {
-                            // Metered caller re-attempts THIS host_call after a
-                            // kernel:oog topup (gated before any instance move, so
-                            // the re-attempt is clean). Unmetered / uncaught →
-                            // bubble EXIT_OOG.
-                            if try_oog_yield(
-                                &mut stack,
-                                top_idx,
-                                &mut gas,
-                                &mut meters,
-                                info.pc.saturating_sub(4),
-                            ) {
-                                continue;
-                            }
-                            break LoopOutcome {
-                                exit_reason: EXIT_OOG,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: gas,
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
-                        }
-                        gas -= frame_cost;
+                        // The ecall floor + this CALL's frame_cost were charged
+                        // atomically at the top of the arm (check-before-charge,
+                        // before `dispatch_host_call` moves any instance, so an
+                        // OOG left the parent slot pristine). Charged in full on
+                        // every CALL — compile/PT memoization is for *work*, never
+                        // a gas discount — so gas is independent of the cache.
+                        //
                         // Snapshot the caller's catch-set at this downward CALL
                         // (§3): the keys it will catch from the callee's whole
                         // subtree. Captured from the caller's CURRENT
@@ -847,16 +841,18 @@ pub fn run_top(
                         let child_idx = stack.len();
                         stack.push(StackEntry::instance(child, child_idx, next_iid));
                         next_iid += 1;
-                        // Per-frame metering: if the child names a gas meter
-                        // (`gas_slots[0]` → `Gas{meter_key}`) that the guest table
-                        // funds, it runs on THAT balance — save the caller's pool
-                        // to restore at the child's HALT, swap the live `gas` to
-                        // the meter balance. Otherwise the child loans the caller's
-                        // pool (the live `gas` threads in unchanged), preserving
-                        // the one-pool subtree model for non-metered sub-VMs.
-                        if let Some(k) = resolve_frame_meter(frame_at(&stack, child_idx))
-                            && let Some(&balance) = meters.get(&k)
-                        {
+                        // Per-frame metering: if the child NAMES a gas meter
+                        // (`gas_slots[0]` → `Gas{meter_key}`) it runs on that
+                        // meter's balance — save the caller's pool to restore at
+                        // the child's HALT, swap the live `gas` to the balance. An
+                        // ABSENT table entry is effective balance 0 (spec:
+                        // kernel-assisted-instances.md §"lazy-load" — unset meters
+                        // are 0), so an unfunded metered child runs on 0 and
+                        // OOG-routes on first debit rather than loaning the
+                        // caller's pool. Only a child with NO gas slot loans the
+                        // caller's pool (the one-pool subtree model).
+                        if let Some(k) = resolve_frame_meter(frame_at(&stack, child_idx)) {
+                            let balance = meters.get(&k).copied().unwrap_or(0);
                             stack[child_idx].meter = Some(k);
                             stack[child_idx].saved_gas = Some(gas);
                             gas = balance;
@@ -1085,12 +1081,20 @@ fn route_yield(
     let Some(j) = catcher else {
         return false;
     };
-    // Suspend the emitter: a metered emitter banks its remaining balance, and the
-    // catcher resumes on the pool the emitter saved at its own CALL.
-    if let Some(k) = stack[top_idx].meter.clone() {
-        meters.insert(k, *gas);
-        if let Some(saved) = stack[top_idx].saved_gas {
-            *gas = saved;
+    // Suspend the whole subtree between the catcher and the emitter, unwinding the
+    // live `gas` back to the catcher's pool. Walk from the emitter down to just
+    // above the catcher: each METERED frame banks its current balance to its meter
+    // (the threaded `gas` is its live balance) and hands its caller-pool up; a
+    // loaned frame passes the pool through unchanged. After the walk `gas` is the
+    // catcher's own pool, and every metered frame in the routed-past subtree has a
+    // consistent meter balance — so a later discard (handler HALT / DROP_PAUSED)
+    // never over-refunds, and a resume re-reads the right balance.
+    for i in (j + 1..=top_idx).rev() {
+        if let Some(k) = stack[i].meter.clone() {
+            meters.insert(k, *gas);
+            if let Some(saved) = stack[i].saved_gas {
+                *gas = saved;
+            }
         }
     }
     let target = stack[j].target;

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -407,6 +407,27 @@ fn reconcile_active(
     };
 }
 
+/// The RPC's ROOT-scope remaining gas — what a break surfaces to the host (which
+/// harvests it into the top-level meter). The live `gas` when the root scope is
+/// the running frame's active meter, else the root scope's banked balance:
+/// `meters[root]` for a metered root, or `host_budget` for a host-budgeted top.
+fn root_remaining(
+    root: &Option<Key>,
+    current: &Option<Key>,
+    gas: i64,
+    host_budget: i64,
+    meters: &BTreeMap<Key, i64>,
+) -> i64 {
+    if current == root {
+        gas
+    } else {
+        match root {
+            Some(k) => meters.get(k).copied().unwrap_or(0),
+            None => host_budget,
+        }
+    }
+}
+
 /// `&mut` to the [`KernelFrame`] the entry at `idx` runs, following a
 /// ReferenceEntry to its referent InstanceEntry. The referent is always an
 /// `Instance` (a Reference's `target` only ever names an InstanceEntry).
@@ -525,18 +546,28 @@ pub fn run_top(
     next_iid += 1;
     // GAS MODEL (single reconciliation point). The threaded `gas` always holds
     // the LIVE balance of the running frame's ACTIVE meter — `active_meter(top)`,
-    // the nearest metered frame at-or-below the top. `meters[k]` is authoritative
-    // for every non-active meter; `host_budget` holds the banked host scope (the
-    // host-budgeted top + its loaned descendants, active == None). At the top of
-    // each iteration we reconcile: if the top's active meter changed since last
+    // the frame's stored `active` (its own meter, or its caller/catcher's).
+    // `meters[k]` is authoritative for every non-active meter. At the top of each
+    // iteration we reconcile: if the top's active meter changed since last
     // iteration, bank the old scope + load the new. Every CALL/HALT/yield/resume/
     // drop changes the top, so this one point catches them all — no per-transition
     // gas bookkeeping. The guest meter table is per-RPC (a block-spanning table is
     // the deferred lazy-load piece).
+    let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
+    // The TOP frame's own meter (its `gas_slots[0]` → `Gas{root_meter_key}`, if
+    // any) is the RPC's ROOT scope: stamp it like any frame and seed the table
+    // from the host-supplied budget, so `set_gas_meter` on the root meter (a chain
+    // self-harvesting, or a child aliasing the root) goes through the SAME table as
+    // sub-meters. A top with NO gas slot is host-budgeted (`root_active == None`,
+    // tracked in `host_budget`).
+    let root_active = resolve_frame_meter(frame_at(&stack, 0));
+    stack[0].active = root_active.clone();
+    if let Some(k) = &root_active {
+        meters.insert(k.clone(), initial_gas);
+    }
     let mut gas = initial_gas;
     let mut host_budget = initial_gas;
-    let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
-    let mut current_active: Option<Key> = active_meter(&stack, 0);
+    let mut current_active: Option<Key> = root_active.clone();
 
     let outcome = loop {
         let top_idx = stack.len() - 1;
@@ -592,11 +623,13 @@ pub fn run_top(
                         exit_reason: info.exit_reason,
                         exit_arg: info.exit_arg,
                         return_value: info.regs[7],
-                        gas_remaining: if current_active.is_none() {
-                            gas
-                        } else {
-                            host_budget
-                        },
+                        gas_remaining: root_remaining(
+                            &root_active,
+                            &current_active,
+                            gas,
+                            host_budget,
+                            &meters,
+                        ),
                         scratchpad_head: head,
                     };
                 }
@@ -642,11 +675,13 @@ pub fn run_top(
                         exit_reason: EXIT_OOG,
                         exit_arg: 0,
                         return_value: info.regs[7],
-                        gas_remaining: if current_active.is_none() {
-                            gas
-                        } else {
-                            host_budget
-                        },
+                        gas_remaining: root_remaining(
+                            &root_active,
+                            &current_active,
+                            gas,
+                            host_budget,
+                            &meters,
+                        ),
                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                     };
                 }
@@ -676,11 +711,13 @@ pub fn run_top(
                                 exit_reason: info.exit_reason,
                                 exit_arg: info.exit_arg,
                                 return_value: info.regs[7],
-                                gas_remaining: if current_active.is_none() {
-                                    gas
-                                } else {
-                                    host_budget
-                                },
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
                                 scratchpad_head: head,
                             };
                         }
@@ -698,11 +735,13 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: if current_active.is_none() {
-                                    gas
-                                } else {
-                                    host_budget
-                                },
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -718,11 +757,13 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: if current_active.is_none() {
-                                    gas
-                                } else {
-                                    host_budget
-                                },
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -743,11 +784,13 @@ pub fn run_top(
                                     exit_reason: EXIT_TRAP,
                                     exit_arg: 0,
                                     return_value: info.regs[7],
-                                    gas_remaining: if current_active.is_none() {
-                                        gas
-                                    } else {
-                                        host_budget
-                                    },
+                                    gas_remaining: root_remaining(
+                                        &root_active,
+                                        &current_active,
+                                        gas,
+                                        host_budget,
+                                        &meters,
+                                    ),
                                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                 };
                             }
@@ -762,11 +805,13 @@ pub fn run_top(
                                         exit_reason: EXIT_TRAP,
                                         exit_arg: ERR_YIELD_UNHANDLED,
                                         return_value: info.regs[7],
-                                        gas_remaining: if current_active.is_none() {
-                                            gas
-                                        } else {
-                                            host_budget
-                                        },
+                                        gas_remaining: root_remaining(
+                                            &root_active,
+                                            &current_active,
+                                            gas,
+                                            host_budget,
+                                            &meters,
+                                        ),
                                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                     };
                                 }
@@ -783,11 +828,13 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: if current_active.is_none() {
-                                    gas
-                                } else {
-                                    host_budget
-                                },
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -822,11 +869,13 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: if current_active.is_none() {
-                                    gas
-                                } else {
-                                    host_budget
-                                },
+                                gas_remaining: root_remaining(
+                                    &root_active,
+                                    &current_active,
+                                    gas,
+                                    host_budget,
+                                    &meters,
+                                ),
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -910,11 +959,13 @@ pub fn run_top(
                             exit_reason: info.exit_reason,
                             exit_arg: info.exit_arg,
                             return_value: info.regs[7],
-                            gas_remaining: if current_active.is_none() {
-                                gas
-                            } else {
-                                host_budget
-                            },
+                            gas_remaining: root_remaining(
+                                &root_active,
+                                &current_active,
+                                gas,
+                                host_budget,
+                                &meters,
+                            ),
                             scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                         };
                     }
@@ -935,11 +986,13 @@ pub fn run_top(
                     exit_reason: info.exit_reason,
                     exit_arg: info.exit_arg,
                     return_value: info.regs[7],
-                    gas_remaining: if current_active.is_none() {
-                        gas
-                    } else {
-                        host_budget
-                    },
+                    gas_remaining: root_remaining(
+                        &root_active,
+                        &current_active,
+                        gas,
+                        host_budget,
+                        &meters,
+                    ),
                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                 };
             }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -752,20 +752,28 @@ pub fn run_top(
                                     .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                             }
                         }
-                        // Gas: the handler's pool must be restored when control
-                        // eventually returns to the catcher — i.e. when the
-                        // catcher's DIRECT child (the bottom of the routed-past
-                        // subtree, == the yielder in the common single-level case)
-                        // HALTs back up. Stash the handler's pool on that child if
-                        // it is metered (its `saved_gas` is what its HALT restores).
-                        let catcher_child = catcher_idx + 1;
-                        if stack[catcher_child].meter.is_some() {
-                            stack[catcher_child].saved_gas = Some(gas);
+                        // Gas across the routed-past subtree (catcher_idx+1 ..=
+                        // yielder_idx), which may mix metered and loaned frames:
+                        //
+                        // (a) The handler's post-spend pool returns to the catcher
+                        //     via the subtree HALTing up. The frame whose
+                        //     `saved_gas` restores the catcher's pool is the FIRST
+                        //     metered frame from the catcher (a loaned prefix just
+                        //     threads gas through). Stash the handler pool there.
+                        //     If the whole subtree is loaned, gas threads up
+                        //     unchanged (no stash) — the catcher's shared pool.
+                        let subtree = catcher_idx + 1..=yielder_idx;
+                        if let Some(i) = subtree.clone().find(|&i| stack[i].meter.is_some()) {
+                            stack[i].saved_gas = Some(gas);
                         }
-                        // The yielder resumes on its meter's CURRENT balance (a
-                        // kernel:oog handler may have topped it up). A non-metered
-                        // yielder keeps the threaded pool (loaned / shared subtree).
-                        if let Some(k) = stack[yielder_idx].meter.clone() {
+                        // (b) The yielder resumes on its ACTIVE meter's CURRENT
+                        //     balance (a kernel:oog handler may have topped it up):
+                        //     the nearest metered frame from the yielder toward the
+                        //     catcher (itself if metered, else its metered ancestor
+                        //     it loans from). If none in the subtree (all loaned to
+                        //     the catcher), it keeps the threaded handler pool.
+                        if let Some(i) = subtree.rev().find(|&i| stack[i].meter.is_some()) {
+                            let k = stack[i].meter.clone().expect("metered");
                             gas = *meters.get(&k).unwrap_or(&0);
                         }
                     }
@@ -1120,13 +1128,27 @@ fn route_yield(
     true
 }
 
-/// On gas exhaustion of a **metered** top frame, inject a routed `kernel:oog`
-/// yield (payload = its `Gas{meter_key}`) so a registered receiver (the chain)
-/// can top up the meter and `CALL_RESUME` — the frame then re-runs from
-/// `reattempt_pc` (a bb_start: the failing block's start, or the ecall's own
-/// pc). Returns `true` if routed (the catcher runs next iteration); `false` if
-/// the frame is unmetered or no receiver caught `kernel:oog` (the caller bubbles
-/// EXIT_OOG — the host-stub root catch).
+/// The gas meter funding the running pool: the nearest metered frame at-or-below
+/// `idx`, following each entry's `target` to its InstanceEntry (a loaned frame
+/// spends its metered ancestor's pool; a handler ReferenceEntry's meter lives on
+/// its referent). `None` when the pool is host-budgeted (no metered frame).
+fn active_meter(stack: &[StackEntry], idx: usize) -> Option<Key> {
+    (0..=idx).rev().find_map(|i| {
+        let inst = stack[i].target;
+        stack[inst].meter.clone()
+    })
+}
+
+/// On gas exhaustion, inject a routed `kernel:oog` yield (payload =
+/// `Gas{meter_key}` of the meter funding the depleted pool) so a registered
+/// receiver (the chain) can top up the meter and `CALL_RESUME` — the frame then
+/// re-runs from `reattempt_pc` (a bb_start: the failing block's start, or the
+/// ecall's own pc). The depleted pool belongs to the ACTIVE meter (nearest
+/// metered ancestor), which may live below a loaned frame or on a handler
+/// ReferenceEntry's referent — not necessarily on the top entry. Returns `true`
+/// if routed; `false` if the pool is host-budgeted (no metered frame) or no
+/// receiver caught `kernel:oog` (the caller bubbles EXIT_OOG — host-stub root
+/// catch).
 fn try_oog_yield(
     stack: &mut Vec<StackEntry>,
     top_idx: usize,
@@ -1134,7 +1156,7 @@ fn try_oog_yield(
     meters: &mut BTreeMap<Key, i64>,
     reattempt_pc: u32,
 ) -> bool {
-    let Some(meter) = stack[top_idx].meter.clone() else {
+    let Some(meter) = active_meter(stack, top_idx) else {
         return false;
     };
     frame_at_mut(stack, top_idx).pc = reattempt_pc;

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -335,40 +335,40 @@ struct StackEntry {
     /// sub-call — a frame cannot shrink its catch-set mid-flight to dodge a
     /// descendant's yield (spec §3 "frozen for the sub-call").
     catch_set: Vec<Key>,
-    /// This frame's gas meter, when it runs on its OWN balance drawn from the
-    /// guest meter table (its `gas_slots[0]` → `Gas{meter_key}` had a funded
-    /// entry at CALL). `None` = the frame *loans* the caller's pool — it debits
-    /// the threaded `gas` directly and returns the remainder to the caller at
-    /// HALT (the one-pool subtree model, the default for non-metered sub-VMs and
-    /// the host-budgeted top frame). `Some(k)` = metered: the live `gas` was
-    /// swapped to `meters[k]` at CALL and is written back to `meters[k]` at HALT.
-    meter: Option<Key>,
-    /// The caller's pool, saved when this frame swapped the live `gas` to its own
-    /// meter balance at CALL; restored into `gas` when this frame pops. `Some`
-    /// iff [`Self::meter`] is `Some`.
-    saved_gas: Option<i64>,
+    /// The gas meter that funds this entry's frame — computed ONCE at push time
+    /// as `own_meter.or(parent_or_catcher.active)`: the frame's own
+    /// `gas_slots[0]` → `Gas{meter_key}` if it declares one, else (loaned) it
+    /// inherits its caller's active meter; a handler `ReferenceEntry` inherits the
+    /// CATCHER's active meter. `None` = host-budgeted (the top frame and its
+    /// loaned descendants). The loop reconciles `gas` to this on each iteration
+    /// (see [`reconcile_active`]). Storing it (vs. a stack walk) is unambiguous in
+    /// the presence of yields, where the entries between a handler Reference and
+    /// its referent are a *suspended* subtree, NOT the running frame's ancestry.
+    /// Aliasing falls out: a child naming the same meter as a live ancestor gets
+    /// the SAME `active`, so no reconcile/swap — it shares the one balance.
+    active: Option<Key>,
 }
 
 impl StackEntry {
     /// A fresh InstanceEntry at stack position `index` carrying a new
     /// `instance_id`. `target` is its own index (it runs its own frame); the
-    /// catch-set is empty until its first downward CALL.
+    /// catch-set is empty until its first downward CALL; `active` is stamped by
+    /// the CALL site (`own_meter.or(parent.active)`).
     fn instance(frame: KernelFrame, index: usize, instance_id: u64) -> Self {
         StackEntry {
             kind: EntryKind::Instance(Box::new(frame)),
             target: index,
             instance_id,
             catch_set: Vec::new(),
-            meter: None,
-            saved_gas: None,
+            active: None,
         }
     }
 }
 
-/// Resolve a frame's active gas meter: read its Image's `gas_slots[0]`, look that
+/// Resolve a frame's own gas meter: read its Image's `gas_slots[0]`, look that
 /// slot up in the frame's cnode, and decode the `Gas{meter_key}` handle there.
 /// `None` if the Image declares no gas slot, the slot is empty, or it doesn't
-/// hold a `Gas` handle (the frame then loans its caller's pool).
+/// hold a `Gas` handle (the frame then loans its caller's active meter).
 fn resolve_frame_meter(frame: &KernelFrame) -> Option<Key> {
     let img_arc = CACHE.get(CapHashOrRef::Hash(frame.image_hash))?;
     let slot = match &*img_arc {
@@ -376,6 +376,35 @@ fn resolve_frame_meter(frame: &KernelFrame) -> Option<Key> {
         _ => return None,
     };
     javm_cap::gas_meter_key(&read_instance_cap(frame, &slot)?)
+}
+
+/// Reconcile the threaded `gas` (the live balance of the running frame's active
+/// meter) when the active meter changes between loop iterations: bank the OLD
+/// active scope's balance, load the NEW scope's. `meters[k]` is authoritative for
+/// every non-active meter; `host_budget` holds the banked host scope (the
+/// host-budgeted top + its loaned descendants, active == `None`). Aliasing falls
+/// out for free: a descendant naming the same meter has the SAME active meter, so
+/// no swap happens and it shares the live balance — no double-spend.
+fn reconcile_active(
+    old: &Option<Key>,
+    new: &Option<Key>,
+    gas: &mut i64,
+    host_budget: &mut i64,
+    meters: &mut BTreeMap<Key, i64>,
+) {
+    if old == new {
+        return;
+    }
+    match old {
+        Some(k) => {
+            meters.insert(k.clone(), *gas);
+        }
+        None => *host_budget = *gas,
+    }
+    *gas = match new {
+        Some(k) => meters.get(k).copied().unwrap_or(0),
+        None => *host_budget,
+    };
 }
 
 /// `&mut` to the [`KernelFrame`] the entry at `idx` runs, following a
@@ -494,17 +523,33 @@ pub fn run_top(
     let mut next_iid: u64 = 0;
     stack.push(StackEntry::instance(top, 0, next_iid));
     next_iid += 1;
-    // The threaded `gas` is the RUNNING frame's live balance: the host-budgeted
-    // top pool, a loaned caller pool, or a metered frame's own balance. The guest
-    // meter table holds balances NAMED by `Gas{meter_key}` and funded via
-    // `kernel:set_gas_meter`; a metered frame draws its balance here at CALL and
-    // writes the remainder back at HALT. Per-RPC (a block-spanning table is the
-    // deferred lazy-load piece); the top frame's meter stays host-owned.
+    // GAS MODEL (single reconciliation point). The threaded `gas` always holds
+    // the LIVE balance of the running frame's ACTIVE meter — `active_meter(top)`,
+    // the nearest metered frame at-or-below the top. `meters[k]` is authoritative
+    // for every non-active meter; `host_budget` holds the banked host scope (the
+    // host-budgeted top + its loaned descendants, active == None). At the top of
+    // each iteration we reconcile: if the top's active meter changed since last
+    // iteration, bank the old scope + load the new. Every CALL/HALT/yield/resume/
+    // drop changes the top, so this one point catches them all — no per-transition
+    // gas bookkeeping. The guest meter table is per-RPC (a block-spanning table is
+    // the deferred lazy-load piece).
     let mut gas = initial_gas;
+    let mut host_budget = initial_gas;
     let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
+    let mut current_active: Option<Key> = active_meter(&stack, 0);
 
     let outcome = loop {
         let top_idx = stack.len() - 1;
+        // Reconcile the active meter for the (possibly new) top frame.
+        let new_active = active_meter(&stack, top_idx);
+        reconcile_active(
+            &current_active,
+            &new_active,
+            &mut gas,
+            &mut host_budget,
+            &mut meters,
+        );
+        current_active = new_active;
         // Phase 1: run one ring-3 entry on the top entry's frame (an
         // InstanceEntry runs its own frame; a ReferenceEntry runs its
         // referent's — the same Instance, sharing one PC/regs/mem).
@@ -538,16 +583,20 @@ pub fn run_top(
                 // resuming/dropping its yielder triggers the sub-tree-atomic
                 // unwind; an ordinary InstanceEntry pops and reflects.
                 let drained = if stack[top_idx].target != top_idx {
-                    unwind_to_handler(&mut stack, top_idx, info.regs[7], &mut gas, &mut meters)
+                    unwind_to_handler(&mut stack, top_idx, info.regs[7])
                 } else {
-                    pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters)
+                    pop_and_reflect(&mut stack, info.regs[7])
                 };
                 if drained {
                     break LoopOutcome {
                         exit_reason: info.exit_reason,
                         exit_arg: info.exit_arg,
                         return_value: info.regs[7],
-                        gas_remaining: gas,
+                        gas_remaining: if current_active.is_none() {
+                            gas
+                        } else {
+                            host_budget
+                        },
                         scratchpad_head: head,
                     };
                 }
@@ -586,20 +635,18 @@ pub fn run_top(
                 if gas < total_cost {
                     // A metered frame re-attempts THIS ecall after a kernel:oog
                     // topup; unmetered / uncaught → bubble EXIT_OOG.
-                    if try_oog_yield(
-                        &mut stack,
-                        top_idx,
-                        &mut gas,
-                        &mut meters,
-                        info.pc.saturating_sub(4),
-                    ) {
+                    if try_oog_yield(&mut stack, top_idx, info.pc.saturating_sub(4)) {
                         continue;
                     }
                     break LoopOutcome {
                         exit_reason: EXIT_OOG,
                         exit_arg: 0,
                         return_value: info.regs[7],
-                        gas_remaining: gas,
+                        gas_remaining: if current_active.is_none() {
+                            gas
+                        } else {
+                            host_budget
+                        },
                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                     };
                 }
@@ -617,15 +664,9 @@ pub fn run_top(
                         // A handler REPLYing without resuming/dropping → sub-tree
                         // unwind; an ordinary InstanceEntry pops and reflects.
                         let drained = if stack[top_idx].target != top_idx {
-                            unwind_to_handler(
-                                &mut stack,
-                                top_idx,
-                                info.regs[7],
-                                &mut gas,
-                                &mut meters,
-                            )
+                            unwind_to_handler(&mut stack, top_idx, info.regs[7])
                         } else {
-                            pop_and_reflect(&mut stack, info.regs[7], &mut gas, &mut meters)
+                            pop_and_reflect(&mut stack, info.regs[7])
                         };
                         if drained {
                             // Preserve the JIT exit shape so the host bench
@@ -635,7 +676,11 @@ pub fn run_top(
                                 exit_reason: info.exit_reason,
                                 exit_arg: info.exit_arg,
                                 return_value: info.regs[7],
-                                gas_remaining: gas,
+                                gas_remaining: if current_active.is_none() {
+                                    gas
+                                } else {
+                                    host_budget
+                                },
                                 scratchpad_head: head,
                             };
                         }
@@ -653,7 +698,11 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: gas,
+                                gas_remaining: if current_active.is_none() {
+                                    gas
+                                } else {
+                                    host_budget
+                                },
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -669,7 +718,11 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: gas,
+                                gas_remaining: if current_active.is_none() {
+                                    gas
+                                } else {
+                                    host_budget
+                                },
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -677,7 +730,7 @@ pub fn run_top(
                     OP_HOST_YIELD => {
                         let outcome = {
                             let frame = frame_at_mut(&mut stack, top_idx);
-                            dispatch_host_yield(frame, &mut meters)?
+                            dispatch_host_yield(frame, &mut meters, &mut gas, &current_active)?
                         };
                         match outcome {
                             // A kernel-root pure-cap syscall handled inline; the
@@ -690,7 +743,11 @@ pub fn run_top(
                                     exit_reason: EXIT_TRAP,
                                     exit_arg: 0,
                                     return_value: info.regs[7],
-                                    gas_remaining: gas,
+                                    gas_remaining: if current_active.is_none() {
+                                        gas
+                                    } else {
+                                        host_budget
+                                    },
                                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                 };
                             }
@@ -700,19 +757,16 @@ pub fn run_top(
                             YieldOutcome::Route { key, sender_slot } => {
                                 let payload =
                                     read_instance_cap(frame_at(&stack, top_idx), &sender_slot);
-                                if !route_yield(
-                                    &mut stack,
-                                    top_idx,
-                                    &key,
-                                    payload,
-                                    &mut gas,
-                                    &mut meters,
-                                ) {
+                                if !route_yield(&mut stack, top_idx, &key, payload) {
                                     break LoopOutcome {
                                         exit_reason: EXIT_TRAP,
                                         exit_arg: ERR_YIELD_UNHANDLED,
                                         return_value: info.regs[7],
-                                        gas_remaining: gas,
+                                        gas_remaining: if current_active.is_none() {
+                                            gas
+                                        } else {
+                                            host_budget
+                                        },
                                         scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                                     };
                                 }
@@ -729,52 +783,31 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: gas,
+                                gas_remaining: if current_active.is_none() {
+                                    gas
+                                } else {
+                                    host_budget
+                                },
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
                         // Reflect the handler's scratchpad slot[0] (its response)
                         // to the yielder, pop the ReferenceEntry, and let the
                         // yielder become the running top (it continues at its
-                        // post-yield PC next iteration).
-                        let catcher_idx = stack[top_idx].target;
+                        // post-yield PC next iteration). Gas is reconciled at the
+                        // next loop top: the handler's active meter banks and the
+                        // yielder's loads (picking up a kernel:oog topup).
                         let response = {
                             let handler = frame_at_mut(&mut stack, top_idx);
                             handler.cnode.take_key(&[javm_cap::abi::SCRATCHPAD_SLOT])
                         };
                         stack.pop();
                         let yielder_idx = stack.len() - 1;
-                        {
-                            let yielder = frame_at_mut(&mut stack, yielder_idx);
-                            if let Some(cap) = response {
-                                yielder
-                                    .cnode
-                                    .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
-                            }
-                        }
-                        // Gas across the routed-past subtree (catcher_idx+1 ..=
-                        // yielder_idx), which may mix metered and loaned frames:
-                        //
-                        // (a) The handler's post-spend pool returns to the catcher
-                        //     via the subtree HALTing up. The frame whose
-                        //     `saved_gas` restores the catcher's pool is the FIRST
-                        //     metered frame from the catcher (a loaned prefix just
-                        //     threads gas through). Stash the handler pool there.
-                        //     If the whole subtree is loaned, gas threads up
-                        //     unchanged (no stash) — the catcher's shared pool.
-                        let subtree = catcher_idx + 1..=yielder_idx;
-                        if let Some(i) = subtree.clone().find(|&i| stack[i].meter.is_some()) {
-                            stack[i].saved_gas = Some(gas);
-                        }
-                        // (b) The yielder resumes on its ACTIVE meter's CURRENT
-                        //     balance (a kernel:oog handler may have topped it up):
-                        //     the nearest metered frame from the yielder toward the
-                        //     catcher (itself if metered, else its metered ancestor
-                        //     it loans from). If none in the subtree (all loaned to
-                        //     the catcher), it keeps the threaded handler pool.
-                        if let Some(i) = subtree.rev().find(|&i| stack[i].meter.is_some()) {
-                            let k = stack[i].meter.clone().expect("metered");
-                            gas = *meters.get(&k).unwrap_or(&0);
+                        let yielder = frame_at_mut(&mut stack, yielder_idx);
+                        if let Some(cap) = response {
+                            yielder
+                                .cnode
+                                .set_key(&[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
                         }
                     }
                     OP_DROP_PAUSED => {
@@ -789,7 +822,11 @@ pub fn run_top(
                                 exit_reason: EXIT_TRAP,
                                 exit_arg: 0,
                                 return_value: info.regs[7],
-                                gas_remaining: gas,
+                                gas_remaining: if current_active.is_none() {
+                                    gas
+                                } else {
+                                    host_budget
+                                },
                                 scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                             };
                         }
@@ -849,22 +886,17 @@ pub fn run_top(
                         let child_idx = stack.len();
                         stack.push(StackEntry::instance(child, child_idx, next_iid));
                         next_iid += 1;
-                        // Per-frame metering: if the child NAMES a gas meter
-                        // (`gas_slots[0]` → `Gas{meter_key}`) it runs on that
-                        // meter's balance — save the caller's pool to restore at
-                        // the child's HALT, swap the live `gas` to the balance. An
-                        // ABSENT table entry is effective balance 0 (spec:
-                        // kernel-assisted-instances.md §"lazy-load" — unset meters
-                        // are 0), so an unfunded metered child runs on 0 and
-                        // OOG-routes on first debit rather than loaning the
-                        // caller's pool. Only a child with NO gas slot loans the
-                        // caller's pool (the one-pool subtree model).
-                        if let Some(k) = resolve_frame_meter(frame_at(&stack, child_idx)) {
-                            let balance = meters.get(&k).copied().unwrap_or(0);
-                            stack[child_idx].meter = Some(k);
-                            stack[child_idx].saved_gas = Some(gas);
-                            gas = balance;
-                        }
+                        // Stamp the child's active (funding) meter: its own
+                        // `gas_slots[0]` meter, else (loaned) the caller's active
+                        // meter. The loop-top reconcile then swaps `gas` only when
+                        // the active meter actually changes — a child naming a NEW
+                        // meter becomes the active scope (gas := meters[k],
+                        // effective-0 if unfunded → OOG-routes on first debit); a
+                        // child naming the SAME meter as a live ancestor keeps the
+                        // shared scope (no swap, no double-spend).
+                        let parent_active = stack[top_idx].active.clone();
+                        stack[child_idx].active =
+                            resolve_frame_meter(frame_at(&stack, child_idx)).or(parent_active);
                     }
                     // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
                     // arbitrary `ecalli imm`, …) is not in-kernel-
@@ -878,7 +910,11 @@ pub fn run_top(
                             exit_reason: info.exit_reason,
                             exit_arg: info.exit_arg,
                             return_value: info.regs[7],
-                            gas_remaining: gas,
+                            gas_remaining: if current_active.is_none() {
+                                gas
+                            } else {
+                                host_budget
+                            },
                             scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                         };
                     }
@@ -892,16 +928,18 @@ pub fn run_top(
                 // the block was not entered and no gas was charged). Unmetered /
                 // uncaught OOG, and every other exit (fault/panic/trap), bubble
                 // verbatim.
-                if info.exit_reason == EXIT_OOG
-                    && try_oog_yield(&mut stack, top_idx, &mut gas, &mut meters, info.pc)
-                {
+                if info.exit_reason == EXIT_OOG && try_oog_yield(&mut stack, top_idx, info.pc) {
                     continue;
                 }
                 break LoopOutcome {
                     exit_reason: info.exit_reason,
                     exit_arg: info.exit_arg,
                     return_value: info.regs[7],
-                    gas_remaining: gas,
+                    gas_remaining: if current_active.is_none() {
+                        gas
+                    } else {
+                        host_budget
+                    },
                     scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
                 };
             }
@@ -1056,14 +1094,12 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
 
 /// Walk the kernel stack for a catcher of `key` (emitter-exclusion: skip every
 /// frame whose instance matches the top emitter's) and, if one is found, suspend
-/// the emitter and transfer control to the catcher as a yield handler:
-/// - a metered emitter banks its remaining balance to its meter and the catcher
-///   resumes on the emitter's saved caller-pool (a non-metered emitter loans its
-///   pool, which threads to the catcher unchanged);
-/// - `payload` (a YieldSender / `Gas` cap copy) reflects into the catcher's
-///   scratchpad slot[0] and φ[8] is flagged YIELDED;
-/// - a ReferenceEntry to the catcher is pushed (the yielder stays Waiting below,
-///   resumed later by `CALL_RESUME`).
+/// the emitter and transfer control to the catcher as a yield handler: reflect
+/// `payload` (a YieldSender / `Gas` cap copy) into the catcher's scratchpad
+/// slot[0], flag φ[8] = YIELDED, and push a ReferenceEntry to the catcher (the
+/// yielder stays Waiting below, resumed later by `CALL_RESUME`). Gas is NOT
+/// handled here — the loop-top [`reconcile_active`] banks the emitter's active
+/// meter and loads the catcher's on the next iteration.
 ///
 /// Returns `true` if routed, `false` if no ancestor catches `key` — the caller
 /// decides (fault the emitter for a user key, or bubble EXIT_OOG for kernel:oog).
@@ -1072,8 +1108,6 @@ fn route_yield(
     top_idx: usize,
     key: &Key,
     payload: Option<InstanceCap>,
-    gas: &mut i64,
-    meters: &mut BTreeMap<Key, i64>,
 ) -> bool {
     let emitter_iid = stack[top_idx].instance_id;
     let mut catcher = None;
@@ -1089,24 +1123,11 @@ fn route_yield(
     let Some(j) = catcher else {
         return false;
     };
-    // Suspend the whole subtree between the catcher and the emitter, unwinding the
-    // live `gas` back to the catcher's pool. Walk from the emitter down to just
-    // above the catcher: each METERED frame banks its current balance to its meter
-    // (the threaded `gas` is its live balance) and hands its caller-pool up; a
-    // loaned frame passes the pool through unchanged. After the walk `gas` is the
-    // catcher's own pool, and every metered frame in the routed-past subtree has a
-    // consistent meter balance — so a later discard (handler HALT / DROP_PAUSED)
-    // never over-refunds, and a resume re-reads the right balance.
-    for i in (j + 1..=top_idx).rev() {
-        if let Some(k) = stack[i].meter.clone() {
-            meters.insert(k, *gas);
-            if let Some(saved) = stack[i].saved_gas {
-                *gas = saved;
-            }
-        }
-    }
     let target = stack[j].target;
     let recv_iid = stack[j].instance_id;
+    // The handler runs the catcher's frame, so it is funded by the catcher's
+    // active meter (NOT the emitter's).
+    let recv_active = stack[j].active.clone();
     {
         let catcher_frame = frame_at_mut(stack, j);
         if let Some(inst) = payload {
@@ -1122,21 +1143,16 @@ fn route_yield(
         target,
         instance_id: recv_iid,
         catch_set: Vec::new(),
-        meter: None,
-        saved_gas: None,
+        active: recv_active,
     });
     true
 }
 
-/// The gas meter funding the running pool: the nearest metered frame at-or-below
-/// `idx`, following each entry's `target` to its InstanceEntry (a loaned frame
-/// spends its metered ancestor's pool; a handler ReferenceEntry's meter lives on
-/// its referent). `None` when the pool is host-budgeted (no metered frame).
+/// The gas meter funding the frame run by the entry at `idx` — the precomputed
+/// [`StackEntry::active`] (own meter, or inherited from the caller/catcher at
+/// push). O(1), unambiguous under yields.
 fn active_meter(stack: &[StackEntry], idx: usize) -> Option<Key> {
-    (0..=idx).rev().find_map(|i| {
-        let inst = stack[i].target;
-        stack[inst].meter.clone()
-    })
+    stack[idx].active.clone()
 }
 
 /// On gas exhaustion, inject a routed `kernel:oog` yield (payload =
@@ -1149,20 +1165,14 @@ fn active_meter(stack: &[StackEntry], idx: usize) -> Option<Key> {
 /// if routed; `false` if the pool is host-budgeted (no metered frame) or no
 /// receiver caught `kernel:oog` (the caller bubbles EXIT_OOG — host-stub root
 /// catch).
-fn try_oog_yield(
-    stack: &mut Vec<StackEntry>,
-    top_idx: usize,
-    gas: &mut i64,
-    meters: &mut BTreeMap<Key, i64>,
-    reattempt_pc: u32,
-) -> bool {
+fn try_oog_yield(stack: &mut Vec<StackEntry>, top_idx: usize, reattempt_pc: u32) -> bool {
     let Some(meter) = active_meter(stack, top_idx) else {
         return false;
     };
     frame_at_mut(stack, top_idx).pc = reattempt_pc;
     let oog_key = Key::from(&javm_cap::yield_cap::YK_OOG[..]);
     let payload = Some(javm_cap::gas_handle(&meter));
-    route_yield(stack, top_idx, &oog_key, payload, gas, meters)
+    route_yield(stack, top_idx, &oog_key, payload)
 }
 
 /// A yield handler (a ReferenceEntry activation) HALTed/REPLYed without resuming
@@ -1173,18 +1183,14 @@ fn try_oog_yield(
 /// handler's InstanceEntry (their frames, banked meters kept), then reflects that
 /// InstanceEntry's HALT exactly as a normal pop. Returns `true` when the stack
 /// drains.
-fn unwind_to_handler(
-    stack: &mut Vec<StackEntry>,
-    top_idx: usize,
-    return_value: u64,
-    gas: &mut i64,
-    meters: &mut BTreeMap<Key, i64>,
-) -> bool {
+fn unwind_to_handler(stack: &mut Vec<StackEntry>, top_idx: usize, return_value: u64) -> bool {
     let h_inst = stack[top_idx].target;
     // Drop the handler activation + the abandoned subtree above the handler's
-    // own frame; the handler's InstanceEntry becomes the top.
+    // own frame; the handler's InstanceEntry becomes the top. Gas is reconciled
+    // at the next loop top (the discarded metered frames bank naturally as the
+    // active meter changes back to the handler's).
     stack.truncate(h_inst + 1);
-    pop_and_reflect(stack, return_value, gas, meters)
+    pop_and_reflect(stack, return_value)
 }
 
 /// Pop the top frame; if a parent exists, reflect the popped child's
@@ -1193,31 +1199,14 @@ fn unwind_to_handler(
 /// `InstanceCap` from the frame's final mem/regs/pc (+ carried identity) and
 /// move it back into the parent's origin slot (the single-owner round trip).
 /// Returns `true` when the stack has been drained (the RPC caller hands a
-/// result back to the host).
-///
-/// Gas: when the popped frame was metered ([`StackEntry::meter`] = `Some(k)`),
-/// its remaining `gas` is written back to `meters[k]` and the caller's pool is
-/// restored from `saved_gas`. A loaned frame (`meter` = `None`) leaves `gas`
-/// threaded as-is (its remainder flows to the caller — the one-pool model).
-fn pop_and_reflect(
-    stack: &mut Vec<StackEntry>,
-    return_value: u64,
-    gas: &mut i64,
-    meters: &mut BTreeMap<Key, i64>,
-) -> bool {
+/// result back to the host). Gas is NOT touched here — the loop-top
+/// [`reconcile_active`] banks the popped frame's meter and loads the parent's on
+/// the next iteration.
+fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> bool {
     // A HALT/REPLY only pops an InstanceEntry — a ReferenceEntry (handler
     // activation) is removed by CALL_RESUME, and a handler that HALTs without
     // resuming is caught by the EXIT_HALT/OP_REPLY guards before this point.
-    let popped_entry = stack.pop().expect("non-empty");
-    // Metered frame: write the remaining balance back to its meter and restore
-    // the caller's pool (done before reflection — independent of the cap moves).
-    if let Some(k) = &popped_entry.meter {
-        meters.insert(k.clone(), *gas);
-        if let Some(saved) = popped_entry.saved_gas {
-            *gas = saved;
-        }
-    }
-    let mut popped = match popped_entry.kind {
+    let mut popped = match stack.pop().expect("non-empty").kind {
         EntryKind::Instance(boxed) => *boxed,
         EntryKind::Reference => unreachable!("pop_and_reflect on a ReferenceEntry"),
     };
@@ -1587,6 +1576,8 @@ enum YieldOutcome {
 fn dispatch_host_yield(
     frame: &mut KernelFrame,
     meters: &mut BTreeMap<Key, i64>,
+    gas: &mut i64,
+    active: &Option<Key>,
 ) -> Result<YieldOutcome, u32> {
     let sender_slot = Key::from((frame.regs[7] & 0xFF) as u8);
     let yield_key = match read_instance_cap(frame, &sender_slot) {
@@ -1671,14 +1662,20 @@ fn dispatch_host_yield(
         )
     } else if k == javm_cap::yield_cap::YK_SET_GAS_METER {
         // kernel:set_gas_meter(φ8=meter_key byte, φ9=value) -> previous (φ7).
-        // Atomically set the guest meter balance and return the previous (0 if
-        // absent) — the chain's topup / harvest primitive. The new balance takes
-        // effect when a frame next READS this meter (a CALL or CALL_RESUME of an
-        // instance whose gas_slots[0] names it), per the frame-entry metering
-        // model — it does not retroactively change a live pool.
+        // Atomically set the meter's balance, returning the previous — the chain's
+        // topup/harvest primitive. If `meter_key` is the CURRENTLY ACTIVE meter
+        // (e.g. a frame topping up the pool it itself loans from), the live `gas`
+        // is authoritative, so set it directly and return its value; otherwise the
+        // table entry is authoritative.
         let meter_key = Key::from((frame.regs[8] & 0xFF) as u8);
         let value = frame.regs[9] as i64;
-        let previous = meters.insert(meter_key, value).unwrap_or(0);
+        let previous = if active.as_ref() == Some(&meter_key) {
+            let p = *gas;
+            *gas = value;
+            p
+        } else {
+            meters.insert(meter_key, value).unwrap_or(0)
+        };
         frame.regs[7] = previous as u64;
         Ok(YieldOutcome::Inline)
     } else {

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -103,7 +103,7 @@ use javm_cap::slot::Key;
 use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
-use crate::cached_cap::{CachedCap, CapCache, ResidentCNode, ResidentInstance};
+use crate::cached_cap::{CachedCap, CapCache, InstanceCache, ResidentCNode, ResidentInstance};
 use crate::jit_run::{self, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
@@ -208,7 +208,9 @@ const ERR_GAS_SLOT_INVALID: u32 = 73;
 const ERR_PENDING_ORIGIN_INVARIANT: u32 = 74;
 
 type ResidentSlotTarget = CapHashOrRef<Box<CachedCap>>;
-type ResidentSlotEntry = ([u8; 32], MissingOr<ResidentSlotTarget>);
+type ResidentSlotEntry = (Key, MissingOr<ResidentSlotTarget>);
+type WireRootCNode = CapHashOrRef<Box<Cap>>;
+type SplitResidentRoot = (WireRootCNode, Option<Box<ResidentCNode>>);
 
 /// One stack frame on the in-kernel call stack. Holds the running Instance
 /// value, the origin reservation metadata for the owner slot it came from, and
@@ -1470,24 +1472,16 @@ fn release_pending_origins_for_dropped(stack: &mut [StackEntry], start: usize) {
 fn restore_instance_to_origin(
     stack: &mut [StackEntry],
     origin: FrameOrigin,
-    inst: InstanceCap,
-    runtime: Option<FrameRuntime>,
+    cap: CachedCap,
 ) -> Result<(), u32> {
     let owner = frame_at_mut(stack, origin.owner);
     if !owner.pending_origins.remove(&origin.slot) {
         return Err(ERR_PENDING_ORIGIN_INVARIANT);
     }
-    let cache = match runtime {
-        Some(rt) => CapCache::Instance(rt),
-        None => CapCache::None,
-    };
     frame_cnode_set_key(
         owner,
         origin.slot.as_slice(),
-        Some(CapHashOrRef::Owned(Box::new(CachedCap {
-            cap: Cap::Instance(inst),
-            cache: spin::Mutex::new(cache),
-        }))),
+        Some(CapHashOrRef::Owned(Box::new(cap))),
     );
     Ok(())
 }
@@ -1564,8 +1558,8 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
                 rt.rearm_cow(popped.instance.mem.overlay.keys().copied());
             }
             popped.instance.gas_remaining = 0;
-            let inst = resident_instance_to_wire(popped.instance)?;
-            Some((origin, inst, runtime))
+            let cap = resident_instance_to_cached_cap(popped.instance, runtime)?;
+            Some((origin, cap))
         }
         None => {
             popped.runtime = None;
@@ -1587,8 +1581,8 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
             frame_cnode_set_key(parent, &[javm_cap::abi::SCRATCHPAD_SLOT], Some(cap));
         }
     }
-    if let Some((origin, inst, runtime)) = owned_back {
-        restore_instance_to_origin(stack, origin, inst, runtime)?;
+    if let Some((origin, cap)) = owned_back {
+        restore_instance_to_origin(stack, origin, cap)?;
     }
     Ok(false)
 }
@@ -2069,13 +2063,19 @@ fn dispatch_host_call(
         // instance back.
         CapHashOrRef::Owned(boxed) => {
             let CachedCap { cap, cache } = *boxed;
-            let cache = cache.into_inner();
-            let mut child = build_frame_from_owned(cap, origin, endpoint_idx, args)?;
+            let mut cached_runtime = None;
+            let mut cached_root_cnode = None;
+            if let CapCache::Instance(mut instance_cache) = cache.into_inner() {
+                cached_runtime = instance_cache.runtime.take();
+                cached_root_cnode = instance_cache.root_cnode.take();
+            }
+            let mut child =
+                build_frame_from_owned(cap, cached_root_cnode, origin, endpoint_idx, args)?;
             // Page-table reuse: if this resident instance carries a parked
             // runtime (re-armed at its last HALT), move it into the child frame
             // instead of rebuilding the page table. The data extent is fixed
             // per image (immutable), so the parked extent must match.
-            if let CapCache::Instance(rt) = cache {
+            if let Some(rt) = cached_runtime {
                 debug_assert_eq!(
                     rt.data_extent(),
                     child.instance.mem.content_len(),
@@ -2096,7 +2096,7 @@ fn dispatch_host_call(
                 Cap::Instance(i) => i.clone(),
                 _ => return Err(ERR_INSTANCE_KIND),
             };
-            build_frame_from_instance(inst, Some(origin), endpoint_idx, args)?
+            build_frame_from_instance(inst, None, Some(origin), endpoint_idx, args)?
         }
     };
     parent.pending_origins.insert(instance_slot.clone());
@@ -2111,28 +2111,26 @@ fn dispatch_host_call(
     //
     // The scratchpad slot (slot[0]) is EXCLUDED here: it is not inherited by
     // copy but *moved* by the caller (the `OP_HOST_CALL` arm).
-    // `key_of` is payload-independent (it hashes the logical key); annotate
-    // the generic so it resolves, matching the parent frame's cnode payload.
-    let scratch_phys = CNodeCap::<Box<CachedCap>>::key_of(&[javm_cap::abi::SCRATCHPAD_SLOT]);
+    let scratch_slot = Key::from(javm_cap::abi::SCRATCHPAD_SLOT);
     let inherited: Vec<ResidentSlotEntry> = with_root_cnode(parent, |parent_cnode| {
         parent_cnode
             .slots
             .iter()
-            .filter_map(|(phys_key, val)| {
-                if *phys_key == scratch_phys {
+            .filter_map(|(slot, val)| {
+                if *slot == scratch_slot {
                     return None;
                 }
                 if let MissingOr::Materialized(CapHashOrRef::Owned(_)) = val {
                     return None;
                 }
-                Some((*phys_key, val.clone()))
+                Some((slot.clone(), val.clone()))
             })
             .collect()
     });
     with_root_cnode_mut(&mut child, |child_cnode| {
-        for (phys_key, val) in inherited {
-            if child_cnode.slots.get(&phys_key).is_none() {
-                child_cnode.slots.insert(phys_key, val);
+        for (slot, val) in inherited {
+            if child_cnode.slots.get(&slot).is_none() {
+                child_cnode.slots.insert(slot, val);
             }
         }
     });
@@ -2220,7 +2218,7 @@ fn build_frame_from_published(
         Cap::Instance(i) => i.clone(),
         _ => return Err(ERR_INSTANCE_KIND),
     };
-    build_frame_from_instance(inst, None, endpoint_idx, args)
+    build_frame_from_instance(inst, None, None, endpoint_idx, args)
 }
 
 /// Build a frame by **moving** an `Owned` `Cap::Instance` into it: the
@@ -2232,6 +2230,7 @@ fn build_frame_from_published(
 /// it.
 fn build_frame_from_owned(
     cap: Cap,
+    cached_root_cnode: Option<Box<ResidentCNode>>,
     origin: FrameOrigin,
     endpoint_idx: u32,
     args: [u64; 4],
@@ -2239,16 +2238,17 @@ fn build_frame_from_owned(
     let Cap::Instance(inst) = cap else {
         return Err(ERR_INSTANCE_KIND);
     };
-    build_frame_from_instance(inst, Some(origin), endpoint_idx, args)
+    build_frame_from_instance(inst, cached_root_cnode, Some(origin), endpoint_idx, args)
 }
 
 fn build_frame_from_instance(
     inst: InstanceCap,
+    cached_root_cnode: Option<Box<ResidentCNode>>,
     origin: Option<FrameOrigin>,
     endpoint_idx: u32,
     args: [u64; 4],
 ) -> Result<KernelFrame, u32> {
-    build_frame_inner(inst, origin, endpoint_idx, args)
+    build_frame_inner(inst, cached_root_cnode, origin, endpoint_idx, args)
 }
 
 fn materialize_root_cnode(root_cnode: &CapHashOrRef) -> Result<ResidentCNode, u32> {
@@ -2281,7 +2281,7 @@ fn copy_wire_cnode_into_cached(src: &CNodeCap<Box<Cap>>, dst: &mut CNodeCap<Box<
             MissingOr::Materialized(t) => MissingOr::Materialized(wire_target_to_cached(t)),
             MissingOr::Missing(h) => MissingOr::Missing(*h),
         };
-        dst.slots.insert(*k, conv);
+        dst.slots.insert(k.clone(), conv);
     }
 }
 
@@ -2299,52 +2299,57 @@ fn wire_target_to_cached(target: &CapHashOrRef<Box<Cap>>) -> CapHashOrRef<Box<Ca
     }
 }
 
-fn cached_target_to_wire_ref(target: &CapHashOrRef<Box<CachedCap>>) -> CapHashOrRef<Box<Cap>> {
-    match target {
-        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
-        CapHashOrRef::Owned(boxed) => CapHashOrRef::Owned(Box::new(cached_cap_to_wire_ref(boxed))),
-    }
-}
-
-fn cached_cap_to_wire_ref(cap: &CachedCap) -> Cap {
-    let cache = cap.cache.lock();
-    match &*cache {
-        CapCache::CNode(cnode) => Cap::CNode(fold_frame_cnode_to_wire_ref(cnode)),
-        CapCache::None | CapCache::Image(_) | CapCache::Instance(_) => cap.cap.clone(),
-    }
-}
-
-fn fold_frame_cnode_to_wire_ref(cnode: &ResidentCNode) -> CNodeCap<Box<Cap>> {
-    let mut out = CNodeCap::new();
-    for (k, mo) in cnode.slots.iter() {
-        let conv = match mo {
-            MissingOr::Materialized(t) => MissingOr::Materialized(cached_target_to_wire_ref(t)),
-            MissingOr::Missing(h) => MissingOr::Missing(*h),
-        };
-        out.slots.insert(*k, conv);
-    }
-    out
-}
-
-fn resident_instance_to_wire(inst: ResidentInstance) -> Result<InstanceCap, u32> {
-    let root_cnode = match &inst.root_cnode {
+fn take_resident_root_cnode(
+    root_cnode: CapHashOrRef<Box<CachedCap>>,
+) -> Result<SplitResidentRoot, u32> {
+    match root_cnode {
+        CapHashOrRef::Hash(h) => Ok((CapHashOrRef::Hash(h), None)),
         CapHashOrRef::Owned(root) => {
-            let cache = root.cache.lock();
-            let CapCache::CNode(cnode) = &*cache else {
-                return Err(ERR_INSTANCE_KIND);
-            };
-            CapHashOrRef::Owned(Box::new(Cap::CNode(fold_frame_cnode_to_wire_ref(cnode))))
+            let CachedCap { cap, cache } = *root;
+            match cache.into_inner() {
+                CapCache::CNode(cnode) => Ok((CapHashOrRef::Hash([0u8; 32]), Some(cnode))),
+                CapCache::None => match cap {
+                    Cap::CNode(cnode) => {
+                        Ok((CapHashOrRef::Owned(Box::new(Cap::CNode(cnode))), None))
+                    }
+                    _ => Err(ERR_INSTANCE_KIND),
+                },
+                CapCache::Image(_) | CapCache::Instance(_) => Err(ERR_INSTANCE_KIND),
+            }
         }
-        CapHashOrRef::Hash(h) => CapHashOrRef::Hash(*h),
-    };
-    Ok(InstanceCap {
-        image_hash_chain: inst.image_hash_chain,
-        image_hash: inst.image_hash,
+    }
+}
+
+fn resident_instance_to_cached_cap(
+    inst: ResidentInstance,
+    runtime: Option<FrameRuntime>,
+) -> Result<CachedCap, u32> {
+    let ResidentInstance {
+        image_hash_chain,
+        image_hash,
         root_cnode,
-        mem: inst.mem,
-        regs: inst.regs,
-        pc: inst.pc,
-        gas_remaining: inst.gas_remaining,
+        mem,
+        regs,
+        pc,
+        gas_remaining,
+    } = inst;
+    let (wire_root_cnode, resident_root_cnode) = take_resident_root_cnode(root_cnode)?;
+    let cap = Cap::Instance(InstanceCap {
+        image_hash_chain,
+        image_hash,
+        root_cnode: wire_root_cnode,
+        mem,
+        regs,
+        pc,
+        gas_remaining,
+    });
+    let cache = match (runtime, resident_root_cnode) {
+        (None, None) => CapCache::None,
+        (runtime, root_cnode) => CapCache::Instance(InstanceCache::new(runtime, root_cnode)),
+    };
+    Ok(CachedCap {
+        cap,
+        cache: spin::Mutex::new(cache),
     })
 }
 
@@ -2359,6 +2364,7 @@ fn resident_instance_to_wire(inst: ResidentInstance) -> Result<InstanceCap, u32>
 #[allow(clippy::too_many_arguments)]
 fn build_frame_inner(
     mut cap: InstanceCap,
+    cached_root_cnode: Option<Box<ResidentCNode>>,
     origin: Option<FrameOrigin>,
     endpoint_idx: u32,
     args: [u64; 4],
@@ -2398,7 +2404,10 @@ fn build_frame_inner(
     cap.pc = ep.entry_pc;
     cap.gas_remaining = 0;
 
-    let mut cnode = materialize_root_cnode(&root_cnode)?;
+    let mut cnode = match cached_root_cnode {
+        Some(cnode) => *cnode,
+        None => materialize_root_cnode(&root_cnode)?,
+    };
     // The persistent root cnode is now resident in `cap.root_cnode` itself:
     // arbitrary caps flow through this cache-carrying CNode, while image pinned
     // and initial slots overlay/fill it below.

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -42,7 +42,7 @@ pub fn nub_invoke_cached(packet_bytes: &[u8]) -> Vec<u8> {
     };
 
     // Caps are resolved via the heap-resident `CACHE`
-    // (`CacheDirectory<FixedState>`) — see `crate::state_cache`.
+    // (`CacheDirectory<FixedState, CachedCap>`) — see `crate::state_cache`.
     let outcome = crate::call_loop::run_top(
         &packet.instance_hash,
         packet.endpoint_idx,

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -29,15 +29,15 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
+use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 
 use javm_cap::CapHash;
 
+use crate::cached_cap::{CachedCap, CapCache};
 use crate::page_alloc::PageBuf;
 use crate::paging::{PAGE_SIZE, Perm, Pml4SlotTemplate, TemplatePT};
 
@@ -101,22 +101,6 @@ pub struct CompiledImage {
     pub template_pdpt_pa: u64,
 }
 
-/// Process-wide compile cache.
-///
-/// Hyperlight serialises host calls, so the guest is single-threaded
-/// and a plain `UnsafeCell` is sound. We wrap it in a newtype so the
-/// `unsafe` is local and the public API can stay safe.
-struct CompileCache {
-    inner: UnsafeCell<BTreeMap<CapHash, CompiledImage>>,
-}
-
-/// SAFETY: single-threaded guest (Hyperlight serialisation).
-unsafe impl Sync for CompileCache {}
-
-static CACHE: CompileCache = CompileCache {
-    inner: UnsafeCell::new(BTreeMap::new()),
-};
-
 static NEXT_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Round a byte count up to the next [`PAGE_SIZE`] boundary, with a
@@ -130,19 +114,22 @@ fn page_round_up_min1(n: usize) -> usize {
 ///
 /// Bench-only: each `CompiledImage`'s `Drop` releases its arena pages
 /// and template PD/PT pages, which is fine between invocations (no
-/// in-flight call references them). The next `get_or_compile` will
+/// in-flight call references them). The next `with_compiled_image` miss will
 /// pay full recompile cost. Safe under Hyperlight serialisation; not
 /// meant for production paths.
 pub fn evict_all() {
-    // SAFETY: single-threaded guest (Hyperlight serialisation), no
-    // concurrent call in progress when this RPC fires.
-    let map = unsafe { &mut *CACHE.inner.get() };
-    map.clear();
+    for (_, cap) in crate::state_cache::CACHE.iter_blobs() {
+        let mut cache = cap.cache.lock();
+        if matches!(&*cache, CapCache::Image(_)) {
+            *cache = CapCache::None;
+        }
+    }
 }
 
-/// Look up the compile cache by `image_hash`. On miss, compile the
-/// Image and materialise the per-Image arena. Returns a `'static`
-/// borrow into the cache entry.
+/// Look up the compile cache attached to `image_cap`. On miss, compile the
+/// Image and materialise the per-Image arena, then run `f` with a borrow of the
+/// boxed cached artifact. The borrow must not escape the closure; callers copy
+/// the stable pointers/metadata they need into their frame runtime.
 ///
 /// `arena_base_va` is the ring-3 VA where the arena will be mapped
 /// (used to compute the per-Image `JIT_VA` so codegen embeds correct
@@ -151,10 +138,12 @@ pub fn evict_all() {
 ///
 /// # Safety
 ///
-/// Hyperlight serialises host calls; the returned reference is valid
-/// until eviction (V1 never evicts), effectively `'static`.
+/// Hyperlight serialises host calls. The compiled artifact is boxed inside the
+/// resident `CachedCap`, so raw pointers into it remain stable as long as that
+/// cap cache is not evicted while frames are live.
 #[allow(clippy::too_many_arguments)]
-pub fn get_or_compile(
+pub fn with_compiled_image<R>(
+    image_cap: &CachedCap,
     image_hash: &CapHash,
     code: &[u8],
     code_base: u32,
@@ -165,142 +154,169 @@ pub fn get_or_compile(
     stack_pd_pa: u64,
     mem_cycles: u8,
     helpers: HelperFns,
-) -> &'static CompiledImage {
-    // SAFETY: single-threaded guest.
-    let map = unsafe { &mut *CACHE.inner.get() };
-    if !map.contains_key(image_hash) {
-        // Region sizing. Layout: DISPATCH | JIT | TRAMP. The dispatch
-        // table is dense — one i32 native offset per code byte — and
-        // doubles as the jalr-target validator (no separate BB set).
-        let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
-
-        let dispatch_offset = 0usize;
-        let jit_offset = dispatch_offset + dispatch_size;
-        let jit_va = arena_base_va + jit_offset as u64;
-
-        let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
-        let CompileResult {
-            native_code,
-            dispatch_entries,
-            trap_table,
-            exit_label_offset,
-            panic_offset,
-        } = compiler.compile(code);
-
-        let jit_size = page_round_up_min1(native_code.len());
-        let tramp_offset = jit_offset + jit_size;
-        let tramp_size = PAGE_SIZE;
-        let total = tramp_offset + tramp_size;
-        let global_arena_token = NEXT_GLOBAL_ARENA_TOKEN.fetch_add(1, Ordering::Relaxed);
-
-        let mut arena = PageBuf::new(total).expect("PageBuf alloc for Image arena");
-        let buf = arena.as_mut_slice();
-
-        // DISPATCH region — dense fill. First set *every* code-byte slot
-        // to the panic-stub offset, so a jalr to any non-block-start
-        // offset lands on the panic stub; then overwrite the block-start
-        // offsets with their real native targets. This folds the
-        // block-start validation into the dispatch lookup.
-        //
-        // SECURITY-CRITICAL: the panic-fill must cover all `code.len()`
-        // slots — a slot left zero (the arena is page-zeroed) would route
-        // a bad jalr target to native offset 0 instead of faulting.
-        //
-        // The panic-fill is the per-recompile (cold-path) cost of the
-        // dense table, so do it at memset speed via a u32 view rather
-        // than a per-slot byte copy. `dispatch_offset` is 0 in the
-        // page-aligned arena, so the region is 4-aligned and holds
-        // exactly `code.len()` i32 slots. The host is little-endian
-        // (x86-64), so a native u32 store matches the LE bytes the JIT
-        // reads back as i32.
-        let dispatch_slots = code.len();
-        debug_assert_eq!(dispatch_offset, 0);
-        // SAFETY: 4-aligned (page-aligned arena base), in-bounds
-        // (dispatch_size ≥ dispatch_slots * 4), no aliasing (exclusive
-        // `buf`).
-        let dispatch_u32: &mut [u32] = unsafe {
-            core::slice::from_raw_parts_mut(
-                buf.as_mut_ptr().add(dispatch_offset) as *mut u32,
-                dispatch_slots,
-            )
-        };
-        dispatch_u32.fill(panic_offset);
-        for &(pvm_pc, off) in &dispatch_entries {
-            dispatch_u32[pvm_pc as usize] = off as u32;
-        }
-
-        // JIT region.
-        buf[jit_offset..jit_offset + native_code.len()].copy_from_slice(&native_code);
-
-        // TRAMP region (same 26-byte sequence as PVM).
-        let tramp_start = tramp_offset;
-        buf[tramp_start] = 0x48;
-        buf[tramp_start + 1] = 0xBF;
-        buf[tramp_start + 2..tramp_start + 10].copy_from_slice(&ctx_va.to_le_bytes());
-        buf[tramp_start + 10] = 0x48;
-        buf[tramp_start + 11] = 0xB8;
-        buf[tramp_start + 12..tramp_start + 20].copy_from_slice(&jit_va.to_le_bytes());
-        buf[tramp_start + 20] = 0xFF;
-        buf[tramp_start + 21] = 0xD0;
-        buf[tramp_start + 22] = 0xCD;
-        buf[tramp_start + 23] = 0x81;
-        buf[tramp_start + 24] = 0x0F;
-        buf[tramp_start + 25] = 0x0B;
-
-        // Template PD: same RO-then-RX split as the PVM path.
-        let arena_pa = arena.pa();
-        let mut template = TemplatePT::new().expect("TemplatePT alloc");
-        let ro_end = jit_offset;
-        let mut off = 0usize;
-        while off < total {
-            let perm = if off < ro_end {
-                Perm::user_ro_global()
-            } else {
-                Perm::user_rx_global()
-            };
-            template
-                .map_leaf(off as u64, arena_pa + off as u64, perm)
-                .expect("TemplatePT::map_leaf");
-            off += PAGE_SIZE;
-        }
-        let template_pd_pa = template
-            .pd_pa()
-            .expect("template PD must be in kernel half");
-
-        // Build this Image's PML4 slot-1 PDPT once: CTX/STACK borrow the
-        // process-global CTX/STACK PD subtrees, META this Image's arena PD. The
-        // PDPT is the only table owned per Image; per-call PTs install it with a
-        // single borrowed PML4 write.
-        let pml4_slot_template = Pml4SlotTemplate::new(
-            ctx_va,
-            ctx_pd_pa,
+    f: impl FnOnce(&CompiledImage) -> R,
+) -> R {
+    let mut cache = image_cap.cache.lock();
+    if !matches!(&*cache, CapCache::Image(_)) {
+        *cache = CapCache::Image(Box::new(compile_image(
+            image_hash,
+            code,
+            code_base,
             arena_base_va,
-            template_pd_pa,
+            ctx_va,
             stack_va,
+            ctx_pd_pa,
             stack_pd_pa,
-        )
-        .expect("Pml4SlotTemplate alloc");
-        let template_pdpt_pa = pml4_slot_template
-            .pdpt_pa()
-            .expect("template PDPT must be in kernel half");
-
-        map.insert(
-            *image_hash,
-            CompiledImage {
-                arena,
-                dispatch_offset,
-                jit_offset,
-                tramp_offset,
-                arena_size: total,
-                global_arena_token,
-                jit_size,
-                exit_label_offset,
-                trap_table,
-                template,
-                pml4_slot_template,
-                template_pdpt_pa,
-            },
-        );
+            mem_cycles,
+            helpers,
+        )));
     }
-    map.get(image_hash).expect("inserted above")
+    let CapCache::Image(compiled) = &*cache else {
+        unreachable!("image cache variant installed above")
+    };
+    f(compiled)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compile_image(
+    _image_hash: &CapHash,
+    code: &[u8],
+    code_base: u32,
+    arena_base_va: u64,
+    ctx_va: u64,
+    stack_va: u64,
+    ctx_pd_pa: u64,
+    stack_pd_pa: u64,
+    mem_cycles: u8,
+    helpers: HelperFns,
+) -> CompiledImage {
+    // Region sizing. Layout: DISPATCH | JIT | TRAMP. The dispatch
+    // table is dense — one i32 native offset per code byte — and
+    // doubles as the jalr-target validator (no separate BB set).
+    let dispatch_size = page_round_up_min1(code.len() * core::mem::size_of::<i32>());
+
+    let dispatch_offset = 0usize;
+    let jit_offset = dispatch_offset + dispatch_size;
+    let jit_va = arena_base_va + jit_offset as u64;
+
+    let compiler = Compiler::new(helpers, code.len(), jit_va, mem_cycles, code_base);
+    let CompileResult {
+        native_code,
+        dispatch_entries,
+        trap_table,
+        exit_label_offset,
+        panic_offset,
+    } = compiler.compile(code);
+
+    let jit_size = page_round_up_min1(native_code.len());
+    let tramp_offset = jit_offset + jit_size;
+    let tramp_size = PAGE_SIZE;
+    let total = tramp_offset + tramp_size;
+    let global_arena_token = NEXT_GLOBAL_ARENA_TOKEN.fetch_add(1, Ordering::Relaxed);
+
+    let mut arena = PageBuf::new(total).expect("PageBuf alloc for Image arena");
+    let buf = arena.as_mut_slice();
+
+    // DISPATCH region — dense fill. First set *every* code-byte slot
+    // to the panic-stub offset, so a jalr to any non-block-start
+    // offset lands on the panic stub; then overwrite the block-start
+    // offsets with their real native targets. This folds the
+    // block-start validation into the dispatch lookup.
+    //
+    // SECURITY-CRITICAL: the panic-fill must cover all `code.len()`
+    // slots — a slot left zero (the arena is page-zeroed) would route
+    // a bad jalr target to native offset 0 instead of faulting.
+    //
+    // The panic-fill is the per-recompile (cold-path) cost of the
+    // dense table, so do it at memset speed via a u32 view rather
+    // than a per-slot byte copy. `dispatch_offset` is 0 in the
+    // page-aligned arena, so the region is 4-aligned and holds
+    // exactly `code.len()` i32 slots. The host is little-endian
+    // (x86-64), so a native u32 store matches the LE bytes the JIT
+    // reads back as i32.
+    let dispatch_slots = code.len();
+    debug_assert_eq!(dispatch_offset, 0);
+    // SAFETY: 4-aligned (page-aligned arena base), in-bounds
+    // (dispatch_size ≥ dispatch_slots * 4), no aliasing (exclusive
+    // `buf`).
+    let dispatch_u32: &mut [u32] = unsafe {
+        core::slice::from_raw_parts_mut(
+            buf.as_mut_ptr().add(dispatch_offset) as *mut u32,
+            dispatch_slots,
+        )
+    };
+    dispatch_u32.fill(panic_offset);
+    for &(pvm_pc, off) in &dispatch_entries {
+        dispatch_u32[pvm_pc as usize] = off as u32;
+    }
+
+    // JIT region.
+    buf[jit_offset..jit_offset + native_code.len()].copy_from_slice(&native_code);
+
+    // TRAMP region (same 26-byte sequence as PVM).
+    let tramp_start = tramp_offset;
+    buf[tramp_start] = 0x48;
+    buf[tramp_start + 1] = 0xBF;
+    buf[tramp_start + 2..tramp_start + 10].copy_from_slice(&ctx_va.to_le_bytes());
+    buf[tramp_start + 10] = 0x48;
+    buf[tramp_start + 11] = 0xB8;
+    buf[tramp_start + 12..tramp_start + 20].copy_from_slice(&jit_va.to_le_bytes());
+    buf[tramp_start + 20] = 0xFF;
+    buf[tramp_start + 21] = 0xD0;
+    buf[tramp_start + 22] = 0xCD;
+    buf[tramp_start + 23] = 0x81;
+    buf[tramp_start + 24] = 0x0F;
+    buf[tramp_start + 25] = 0x0B;
+
+    // Template PD: same RO-then-RX split as the PVM path.
+    let arena_pa = arena.pa();
+    let mut template = TemplatePT::new().expect("TemplatePT alloc");
+    let ro_end = jit_offset;
+    let mut off = 0usize;
+    while off < total {
+        let perm = if off < ro_end {
+            Perm::user_ro_global()
+        } else {
+            Perm::user_rx_global()
+        };
+        template
+            .map_leaf(off as u64, arena_pa + off as u64, perm)
+            .expect("TemplatePT::map_leaf");
+        off += PAGE_SIZE;
+    }
+    let template_pd_pa = template
+        .pd_pa()
+        .expect("template PD must be in kernel half");
+
+    // Build this Image's PML4 slot-1 PDPT once: CTX/STACK borrow the
+    // process-global CTX/STACK PD subtrees, META this Image's arena PD. The
+    // PDPT is the only table owned per Image; per-call PTs install it with a
+    // single borrowed PML4 write.
+    let pml4_slot_template = Pml4SlotTemplate::new(
+        ctx_va,
+        ctx_pd_pa,
+        arena_base_va,
+        template_pd_pa,
+        stack_va,
+        stack_pd_pa,
+    )
+    .expect("Pml4SlotTemplate alloc");
+    let template_pdpt_pa = pml4_slot_template
+        .pdpt_pa()
+        .expect("template PDPT must be in kernel half");
+
+    CompiledImage {
+        arena,
+        dispatch_offset,
+        jit_offset,
+        tramp_offset,
+        arena_size: total,
+        global_arena_token,
+        jit_size,
+        exit_label_offset,
+        trap_table,
+        template,
+        pml4_slot_template,
+        template_pdpt_pa,
+    }
 }

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -50,6 +50,7 @@
 
 extern crate alloc;
 
+use crate::cached_cap::CachedCap;
 use crate::jit_cache;
 use crate::page_alloc::GlobalPage;
 use crate::paging::{PAGE_SIZE, PageTable};
@@ -884,7 +885,7 @@ impl FrameRuntime {
 /// `auipc`/`jalr` resolve correctly) and into the cache key.
 ///
 /// The dense dispatch table (one `i32` per code byte, built by
-/// `jit_cache::get_or_compile`; non-block-start slots hold the
+/// `jit_cache::with_compiled_image`; non-block-start slots hold the
 /// panic-stub offset) doubles as the `jalr`-target validator — there
 /// is no BB region or jump table.
 ///
@@ -901,6 +902,7 @@ impl FrameRuntime {
 /// returned [`FrameRuntime`], which owns the per-call page table.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn build_frame_runtime(
+    image_cap: &CachedCap,
     image_hash: &javm_cap::CapHash,
     code: &[u8],
     code_base: u32,
@@ -927,7 +929,8 @@ pub unsafe fn build_frame_runtime(
         mem_size,
         javm_cap::layout::DATA_BASE,
     ));
-    let cached = jit_cache::get_or_compile(
+    jit_cache::with_compiled_image(
+        image_cap,
         image_hash,
         code,
         code_base,
@@ -938,77 +941,79 @@ pub unsafe fn build_frame_runtime(
         global_pd_pa(&STACK_PD_PA, STACK_VA_M, STACK_PAGE.pa()),
         mem_cycles,
         helpers,
-    );
-    if cached.jit_size == 0 {
-        return None;
-    }
+        |cached| {
+            if cached.jit_size == 0 {
+                return None;
+            }
 
-    let dispatch_va = META_BASE_M + cached.dispatch_offset as u64;
-    let jit_va = META_BASE_M + cached.jit_offset as u64;
-    let tramp_va = META_BASE_M + cached.tramp_offset as u64;
+            let dispatch_va = META_BASE_M + cached.dispatch_offset as u64;
+            let jit_va = META_BASE_M + cached.jit_offset as u64;
+            let tramp_va = META_BASE_M + cached.tramp_offset as u64;
 
-    // Data lives at [DATA_BASE, mem_size). The flat RW buffer covers
-    // only that extent and is mapped at native VA DATA_BASE, leaving
-    // [0, DATA_BASE) unmapped — a null guard, save for the code
-    // direct-map at CODE_BASE. `mem_size` is the absolute max data VA.
-    let data_base = javm_cap::layout::DATA_BASE as usize;
-    let mem_bytes = (mem_size as usize)
-        .saturating_sub(data_base)
-        .next_multiple_of(PAGE_SIZE);
+            // Data lives at [DATA_BASE, mem_size). The flat RW buffer covers
+            // only that extent and is mapped at native VA DATA_BASE, leaving
+            // [0, DATA_BASE) unmapped — a null guard, save for the code
+            // direct-map at CODE_BASE. `mem_size` is the absolute max data VA.
+            let data_base = javm_cap::layout::DATA_BASE as usize;
+            let mem_bytes = (mem_size as usize)
+                .saturating_sub(data_base)
+                .next_multiple_of(PAGE_SIZE);
 
-    // Memory is sourced lazily from the Instance's `mem` DataCap via
-    // `mat_ranges`: every data page is covered by a `MatRange` (initial/pinned
-    // slabs or the shared zero page), so there is NO eager flat buffer. CTX and
-    // STACK are process-global shared pages ([`CTX_PAGE`] / [`STACK_PAGE`]) —
-    // nothing is allocated per call but the page table itself. The shared ctx's
-    // frame-constant fields (`dispatch_table` / `code_base`) are re-stamped by
-    // [`enter_frame`] each entry (the page is shared, the image differs).
+            // Memory is sourced lazily from the Instance's `mem` DataCap via
+            // `mat_ranges`: every data page is covered by a `MatRange` (initial/pinned
+            // slabs or the shared zero page), so there is NO eager flat buffer. CTX and
+            // STACK are process-global shared pages ([`CTX_PAGE`] / [`STACK_PAGE`]) —
+            // nothing is allocated per call but the page table itself. The shared ctx's
+            // frame-constant fields (`dispatch_table` / `code_base`) are re-stamped by
+            // [`enter_frame`] each entry (the page is shared, the image differs).
 
-    let mut pt = PageTable::new()?;
-    // True zero-setup demand paging: the WHOLE guest low VA range (PML4[0]
-    // — both CODE at CODE_BASE and DATA at DATA_BASE) is left with NO
-    // page-table entries here. The first guest touch of each page faults
-    // into `jit_pf_handler`, which builds the PML4→PT path (recording the
-    // new tables in `pt.owned`) and materializes the page (page-in / CoW),
-    // charging #3. There is no eager data buffer: every page is materialized
-    // from the frame's `mem` DataCap (cap slabs or the shared zero page).
-    //
-    // The per-page #3 *state* (`mat_state`) and the RO-unit set (`ro_units`)
-    // live on the owning `KernelFrame`, NOT here — they are gas history that
-    // must outlive any future reclamation of this runtime (host-backed swap).
-    let mem_top = (data_base + mem_bytes) as u32;
-    // Code region: page-rounded `[code_base, code_top)`, lazily paged in
-    // RO (PinnedCapRo) per unit on guest PIC reads. The code buffer is
-    // page-aligned with a zeroed tail, so paging in the last (partial) page
-    // is safe.
-    let code_bytes_rounded = code.len().next_multiple_of(PAGE_SIZE);
-    let code_top = code_base.saturating_add(code_bytes_rounded as u32);
-    // Install the entire PML4 slot-1 subtree (CTX | META arena | STACK) with a
-    // single borrowed PML4 write. CTX/STACK are the global shared pages and the
-    // arena PD is per-Image, so the whole PDPT is an Image constant built once
-    // in `get_or_compile` — no per-frame CTX/STACK PDPT/PD/PT allocation.
-    pt.install_borrowed_pdpt(META_PML4_BASE, cached.template_pdpt_pa)?;
-    let new_cr3 = pt.cr3()?;
+            let mut pt = PageTable::new()?;
+            // True zero-setup demand paging: the WHOLE guest low VA range (PML4[0]
+            // — both CODE at CODE_BASE and DATA at DATA_BASE) is left with NO
+            // page-table entries here. The first guest touch of each page faults
+            // into `jit_pf_handler`, which builds the PML4→PT path (recording the
+            // new tables in `pt.owned`) and materializes the page (page-in / CoW),
+            // charging #3. There is no eager data buffer: every page is materialized
+            // from the frame's `mem` DataCap (cap slabs or the shared zero page).
+            //
+            // The per-page #3 *state* (`mat_state`) and the RO-unit set (`ro_units`)
+            // live on the owning `KernelFrame`, NOT here — they are gas history that
+            // must outlive any future reclamation of this runtime (host-backed swap).
+            let mem_top = (data_base + mem_bytes) as u32;
+            // Code region: page-rounded `[code_base, code_top)`, lazily paged in
+            // RO (PinnedCapRo) per unit on guest PIC reads. The code buffer is
+            // page-aligned with a zeroed tail, so paging in the last (partial) page
+            // is safe.
+            let code_bytes_rounded = code.len().next_multiple_of(PAGE_SIZE);
+            let code_top = code_base.saturating_add(code_bytes_rounded as u32);
+            // Install the entire PML4 slot-1 subtree (CTX | META arena | STACK) with a
+            // single borrowed PML4 write. CTX/STACK are the global shared pages and the
+            // arena PD is per-Image, so the whole PDPT is an Image constant built once
+            // in `with_compiled_image` — no per-frame CTX/STACK PDPT/PD/PT allocation.
+            pt.install_borrowed_pdpt(META_PML4_BASE, cached.template_pdpt_pa)?;
+            let new_cr3 = pt.cr3()?;
 
-    Some(FrameRuntime {
-        pt,
-        jit_va,
-        jit_size: cached.jit_size as u64,
-        dispatch_va,
-        exit_label_va: jit_va + cached.exit_label_offset as u64,
-        trap_table_ptr: cached.trap_table.as_ptr(),
-        trap_table_len: cached.trap_table.len() as u64,
-        tramp_va,
-        new_cr3,
-        global_arena_token: cached.global_arena_token,
-        global_arena_pages: (cached.arena_size / PAGE_SIZE) as u64,
-        mat_ranges,
-        data_base: data_base as u32,
-        mem_top,
-        code_base,
-        code_top,
-        code_pa,
-    })
+            Some(FrameRuntime {
+                pt,
+                jit_va,
+                jit_size: cached.jit_size as u64,
+                dispatch_va,
+                exit_label_va: jit_va + cached.exit_label_offset as u64,
+                trap_table_ptr: cached.trap_table.as_ptr(),
+                trap_table_len: cached.trap_table.len() as u64,
+                tramp_va,
+                new_cr3,
+                global_arena_token: cached.global_arena_token,
+                global_arena_pages: (cached.arena_size / PAGE_SIZE) as u64,
+                mat_ranges,
+                data_base: data_base as u32,
+                mem_top,
+                code_base,
+                code_top,
+                code_pa,
+            })
+        },
+    )
 }
 
 /// Enter ring 3 on `rt`. Updates per-entry `JitContext` fields (regs,

--- a/rust/nub-arch-x86/src/state_cache.rs
+++ b/rust/nub-arch-x86/src/state_cache.rs
@@ -2,7 +2,7 @@
 //!
 //! ## CACHE
 //!
-//! The cap store is a `CacheDirectory<FixedState>` that lives entirely
+//! The cap store is a `CacheDirectory<FixedState, CachedCap>` that lives entirely
 //! in the guest's talc heap. The host populates blobs via the
 //! [`FN_ID_NUB_PUT_CAP`](nub_arch_x86_abi::FN_ID_NUB_PUT_CAP) RPC:
 //! ship a rkyv-archived `Cap` payload, the guest validates via
@@ -36,6 +36,8 @@ use foldhash::fast::FixedState;
 use javm_cap::cache::CacheDirectory;
 use nub_arch_x86_abi::BootInfo;
 
+use crate::cached_cap::CachedCap;
+
 /// Per-cache hasher seed. Pinned at a constant so the host's
 /// direct-dereference reader (via `BootInfo.directory_va`) agrees on
 /// bucket assignments. Any value works; using the magic for symmetry
@@ -50,7 +52,7 @@ const DIRECTORY_HASHER_SEED: u64 = 0x4A41_525F_4449_5230; // "JAR_DIR0"
 ///
 /// `CacheDirectory::new_const` is `const fn`, so the static initialiser
 /// runs at link time — the cache is ready before `hyperlight_main`.
-pub static CACHE: CacheDirectory<FixedState> = CacheDirectory::new_const(
+pub static CACHE: CacheDirectory<FixedState, CachedCap> = CacheDirectory::new_const(
     FixedState::with_seed(DIRECTORY_HASHER_SEED),
     FixedState::with_seed(DIRECTORY_HASHER_SEED),
 );
@@ -69,10 +71,9 @@ pub static mut BOOT_INFO: BootInfo = BootInfo {
     magic: BootInfo::MAGIC,
     directory_va: 0,
     // Sentinel: hash of the published directory's type signature.
-    // Bumped to 0x0003 when CapRef became a handle and the
-    // instances tier shape changed to `HashMap<u64, (CapRef,
-    // Arc<Cap>)>`.
-    directory_type_id: 0x0003,
+    // Bumped to 0x0004 when the guest resident directory payload changed from
+    // `Arc<Cap>` to `Arc<CachedCap>`.
+    directory_type_id: 0x0004,
     // Patched at boot from `kernel_base_va() - KERNEL_OFFSET`.
     guest_va_base: 0,
     _reserved: [0u64; 12],
@@ -96,7 +97,7 @@ pub fn init_directory_va() {
     {
         return;
     }
-    let va = &CACHE as *const CacheDirectory<FixedState> as u64;
+    let va = &CACHE as *const CacheDirectory<FixedState, CachedCap> as u64;
     let kernel_base = &_kernel_start as *const u8 as u64;
     let guest_va_base = kernel_base - nub_host_common::layout::KERNEL_OFFSET;
     // SAFETY: `BOOT_INFO` is `static mut` but we're the only writer

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -70,11 +70,10 @@ pub struct Nub {
     backend: Backend,
     /// The kernel-maintained gas meter mapping (`meter_key -> remaining gas`).
     /// The interim "static meter mapping" of the kernel-assisted GasMeter
-    /// design — a later spec change moves it behind a YieldCatcher. At frame
-    /// entry the kernel resolves the running Instance's `gas_slots[0]` →
-    /// `Gas{meter_key}` handle → `meter_key`, seeds the run from this map (a
-    /// missing/zero entry falls back to the call-supplied budget), and writes
-    /// the remaining gas back here at frame exit.
+    /// design — a later spec change moves it behind a YieldCatcher. At top-level
+    /// invoke the host resolves the running Instance's primary usable gas slot
+    /// (first non-empty valid `Gas{meter_key}`), seeds the run from this map
+    /// when non-zero, and writes the remaining primary balance back here.
     meters: HashMap<Key, u64>,
     /// The kernel-maintained storage quota mapping (`quota_key -> remaining`).
     /// Symmetric to [`Self::meters`]; quota *charging* is not yet wired (V1),
@@ -106,7 +105,7 @@ struct HyperlightDriver {
     sandbox: MultiUseSandbox,
     state_root_cache: CapHash,
     /// Host-side mirror of the published cap graph, used **only** to resolve an
-    /// Instance's `gas_slots[0]` → `Gas{meter_key}` handle host-side (the
+    /// Instance's primary usable gas slot → `Gas{meter_key}` handle host-side (the
     /// authoritative cap directory lives guest-side). This is the host's own
     /// `CacheDirectory` — not a deref of the guest's hashbrown (which is
     /// unsound across the SIMD-width boundary; see `MultiUseSandbox`).
@@ -278,11 +277,11 @@ impl Nub {
         self.quotas.get(quota_key).copied().unwrap_or(0)
     }
 
-    /// Resolve the running Instance's active gas `meter_key` from its Image's
-    /// `gas_slots[0]` → `Gas{meter_key}` handle, via the appropriate host-side
-    /// cache (the Local cache, or the Hyperlight host mirror). `None` if the
-    /// Image declares no gas slot, the slot is empty, or the cap there is not a
-    /// kernel `Gas` handle.
+    /// Resolve the running Instance's primary usable gas `meter_key` from its
+    /// Image gas slots, via the appropriate host-side cache (the Local cache, or
+    /// the Hyperlight host mirror). Empty slots are skipped. This host-side path
+    /// is only for budget seeding; guest-side execution still performs the strict
+    /// invalid-slot checks.
     fn resolve_gas_meter_key(&self, instance_hash: AbiCapHash) -> Option<Key> {
         let cache = match &self.backend {
             Backend::Local { cache, .. } => cache,
@@ -295,9 +294,9 @@ impl Nub {
     /// are 4 u64s laid into φ[7..=10] on top of the published
     /// endpoint's `initial_regs` baseline.
     ///
-    /// Meter-driven gas: if the Instance's `gas_slots[0]` names a `Gas` handle
-    /// whose `meter_key` has a non-zero entry in the kernel meter mapping, the
-    /// run is seeded from that meter and the remaining gas is written back at
+    /// Meter-driven gas: if the Instance's primary usable gas slot names a `Gas`
+    /// handle whose `meter_key` has a non-zero entry in the kernel meter mapping,
+    /// the run is seeded from that meter and the remaining gas is written back at
     /// exit. Otherwise the call-supplied `initial_gas` is used (and the meter is
     /// left untouched), preserving the bare-budget path.
     pub fn invoke_cached(
@@ -396,10 +395,10 @@ impl Nub {
     }
 }
 
-/// Walk `instance_hash → image.gas_slots[0] → cnode slot → Gas{meter_key}` in
-/// `cache`, returning the `meter_key`. `None` if any hop is missing or the slot
-/// does not hold a kernel `Gas` handle. The cnode resolution uses the
-/// Instance's `root_cnode` (a content hash for a settled top-level instance).
+/// Walk `instance_hash → image.gas_slots[*] → cnode slot → Gas{meter_key}` in
+/// `cache`, returning the first valid non-empty `meter_key`. `None` if the
+/// Image declares no usable gas slot. This helper is intentionally soft: the
+/// guest-side kernel loop performs the strict invalid-slot hard faults.
 fn resolve_meter_key_from(cache: &CacheDirectory, instance_hash: AbiCapHash) -> Option<Key> {
     let inst_cap = cache.get(CapHashOrRef::Hash(instance_hash))?;
     let Cap::Instance(inst) = &*inst_cap else {
@@ -409,18 +408,22 @@ fn resolve_meter_key_from(cache: &CacheDirectory, instance_hash: AbiCapHash) -> 
     let Cap::Image(img) = &*img_cap else {
         return None;
     };
-    let slot = img.gas_slots.first()?;
     let cnode_cap = cache.get(inst.root_cnode.clone())?;
     let Cap::CNode(cnode) = &*cnode_cap else {
         return None;
     };
-    let gas_ref = cnode.get(slot)?;
-    let gas_cap = cache.get(gas_ref)?;
-    let Cap::Instance(g) = &*gas_cap else {
-        return None;
-    };
-    if recognize_kernel_image(g.image_hash_chain) != Some(KernelImage::Gas) {
-        return None;
+    for slot in &img.gas_slots {
+        let Some(gas_ref) = cnode.get(slot) else {
+            continue;
+        };
+        let gas_cap = cache.get(gas_ref)?;
+        let Cap::Instance(g) = &*gas_cap else {
+            return None;
+        };
+        if recognize_kernel_image(g.image_hash_chain) != Some(KernelImage::Gas) {
+            return None;
+        }
+        return Some(key_from_regs(g.regs[0], g.regs[1]));
     }
-    Some(key_from_regs(g.regs[0], g.regs[1]))
+    None
 }

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -17,9 +17,9 @@ const GAS_SLOT: u8 = 5;
 fn ecalli_42_image(with_gas_slot: bool) -> Image {
     let mut img = Image::empty();
     img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
-    let mut endpoints: BTreeMap<u8, EndpointDef> = BTreeMap::new();
+    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,

--- a/rust/nub/tests/smoke.rs
+++ b/rust/nub/tests/smoke.rs
@@ -4,7 +4,7 @@
 //! `HostCall(42)` result.
 
 use javm_cap::image::{EndpointDef, Image};
-use javm_cap::{Cap, NUM_REGS};
+use javm_cap::{Cap, Key, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
 
@@ -17,9 +17,9 @@ fn ecalli_42_image() -> Image {
     img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
     // Code is mapped at the fixed CODE_BASE; no data mappings.
 
-    let mut endpoints: BTreeMap<u8, EndpointDef> = BTreeMap::new();
+    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     endpoints.insert(
-        0,
+        Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
             arg_registers: 0,


### PR DESCRIPTION
## Summary

This PR implements the in-kernel yield/resume model and related resident-cap runtime changes for the x86 JIT path.

Key pieces:
- replace dense/index-shaped endpoint and CNode assumptions with Key-addressed endpoints and CNode slots
- remove `Cap::Type`; expose image/type identity through `host_image_hash_chain`
- add kernel-assisted YieldSender/YieldReceiver helpers and `host_yield`
- implement in-flight yield suspension with ReferenceEntry stack activations, `CALL_RESUME`, `DROP_RESUME`, and owner-edge yield routing
- route `kernel:oog` through the same owner-edge yield machinery, with per-frame/multi-slot gas metering and `kernel:set_gas_meter`
- move called Instances into kernel frames and reserve their origin slots as empty/pinned while running
- store resident `CachedCap`s in the guest cache, including per-cap image JIT caches and parked Instance runtime/root-CNode state
- make runtime CNode access direct by `Key`; hash CNode keys only when computing commitments/roots

A companion staging-spec update was committed in the docs repo as `289ac85 Clarify CNode runtime key addressing`.

## Validation

Ran on this branch:
- `cargo fmt --all`
- `cargo test -p javm-cap`
- `cargo test -p javm-guest-tests -- --test-threads=1`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo bench -p javm-bench`

Also ran a fresh `master` worktree full `cargo bench -p javm-bench` for comparison.

## Bench Notes

Current branch vs fresh `master@9e824922`, negative means faster:

- compute workloads are neutral to modestly faster overall; one noisy cold row (`fri_fold_tree/cold`) was +2.2%
- CALL/root-CNode paths improve substantially:
  - `pt_cache_call/1000`: `3.089 ms` vs `4.673 ms` (`-33.9%`)
  - `sub_vm_recurse/1000`: `5.422 ms` vs `6.970 ms` (`-22.2%`)
  - `sub_vm_data_recurse/1000`: `13.187 ms` vs `14.637 ms` (`-9.9%`)
