### PR TITLE
Parallel KVM singleton and performance recovery

### DIFF
--- a/rust/javm-bench/benches/bench.rs
+++ b/rust/javm-bench/benches/bench.rs
@@ -31,9 +31,9 @@ macro_rules! bench_workload {
             g.bench_function("recompiler_warm", |b| {
                 b.iter_batched(
                     || javm_bench::nub_hyperlight_lock(),
-                    |mut nub| {
-                        built.put_into(&mut nub);
-                        javm_bench::invoke(&mut *nub, &built)
+                    |nub| {
+                        built.put_into(&nub);
+                        javm_bench::invoke(&nub, &built)
                     },
                     BatchSize::PerIteration,
                 )
@@ -41,13 +41,13 @@ macro_rules! bench_workload {
             g.bench_function("recompiler_cold", |b| {
                 b.iter_batched(
                     || {
-                        let mut nub = javm_bench::nub_hyperlight_lock();
+                        let nub = javm_bench::nub_hyperlight_lock();
                         nub.evict_jit_all().expect("evict_jit_all");
                         nub
                     },
-                    |mut nub| {
-                        built.put_into(&mut nub);
-                        javm_bench::invoke(&mut *nub, &built)
+                    |nub| {
+                        built.put_into(&nub);
+                        javm_bench::invoke(&nub, &built)
                     },
                     BatchSize::PerIteration,
                 )

--- a/rust/javm-bench/benches/sub_vm_data_recurse.rs
+++ b/rust/javm-bench/benches/sub_vm_data_recurse.rs
@@ -48,7 +48,7 @@ fn sub_vm_data_recurse(c: &mut Criterion) {
         let top = javm_bench::build_sub_vm_top(&mut nub, BLOB);
         const RO_SUM: u64 = 98_304;
         for depth in [0u64, 1, 2, 5, 300] {
-            javm_bench::invoke_sub_vm_expect(&mut nub, &top, depth, RO_SUM + (depth & 0xFF));
+            javm_bench::invoke_sub_vm_expect(&nub, &top, depth, RO_SUM + (depth & 0xFF));
         }
     }
 

--- a/rust/javm-bench/examples/smoke.rs
+++ b/rust/javm-bench/examples/smoke.rs
@@ -96,7 +96,7 @@ mod imp {
         // One long-lived Hyperlight sandbox for every workload — never torn
         // down and rebuilt (that re-mmap'd the snapshot at the same fixed guest
         // VA and corrupted host heap). It publishes all workloads' caps cleanly.
-        let mut recomp = Nub::new_hyperlight().expect("Nub::new_hyperlight");
+        let mut recomp = Nub::hyperlight().expect("Nub::hyperlight");
         let mut passes = 0usize;
         let mut fails: Vec<(&str, String)> = Vec::new();
 

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -12,9 +12,8 @@
 //!
 //! - `run_interpreter` — `Nub::new_local()` drives the byte-PVM
 //!   interpreter (`javm-exec`) in-process.
-//! - `run_recompiler` — a long-lived `Nub::new_hyperlight()` sandbox
-//!   (cached in a `OnceLock`) drives the in-kernel JIT path through
-//!   the same `invoke_cached` API.
+//! - `run_recompiler` — the process-wide `Nub::hyperlight()` singleton
+//!   drives the in-kernel JIT path through the same `invoke_cached` API.
 //!
 //! `BuiltCaps` holds the pre-built `Cap` graph + its precomputed
 //! hashes. Construction happens once per workload at bench warm-up via
@@ -30,8 +29,7 @@ use javm_cap::NUM_REGS;
 use javm_cap::image::{Image, PinnedCap};
 use javm_cap::slot::Key;
 use javm_cap::{Cap, CapHash};
-use nub::{InvocationResult, Nub, SCRATCHPAD_HEAD_LEN};
-use std::sync::{Mutex, OnceLock};
+use nub::{HyperlightNubGuard, InvocationResult, Nub, SCRATCHPAD_HEAD_LEN};
 
 /// HostCall(0) — the trampoline halt all bench programs end on
 /// (`ecalli 0`). Both backends surface it as `exit_reason=4,
@@ -154,38 +152,14 @@ impl BuiltCaps {
     }
 }
 
-/// RAII guard around the singleton Hyperlight Nub. Derefs to `&mut Nub`.
-///
-/// The sandbox is **never** torn down and rebuilt — doing so (the former
-/// `reset_nub_hyperlight`) re-`mmap`'d the snapshot at the same fixed guest VA
-/// while the prior KVM memslot/mapping could still alias it, which trampled
-/// host heap (the "went past end of probe sequence" corruption). One long-lived
-/// sandbox runs thousands of distinct invocations cleanly, so the guard simply
-/// holds the singleton.
-pub struct NubGuard {
-    inner: std::sync::MutexGuard<'static, Nub>,
-}
-
-impl std::ops::Deref for NubGuard {
-    type Target = Nub;
-    fn deref(&self) -> &Nub {
-        &self.inner
-    }
-}
-
-impl std::ops::DerefMut for NubGuard {
-    fn deref_mut(&mut self) -> &mut Nub {
-        &mut self.inner
-    }
-}
+/// RAII guard around the process-wide Hyperlight Nub. Derefs to `&mut Nub`.
+pub type NubGuard = HyperlightNubGuard;
 
 /// Bench-side accessor for the long-lived Hyperlight Nub. Returned
 /// guard holds the singleton mutex for the duration of one
 /// criterion `iter_batched` step (setup + routine).
 pub fn nub_hyperlight_lock() -> NubGuard {
-    NubGuard {
-        inner: nub_hyperlight().lock().expect("nub mutex"),
-    }
+    Nub::hyperlight().expect("Hyperlight sandbox")
 }
 
 /// Bench helper: drive one invocation through an already-locked Nub.
@@ -321,13 +295,6 @@ pub fn run_recompiler_raw(built: &BuiltCaps) -> RawRun {
         Ok(r) => RawRun::from_result(&r),
         Err(_) => RawRun::aborted(),
     }
-}
-
-/// The long-lived Hyperlight sandbox, shared across every invocation. Built
-/// once and never torn down (see [`NubGuard`] for why a rebuild corrupts).
-fn nub_hyperlight() -> &'static Mutex<Nub> {
-    static NUB: OnceLock<Mutex<Nub>> = OnceLock::new();
-    NUB.get_or_init(|| Mutex::new(Nub::new_hyperlight().expect("Hyperlight sandbox")))
 }
 
 // ============================================================================

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -138,7 +138,7 @@ impl BuiltCaps {
 
     /// Put every cap into `nub`'s cache via `put_cap_with_hash`.
     /// Idempotent re-puts after the first call are refcount bumps only.
-    pub fn put_into(&self, nub: &mut Nub) {
+    pub fn put_into(&self, nub: &Nub) {
         for (h, cap) in &self.data_caps {
             nub.put_cap_with_hash(*h, cap)
                 .unwrap_or_else(|e| panic!("put_cap_with_hash data: {e}"));
@@ -152,7 +152,7 @@ impl BuiltCaps {
     }
 }
 
-/// RAII guard around the process-wide Hyperlight Nub. Derefs to `&mut Nub`.
+/// Cloneable handle to the process-wide Hyperlight Nub.
 pub type NubGuard = HyperlightNubGuard;
 
 /// Bench-side accessor for the long-lived Hyperlight Nub. Returned
@@ -166,7 +166,7 @@ pub fn nub_hyperlight_lock() -> NubGuard {
 /// Used inside `iter_batched`'s routine closure so the timed body is
 /// just the host-call round-trip + JIT path (no mutex acquire, no
 /// cap publish, no sandbox rebuild).
-pub fn invoke(nub: &mut Nub, built: &BuiltCaps) -> (u64, u64) {
+pub fn invoke(nub: &Nub, built: &BuiltCaps) -> (u64, u64) {
     let result = nub
         .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
         .unwrap_or_else(|e| panic!("invoke_cached: {e}"));
@@ -178,8 +178,8 @@ pub fn invoke(nub: &mut Nub, built: &BuiltCaps) -> (u64, u64) {
 /// state, so a fresh Nub each call is fine — and matches the chain's
 /// per-event allocation model).
 pub fn run_interpreter(built: &BuiltCaps) -> (u64, u64) {
-    let mut nub = Nub::new_local();
-    built.put_into(&mut nub);
+    let nub = Nub::new_local();
+    built.put_into(&nub);
     let result = nub
         .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
         .unwrap_or_else(|e| panic!("interpreter invoke_cached: {e}"));
@@ -191,8 +191,8 @@ pub fn run_interpreter(built: &BuiltCaps) -> (u64, u64) {
 /// the same Image hit the JIT compile cache. Useful for measuring
 /// steady-state execute throughput in isolation.
 pub fn run_recompiler(built: &BuiltCaps) -> (u64, u64) {
-    let mut nub = nub_hyperlight_lock();
-    built.put_into(&mut nub);
+    let nub = nub_hyperlight_lock();
+    built.put_into(&nub);
     let result = nub
         .invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS)
         .unwrap_or_else(|e| panic!("recompiler invoke_cached: {e}"));
@@ -272,8 +272,8 @@ impl RawRun {
 /// `Ok` in practice; an `Err` is still mapped to the abort sentinel for
 /// symmetry with the recompiler.
 pub fn run_interpreter_raw(built: &BuiltCaps) -> RawRun {
-    let mut nub = Nub::new_local();
-    built.put_into(&mut nub);
+    let nub = Nub::new_local();
+    built.put_into(&nub);
     match nub.invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS) {
         Ok(r) => RawRun::from_result(&r),
         Err(_) => RawRun::aborted(),
@@ -289,8 +289,8 @@ pub fn run_interpreter_raw(built: &BuiltCaps) -> RawRun {
 /// returns `Err` → `ABORT_SENTINEL`. (For valid PVM2 code no abort occurs, so
 /// long differential sweeps run uninterrupted.)
 pub fn run_recompiler_raw(built: &BuiltCaps) -> RawRun {
-    let mut nub = nub_hyperlight_lock();
-    built.put_into(&mut nub);
+    let nub = nub_hyperlight_lock();
+    built.put_into(&nub);
     match nub.invoke_cached(built.instance_hash, built.endpoint_idx, [0; 4], INITIAL_GAS) {
         Ok(r) => RawRun::from_result(&r),
         Err(_) => RawRun::aborted(),
@@ -423,7 +423,7 @@ pub fn build_sub_vm_top(nub: &mut Nub, blob: &[u8]) -> SubVmTop {
 
 /// One sub-VM bench iteration: invoke the top instance with `depth` and
 /// panic unless it halted cleanly on the trampoline HostCall(0).
-pub fn invoke_sub_vm(nub: &mut Nub, top: &SubVmTop, depth: u64) {
+pub fn invoke_sub_vm(nub: &Nub, top: &SubVmTop, depth: u64) {
     let result = nub
         .invoke_cached(top.top_instance, 0, [depth, 0, 0, 0], INITIAL_GAS)
         .expect("invoke_cached");
@@ -441,7 +441,7 @@ pub fn invoke_sub_vm(nub: &mut Nub, top: &SubVmTop, depth: u64) {
 /// a clean trampoline halt. Used by the `sub_vm_gas_parity` test to check the
 /// recompiler's category-#3 charge is identical per recursion level (gas affine
 /// in depth — a multi-frame determinism guard).
-pub fn invoke_sub_vm_gas(nub: &mut Nub, top: &SubVmTop, depth: u64) -> (u64, u64) {
+pub fn invoke_sub_vm_gas(nub: &Nub, top: &SubVmTop, depth: u64) -> (u64, u64) {
     let result = nub
         .invoke_cached(top.top_instance, 0, [depth, 0, 0, 0], INITIAL_GAS)
         .expect("invoke_cached");
@@ -462,7 +462,7 @@ pub fn invoke_sub_vm_gas(nub: &mut Nub, top: &SubVmTop, depth: u64) -> (u64, u64
 /// Like [`invoke_sub_vm`] but also asserts the top-level return value. Used by
 /// the data-recurse correctness check to confirm each level reads its pinned
 /// RO data + writes its initial RW data correctly (not just that it halts).
-pub fn invoke_sub_vm_expect(nub: &mut Nub, top: &SubVmTop, depth: u64, expected_return: u64) {
+pub fn invoke_sub_vm_expect(nub: &Nub, top: &SubVmTop, depth: u64, expected_return: u64) {
     let result = nub
         .invoke_cached(top.top_instance, 0, [depth, 0, 0, 0], INITIAL_GAS)
         .expect("invoke_cached");
@@ -507,9 +507,9 @@ pub fn run_recurse_bench(c: &mut Criterion, blob: &[u8], label: &str) {
     // depth 0 (single CALL/HALT) + depth 1 sanity before the loop —
     // catches top-frame / direct-mapping setup bugs early.
     {
-        let mut nub = nub_hyperlight_lock();
-        invoke_sub_vm(&mut nub, &top, 0);
-        invoke_sub_vm(&mut nub, &top, 1);
+        let nub = nub_hyperlight_lock();
+        invoke_sub_vm(&nub, &top, 0);
+        invoke_sub_vm(&nub, &top, 1);
     }
     eprintln!("[{label}] depth 0/1 ok");
 
@@ -518,7 +518,7 @@ pub fn run_recurse_bench(c: &mut Criterion, blob: &[u8], label: &str) {
     for &depth in &[10u64, 100, 1_000] {
         g.throughput(Throughput::Elements(depth));
         g.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, &d| {
-            b.iter(|| invoke_sub_vm(&mut nub_hyperlight_lock(), &top, d))
+            b.iter(|| invoke_sub_vm(&nub_hyperlight_lock(), &top, d))
         });
     }
     g.finish();
@@ -568,7 +568,7 @@ fn pt_cache_expected_return(n: u64) -> u64 {
 /// `host_call`s the resident `B` `n` times. Asserts a clean trampoline
 /// halt and that the summed echoes match. Returns
 /// `(return_value, gas_used)`.
-pub fn invoke_pt_cache(nub: &mut Nub, top: &PtCacheTop, n: u64) -> (u64, u64) {
+pub fn invoke_pt_cache(nub: &Nub, top: &PtCacheTop, n: u64) -> (u64, u64) {
     let result = nub
         .invoke_cached(top.top_instance, 0, [n, 0, 0, 0], INITIAL_GAS)
         .expect("invoke_cached");
@@ -607,9 +607,9 @@ pub fn run_pt_cache_bench(c: &mut Criterion, blob: &[u8], label: &str) {
     );
 
     {
-        let mut nub = nub_hyperlight_lock();
-        invoke_pt_cache(&mut nub, &top, 1);
-        invoke_pt_cache(&mut nub, &top, 2);
+        let nub = nub_hyperlight_lock();
+        invoke_pt_cache(&nub, &top, 1);
+        invoke_pt_cache(&nub, &top, 2);
     }
     eprintln!("[{label}] n 1/2 ok");
 
@@ -618,7 +618,7 @@ pub fn run_pt_cache_bench(c: &mut Criterion, blob: &[u8], label: &str) {
     for &n in &[10u64, 100, 1_000] {
         g.throughput(Throughput::Elements(n));
         g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
-            b.iter(|| invoke_pt_cache(&mut nub_hyperlight_lock(), &top, n))
+            b.iter(|| invoke_pt_cache(&nub_hyperlight_lock(), &top, n))
         });
     }
     g.finish();

--- a/rust/javm-bench/tests/heap_drift.rs
+++ b/rust/javm-bench/tests/heap_drift.rs
@@ -31,7 +31,7 @@ const GAS: u64 = 100_000_000_000;
 #[ignore]
 fn heap_drift_prime_sieve() {
     let image = Image::from_ssz_bytes(PRIME_SIEVE_BLOB).expect("decode prime_sieve Image");
-    let mut nub = Nub::new_hyperlight().expect("sandbox");
+    let mut nub = Nub::hyperlight().expect("sandbox");
     let built = javm_bench::BuiltCaps::for_image(&image, 0);
     for (h, cap) in &built.data_caps {
         nub.put_cap_with_hash(*h, cap).expect("put_cap data");

--- a/rust/javm-bench/tests/parallel_refine.rs
+++ b/rust/javm-bench/tests/parallel_refine.rs
@@ -1,0 +1,126 @@
+//! End-to-end refine-style API smoke over one cloneable Hyperlight Nub.
+//!
+//! This test prepublishes several independent compute workloads, submits them
+//! through cloned `Nub` handles, checks the pinned serial results, then runs one
+//! normal follow-up invoke on the same singleton. Today the host call boundary
+//! still serializes inside the sandbox; this test locks in the public API shape
+//! that the guest multi-lane worker will use for true KVM parallelism.
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::CapHash;
+use javm_cap::image::Image;
+use nub::{InvokeRequest, Nub, NubOptions};
+use ssz::Decode;
+
+#[derive(Clone, Copy)]
+struct PublishedWorkload {
+    name: &'static str,
+    instance_hash: CapHash,
+    endpoint_idx: u8,
+    expected_value: u64,
+    expected_gas_used: u64,
+}
+
+fn publish(
+    nub: &Nub,
+    name: &'static str,
+    blob: &[u8],
+    expected_value: u64,
+    expected_gas_used: u64,
+) -> PublishedWorkload {
+    let image = Image::from_ssz_bytes(blob).unwrap_or_else(|e| panic!("[{name}] decode: {e:?}"));
+    let built = javm_bench::BuiltCaps::for_image(&image, 0);
+    built.put_into(nub);
+    PublishedWorkload {
+        name,
+        instance_hash: built.instance_hash,
+        endpoint_idx: built.endpoint_idx,
+        expected_value,
+        expected_gas_used,
+    }
+}
+
+fn assert_result(workload: PublishedWorkload, result: nub::InvocationResult) {
+    assert_eq!(
+        (result.exit_reason, result.exit_arg),
+        (4, 0),
+        "[{}] expected clean HostCall(0)",
+        workload.name,
+    );
+    assert_eq!(
+        result.return_value, workload.expected_value,
+        "[{}] return value drifted",
+        workload.name,
+    );
+    assert_eq!(
+        javm_bench::INITIAL_GAS - result.gas_remaining,
+        workload.expected_gas_used,
+        "[{}] gas drifted",
+        workload.name,
+    );
+}
+
+#[test]
+fn cloned_nub_handles_run_compute_refine_jobs_then_serial_accumulate() {
+    let nub = Nub::hyperlight_with_options(NubOptions::new().with_vcpu_count(2))
+        .expect("Hyperlight sandbox");
+    let workloads = [
+        publish(
+            &nub,
+            "prime_sieve",
+            include_bytes!(env!("PRIME_SIEVE_BLOB")),
+            0x2578,
+            8_972_959,
+        ),
+        publish(
+            &nub,
+            "keccak",
+            include_bytes!(env!("KECCAK_BLOB")),
+            0x39e5_0259,
+            100_934,
+        ),
+        publish(
+            &nub,
+            "blake2b",
+            include_bytes!(env!("BLAKE2B_BLOB")),
+            0xee1f_55f1,
+            62_396,
+        ),
+        publish(
+            &nub,
+            "goldilocks_mul",
+            include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
+            0x2cf7_3e57,
+            2_400_166,
+        ),
+    ];
+
+    let jobs = workloads.map(|workload| {
+        let handle = nub.clone();
+        let job = handle
+            .submit_invoke(InvokeRequest {
+                instance_hash: workload.instance_hash,
+                endpoint_idx: workload.endpoint_idx,
+                args: [0; 4],
+                initial_gas: javm_bench::INITIAL_GAS,
+            })
+            .expect("submit refine invoke");
+        (workload, job)
+    });
+
+    for (workload, job) in jobs {
+        assert_result(workload, job.wait().expect("refine job wait"));
+    }
+
+    let accumulate = workloads[0];
+    let result = nub
+        .invoke_cached(
+            accumulate.instance_hash,
+            accumulate.endpoint_idx,
+            [0; 4],
+            javm_bench::INITIAL_GAS,
+        )
+        .expect("serial accumulate invoke");
+    assert_result(accumulate, result);
+}

--- a/rust/javm-bench/tests/parallel_refine.rs
+++ b/rust/javm-bench/tests/parallel_refine.rs
@@ -2,9 +2,9 @@
 //!
 //! This test prepublishes several independent compute workloads, submits them
 //! through cloned `Nub` handles, checks the pinned serial results, then runs one
-//! normal follow-up invoke on the same singleton. Today the host call boundary
-//! still serializes inside the sandbox; this test locks in the public API shape
-//! that the guest multi-lane worker will use for true KVM parallelism.
+//! normal follow-up invoke on the same singleton. With `vcpu_count > 1`, the
+//! submitted refine jobs are routed through the KVM worker lanes rather than
+//! the legacy serialized control call path.
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 

--- a/rust/javm-bench/tests/parallel_refine.rs
+++ b/rust/javm-bench/tests/parallel_refine.rs
@@ -8,8 +8,8 @@
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use javm_cap::CapHash;
 use javm_cap::image::Image;
+use javm_cap::{Cap, CapHash};
 use nub::{InvokeRequest, Nub, NubOptions};
 use ssz::Decode;
 
@@ -108,6 +108,9 @@ fn cloned_nub_handles_run_compute_refine_jobs_then_serial_accumulate() {
             .expect("submit refine invoke");
         (workload, job)
     });
+
+    nub.put_cap(&Cap::empty_cnode())
+        .expect("serialized publish while refine jobs are queued/running");
 
     for (workload, job) in jobs {
         assert_result(workload, job.wait().expect("refine job wait"));

--- a/rust/javm-bench/tests/pt_cache_heap.rs
+++ b/rust/javm-bench/tests/pt_cache_heap.rs
@@ -63,7 +63,7 @@ fn invoke_churn(nub: &mut Nub, top: &PtCacheTop, n: u64) -> u64 {
 #[test]
 #[ignore]
 fn pt_cache_heap_per_call_churn() {
-    let mut nub = Nub::new_hyperlight().expect("sandbox");
+    let mut nub = Nub::hyperlight().expect("sandbox");
     let top = build_pt_cache_top(&mut nub, BLOB);
 
     // Warm up (A's + B's JIT compile, the per-image mem backing, any

--- a/rust/javm-bench/tests/sub_vm_gas_parity.rs
+++ b/rust/javm-bench/tests/sub_vm_gas_parity.rs
@@ -52,7 +52,7 @@ fn expected_return(depth: u64) -> u64 {
 fn recomp_run(depth: u64) -> (u64, u64) {
     let mut nub = javm_bench::nub_hyperlight_lock();
     let top = javm_bench::build_sub_vm_top(&mut nub, BLOB);
-    javm_bench::invoke_sub_vm_gas(&mut nub, &top, depth)
+    javm_bench::invoke_sub_vm_gas(&nub, &top, depth)
 }
 
 #[test]

--- a/rust/javm-bench/tests/workloads.rs
+++ b/rust/javm-bench/tests/workloads.rs
@@ -2,7 +2,7 @@
 //!
 //! For each workload we:
 //!   1. Drive the interpreter through `Nub::new_local()`.
-//!   2. Drive the JIT recompiler through `Nub::new_hyperlight()`.
+//!   2. Drive the JIT recompiler through `Nub::hyperlight()`.
 //!   3. Assert both backends agree on `(return_value, gas_used)`.
 //!   4. Pin both against a hardcoded `(value, gas)` from the
 //!      reference run on this branch — a deliberate floor that

--- a/rust/javm-guest-tests/tests/call_status.rs
+++ b/rust/javm-guest-tests/tests/call_status.rs
@@ -87,7 +87,7 @@ fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHas
 
 #[test]
 fn phi8_status_is_ok_after_normal_call() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let sender_h = nub
         .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))

--- a/rust/javm-guest-tests/tests/conformance.rs
+++ b/rust/javm-guest-tests/tests/conformance.rs
@@ -27,25 +27,12 @@ mod backend {
     use javm_cap::{Cap, Key, NUM_REGS};
     use nub::Nub;
     use ssz::Decode;
-    use std::sync::{Mutex, OnceLock};
 
     const BLOB: &[u8] = include_bytes!(env!("GUEST_TESTS_BLOB"));
     const GAS_BUDGET: u64 = 10_000_000_000;
 
     pub fn image() -> Image {
         Image::from_ssz_bytes(BLOB).expect("SSZ-decode guest-tests Image")
-    }
-
-    /// One Hyperlight sandbox shared across every test thread.
-    /// `Nub::new_hyperlight()` reserves a fixed host VA range and only one
-    /// live sandbox per process can occupy it (see
-    /// `nub_host_common::layout::reserve_guest_va_range`); sandbox
-    /// construction also costs ~hundreds of ms, so sharing keeps the run
-    /// dominated by JIT execution rather than boot. The same pattern is
-    /// used by the bench drivers in `javm-bench`.
-    fn hyperlight() -> &'static Mutex<Nub> {
-        static NUB: OnceLock<Mutex<Nub>> = OnceLock::new();
-        NUB.get_or_init(|| Mutex::new(Nub::new_hyperlight().expect("Hyperlight sandbox")))
     }
 
     /// Interpreter arm: a fresh in-process `LocalArch` Nub per call (cheap —
@@ -56,7 +43,11 @@ mod backend {
 
     /// Recompiler arm: the shared Hyperlight sandbox.
     pub fn recomp(image: &Image, ep: u8) -> (u64, u64) {
-        run(&mut hyperlight().lock().expect("nub mutex"), image, ep)
+        run(
+            &mut Nub::hyperlight().expect("Hyperlight sandbox"),
+            image,
+            ep,
+        )
     }
 
     /// Publish the canonical Image + an empty root CNode + an Instance

--- a/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
+++ b/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
@@ -94,7 +94,7 @@ fn recomp_traps_on_derive_spawn_into_pinned() {
     // JIT codegen ABI: `ExitReason::Trap` surfaces as exit_reason 7.
     const EXIT_TRAP: u32 = 7;
 
-    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
+    let nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let child_cap = Cap::image_with_slots(&child_image(), &[], &[]).expect("child image");
     let child_hash = nub.put_cap(&child_cap).expect("put child image");

--- a/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
+++ b/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
@@ -94,7 +94,7 @@ fn recomp_traps_on_derive_spawn_into_pinned() {
     // JIT codegen ABI: `ExitReason::Trap` surfaces as exit_reason 7.
     const EXIT_TRAP: u32 = 7;
 
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let child_cap = Cap::image_with_slots(&child_image(), &[], &[]).expect("child image");
     let child_hash = nub.put_cap(&child_cap).expect("put child image");

--- a/rust/javm-guest-tests/tests/gas_slots.rs
+++ b/rust/javm-guest-tests/tests/gas_slots.rs
@@ -10,7 +10,6 @@ use javm_cap::{
 };
 use nub::Nub;
 use std::collections::BTreeMap;
-use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -28,14 +27,6 @@ const METER_A: u8 = 0;
 const METER_B: u8 = 1;
 const GAS_BUDGET: u64 = 10_000_000_000;
 const FUNDED: u64 = 1_000_000;
-
-static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
-    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
-    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
-    (guard, nub)
-}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -192,7 +183,7 @@ fn run_child(
 
 #[test]
 fn empty_first_slot_skips_to_later_valid_meter() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     assert_eq!(
         run_child(
             &mut nub,
@@ -211,7 +202,7 @@ fn empty_first_slot_skips_to_later_valid_meter() {
 
 #[test]
 fn exhausted_first_meter_falls_through_to_second_meter() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     assert_eq!(
         run_child(
             &mut nub,
@@ -230,7 +221,7 @@ fn exhausted_first_meter_falls_through_to_second_meter() {
 
 #[test]
 fn invalid_non_empty_gas_slot_hard_faults() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     assert_eq!(
         run_child(
             &mut nub,
@@ -248,7 +239,7 @@ fn invalid_non_empty_gas_slot_hard_faults() {
 
 #[test]
 fn all_empty_declared_gas_slots_hard_fault() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     assert_eq!(
         run_child(
             &mut nub,
@@ -266,7 +257,7 @@ fn all_empty_declared_gas_slots_hard_fault() {
 
 #[test]
 fn exhausted_all_meters_oog_resumes_from_primary() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     assert_eq!(
         run_child(
             &mut nub,

--- a/rust/javm-guest-tests/tests/host_image_hash_chain.rs
+++ b/rust/javm-guest-tests/tests/host_image_hash_chain.rs
@@ -87,7 +87,7 @@ fn parent_image(child_hash: CapHash) -> Image {
 /// Publish the parent instance and invoke endpoint 0 with the given
 /// (src, dst) slot args, returning the JIT exit_reason / exit_arg.
 ///
-/// `Nub::new_hyperlight()` reserves a fixed host VA range, so only one sandbox
+/// `Nub::hyperlight()` reserves a fixed host VA range, so only one sandbox
 /// can exist at a time; the single `#[test]` below threads one `nub` through
 /// both cases (the harness would otherwise race two sandboxes — see
 /// `conformance.rs`'s shared-sandbox note).
@@ -128,7 +128,7 @@ fn run(nub: &mut Nub, src: u8, dst: u8) -> (u32, u32) {
 
 #[test]
 fn image_hash_chain_traps_on_pinned_and_halts_on_valid() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // 1. Writing the identity DataCap into a PINNED dst slot traps.
     // JIT codegen ABI: `ExitReason::Trap` surfaces as exit_reason 7.

--- a/rust/javm-guest-tests/tests/host_yield_mint.rs
+++ b/rust/javm-guest-tests/tests/host_yield_mint.rs
@@ -110,7 +110,7 @@ fn run(nub: &mut Nub, sender_slot: u8) -> (u32, u32) {
 
 #[test]
 fn host_yield_mint_yield_via_kernel_root() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Positive: yielding the kernel:mint_yield sender runs the syscall inline;
     // the guest resumes and halts cleanly (reason 4, arg 0 — the trailing

--- a/rust/javm-guest-tests/tests/jit_cache.rs
+++ b/rust/javm-guest-tests/tests/jit_cache.rs
@@ -40,7 +40,7 @@ fn reply_image() -> Image {
 
 #[test]
 fn evict_jit_cache_then_reinvoke_rebuilds_image_cache() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
     let img = reply_image();
     let image_h = nub
         .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))

--- a/rust/javm-guest-tests/tests/jit_cache.rs
+++ b/rust/javm-guest-tests/tests/jit_cache.rs
@@ -40,7 +40,7 @@ fn reply_image() -> Image {
 
 #[test]
 fn evict_jit_cache_then_reinvoke_rebuilds_image_cache() {
-    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
+    let nub = Nub::hyperlight().expect("Hyperlight sandbox");
     let img = reply_image();
     let image_h = nub
         .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))

--- a/rust/javm-guest-tests/tests/mint_gas.rs
+++ b/rust/javm-guest-tests/tests/mint_gas.rs
@@ -116,7 +116,7 @@ fn run(nub: &mut Nub, mint_key: &[u8], dst: u8) -> (u32, u32) {
 
 #[test]
 fn mint_gas_and_quota_via_kernel_root() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Positive: kernel:mint_gas into a free slot is handled inline and resumes
     // → clean halt (reason 4, arg 0 — the trailing REPLY).

--- a/rust/javm-guest-tests/tests/oog_yield.rs
+++ b/rust/javm-guest-tests/tests/oog_yield.rs
@@ -163,7 +163,7 @@ fn run(nub: &mut Nub, catch_oog: bool) -> u32 {
 
 #[test]
 fn oog_routes_to_chain_handler_and_resumes() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // With the chain catching kernel:oog: the child OOGs at meter 0, routes to
     // the chain, the chain tops up + resumes, the child completes, and the chain

--- a/rust/javm-guest-tests/tests/pending_origin.rs
+++ b/rust/javm-guest-tests/tests/pending_origin.rs
@@ -8,7 +8,6 @@ use javm_cap::yield_cap::YK_MINT_GAS;
 use javm_cap::{yield_receiver, yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
-use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -25,14 +24,6 @@ const TYPE_DST_SLOT: u8 = 11;
 const METER_KEY: u8 = 3;
 const YIELD_KEY: u8 = 0x42;
 const GAS_BUDGET: u64 = 10_000_000_000;
-
-static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
-    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
-    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
-    (guard, nub)
-}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -94,7 +85,7 @@ fn b_image() -> Image {
 }
 
 fn run_a(a_code: Vec<u8>) -> (u32, u32) {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let sender_h = nub
         .put_cap(&Cap::Instance(yield_sender(&Key::from(YIELD_KEY))))

--- a/rust/javm-guest-tests/tests/root_cnode_seeding.rs
+++ b/rust/javm-guest-tests/tests/root_cnode_seeding.rs
@@ -110,7 +110,7 @@ fn run(nub: &mut Nub, src: u8) -> (u32, u32) {
 
 #[test]
 fn root_cnode_instance_is_visible_to_guest() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Positive: the root-cnode Cap::Instance at INSTANCE_SLOT is visible, so
     // host_image_hash_chain reads it and the guest halts cleanly (reason 4,

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -29,7 +29,7 @@ fn ecalli(imm: u32) -> u32 {
 
 #[test]
 fn root_meter_self_harvest_via_set_gas_meter() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // The set_gas_meter YieldSender + the top's Gas{ROOT_METER} handle.
     let sender_h = nub

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -29,7 +29,7 @@ fn ecalli(imm: u32) -> u32 {
 
 #[test]
 fn root_meter_self_harvest_via_set_gas_meter() {
-    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
+    let nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // The set_gas_meter YieldSender + the top's Gas{ROOT_METER} handle.
     let sender_h = nub

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -1,11 +1,13 @@
-//! The TOP-level frame's own primary gas meter (`gas_slots` → `Gas{root_meter}`)
-//! is a first-class meter: `kernel:set_gas_meter` on it reads/writes the LIVE
-//! balance, so a chain can self-harvest its root meter (`set_gas_meter(root, 0)`
-//! returns the remaining and zeroes it), exactly like a child meter.
+//! The TOP-level frame's own primary gas meter (`gas_slots` -> `Gas{root_meter}`)
+//! is a first-class task-local meter: `kernel:set_gas_meter` on it reads/writes
+//! the LIVE balance, so a chain can self-harvest its root meter
+//! (`set_gas_meter(root, 0)` returns the remaining and zeroes it), exactly like
+//! a child meter.
 //!
 //! Regression for the validation finding "the top frame's own meter cannot be
 //! read/written via set_gas_meter" (it was stamped active=None and never seeded).
-//! With the fix the guest resolves and seeds the root meter from the host budget.
+//! With the fix the guest resolves and seeds the root meter from the invoke's
+//! initial gas budget.
 //!
 //! Gated to the nub Hyperlight host (linux-x86_64).
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -91,9 +93,6 @@ fn root_meter_self_harvest_via_set_gas_meter() {
         ))
         .expect("put instance");
 
-    // Fund the root meter host-side; invoke_cached seeds the run from it.
-    nub.set_meter(Key::from(ROOT_METER), BUDGET);
-
     // φ7=SENDER_SLOT, φ8=ROOT_METER, φ9=0 (the harvest value).
     let r = nub
         .invoke_cached(
@@ -111,10 +110,9 @@ fn root_meter_self_harvest_via_set_gas_meter() {
         "set_gas_meter(root,0) must return the live remaining, got {}",
         r.return_value,
     );
-    // It zeroed the meter: the harvested run leaves the root meter at 0.
+    // It zeroed the task-local meter; there is no host-side meter map to update.
     assert_eq!(
-        nub.get_meter(&Key::from(ROOT_METER)),
-        0,
-        "set_gas_meter(root,0) must zero the root meter",
+        r.gas_remaining, 0,
+        "set_gas_meter(root,0) must zero the root meter for this invocation",
     );
 }

--- a/rust/javm-guest-tests/tests/set_gas_meter.rs
+++ b/rust/javm-guest-tests/tests/set_gas_meter.rs
@@ -174,7 +174,7 @@ fn run_metered(nub: &mut Nub, meter_value: u64) -> u32 {
 
 #[test]
 fn set_gas_meter_funds_per_frame_metering() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Probe the φ7→x10 register mapping the chain relies on: `addi(10,0,55);
     // reply` must return 55 in φ7. A wrong mapping here would silently corrupt

--- a/rust/javm-guest-tests/tests/unfunded_meter.rs
+++ b/rust/javm-guest-tests/tests/unfunded_meter.rs
@@ -124,7 +124,7 @@ fn run(nub: &mut Nub, declare_meter: bool) -> u32 {
 
 #[test]
 fn unfunded_declared_meter_oogs_not_loans() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Declared-but-unfunded meter: the child runs metered@0 and OOGs; with no
     // kernel:oog receiver it bubbles (reason 2). If it had instead loaned the

--- a/rust/javm-guest-tests/tests/yield_owner_edge.rs
+++ b/rust/javm-guest-tests/tests/yield_owner_edge.rs
@@ -15,7 +15,6 @@ use javm_cap::{
 };
 use nub::Nub;
 use std::collections::BTreeMap;
-use std::sync::{Mutex, MutexGuard};
 
 const OP_REPLY: u32 = 0;
 const OP_HOST_YIELD: u32 = 16;
@@ -36,14 +35,6 @@ const ROOT_METER: u8 = 3;
 const B_KEY: u8 = 0x42;
 const C_KEY: u8 = 0x43;
 const GAS_BUDGET: u64 = 10_000_000_000;
-
-static HYPERLIGHT_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-fn new_serial_nub() -> (MutexGuard<'static, ()>, Nub) {
-    let guard = HYPERLIGHT_TEST_LOCK.lock().expect("hyperlight test mutex");
-    let nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
-    (guard, nub)
-}
 
 fn ecalli(imm: u32) -> u32 {
     ((imm & 0xFFF) << 20) | (0b010 << 12) | 0b000_1011
@@ -191,7 +182,7 @@ fn run_c_yield(nub: &mut Nub, a_catches_c: bool) -> (u32, u32) {
 
 #[test]
 fn yielded_owner_call_uses_owner_edge_not_waiting_b() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let (reason, arg) = run_c_yield(&mut nub, false);
     assert_eq!(
@@ -209,7 +200,7 @@ fn yielded_owner_call_uses_owner_edge_not_waiting_b() {
 
 #[test]
 fn yielded_owner_oog_is_not_caught_by_waiting_b() {
-    let (_guard, mut nub) = new_serial_nub();
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     let set_gas_sender_h = nub
         .put_cap(&Cap::Instance(yield_sender(&Key::from(

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -196,7 +196,7 @@ fn run_bare(nub: &mut Nub, op: u32) -> (u32, u32) {
 
 #[test]
 fn user_key_yield_routes_to_ancestor_and_resumes() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // Positive: A's receiver registers YIELD_KEY, so B's yield routes to A
     // (skipping B's frames), A resumes B, B halts, A halts cleanly (reason 4 —

--- a/rust/javm-guest-tests/tests/yield_walk_past.rs
+++ b/rust/javm-guest-tests/tests/yield_walk_past.rs
@@ -148,7 +148,7 @@ fn run(nub: &mut Nub, handler_ops: &[u32]) -> u32 {
 
 #[test]
 fn walk_past_intermediate_routing() {
-    let mut nub = Nub::new_hyperlight().expect("Hyperlight sandbox");
+    let mut nub = Nub::hyperlight().expect("Hyperlight sandbox");
 
     // CALL_RESUME: C's yield routes past B to A; A resumes C (the real yielder),
     // C completes and unwinds C→B→A → clean halt (reason 4).

--- a/rust/nub-arch-guestbin/src/arch/amd64/init.rs
+++ b/rust/nub-arch-guestbin/src/arch/amd64/init.rs
@@ -104,17 +104,20 @@ unsafe fn init_tss(pc: *mut ProcCtrl) {
     }
 }
 
-/// To initialise the main stack, we just pre-emptively map the first
-/// page of it.
+/// Initialise the dispatch stacks used by host→guest calls. Phase-1 parallel
+/// invoke workers are long-lived guest functions, so each vCPU lane needs a
+/// private stack instead of sharing the single legacy Hyperlight stack page.
 unsafe fn init_stack() -> u64 {
     use hyperlight_guest::layout::MAIN_STACK_TOP_GVA;
-    let stack_top_page_base = (MAIN_STACK_TOP_GVA - 1) & !0xfff;
+    let stack_bytes = nub_host_common::layout::VCPU_DISPATCH_STACK_STRIDE
+        * nub_host_common::layout::VCPU_DISPATCH_STACK_LANES;
+    let stack_base = MAIN_STACK_TOP_GVA - stack_bytes;
     unsafe {
         use nub_host_common::vmem::{BasicMapping, MappingKind, PAGE_SIZE};
         crate::paging::map_region(
-            hyperlight_guest::prim_alloc::alloc_phys_pages(1),
-            stack_top_page_base as *mut u8,
-            PAGE_SIZE as u64,
+            hyperlight_guest::prim_alloc::alloc_phys_pages(stack_bytes / PAGE_SIZE as u64),
+            stack_base as *mut u8,
+            stack_bytes,
             MappingKind::Basic(BasicMapping {
                 readable: true,
                 writable: true,

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -189,6 +189,7 @@ pub const PARALLEL_INVOKE_STATUS_RUNNING: u32 = 2;
 pub const PARALLEL_INVOKE_STATUS_DONE: u32 = 3;
 pub const PARALLEL_INVOKE_STATUS_STOP: u32 = 4;
 pub const PARALLEL_INVOKE_STATUS_STARTING: u32 = 5;
+pub const PARALLEL_INVOKE_STATUS_EVICT_JIT_READY: u32 = 6;
 
 /// One host<->guest invoke slot. Slots are addressed by lane index at
 /// `parallel_slot_base + lane * PARALLEL_INVOKE_SLOT_BYTES`.
@@ -198,6 +199,10 @@ pub const PARALLEL_INVOKE_STATUS_STARTING: u32 = 5;
 /// - guest CASes `READY -> RUNNING`, runs the invoke, writes `result`, then
 ///   stores `DONE` with release;
 /// - host reads `DONE` with acquire, copies `result`, then stores `EMPTY`.
+///
+/// Bench-only control commands, such as `EVICT_JIT_READY`, use the same
+/// `RUNNING -> DONE -> EMPTY` completion protocol after the host reserves all
+/// lanes.
 #[repr(C, align(64))]
 pub struct ParallelInvokeSlot {
     pub status: AtomicU32,

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -183,6 +183,7 @@ pub const PARALLEL_INVOKE_STATUS_READY: u32 = 1;
 pub const PARALLEL_INVOKE_STATUS_RUNNING: u32 = 2;
 pub const PARALLEL_INVOKE_STATUS_DONE: u32 = 3;
 pub const PARALLEL_INVOKE_STATUS_STOP: u32 = 4;
+pub const PARALLEL_INVOKE_STATUS_STARTING: u32 = 5;
 
 /// One host<->guest invoke slot. Slots are addressed by lane index at
 /// `parallel_slot_base + lane * PARALLEL_INVOKE_SLOT_BYTES`.

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -15,6 +15,11 @@ extern crate alloc;
 
 use core::sync::atomic::{AtomicU32, AtomicU64};
 
+/// Maximum fixed execution lanes the guest runtime can address. The production
+/// default vCPU pool is capped lower, but host configuration must not exceed
+/// this ABI-visible lane table size.
+pub const MAX_EXECUTION_LANES: usize = 64;
+
 /// `fn_id` for the `nub_heap_stats` diagnostic. Payload is empty;
 /// response is 32 bytes packing four LE u64s (allocated_bytes,
 /// allocation_count, fragment_count, available_bytes).

--- a/rust/nub-arch-x86-abi/src/lib.rs
+++ b/rust/nub-arch-x86-abi/src/lib.rs
@@ -13,6 +13,8 @@
 
 extern crate alloc;
 
+use core::sync::atomic::{AtomicU32, AtomicU64};
+
 /// `fn_id` for the `nub_heap_stats` diagnostic. Payload is empty;
 /// response is 32 bytes packing four LE u64s (allocated_bytes,
 /// allocation_count, fragment_count, available_bytes).
@@ -49,6 +51,11 @@ pub const FN_ID_NUB_GET_BOOT_INFO: u32 = 5;
 /// JIT cache turns the loop into pure warm-cache execute, which isn't
 /// what we want to measure for PolkaVM-shaped workloads).
 pub const FN_ID_NUB_EVICT_JIT_ALL: u32 = 6;
+/// `fn_id` for a long-lived per-vCPU invoke worker. Payload is a little-endian
+/// `u32` lane index. The function does not use the legacy rkyv response ring;
+/// it polls that lane's [`ParallelInvokeSlot`] in scratch memory, runs invokes
+/// with `run_top_on_lane`, and writes results back into the same slot.
+pub const FN_ID_NUB_INVOKE_WORKER: u32 = 7;
 
 /// Boot-time info published by the guest at a known location (linker
 /// section `.boot_info`). The host reads it after the sandbox boots
@@ -155,6 +162,7 @@ pub const SCRATCHPAD_HEAD_LEN: usize = 128;
 
 /// Invocation result. Both backends produce this shape on completion;
 /// rkyv-archived on the wire from the cached path's response.
+#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, rkyv::Archive, rkyv::Serialize)]
 #[rkyv(derive(Debug, PartialEq, Eq))]
 pub struct InvocationResult {
@@ -167,3 +175,31 @@ pub struct InvocationResult {
     /// region is mapped.
     pub scratchpad_head: [u8; SCRATCHPAD_HEAD_LEN],
 }
+
+pub const PARALLEL_INVOKE_SLOT_BYTES: usize = 512;
+
+pub const PARALLEL_INVOKE_STATUS_EMPTY: u32 = 0;
+pub const PARALLEL_INVOKE_STATUS_READY: u32 = 1;
+pub const PARALLEL_INVOKE_STATUS_RUNNING: u32 = 2;
+pub const PARALLEL_INVOKE_STATUS_DONE: u32 = 3;
+pub const PARALLEL_INVOKE_STATUS_STOP: u32 = 4;
+
+/// One host<->guest invoke slot. Slots are addressed by lane index at
+/// `parallel_slot_base + lane * PARALLEL_INVOKE_SLOT_BYTES`.
+///
+/// Synchronization protocol:
+/// - host writes `job_id` and `packet`, then stores `READY` with release;
+/// - guest CASes `READY -> RUNNING`, runs the invoke, writes `result`, then
+///   stores `DONE` with release;
+/// - host reads `DONE` with acquire, copies `result`, then stores `EMPTY`.
+#[repr(C, align(64))]
+pub struct ParallelInvokeSlot {
+    pub status: AtomicU32,
+    pub _pad0: u32,
+    pub job_id: AtomicU64,
+    pub packet: InvokePacket,
+    pub result: InvocationResult,
+}
+
+const _: () = assert!(core::mem::size_of::<ParallelInvokeSlot>() <= PARALLEL_INVOKE_SLOT_BYTES);
+const _: () = assert!(core::mem::align_of::<ParallelInvokeSlot>() <= 64);

--- a/rust/nub-arch-x86/src/bin/tests.rs
+++ b/rust/nub-arch-x86/src/bin/tests.rs
@@ -18,7 +18,8 @@ extern crate nub_arch_x86;
 mod test_fns {
     use alloc::vec::Vec;
     use hyperlight_guest_bin::guest_function;
-    use nub_arch_x86::test_abi::FN_ID_TEST_SMOKE;
+    use nub_arch_x86::test_abi::{FN_ID_TEST_INVOKE_TWO_SERIAL, FN_ID_TEST_SMOKE};
+    use nub_arch_x86_abi::{InvocationResult, InvokePacket, SCRATCHPAD_HEAD_LEN};
 
     /// Smoke probe. Returns rkyv-encoded `42u64`. Used by
     /// `nub/tests/test_bin_smoke.rs` to verify the test bin loads
@@ -28,6 +29,62 @@ mod test_fns {
         let v: u64 = 42;
         rkyv::to_bytes::<rkyv::rancor::Error>(&v)
             .expect("rkyv-encode u64")
+            .into_vec()
+    }
+
+    fn encode_result_error(exit_arg: u32) -> InvocationResult {
+        InvocationResult {
+            exit_reason: u32::MAX,
+            exit_arg,
+            return_value: 0,
+            gas_remaining: 0,
+            scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+        }
+    }
+
+    /// Scheduler probe. Runs two top-level invokes through one in-guest
+    /// `KernelScheduler`, proving phase-1 can host multiple task stacks while
+    /// the production RPC stays one invoke in, one result out.
+    #[guest_function(fn_id = FN_ID_TEST_INVOKE_TWO_SERIAL)]
+    pub fn nub_invoke_two_serial(input: &[u8]) -> Vec<u8> {
+        let expected = InvokePacket::SIZE * 2;
+        let results = if input.len() == expected {
+            let Some(first) = InvokePacket::from_bytes(&input[..InvokePacket::SIZE]) else {
+                let results = [encode_result_error(10), encode_result_error(10)];
+                return rkyv::to_bytes::<rkyv::rancor::Error>(&results)
+                    .expect("rkyv-encode scheduler probe error")
+                    .into_vec();
+            };
+            let Some(second) = InvokePacket::from_bytes(&input[InvokePacket::SIZE..]) else {
+                let results = [encode_result_error(10), encode_result_error(10)];
+                return rkyv::to_bytes::<rkyv::rancor::Error>(&results)
+                    .expect("rkyv-encode scheduler probe error")
+                    .into_vec();
+            };
+            match nub_arch_x86::call_loop::run_two_for_test(&first, &second) {
+                Ok((a, b)) => [
+                    InvocationResult {
+                        exit_reason: a.exit_reason,
+                        exit_arg: a.exit_arg,
+                        return_value: a.return_value,
+                        gas_remaining: a.gas_remaining.max(0) as u64,
+                        scratchpad_head: a.scratchpad_head,
+                    },
+                    InvocationResult {
+                        exit_reason: b.exit_reason,
+                        exit_arg: b.exit_arg,
+                        return_value: b.return_value,
+                        gas_remaining: b.gas_remaining.max(0) as u64,
+                        scratchpad_head: b.scratchpad_head,
+                    },
+                ],
+                Err(code) => [encode_result_error(code), encode_result_error(code)],
+            }
+        } else {
+            [encode_result_error(10), encode_result_error(10)]
+        };
+        rkyv::to_bytes::<rkyv::rancor::Error>(&results)
+            .expect("rkyv-encode scheduler probe results")
             .into_vec()
     }
 }

--- a/rust/nub-arch-x86/src/cached_cap.rs
+++ b/rust/nub-arch-x86/src/cached_cap.rs
@@ -50,11 +50,12 @@ pub struct CachedCap {
     pub cache: SpinMutex<CapCache>,
 }
 
-/// SAFETY: Hyperlight serialises guest execution and RPCs; these resident
-/// caches never move across concurrently-running threads. The impl only lets
-/// them live behind the static directory mutex.
+/// SAFETY: the cap payload is immutable once resident; mutable derived state
+/// lives behind `cache`'s spin mutex or is moved into a `KernelFrame` while
+/// running. Sharing `CachedCap` through the static directory therefore does not
+/// create unsynchronized mutation of the cache or of a live frame runtime.
 unsafe impl Send for CachedCap {}
-/// SAFETY: same single-threaded guest invariant as the `Send` impl above.
+/// SAFETY: same synchronization and move-ownership invariant as `Send`.
 unsafe impl Sync for CachedCap {}
 
 /// The derived runtime cache attached to a resident cap. `None` for a cap with

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -103,7 +103,8 @@ use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
 use crate::cached_cap::{CachedCap, CapCache, InstanceCache, ResidentCNode, ResidentInstance};
-use crate::jit_run::{self, ExecutionLane, ExitInfo, FrameRuntime};
+use crate::execution_lane::ExecutionLane;
+use crate::jit_run::{self, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
 

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -90,7 +90,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 
@@ -678,117 +678,167 @@ fn read_scratchpad_head(frame: &KernelFrame) -> [u8; SCRATCHPAD_HEAD_LEN] {
     out
 }
 
-/// Drive the CALL/HALT loop until either the top frame HALTs (clean
-/// exit) or the JIT signals an unrecoverable condition (page fault,
-/// gas exhaustion, …). See module docs for the loop body.
-///
-/// Cap lookups go through the heap-resident [`CACHE`] static. Each
-/// lookup takes the cache's spinlock; we keep lock scopes tight
-/// (clone out the fields we need, drop the guard) so other guest-mode
-/// lookups can proceed concurrently.
-pub fn run_top(
-    instance_hash: &CapHash,
-    endpoint_idx: u32,
-    args: [u64; 4],
-    initial_gas: i64,
-) -> Result<LoopOutcome, u32> {
-    let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
-    let mut stack: Vec<StackEntry> = Vec::with_capacity(8);
-    // Monotonic Instance identity. The top-level invocation is instance 0; every
-    // CALL mints the next id.
-    let mut next_iid: u64 = 0;
-    stack.push(StackEntry::instance(top, 0, next_iid));
-    next_iid += 1;
-    // GAS MODEL (single reconciliation point). The threaded `gas` always holds
-    // the LIVE balance of the running frame's ACTIVE meter — `active_meter(top)`,
-    // the frame's stored gas scope (its own declared meter list, or its
-    // caller/catcher's loaned scope).
-    // `meters[k]` is authoritative for every non-active meter. At the top of each
-    // iteration we reconcile: if the top's active meter changed since last
-    // iteration, bank the old scope + load the new. Every CALL/HALT/yield/resume/
-    // drop changes the top, so this one point catches them all — no per-transition
-    // gas bookkeeping. The guest meter table is per-RPC (a block-spanning table is
-    // the deferred lazy-load piece).
-    let mut meters: BTreeMap<Key, i64> = BTreeMap::new();
-    // The TOP frame's primary usable meter, if declared, is the RPC's ROOT
-    // scope: stamp it like any frame and seed the table from the host-supplied
-    // budget, so `set_gas_meter` on the root meter goes through the SAME table
-    // as sub-meters. A top with NO gas slot is host-budgeted
-    // (`root_active == None`, tracked in `host_budget`). The host ABI still
-    // supplies one budget; secondary root gas slots are usable if a guest-side
-    // syscall funds them during the run.
-    stack[0].gas = resolve_frame_gas(frame_at(&stack, 0))?.unwrap_or_else(FrameGas::host_budgeted);
-    let root_active = stack[0].gas.active_key();
-    if let Some(k) = &root_active {
-        meters.insert(k.clone(), initial_gas);
-    }
-    let mut gas = initial_gas;
-    let mut host_budget = initial_gas;
-    let mut current_active: Option<Key> = root_active.clone();
+type TaskId = u64;
 
-    let outcome = loop {
-        let top_idx = stack.len() - 1;
-        // Reconcile the active meter for the (possibly new) top frame.
-        let new_active = active_meter(&stack, top_idx);
+/// GAS MODEL (single reconciliation point). `live_gas` always holds the live
+/// balance of the running frame's active meter. `meters[k]` is authoritative for
+/// every non-active meter, while `host_budget` is the banked unmetered scope.
+/// Every CALL/HALT/yield/resume/drop changes the top through one scheduler poll
+/// boundary, so this one task-local state object catches all gas scope changes.
+struct TaskGasState {
+    meters: BTreeMap<Key, i64>,
+    live_gas: i64,
+    host_budget: i64,
+    root_active: Option<Key>,
+    current_active: Option<Key>,
+}
+
+impl TaskGasState {
+    fn new(root_gas: &FrameGas, initial_gas: i64) -> Self {
+        let root_active = root_gas.active_key();
+        let mut meters = BTreeMap::new();
+        if let Some(k) = &root_active {
+            meters.insert(k.clone(), initial_gas);
+        }
+        Self {
+            meters,
+            live_gas: initial_gas,
+            host_budget: initial_gas,
+            root_active: root_active.clone(),
+            current_active: root_active,
+        }
+    }
+
+    fn reconcile_for(&mut self, stack: &[StackEntry], top_idx: usize) {
+        let new_active = active_meter(stack, top_idx);
         reconcile_active(
-            &current_active,
+            &self.current_active,
             &new_active,
-            &mut gas,
-            &mut host_budget,
-            &mut meters,
+            &mut self.live_gas,
+            &mut self.host_budget,
+            &mut self.meters,
         );
-        current_active = new_active;
+        self.current_active = new_active;
+    }
+
+    fn root_remaining(&self) -> i64 {
+        root_remaining(
+            &self.root_active,
+            &self.current_active,
+            self.live_gas,
+            self.host_budget,
+            &self.meters,
+        )
+    }
+}
+
+enum TaskPoll {
+    Pending,
+    Done(LoopOutcome),
+}
+
+/// One top-level invocation as a resumable kernel task. The task owns exactly
+/// the state that used to live in `run_top` locals: one physical caller stack,
+/// one task-local gas bank, and one monotonic Instance id allocator.
+struct KernelTask {
+    id: TaskId,
+    stack: Vec<StackEntry>,
+    next_iid: u64,
+    gas_state: TaskGasState,
+}
+
+impl KernelTask {
+    fn new(
+        id: TaskId,
+        instance_hash: &CapHash,
+        endpoint_idx: u32,
+        args: [u64; 4],
+        initial_gas: i64,
+    ) -> Result<Self, u32> {
+        let top = build_frame_from_published(instance_hash, endpoint_idx, args)?;
+        let mut stack: Vec<StackEntry> = Vec::with_capacity(8);
+        // Monotonic Instance identity. The top-level invocation is instance 0;
+        // every CALL mints the next id.
+        let mut next_iid: u64 = 0;
+        stack.push(StackEntry::instance(top, 0, next_iid));
+        next_iid += 1;
+
+        // The TOP frame's primary usable meter, if declared, is the task's root
+        // scope. A top with no gas slot is host-budgeted.
+        stack[0].gas =
+            resolve_frame_gas(frame_at(&stack, 0))?.unwrap_or_else(FrameGas::host_budgeted);
+        let gas_state = TaskGasState::new(&stack[0].gas, initial_gas);
+        Ok(Self {
+            id,
+            stack,
+            next_iid,
+            gas_state,
+        })
+    }
+
+    fn outcome(
+        &self,
+        exit_reason: u32,
+        exit_arg: u32,
+        return_value: u64,
+        scratchpad_head: [u8; SCRATCHPAD_HEAD_LEN],
+    ) -> LoopOutcome {
+        LoopOutcome {
+            exit_reason,
+            exit_arg,
+            return_value,
+            gas_remaining: self.gas_state.root_remaining(),
+            scratchpad_head,
+        }
+    }
+
+    fn poll_once(&mut self) -> Result<TaskPoll, u32> {
+        let top_idx = self.stack.len() - 1;
+        // Reconcile the active meter for the (possibly new) top frame.
+        self.gas_state.reconcile_for(&self.stack, top_idx);
+
         // Phase 1: run one ring-3 entry on the top entry's frame (an
-        // InstanceEntry runs its own frame; a ReferenceEntry runs its
-        // referent's — the same Instance, sharing one PC/regs/mem).
+        // InstanceEntry runs its own frame; a ReferenceEntry runs its referent's
+        // — the same Instance, sharing one PC/regs/mem).
         let info = {
-            let frame = frame_at_mut(&mut stack, top_idx);
-            run_one_entry(frame, gas)?
+            let frame = frame_at_mut(&mut self.stack, top_idx);
+            run_one_entry(frame, self.gas_state.live_gas)?
         };
-        gas = info.gas_remaining;
+        self.gas_state.live_gas = info.gas_remaining;
+
         // Mirror the JIT's post-exit state back into the running frame.
         {
-            let frame = frame_at_mut(&mut stack, top_idx);
+            let frame = frame_at_mut(&mut self.stack, top_idx);
             frame.instance.regs = info.regs;
             frame.instance.pc = info.pc as u64;
         }
 
-        // Phase 2: classify the exit. Borrow scopes are kept tight so
-        // we can mutate `stack` (push/pop) inside each arm.
+        // Phase 2: classify the exit. Borrow scopes are kept tight so we can
+        // mutate `stack` (push/pop) inside each arm.
         match info.exit_reason {
             EXIT_HALT => {
-                // Read the scratchpad head from the InstanceEntry that will drain
-                // (its `target` reaches stack[0]) BEFORE it is popped — meaningful
-                // only at the top-level HALT. `frame_at(top_idx)` resolves the
-                // running frame whether the top is an InstanceEntry or a handler
-                // ReferenceEntry.
-                let head = if stack[top_idx].target == 0 {
-                    read_scratchpad_head(frame_at(&stack, top_idx))
+                // Read the scratchpad head from the InstanceEntry that will
+                // drain before it is popped — meaningful only at top-level HALT.
+                let head = if self.stack[top_idx].target == 0 {
+                    read_scratchpad_head(frame_at(&self.stack, top_idx))
                 } else {
                     [0u8; SCRATCHPAD_HEAD_LEN]
                 };
                 // A handler activation (ReferenceEntry) that HALTs without
                 // resuming/dropping its yielder triggers the sub-tree-atomic
                 // unwind; an ordinary InstanceEntry pops and reflects.
-                let drained = if stack[top_idx].target != top_idx {
-                    unwind_to_handler(&mut stack, top_idx, info.regs[7])?
+                let drained = if self.stack[top_idx].target != top_idx {
+                    unwind_to_handler(&mut self.stack, top_idx, info.regs[7])?
                 } else {
-                    pop_and_reflect(&mut stack, info.regs[7])?
+                    pop_and_reflect(&mut self.stack, info.regs[7])?
                 };
                 if drained {
-                    break LoopOutcome {
-                        exit_reason: info.exit_reason,
-                        exit_arg: info.exit_arg,
-                        return_value: info.regs[7],
-                        gas_remaining: root_remaining(
-                            &root_active,
-                            &current_active,
-                            gas,
-                            host_budget,
-                            &meters,
-                        ),
-                        scratchpad_head: head,
-                    };
+                    return Ok(TaskPoll::Done(self.outcome(
+                        info.exit_reason,
+                        info.exit_arg,
+                        info.regs[7],
+                        head,
+                    )));
                 }
             }
             EXIT_HOST_CALL | EXIT_ECALL => {
@@ -814,10 +864,10 @@ pub fn run_top(
                 // not an OOG.
                 let mut host_call_pending = false;
                 let frame_cost = if op == OP_HOST_CALL {
-                    if stack.len() >= MAX_DEPTH {
+                    if self.stack.len() >= MAX_DEPTH {
                         return Err(ERR_DEPTH_LIMIT);
                     }
-                    let parent = frame_at(&stack, top_idx);
+                    let parent = frame_at(&self.stack, top_idx);
                     match host_call_frame_cost(parent)? {
                         Some(cost) => cost,
                         None => {
@@ -829,155 +879,118 @@ pub fn run_top(
                     0
                 };
                 let total_cost = ecall_cost + frame_cost;
-                if gas < total_cost {
+                if self.gas_state.live_gas < total_cost {
                     // A metered frame re-attempts THIS ecall after a kernel:oog
-                    // topup; unmetered / uncaught → bubble EXIT_OOG.
-                    if try_oog_yield(&mut stack, top_idx, info.pc.saturating_sub(4)) {
-                        continue;
+                    // topup; unmetered / uncaught -> bubble EXIT_OOG.
+                    if try_oog_yield(&mut self.stack, top_idx, info.pc.saturating_sub(4)) {
+                        return Ok(TaskPoll::Pending);
                     }
-                    break LoopOutcome {
-                        exit_reason: EXIT_OOG,
-                        exit_arg: 0,
-                        return_value: info.regs[7],
-                        gas_remaining: root_remaining(
-                            &root_active,
-                            &current_active,
-                            gas,
-                            host_budget,
-                            &meters,
-                        ),
-                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                    };
+                    return Ok(TaskPoll::Done(self.outcome(
+                        EXIT_OOG,
+                        0,
+                        info.regs[7],
+                        [0u8; SCRATCHPAD_HEAD_LEN],
+                    )));
                 }
-                gas -= total_cost;
+                self.gas_state.live_gas -= total_cost;
 
                 match op {
                     OP_REPLY => {
                         // Read the scratchpad head from the InstanceEntry that
                         // will drain before the pop (see EXIT_HALT).
-                        let head = if stack[top_idx].target == 0 {
-                            read_scratchpad_head(frame_at(&stack, top_idx))
+                        let head = if self.stack[top_idx].target == 0 {
+                            read_scratchpad_head(frame_at(&self.stack, top_idx))
                         } else {
                             [0u8; SCRATCHPAD_HEAD_LEN]
                         };
-                        // A handler REPLYing without resuming/dropping → sub-tree
+                        // A handler REPLYing without resuming/dropping -> sub-tree
                         // unwind; an ordinary InstanceEntry pops and reflects.
-                        let drained = if stack[top_idx].target != top_idx {
-                            unwind_to_handler(&mut stack, top_idx, info.regs[7])?
+                        let drained = if self.stack[top_idx].target != top_idx {
+                            unwind_to_handler(&mut self.stack, top_idx, info.regs[7])?
                         } else {
-                            pop_and_reflect(&mut stack, info.regs[7])?
+                            pop_and_reflect(&mut self.stack, info.regs[7])?
                         };
                         if drained {
                             // Preserve the JIT exit shape so the host bench
                             // harness (which asserts `(reason=4, arg=0)` for the
                             // subsoil trampoline halt) doesn't trip.
-                            break LoopOutcome {
-                                exit_reason: info.exit_reason,
-                                exit_arg: info.exit_arg,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: head,
-                            };
+                            return Ok(TaskPoll::Done(self.outcome(
+                                info.exit_reason,
+                                info.exit_arg,
+                                info.regs[7],
+                                head,
+                            )));
                         }
                         // Stack still has frames; the parent picks up at the next
-                        // iter with the child's φ[7] reflected.
+                        // poll with the child's phi[7] reflected.
                     }
                     OP_DERIVE_SPAWN => {
                         let trapped = {
-                            let frame = frame_at_mut(&mut stack, top_idx);
+                            let frame = frame_at_mut(&mut self.stack, top_idx);
                             dispatch_derive_spawn(frame)?
                         };
                         if trapped {
-                            // Pinned dst → guest trap, mirroring the interpreter.
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                            // Pinned dst -> guest trap, mirroring the interpreter.
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         }
                     }
                     OP_IMAGE_HASH_CHAIN => {
                         let trapped = {
-                            let frame = frame_at_mut(&mut stack, top_idx);
+                            let frame = frame_at_mut(&mut self.stack, top_idx);
                             dispatch_image_hash_chain(frame)?
                         };
                         if trapped {
-                            // Pinned/empty dst or wrong src kind → guest trap.
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                            // Pinned/empty dst or wrong src kind -> guest trap.
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         }
                     }
                     OP_HOST_YIELD => {
                         let outcome = {
-                            let frame = frame_at_mut(&mut stack, top_idx);
-                            dispatch_host_yield(frame, &mut meters, &mut gas, &current_active)?
+                            let frame = frame_at_mut(&mut self.stack, top_idx);
+                            dispatch_host_yield(
+                                frame,
+                                &mut self.gas_state.meters,
+                                &mut self.gas_state.live_gas,
+                                &self.gas_state.current_active,
+                            )?
                         };
                         match outcome {
                             // A kernel-root pure-cap syscall handled inline; the
                             // guest resumes at the next instruction (the
                             // "conceptually push a kernel frame but don't" path).
                             YieldOutcome::Inline => {}
-                            // Bad/empty sender slot or pinned dst → guest trap.
+                            // Bad/empty sender slot or pinned dst -> guest trap.
                             YieldOutcome::Trap => {
-                                break LoopOutcome {
-                                    exit_reason: EXIT_TRAP,
-                                    exit_arg: 0,
-                                    return_value: info.regs[7],
-                                    gas_remaining: root_remaining(
-                                        &root_active,
-                                        &current_active,
-                                        gas,
-                                        host_budget,
-                                        &meters,
-                                    ),
-                                    scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                                };
+                                return Ok(TaskPoll::Done(self.outcome(
+                                    EXIT_TRAP,
+                                    0,
+                                    info.regs[7],
+                                    [0u8; SCRATCHPAD_HEAD_LEN],
+                                )));
                             }
                             // Route `key` to an owner YieldReceiver (the payload
                             // is a copy of the emitted YieldSender). No catcher
-                            // → the emitter faults ("unhandled yield_key").
+                            // -> the emitter faults ("unhandled yield_key").
                             YieldOutcome::Route { key, sender_slot } => {
                                 let payload =
-                                    read_instance_cap(frame_at(&stack, top_idx), &sender_slot);
-                                if !route_yield(&mut stack, top_idx, &key, payload) {
-                                    break LoopOutcome {
-                                        exit_reason: EXIT_TRAP,
-                                        exit_arg: ERR_YIELD_UNHANDLED,
-                                        return_value: info.regs[7],
-                                        gas_remaining: root_remaining(
-                                            &root_active,
-                                            &current_active,
-                                            gas,
-                                            host_budget,
-                                            &meters,
-                                        ),
-                                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                                    };
+                                    read_instance_cap(frame_at(&self.stack, top_idx), &sender_slot);
+                                if !route_yield(&mut self.stack, top_idx, &key, payload) {
+                                    return Ok(TaskPoll::Done(self.outcome(
+                                        EXIT_TRAP,
+                                        ERR_YIELD_UNHANDLED,
+                                        info.regs[7],
+                                        [0u8; SCRATCHPAD_HEAD_LEN],
+                                    )));
                                 }
                             }
                         }
@@ -986,35 +999,26 @@ pub fn run_top(
                         // Resume the Waiting yielder directly below this handler
                         // activation. The top MUST be a ReferenceEntry (we are
                         // running as a yield handler); an InstanceEntry top has no
-                        // outstanding yield to resume → trap.
-                        if stack[top_idx].target == top_idx {
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                        // outstanding yield to resume -> trap.
+                        if self.stack[top_idx].target == top_idx {
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         }
                         // Reflect the handler's scratchpad slot[0] (its response)
                         // to the yielder, pop the ReferenceEntry, and let the
                         // yielder become the running top (it continues at its
-                        // post-yield PC next iteration). Gas is reconciled at the
-                        // next loop top: the handler's active meter banks and the
-                        // yielder's loads (picking up a kernel:oog topup).
+                        // post-yield PC next poll).
                         let response = {
-                            let handler = frame_at_mut(&mut stack, top_idx);
+                            let handler = frame_at_mut(&mut self.stack, top_idx);
                             frame_cnode_take_key(handler, &[javm_cap::abi::SCRATCHPAD_SLOT])
                         };
-                        stack.pop();
-                        let yielder_idx = stack.len() - 1;
-                        let yielder = frame_at_mut(&mut stack, yielder_idx);
+                        self.stack.pop();
+                        let yielder_idx = self.stack.len() - 1;
+                        let yielder = frame_at_mut(&mut self.stack, yielder_idx);
                         if let Some(cap) = response {
                             frame_cnode_set_key(
                                 yielder,
@@ -1022,123 +1026,69 @@ pub fn run_top(
                                 Some(cap),
                             );
                         }
-                        // Spec §4: a resumed yielder sees φ[8] = Ok (the handler's
-                        // response status) — its host_yield "returns" here.
+                        // Spec section 4: a resumed yielder sees phi[8] = Ok.
                         yielder.instance.regs[8] = STATUS_OK;
                     }
                     OP_DROP_RESUME => {
                         // Give up on the Waiting yielder: discard the WHOLE caught
-                        // subtree (the yielder + any intermediates a descendant
-                        // routed past — same scope as a handler HALT, §10), but
-                        // keep the handler running. Full DROP_RESUME will detach
-                        // the yielder as sigma-resident Paused; this V1 path only
-                        // implements the discard behavior. The top must be a
-                        // handler ReferenceEntry — an InstanceEntry top has no
-                        // outstanding yield → trap.
-                        if stack[top_idx].target == top_idx {
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                        // subtree, but keep the handler running.
+                        if self.stack[top_idx].target == top_idx {
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         }
-                        // Truncate everything above the handler's InstanceEntry
-                        // (the ReferenceEntry + the discarded subtree); the handler
-                        // becomes a plain InstanceEntry again and continues at its
-                        // post-drop pc. (Discarded metered frames were banked at
-                        // route_yield, so the meter table stays consistent — gas is
-                        // STM-exempt: a dropped subtree's spend is NOT refunded.)
-                        // Using `target+1` (not `top_idx-1`) keeps subsequent
-                        // CALL_RESUME/DROP_RESUME sound — there is no longer a stale
-                        // handler with a wedged intermediate below it.
-                        let handler_inst = stack[top_idx].target;
-                        release_pending_origins_for_dropped(&mut stack, handler_inst + 1);
-                        stack.truncate(handler_inst + 1);
+                        let handler_inst = self.stack[top_idx].target;
+                        release_pending_origins_for_dropped(&mut self.stack, handler_inst + 1);
+                        self.stack.truncate(handler_inst + 1);
                     }
                     OP_HOST_CALL => {
                         if host_call_pending {
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         }
-                        // The ecall floor + this CALL's frame_cost were charged
-                        // atomically at the top of the arm (check-before-charge,
-                        // before `dispatch_host_call` moves any instance, so an
-                        // OOG left the parent slot pristine). Charged in full on
-                        // every CALL — compile/PT memoization is for *work*, never
-                        // a gas discount — so gas is independent of the cache.
-                        //
                         // Snapshot the logical owner's catch-set at this CALL:
                         // the keys on the owner edge `owner -> child`. When A is
                         // running via `ref[A]`, the physical caller is the
                         // ReferenceEntry but the logical owner is A itself.
-                        let logical_owner = stack[top_idx].target;
+                        let logical_owner = self.stack[top_idx].target;
                         let catch_result = {
-                            let parent = frame_at(&stack, top_idx);
+                            let parent = frame_at(&self.stack, top_idx);
                             snapshot_catch_set(parent)
                         };
                         let catch_set = match catch_result {
                             Ok(set) => set,
                             Err(EXIT_TRAP) => {
-                                break LoopOutcome {
-                                    exit_reason: EXIT_TRAP,
-                                    exit_arg: 0,
-                                    return_value: info.regs[7],
-                                    gas_remaining: root_remaining(
-                                        &root_active,
-                                        &current_active,
-                                        gas,
-                                        host_budget,
-                                        &meters,
-                                    ),
-                                    scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                                };
+                                return Ok(TaskPoll::Done(self.outcome(
+                                    EXIT_TRAP,
+                                    0,
+                                    info.regs[7],
+                                    [0u8; SCRATCHPAD_HEAD_LEN],
+                                )));
                             }
                             Err(e) => return Err(e),
                         };
                         let child_result = {
-                            let parent = frame_at_mut(&mut stack, top_idx);
+                            let parent = frame_at_mut(&mut self.stack, top_idx);
                             dispatch_host_call(parent, logical_owner)?
                         };
                         let Some(mut child) = child_result else {
-                            break LoopOutcome {
-                                exit_reason: EXIT_TRAP,
-                                exit_arg: 0,
-                                return_value: info.regs[7],
-                                gas_remaining: root_remaining(
-                                    &root_active,
-                                    &current_active,
-                                    gas,
-                                    host_budget,
-                                    &meters,
-                                ),
-                                scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                            };
+                            return Ok(TaskPoll::Done(self.outcome(
+                                EXIT_TRAP,
+                                0,
+                                info.regs[7],
+                                [0u8; SCRATCHPAD_HEAD_LEN],
+                            )));
                         };
-                        // Scratchpad: MOVE the caller's slot[0] into the
-                        // callee. `take_key` empties the parent (one owner);
-                        // the callee's image-default slot[0], if any, is
-                        // overwritten by the caller-provided scratchpad.
+                        // Scratchpad: MOVE the caller's slot[0] into the callee.
                         {
-                            let parent = frame_at_mut(&mut stack, top_idx);
+                            let parent = frame_at_mut(&mut self.stack, top_idx);
                             if let Some(cap) =
                                 frame_cnode_take_key(parent, &[javm_cap::abi::SCRATCHPAD_SLOT])
                             {
@@ -1149,81 +1099,157 @@ pub fn run_top(
                                 );
                             }
                         }
-                        // No runtime eviction: every live frame keeps its page
-                        // table resident. The call stack is depth-bounded by
-                        // `MAX_DEPTH` (interim) / the cnode nesting limit
-                        // (target), so the resident page-table set is bounded
-                        // structurally rather than by an LRU cap.
-                        let child_idx = stack.len();
-                        stack.push(StackEntry::instance(child, child_idx, next_iid));
-                        next_iid += 1;
+                        let child_idx = self.stack.len();
+                        self.stack
+                            .push(StackEntry::instance(child, child_idx, self.next_iid));
+                        self.next_iid += 1;
                         // Stamp owner-edge routing and funding. The child owns
                         // its declared gas scope if it has one; otherwise it
                         // loans the caller/catcher's current gas scope.
-                        stack[child_idx].owner = Some(logical_owner);
-                        stack[child_idx].owner_catch_set = catch_set;
-                        let inherited_gas = stack[top_idx].gas.clone();
-                        stack[child_idx].gas = resolve_frame_gas(frame_at(&stack, child_idx))?
-                            .unwrap_or(inherited_gas);
+                        self.stack[child_idx].owner = Some(logical_owner);
+                        self.stack[child_idx].owner_catch_set = catch_set;
+                        let inherited_gas = self.stack[top_idx].gas.clone();
+                        self.stack[child_idx].gas =
+                            resolve_frame_gas(frame_at(&self.stack, child_idx))?
+                                .unwrap_or(inherited_gas);
                     }
-                    // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD,
-                    // arbitrary `ecalli imm`, …) is not in-kernel-
-                    // handled in V1: bubble it up to the host with
-                    // the JIT's reported exit reason/arg verbatim.
-                    // Mirrors pre-call-loop behaviour so unit tests
-                    // that fire `ecalli imm` and check `(reason=4,
-                    // arg=imm)` keep passing.
+                    // Anything else (MGMT ops, SET_IMAGE, HOST_YIELD, arbitrary
+                    // `ecalli imm`, ...) is not in-kernel-handled in V1: bubble it
+                    // up to the host with the JIT's reported exit reason/arg.
                     _ => {
-                        break LoopOutcome {
-                            exit_reason: info.exit_reason,
-                            exit_arg: info.exit_arg,
-                            return_value: info.regs[7],
-                            gas_remaining: root_remaining(
-                                &root_active,
-                                &current_active,
-                                gas,
-                                host_budget,
-                                &meters,
-                            ),
-                            scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                        };
+                        return Ok(TaskPoll::Done(self.outcome(
+                            info.exit_reason,
+                            info.exit_arg,
+                            info.regs[7],
+                            [0u8; SCRATCHPAD_HEAD_LEN],
+                        )));
                     }
                 }
             }
             _ => {
-                // PageFault (3), Panic (1), OOG (2), Trap (7), …
-                // An in-block OOG (the JIT's per-block gas gate) on a metered
-                // frame re-attempts the SAME block after a kernel:oog topup —
-                // `info.pc` is that block's bb_start (the gate is a pre-charge:
-                // the block was not entered and no gas was charged). Unmetered /
-                // uncaught OOG, and every other exit (fault/panic/trap), bubble
-                // verbatim.
-                if info.exit_reason == EXIT_OOG && try_oog_yield(&mut stack, top_idx, info.pc) {
-                    continue;
+                // PageFault (3), Panic (1), OOG (2), Trap (7), ...
+                // An in-block OOG on a metered frame re-attempts the SAME block
+                // after a kernel:oog topup. Unmetered / uncaught OOG, and every
+                // other exit, bubble verbatim.
+                if info.exit_reason == EXIT_OOG && try_oog_yield(&mut self.stack, top_idx, info.pc)
+                {
+                    return Ok(TaskPoll::Pending);
                 }
-                break LoopOutcome {
-                    exit_reason: info.exit_reason,
-                    exit_arg: info.exit_arg,
-                    return_value: info.regs[7],
-                    gas_remaining: root_remaining(
-                        &root_active,
-                        &current_active,
-                        gas,
-                        host_budget,
-                        &meters,
-                    ),
-                    scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
-                };
+                return Ok(TaskPoll::Done(self.outcome(
+                    info.exit_reason,
+                    info.exit_arg,
+                    info.regs[7],
+                    [0u8; SCRATCHPAD_HEAD_LEN],
+                )));
             }
         }
-    };
 
-    // Drop the stack BEFORE we hand the outcome back. Each frame owns its
-    // `mem` DataCap and any inline `Owned` cnode caps outright, so the drop
-    // frees them directly — there are no `cache.instances` entries to reclaim
-    // (the recompiler no longer mints `Ref`).
-    drop(stack);
-    Ok(outcome)
+        Ok(TaskPoll::Pending)
+    }
+}
+
+/// Cooperative phase-1 scheduler: many task stacks can be resident, but exactly
+/// one is active on the single vCPU at any instant. Switching only happens at
+/// existing ring-3 exits. Later phases should keep the singleton host Nub, add a
+/// production batch/async submission API, and then split the ring3/JIT globals
+/// into per-vCPU execution lanes before true parallel scheduling.
+struct KernelScheduler {
+    next_task_id: TaskId,
+    tasks: BTreeMap<TaskId, KernelTask>,
+    completed: BTreeMap<TaskId, LoopOutcome>,
+    ready: VecDeque<TaskId>,
+}
+
+impl KernelScheduler {
+    fn new() -> Self {
+        Self {
+            next_task_id: 0,
+            tasks: BTreeMap::new(),
+            completed: BTreeMap::new(),
+            ready: VecDeque::new(),
+        }
+    }
+
+    fn submit_invoke(
+        &mut self,
+        instance_hash: &CapHash,
+        endpoint_idx: u32,
+        args: [u64; 4],
+        initial_gas: i64,
+    ) -> Result<TaskId, u32> {
+        let id = self.next_task_id;
+        self.next_task_id += 1;
+        let task = KernelTask::new(id, instance_hash, endpoint_idx, args, initial_gas)?;
+        self.tasks.insert(id, task);
+        self.ready.push_back(id);
+        Ok(id)
+    }
+
+    fn run_until_result(&mut self, target: TaskId) -> Result<LoopOutcome, u32> {
+        if let Some(outcome) = self.completed.remove(&target) {
+            return Ok(outcome);
+        }
+        while let Some(id) = self.ready.pop_front() {
+            let mut task = self.tasks.remove(&id).ok_or(ERR_PENDING_ORIGIN_INVARIANT)?;
+            debug_assert_eq!(task.id, id);
+            match task.poll_once()? {
+                TaskPoll::Pending => {
+                    self.tasks.insert(id, task);
+                    self.ready.push_back(id);
+                }
+                TaskPoll::Done(outcome) if id == target => return Ok(outcome),
+                TaskPoll::Done(outcome) => {
+                    self.completed.insert(id, outcome);
+                }
+            }
+            if let Some(outcome) = self.completed.remove(&target) {
+                return Ok(outcome);
+            }
+        }
+        Err(ERR_PENDING_ORIGIN_INVARIANT)
+    }
+}
+
+/// Drive the CALL/HALT loop until either the top frame HALTs (clean
+/// exit) or the JIT signals an unrecoverable condition (page fault,
+/// gas exhaustion, ...). See module docs for the loop body.
+///
+/// Cap lookups go through the heap-resident [`CACHE`] static. Each
+/// lookup takes the cache's spinlock; we keep lock scopes tight
+/// (clone out the fields we need, drop the guard) so other guest-mode
+/// lookups can proceed concurrently.
+pub fn run_top(
+    instance_hash: &CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+    initial_gas: i64,
+) -> Result<LoopOutcome, u32> {
+    let mut scheduler = KernelScheduler::new();
+    let task = scheduler.submit_invoke(instance_hash, endpoint_idx, args, initial_gas)?;
+    scheduler.run_until_result(task)
+}
+
+#[doc(hidden)]
+pub fn run_two_for_test(
+    first: &nub_arch_x86_abi::InvokePacket,
+    second: &nub_arch_x86_abi::InvokePacket,
+) -> Result<(LoopOutcome, LoopOutcome), u32> {
+    let mut scheduler = KernelScheduler::new();
+    let first_id = scheduler.submit_invoke(
+        &first.instance_hash,
+        first.endpoint_idx,
+        first.args,
+        first.initial_gas as i64,
+    )?;
+    let second_id = scheduler.submit_invoke(
+        &second.instance_hash,
+        second.endpoint_idx,
+        second.args,
+        second.initial_gas as i64,
+    )?;
+    let first_outcome = scheduler.run_until_result(first_id)?;
+    let second_outcome = scheduler.run_until_result(second_id)?;
+    Ok((first_outcome, second_outcome))
 }
 
 /// Run exactly one ring-3 cycle for `frame`. The first call on a

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -92,7 +92,6 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::vec::Vec;
-use core::cell::UnsafeCell;
 
 use javm_cap::cache::CapHashOrRef;
 use javm_cap::cap::Cap;
@@ -1626,24 +1625,15 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
 /// and each CoWs only the pages it writes, so sharing is sound (single
 /// mutator: each instance's overlay).
 ///
-/// `UnsafeCell<BTreeMap>` mirrors [`crate::jit_cache`]'s compile cache: the
-/// Hyperlight guest is single-threaded, so the `unsafe` is sound and local.
-struct MemCache {
-    inner: UnsafeCell<BTreeMap<CapHash, DataCap>>,
-}
-/// SAFETY: single-threaded guest (Hyperlight serialisation).
-unsafe impl Sync for MemCache {}
-static MEM_CACHE: MemCache = MemCache {
-    inner: UnsafeCell::new(BTreeMap::new()),
-};
+/// Protected by a spin mutex so future multi-vCPU workers can derive/spawn
+/// independent Images without racing the shared clean-backing memo.
+static MEM_CACHE: spin::Mutex<BTreeMap<CapHash, DataCap>> = spin::Mutex::new(BTreeMap::new());
 
 /// Drop every cached clean instance-mem backing. Bench-only (paired with
 /// [`crate::jit_cache::evict_all`]) so a "cold" measurement re-composes;
 /// correctness never needs it (the cache is content-addressed by `image_hash`).
 pub fn evict_mem_cache() {
-    // SAFETY: single-threaded guest; no in-flight call when this RPC fires.
-    let map = unsafe { &mut *MEM_CACHE.inner.get() };
-    map.clear();
+    MEM_CACHE.lock().clear();
 }
 
 /// Build a derived sub-VM's initial `mem` DataCap from its Image. The composed
@@ -1652,18 +1642,13 @@ pub fn evict_mem_cache() {
 /// [`compose_instance_mem`] builds it once.
 fn build_instance_mem(image_hash: &CapHash, img: &ImageCap) -> DataCap {
     // Fast path: clone the cached clean backing (Arc-bump + empty overlay).
-    // SAFETY: single-threaded guest (Hyperlight serialisation); the returned
-    // borrow is cloned before any mutation of the map.
-    if let Some(clean) = unsafe { (*MEM_CACHE.inner.get()).get(image_hash) } {
-        return clean.clone();
+    if let Some(clean) = MEM_CACHE.lock().get(image_hash).cloned() {
+        return clean;
     }
     // Miss: compose once (no MEM_CACHE borrow held across the compose), cache,
     // hand out a clone.
     let mem = compose_instance_mem(img);
-    // SAFETY: single-threaded guest.
-    unsafe {
-        (*MEM_CACHE.inner.get()).insert(*image_hash, mem.clone());
-    }
+    MEM_CACHE.lock().insert(*image_hash, mem.clone());
     mem
 }
 

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1705,9 +1705,8 @@ fn pop_and_reflect(stack: &mut Vec<StackEntry>, return_value: u64) -> Result<boo
 /// independent Images without racing the shared clean-backing memo.
 static MEM_CACHE: spin::Mutex<BTreeMap<CapHash, DataCap>> = spin::Mutex::new(BTreeMap::new());
 
-/// Drop every cached clean instance-mem backing. Bench-only (paired with
-/// [`crate::jit_cache::evict_all`]) so a "cold" measurement re-composes;
-/// correctness never needs it (the cache is content-addressed by `image_hash`).
+/// Drop every cached clean instance-mem backing. Diagnostic-only: correctness
+/// never needs it because the cache is content-addressed by `image_hash`.
 pub fn evict_mem_cache() {
     MEM_CACHE.lock().clear();
 }

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1149,6 +1149,15 @@ impl KernelTask {
 
         Ok(TaskPoll::Pending)
     }
+
+    fn run_to_completion(&mut self) -> Result<LoopOutcome, u32> {
+        loop {
+            match self.poll_once()? {
+                TaskPoll::Pending => {}
+                TaskPoll::Done(outcome) => return Ok(outcome),
+            }
+        }
+    }
 }
 
 /// Cooperative per-lane scheduler: many task stacks can be resident for one
@@ -1283,10 +1292,13 @@ pub fn run_top_on_lane(
     args: [u64; 4],
     initial_gas: i64,
 ) -> Result<LoopOutcome, u32> {
-    with_lane_scheduler(lane, |scheduler| {
-        let task = scheduler.submit_invoke(instance_hash, endpoint_idx, args, initial_gas)?;
-        scheduler.run_until_result(task)
-    })
+    // The production ABI submits exactly one top-level invoke per worker/lane
+    // call. Drive that task directly so the hot CALL/HALT path does not pay the
+    // cooperative scheduler's map/queue churn on every ring-3 exit. The
+    // scheduler stays available for the test-only two-task probe below and for
+    // future batch/async guest entry points.
+    let mut task = KernelTask::new(0, lane, instance_hash, endpoint_idx, args, initial_gas)?;
+    task.run_to_completion()
 }
 
 #[doc(hidden)]

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -103,7 +103,7 @@ use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
 use crate::cached_cap::{CachedCap, CapCache, InstanceCache, ResidentCNode, ResidentInstance};
-use crate::jit_run::{self, ExitInfo, FrameRuntime};
+use crate::jit_run::{self, ExecutionLane, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
 
@@ -741,6 +741,7 @@ enum TaskPoll {
 /// one task-local gas bank, and one monotonic Instance id allocator.
 struct KernelTask {
     id: TaskId,
+    lane: ExecutionLane,
     stack: Vec<StackEntry>,
     next_iid: u64,
     gas_state: TaskGasState,
@@ -749,6 +750,7 @@ struct KernelTask {
 impl KernelTask {
     fn new(
         id: TaskId,
+        lane: ExecutionLane,
         instance_hash: &CapHash,
         endpoint_idx: u32,
         args: [u64; 4],
@@ -769,6 +771,7 @@ impl KernelTask {
         let gas_state = TaskGasState::new(&stack[0].gas, initial_gas);
         Ok(Self {
             id,
+            lane,
             stack,
             next_iid,
             gas_state,
@@ -801,7 +804,7 @@ impl KernelTask {
         // — the same Instance, sharing one PC/regs/mem).
         let info = {
             let frame = frame_at_mut(&mut self.stack, top_idx);
-            run_one_entry(frame, self.gas_state.live_gas)?
+            run_one_entry(self.lane, frame, self.gas_state.live_gas)?
         };
         self.gas_state.live_gas = info.gas_remaining;
 
@@ -1153,6 +1156,7 @@ impl KernelTask {
 /// production batch/async submission API, and then split the ring3/JIT globals
 /// into per-vCPU execution lanes before true parallel scheduling.
 struct KernelScheduler {
+    lane: ExecutionLane,
     next_task_id: TaskId,
     tasks: BTreeMap<TaskId, KernelTask>,
     completed: BTreeMap<TaskId, LoopOutcome>,
@@ -1160,8 +1164,9 @@ struct KernelScheduler {
 }
 
 impl KernelScheduler {
-    fn new() -> Self {
+    fn new(lane: ExecutionLane) -> Self {
         Self {
+            lane,
             next_task_id: 0,
             tasks: BTreeMap::new(),
             completed: BTreeMap::new(),
@@ -1178,7 +1183,14 @@ impl KernelScheduler {
     ) -> Result<TaskId, u32> {
         let id = self.next_task_id;
         self.next_task_id += 1;
-        let task = KernelTask::new(id, instance_hash, endpoint_idx, args, initial_gas)?;
+        let task = KernelTask::new(
+            id,
+            self.lane,
+            instance_hash,
+            endpoint_idx,
+            args,
+            initial_gas,
+        )?;
         self.tasks.insert(id, task);
         self.ready.push_back(id);
         Ok(id)
@@ -1223,7 +1235,23 @@ pub fn run_top(
     args: [u64; 4],
     initial_gas: i64,
 ) -> Result<LoopOutcome, u32> {
-    let mut scheduler = KernelScheduler::new();
+    run_top_on_lane(
+        ExecutionLane::PRIMARY,
+        instance_hash,
+        endpoint_idx,
+        args,
+        initial_gas,
+    )
+}
+
+pub fn run_top_on_lane(
+    lane: ExecutionLane,
+    instance_hash: &CapHash,
+    endpoint_idx: u32,
+    args: [u64; 4],
+    initial_gas: i64,
+) -> Result<LoopOutcome, u32> {
+    let mut scheduler = KernelScheduler::new(lane);
     let task = scheduler.submit_invoke(instance_hash, endpoint_idx, args, initial_gas)?;
     scheduler.run_until_result(task)
 }
@@ -1233,7 +1261,7 @@ pub fn run_two_for_test(
     first: &nub_arch_x86_abi::InvokePacket,
     second: &nub_arch_x86_abi::InvokePacket,
 ) -> Result<(LoopOutcome, LoopOutcome), u32> {
-    let mut scheduler = KernelScheduler::new();
+    let mut scheduler = KernelScheduler::new(ExecutionLane::PRIMARY);
     let first_id = scheduler.submit_invoke(
         &first.instance_hash,
         first.endpoint_idx,
@@ -1257,9 +1285,9 @@ pub fn run_two_for_test(
 /// evicted, so it is built exactly once per frame. Frame mem + `mat_state`
 /// persist across re-entries — the parent's writes and gas history survive
 /// the child's execution.
-fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
+fn run_one_entry(lane: ExecutionLane, frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
     if frame.runtime.is_none() {
-        let rt = build_runtime(frame)?;
+        let rt = build_runtime(lane, frame)?;
         frame.runtime = Some(rt);
     }
     let pc = frame.instance.pc as u32;
@@ -1276,6 +1304,7 @@ fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
     let rt = frame.runtime.as_mut().expect("just built");
     let info = unsafe {
         jit_run::enter_frame(
+            lane,
             rt,
             gas,
             pc,
@@ -1299,7 +1328,7 @@ fn run_one_entry(frame: &mut KernelFrame, gas: i64) -> Result<ExitInfo, u32> {
 /// `DIRECTORY` lock scope. The PAs installed in the PT stay valid
 /// for the frame's lifetime per the V1 invariant (no eviction mid-
 /// RPC) even after this function returns and the guard is dropped.
-fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
+fn build_runtime(lane: ExecutionLane, frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // CacheDirectory is interior-mutable; each `get` takes the inner
     // spin::Mutex briefly and returns an `Arc<CachedCap>`. We keep the Arc
     // locals alive for the duration of the function so any borrowed
@@ -1378,6 +1407,7 @@ fn build_runtime(frame: &KernelFrame) -> Result<FrameRuntime, u32> {
     // the no-eviction V1 invariant.
     unsafe {
         jit_run::build_frame_runtime(
+            lane,
             &img_arc,
             &frame.instance.image_hash,
             code_bytes,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1294,22 +1294,23 @@ pub fn run_two_for_test(
     first: &nub_arch_x86_abi::InvokePacket,
     second: &nub_arch_x86_abi::InvokePacket,
 ) -> Result<(LoopOutcome, LoopOutcome), u32> {
-    let mut scheduler = KernelScheduler::new(ExecutionLane::PRIMARY);
-    let first_id = scheduler.submit_invoke(
-        &first.instance_hash,
-        first.endpoint_idx,
-        first.args,
-        first.initial_gas as i64,
-    )?;
-    let second_id = scheduler.submit_invoke(
-        &second.instance_hash,
-        second.endpoint_idx,
-        second.args,
-        second.initial_gas as i64,
-    )?;
-    let first_outcome = scheduler.run_until_result(first_id)?;
-    let second_outcome = scheduler.run_until_result(second_id)?;
-    Ok((first_outcome, second_outcome))
+    with_lane_scheduler(ExecutionLane::PRIMARY, |scheduler| {
+        let first_id = scheduler.submit_invoke(
+            &first.instance_hash,
+            first.endpoint_idx,
+            first.args,
+            first.initial_gas as i64,
+        )?;
+        let second_id = scheduler.submit_invoke(
+            &second.instance_hash,
+            second.endpoint_idx,
+            second.args,
+            second.initial_gas as i64,
+        )?;
+        let first_outcome = scheduler.run_until_result(first_id)?;
+        let second_outcome = scheduler.run_until_result(second_id)?;
+        Ok((first_outcome, second_outcome))
+    })
 }
 
 /// Run exactly one ring-3 cycle for `frame`. The first call on a

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -2042,7 +2042,7 @@ fn dispatch_host_yield(
     } else if k == javm_cap::yield_cap::YK_MINT_GAS {
         // kernel:mint_gas(φ8=meter_key byte, φ9=dst): mint a Gas{meter_key}
         // handle (pure-cap, like mint_yield). The meter mapping it indexes is
-        // managed separately (set_gas_meter / the host meter table).
+        // task-local and managed through set_gas_meter.
         mint_unit_handle(
             frame,
             javm_cap::gas_handle(&Key::from((frame.instance.regs[8] & 0xFF) as u8)),

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -1151,11 +1151,11 @@ impl KernelTask {
     }
 }
 
-/// Cooperative phase-1 scheduler: many task stacks can be resident, but exactly
-/// one is active on the single vCPU at any instant. Switching only happens at
-/// existing ring-3 exits. Later phases should keep the singleton host Nub, add a
-/// production batch/async submission API, and then split the ring3/JIT globals
-/// into per-vCPU execution lanes before true parallel scheduling.
+/// Cooperative per-lane scheduler: many task stacks can be resident for one
+/// execution lane, but exactly one task is active on that lane at any instant.
+/// Switching only happens at existing ring-3 exits. Multi-vCPU Hyperlight runs
+/// one worker per lane; cross-lane task migration and work stealing remain
+/// future scheduler work.
 struct KernelScheduler {
     lane: ExecutionLane,
     next_task_id: TaskId,

--- a/rust/nub-arch-x86/src/call_loop.rs
+++ b/rust/nub-arch-x86/src/call_loop.rs
@@ -103,7 +103,7 @@ use javm_cap::{CNodeCap, CapHash, DataCap, MissingOr, NUM_REGS};
 use nub_arch_x86_abi::SCRATCHPAD_HEAD_LEN;
 
 use crate::cached_cap::{CachedCap, CapCache, InstanceCache, ResidentCNode, ResidentInstance};
-use crate::execution_lane::ExecutionLane;
+use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 use crate::jit_run::{self, ExitInfo, FrameRuntime};
 use crate::paging;
 use crate::state_cache::CACHE;
@@ -1154,8 +1154,8 @@ impl KernelTask {
 /// Cooperative per-lane scheduler: many task stacks can be resident for one
 /// execution lane, but exactly one task is active on that lane at any instant.
 /// Switching only happens at existing ring-3 exits. Multi-vCPU Hyperlight runs
-/// one worker per lane; cross-lane task migration and work stealing remain
-/// future scheduler work.
+/// one worker per lane; each worker submits into its lane's persistent scheduler.
+/// Cross-lane task migration and work stealing remain future scheduler work.
 struct KernelScheduler {
     lane: ExecutionLane,
     next_task_id: TaskId,
@@ -1222,6 +1222,37 @@ impl KernelScheduler {
     }
 }
 
+struct LaneSchedulerCell {
+    scheduler: spin::Mutex<Option<KernelScheduler>>,
+}
+
+impl LaneSchedulerCell {
+    const fn new() -> Self {
+        Self {
+            scheduler: spin::Mutex::new(None),
+        }
+    }
+}
+
+// SAFETY: a `KernelScheduler` may contain live `FrameRuntime`s, which are
+// lane-affine raw page-table/JIT pointers and deliberately not `Send`. The static
+// table is indexed by lane, and the host owns each lane with exactly one KVM
+// worker thread; the spin lock guards accidental same-lane re-entry. We mark the
+// cell `Sync` without making the scheduler or runtime generally sendable.
+unsafe impl Sync for LaneSchedulerCell {}
+
+static LANE_SCHEDULERS: [LaneSchedulerCell; MAX_EXECUTION_LANES] =
+    [const { LaneSchedulerCell::new() }; MAX_EXECUTION_LANES];
+
+/// Guest-global lane scheduler table. The host owns each lane through one KVM
+/// worker, so the lock is a structural guard rather than a hot contention point.
+fn with_lane_scheduler<R>(lane: ExecutionLane, f: impl FnOnce(&mut KernelScheduler) -> R) -> R {
+    lane.assert_in_range();
+    let mut guard = LANE_SCHEDULERS[lane.index()].scheduler.lock();
+    let scheduler = guard.get_or_insert_with(|| KernelScheduler::new(lane));
+    f(scheduler)
+}
+
 /// Drive the CALL/HALT loop until either the top frame HALTs (clean
 /// exit) or the JIT signals an unrecoverable condition (page fault,
 /// gas exhaustion, ...). See module docs for the loop body.
@@ -1252,9 +1283,10 @@ pub fn run_top_on_lane(
     args: [u64; 4],
     initial_gas: i64,
 ) -> Result<LoopOutcome, u32> {
-    let mut scheduler = KernelScheduler::new(lane);
-    let task = scheduler.submit_invoke(instance_hash, endpoint_idx, args, initial_gas)?;
-    scheduler.run_until_result(task)
+    with_lane_scheduler(lane, |scheduler| {
+        let task = scheduler.submit_invoke(instance_hash, endpoint_idx, args, initial_gas)?;
+        scheduler.run_until_result(task)
+    })
 }
 
 #[doc(hidden)]

--- a/rust/nub-arch-x86/src/execution_lane.rs
+++ b/rust/nub-arch-x86/src/execution_lane.rs
@@ -1,0 +1,28 @@
+/// Maximum fixed execution lanes the guest runtime can address. The production
+/// default vCPU pool is capped at 8; this leaves room for explicit overrides
+/// while keeping lane-local hot state static and allocation-free.
+pub const MAX_EXECUTION_LANES: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExecutionLane {
+    index: usize,
+}
+
+impl ExecutionLane {
+    pub const PRIMARY: Self = Self { index: 0 };
+
+    pub const fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub const fn index(self) -> usize {
+        self.index
+    }
+
+    pub fn assert_in_range(self) {
+        assert!(
+            self.index < MAX_EXECUTION_LANES,
+            "execution lane index exceeds guest lane table"
+        );
+    }
+}

--- a/rust/nub-arch-x86/src/execution_lane.rs
+++ b/rust/nub-arch-x86/src/execution_lane.rs
@@ -1,7 +1,4 @@
-/// Maximum fixed execution lanes the guest runtime can address. The production
-/// default vCPU pool is capped at 8; this leaves room for explicit overrides
-/// while keeping lane-local hot state static and allocation-free.
-pub const MAX_EXECUTION_LANES: usize = 64;
+pub use nub_arch_x86_abi::MAX_EXECUTION_LANES;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ExecutionLane {

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -4,13 +4,17 @@
 //! automatically.
 
 use alloc::vec::Vec;
+use core::sync::atomic::Ordering;
 use hyperlight_guest_bin::guest_function;
 use javm_cap::cap::Cap;
 #[cfg(feature = "heap-diag")]
 use nub_arch_x86_abi::FN_ID_NUB_HEAP_STATS;
 use nub_arch_x86_abi::{
     BootInfo, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_GET_BOOT_INFO, FN_ID_NUB_INVOKE_CACHED,
-    FN_ID_NUB_PUT_CAP, InvocationResult, InvokePacket, SCRATCHPAD_HEAD_LEN,
+    FN_ID_NUB_INVOKE_WORKER, FN_ID_NUB_PUT_CAP, InvocationResult, InvokePacket,
+    PARALLEL_INVOKE_SLOT_BYTES, PARALLEL_INVOKE_STATUS_DONE, PARALLEL_INVOKE_STATUS_EMPTY,
+    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STOP,
+    ParallelInvokeSlot, SCRATCHPAD_HEAD_LEN,
 };
 
 fn encode_result_error(exit_arg: u32) -> Vec<u8> {
@@ -78,6 +82,95 @@ pub fn nub_invoke_cached(packet_bytes: &[u8]) -> Vec<u8> {
     rkyv::to_bytes::<rkyv::rancor::Error>(&result)
         .expect("rkyv-encode InvocationResult")
         .into_vec()
+}
+
+fn invocation_result_from_outcome(
+    outcome: Result<crate::call_loop::LoopOutcome, u32>,
+) -> InvocationResult {
+    match outcome {
+        Ok(o) => InvocationResult {
+            exit_reason: o.exit_reason,
+            exit_arg: o.exit_arg,
+            return_value: o.return_value,
+            gas_remaining: o.gas_remaining.max(0) as u64,
+            scratchpad_head: o.scratchpad_head,
+        },
+        Err(code) => InvocationResult {
+            exit_reason: u32::MAX,
+            exit_arg: code,
+            return_value: 0,
+            gas_remaining: 0,
+            scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+        },
+    }
+}
+
+fn parallel_slot_for_lane(lane: usize) -> Option<*mut ParallelInvokeSlot> {
+    let handle = unsafe { &*core::ptr::addr_of!(hyperlight_guest_bin::GUEST_HANDLE) };
+    let peb = handle.peb()?;
+    let output_ptr = unsafe { (*peb).output_stack.ptr as usize };
+    let output_size = unsafe { (*peb).output_stack.size as usize };
+    let base = output_ptr.checked_add(output_size)?;
+    let offset = lane.checked_mul(PARALLEL_INVOKE_SLOT_BYTES)?;
+    Some((base + offset) as *mut ParallelInvokeSlot)
+}
+
+/// Long-lived lane worker for the parallel invoke slot ABI. This function is
+/// started once per vCPU lane by the host and intentionally does not use the
+/// legacy rkyv response ring while running.
+#[guest_function(fn_id = FN_ID_NUB_INVOKE_WORKER)]
+pub fn nub_invoke_worker(payload: &[u8]) -> Vec<u8> {
+    if payload.len() != core::mem::size_of::<u32>() {
+        return Vec::new();
+    }
+    let lane =
+        u32::from_le_bytes(payload.try_into().expect("lane payload length checked")) as usize;
+    let Some(slot) = parallel_slot_for_lane(lane) else {
+        return Vec::new();
+    };
+    let lane = crate::execution_lane::ExecutionLane::new(lane);
+
+    loop {
+        let status = unsafe { (*slot).status.load(Ordering::Acquire) };
+        match status {
+            PARALLEL_INVOKE_STATUS_READY => {
+                let claimed = unsafe {
+                    (*slot).status.compare_exchange(
+                        PARALLEL_INVOKE_STATUS_READY,
+                        PARALLEL_INVOKE_STATUS_RUNNING,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                };
+                if claimed.is_err() {
+                    continue;
+                }
+                let packet = unsafe { core::ptr::addr_of!((*slot).packet).read_volatile() };
+                let outcome = crate::call_loop::run_top_on_lane(
+                    lane,
+                    &packet.instance_hash,
+                    packet.endpoint_idx,
+                    packet.args,
+                    packet.initial_gas as i64,
+                );
+                crate::state_cache::CACHE.sweep_instances();
+                let result = invocation_result_from_outcome(outcome);
+                unsafe {
+                    core::ptr::addr_of_mut!((*slot).result).write_volatile(result);
+                    (*slot)
+                        .status
+                        .store(PARALLEL_INVOKE_STATUS_DONE, Ordering::Release);
+                }
+            }
+            PARALLEL_INVOKE_STATUS_STOP => unsafe {
+                (*slot)
+                    .status
+                    .store(PARALLEL_INVOKE_STATUS_EMPTY, Ordering::Release);
+                return Vec::new();
+            },
+            _ => core::hint::spin_loop(),
+        }
+    }
 }
 
 /// Heap-resident cap-directory publisher. Validates the

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -183,7 +183,6 @@ pub fn nub_invoke_worker(payload: &[u8]) -> Vec<u8> {
                     continue;
                 }
                 crate::jit_cache::evict_all();
-                crate::call_loop::evict_mem_cache();
                 crate::state_cache::CACHE.sweep_instances();
                 unsafe {
                     core::ptr::addr_of_mut!((*slot).result).write_volatile(InvocationResult {
@@ -250,13 +249,12 @@ pub fn nub_put_cap(payload: &[u8]) -> Vec<u8> {
 /// next `nub_invoke_cached` call pays a full recompile. Empty
 /// payload, empty response. Not meant for production paths — the
 /// cache is content-addressed and re-compiling the same Image
-/// produces identical native code.
+/// produces identical native code. This intentionally leaves clean
+/// instance-memory memos intact; the cold bench target is "recompile +
+/// execute", not "rebuild every runtime memo".
 #[guest_function(fn_id = FN_ID_NUB_EVICT_JIT_ALL)]
 pub fn nub_evict_jit_all(_input: &[u8]) -> Vec<u8> {
     crate::jit_cache::evict_all();
-    // Drop the per-image clean-mem memo too, so a "cold" bench re-composes the
-    // instance backing rather than cloning a warm one.
-    crate::call_loop::evict_mem_cache();
     Vec::new()
 }
 

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -13,8 +13,8 @@ use nub_arch_x86_abi::{
     BootInfo, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_GET_BOOT_INFO, FN_ID_NUB_INVOKE_CACHED,
     FN_ID_NUB_INVOKE_WORKER, FN_ID_NUB_PUT_CAP, InvocationResult, InvokePacket,
     PARALLEL_INVOKE_SLOT_BYTES, PARALLEL_INVOKE_STATUS_DONE, PARALLEL_INVOKE_STATUS_EMPTY,
-    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STOP,
-    ParallelInvokeSlot, SCRATCHPAD_HEAD_LEN,
+    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING,
+    PARALLEL_INVOKE_STATUS_STOP, ParallelInvokeSlot, SCRATCHPAD_HEAD_LEN,
 };
 
 fn encode_result_error(exit_arg: u32) -> Vec<u8> {
@@ -129,6 +129,13 @@ pub fn nub_invoke_worker(payload: &[u8]) -> Vec<u8> {
         return Vec::new();
     };
     let lane = crate::execution_lane::ExecutionLane::new(lane);
+    unsafe {
+        if (*slot).status.load(Ordering::Acquire) == PARALLEL_INVOKE_STATUS_STARTING {
+            (*slot)
+                .status
+                .store(PARALLEL_INVOKE_STATUS_EMPTY, Ordering::Release);
+        }
+    }
 
     loop {
         let status = unsafe { (*slot).status.load(Ordering::Acquire) };

--- a/rust/nub-arch-x86/src/guest_prod.rs
+++ b/rust/nub-arch-x86/src/guest_prod.rs
@@ -13,8 +13,9 @@ use nub_arch_x86_abi::{
     BootInfo, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_GET_BOOT_INFO, FN_ID_NUB_INVOKE_CACHED,
     FN_ID_NUB_INVOKE_WORKER, FN_ID_NUB_PUT_CAP, InvocationResult, InvokePacket,
     PARALLEL_INVOKE_SLOT_BYTES, PARALLEL_INVOKE_STATUS_DONE, PARALLEL_INVOKE_STATUS_EMPTY,
-    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING,
-    PARALLEL_INVOKE_STATUS_STOP, ParallelInvokeSlot, SCRATCHPAD_HEAD_LEN,
+    PARALLEL_INVOKE_STATUS_EVICT_JIT_READY, PARALLEL_INVOKE_STATUS_READY,
+    PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING, PARALLEL_INVOKE_STATUS_STOP,
+    ParallelInvokeSlot, SCRATCHPAD_HEAD_LEN,
 };
 
 fn encode_result_error(exit_arg: u32) -> Vec<u8> {
@@ -164,6 +165,34 @@ pub fn nub_invoke_worker(payload: &[u8]) -> Vec<u8> {
                 let result = invocation_result_from_outcome(outcome);
                 unsafe {
                     core::ptr::addr_of_mut!((*slot).result).write_volatile(result);
+                    (*slot)
+                        .status
+                        .store(PARALLEL_INVOKE_STATUS_DONE, Ordering::Release);
+                }
+            }
+            PARALLEL_INVOKE_STATUS_EVICT_JIT_READY => {
+                let claimed = unsafe {
+                    (*slot).status.compare_exchange(
+                        PARALLEL_INVOKE_STATUS_EVICT_JIT_READY,
+                        PARALLEL_INVOKE_STATUS_RUNNING,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                };
+                if claimed.is_err() {
+                    continue;
+                }
+                crate::jit_cache::evict_all();
+                crate::call_loop::evict_mem_cache();
+                crate::state_cache::CACHE.sweep_instances();
+                unsafe {
+                    core::ptr::addr_of_mut!((*slot).result).write_volatile(InvocationResult {
+                        exit_reason: 0,
+                        exit_arg: 0,
+                        return_value: 0,
+                        gas_remaining: 0,
+                        scratchpad_head: [0u8; SCRATCHPAD_HEAD_LEN],
+                    });
                     (*slot)
                         .status
                         .store(PARALLEL_INVOKE_STATUS_DONE, Ordering::Release);

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -38,8 +38,9 @@ use javm_recompiler_x86::codegen::{CompileResult, Compiler, HelperFns};
 use javm_cap::CapHash;
 
 use crate::cached_cap::{CachedCap, CapCache};
+use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 use crate::page_alloc::PageBuf;
-use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
+use crate::paging::{PAGE_SIZE, Perm, Pml4SlotTemplate, TemplatePT};
 
 /// One cached Image's worth of compiled artifacts.
 ///
@@ -88,6 +89,38 @@ pub struct CompiledImage {
     /// Physical address of `template`'s PD page, cached for fast composition
     /// into a frame runtime's CTX | META | STACK slot template.
     pub template_pd_pa: u64,
+    /// Per-lane PML4 slot-1 templates joining that lane's CTX/STACK PDs with
+    /// this Image's META arena PD. Frame runtimes borrow the PDPT from here,
+    /// restoring the old one-PML4-write hot path without sharing CTX/STACK
+    /// scratch pages across vCPUs.
+    lane_slot_templates: Vec<Option<Pml4SlotTemplate>>,
+}
+
+impl CompiledImage {
+    #[allow(clippy::too_many_arguments)]
+    pub fn template_pdpt_pa_for_lane(
+        &mut self,
+        lane: ExecutionLane,
+        ctx_va: u64,
+        ctx_pd_pa: u64,
+        arena_base_va: u64,
+        stack_va: u64,
+        stack_pd_pa: u64,
+    ) -> Option<u64> {
+        lane.assert_in_range();
+        let slot = &mut self.lane_slot_templates[lane.index()];
+        if slot.is_none() {
+            *slot = Some(Pml4SlotTemplate::new(
+                ctx_va,
+                ctx_pd_pa,
+                arena_base_va,
+                self.template_pd_pa,
+                stack_va,
+                stack_pd_pa,
+            )?);
+        }
+        slot.as_ref()?.pdpt_pa()
+    }
 }
 
 static NEXT_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(1);
@@ -140,7 +173,7 @@ pub fn with_compiled_image<R>(
     ctx_va: u64,
     mem_cycles: u8,
     helpers: HelperFns,
-    f: impl FnOnce(&CompiledImage) -> R,
+    f: impl FnOnce(&mut CompiledImage) -> R,
 ) -> R {
     let mut cache = image_cap.cache.lock();
     if !matches!(&*cache, CapCache::Image(_)) {
@@ -154,7 +187,7 @@ pub fn with_compiled_image<R>(
             helpers,
         )));
     }
-    let CapCache::Image(compiled) = &*cache else {
+    let CapCache::Image(compiled) = &mut *cache else {
         unreachable!("image cache variant installed above")
     };
     f(compiled)
@@ -267,6 +300,8 @@ fn compile_image(
     let template_pd_pa = template
         .pd_pa()
         .expect("template PD must be in kernel half");
+    let mut lane_slot_templates = Vec::with_capacity(MAX_EXECUTION_LANES);
+    lane_slot_templates.resize_with(MAX_EXECUTION_LANES, || None);
 
     CompiledImage {
         arena,
@@ -280,5 +315,6 @@ fn compile_image(
         trap_table,
         template,
         template_pd_pa,
+        lane_slot_templates,
     }
 }

--- a/rust/nub-arch-x86/src/jit_cache.rs
+++ b/rust/nub-arch-x86/src/jit_cache.rs
@@ -39,19 +39,15 @@ use javm_cap::CapHash;
 
 use crate::cached_cap::{CachedCap, CapCache};
 use crate::page_alloc::PageBuf;
-use crate::paging::{PAGE_SIZE, Perm, Pml4SlotTemplate, TemplatePT};
+use crate::paging::{PAGE_SIZE, Perm, TemplatePT};
 
 /// One cached Image's worth of compiled artifacts.
 ///
 /// The arena holds DISPATCH / JIT / TRAMP regions contiguously,
 /// page-aligned. The `template` is a pre-built PD subtree (one PD + up to a
 /// handful of PT pages) whose leaf PTEs already point at the arena's pages
-/// with the right permissions. It is borrowed as the META entry of
-/// `pml4_slot_template` (the whole PML4 slot-1 PDPT, which also points
-/// CTX/STACK at the global shared pages); per-call page tables install that
-/// whole subtree with one
-/// [`PageTable::install_borrowed_pdpt`](crate::paging::PageTable::install_borrowed_pdpt)
-/// instead of running `pt.map` over the arena + CTX + STACK.
+/// with the right permissions. Per-frame runtimes compose this META PD with
+/// lane-local CTX/STACK PDs into their own small PML4 slot template.
 ///
 /// The `trap_table` is kept outside the arena — `jit_pf_handler` reads
 /// it via static atomics and never needs it mapped into ring-3.
@@ -86,19 +82,12 @@ pub struct CompiledImage {
     pub trap_table: Vec<(u32, u32, u32)>,
     /// Template PD subtree mapping the arena pages at per-call VAs. Owns the
     /// backing PD + PT pages (freed on image eviction — V1: effectively never);
-    /// its PD is borrowed as PDPT[META] by [`pml4_slot_template`] below.
+    /// its PD is borrowed as PDPT[META] by each frame runtime's slot template.
     #[allow(dead_code)]
     pub template: TemplatePT,
-    /// Template for the whole PML4 slot-1 subtree (PDPT covering CTX | META |
-    /// STACK). Per-call PTs install [`template_pdpt_pa`] into the PML4 with one
-    /// borrowed write ([`PageTable::install_borrowed_pdpt`](crate::paging::PageTable::install_borrowed_pdpt)),
-    /// avoiding per-frame CTX/STACK PDPT/PD/PT allocation. Owns the PDPT + the
-    /// CTX/STACK PD/PT pages (the META PD is owned by `template`).
-    #[allow(dead_code)]
-    pub pml4_slot_template: Pml4SlotTemplate,
-    /// Physical address of `pml4_slot_template`'s PDPT page, cached for fast
-    /// install on the per-call hot path.
-    pub template_pdpt_pa: u64,
+    /// Physical address of `template`'s PD page, cached for fast composition
+    /// into a frame runtime's CTX | META | STACK slot template.
+    pub template_pd_pa: u64,
 }
 
 static NEXT_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(1);
@@ -138,9 +127,9 @@ pub fn evict_all() {
 ///
 /// # Safety
 ///
-/// Hyperlight serialises host calls. The compiled artifact is boxed inside the
-/// resident `CachedCap`, so raw pointers into it remain stable as long as that
-/// cap cache is not evicted while frames are live.
+/// The compiled artifact is boxed inside the resident `CachedCap`, so raw
+/// pointers into it remain stable as long as that cap cache is not evicted
+/// while frame runtimes are live.
 #[allow(clippy::too_many_arguments)]
 pub fn with_compiled_image<R>(
     image_cap: &CachedCap,
@@ -149,9 +138,6 @@ pub fn with_compiled_image<R>(
     code_base: u32,
     arena_base_va: u64,
     ctx_va: u64,
-    stack_va: u64,
-    ctx_pd_pa: u64,
-    stack_pd_pa: u64,
     mem_cycles: u8,
     helpers: HelperFns,
     f: impl FnOnce(&CompiledImage) -> R,
@@ -164,9 +150,6 @@ pub fn with_compiled_image<R>(
             code_base,
             arena_base_va,
             ctx_va,
-            stack_va,
-            ctx_pd_pa,
-            stack_pd_pa,
             mem_cycles,
             helpers,
         )));
@@ -184,9 +167,6 @@ fn compile_image(
     code_base: u32,
     arena_base_va: u64,
     ctx_va: u64,
-    stack_va: u64,
-    ctx_pd_pa: u64,
-    stack_pd_pa: u64,
     mem_cycles: u8,
     helpers: HelperFns,
 ) -> CompiledImage {
@@ -288,23 +268,6 @@ fn compile_image(
         .pd_pa()
         .expect("template PD must be in kernel half");
 
-    // Build this Image's PML4 slot-1 PDPT once: CTX/STACK borrow the
-    // process-global CTX/STACK PD subtrees, META this Image's arena PD. The
-    // PDPT is the only table owned per Image; per-call PTs install it with a
-    // single borrowed PML4 write.
-    let pml4_slot_template = Pml4SlotTemplate::new(
-        ctx_va,
-        ctx_pd_pa,
-        arena_base_va,
-        template_pd_pa,
-        stack_va,
-        stack_pd_pa,
-    )
-    .expect("Pml4SlotTemplate alloc");
-    let template_pdpt_pa = pml4_slot_template
-        .pdpt_pa()
-        .expect("template PDPT must be in kernel half");
-
     CompiledImage {
         arena,
         dispatch_offset,
@@ -316,7 +279,6 @@ fn compile_image(
         exit_label_offset,
         trap_table,
         template,
-        pml4_slot_template,
-        template_pdpt_pa,
+        template_pd_pa,
     }
 }

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -113,16 +113,21 @@ static CTX_PAGE: GlobalPage = GlobalPage::new();
 static STACK_PAGE: GlobalPage = GlobalPage::new();
 
 /// PD physical addresses of the process-global CTX / STACK 1 GiB PD subtrees
-/// (PD → PT → the shared CTX/STACK page above), built + leaked once and
+/// (PD -> PT -> the shared CTX/STACK page above), built + leaked once and
 /// borrowed as the CTX/STACK entries of *every* Image's `Pml4SlotTemplate`, so
-/// those identical tables are not duplicated per Image. Lazily resolved on
-/// first compile (single-threaded guest → a plain load/store suffices).
+/// those identical tables are not duplicated per Image.
 static CTX_PD_PA: AtomicU64 = AtomicU64::new(0);
 static STACK_PD_PA: AtomicU64 = AtomicU64::new(0);
+static GLOBAL_PD_INIT: spin::Mutex<()> = spin::Mutex::new(());
 
 /// Resolve a global CTX/STACK PD PA, building + leaking the PD subtree mapping
 /// `page_pa` at `va` on first call.
 fn global_pd_pa(slot: &AtomicU64, va: u64, page_pa: u64) -> u64 {
+    let cur = slot.load(Ordering::Acquire);
+    if cur != 0 {
+        return cur;
+    }
+    let _guard = GLOBAL_PD_INIT.lock();
     let cur = slot.load(Ordering::Acquire);
     if cur != 0 {
         return cur;

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -68,12 +68,95 @@ use javm_recompiler_x86::codegen::HelperFns;
 // Single-threaded (Hyperlight serialises calls), so unsynchronised
 // statics are safe — we use atomics for `&'static mut` avoidance only.
 
-static JIT_CODE_BASE: AtomicU64 = AtomicU64::new(0);
-static JIT_CODE_LEN: AtomicU64 = AtomicU64::new(0);
-static EXIT_LABEL_VA: AtomicU64 = AtomicU64::new(0);
-static TRAP_TABLE_PTR: AtomicPtr<(u32, u32, u32)> = AtomicPtr::new(core::ptr::null_mut());
-static TRAP_TABLE_LEN: AtomicU64 = AtomicU64::new(0);
-static CTX_KVA: AtomicU64 = AtomicU64::new(0);
+struct LaneJitState {
+    active_cr3: AtomicU64,
+    jit_code_base: AtomicU64,
+    jit_code_len: AtomicU64,
+    exit_label_va: AtomicU64,
+    trap_table_ptr: AtomicPtr<(u32, u32, u32)>,
+    trap_table_len: AtomicU64,
+    ctx_kva: AtomicU64,
+    mat_ranges_ptr: AtomicPtr<crate::call_loop::MatRange>,
+    mat_ranges_len: AtomicU64,
+    mat_zero_pa: AtomicU64,
+    mat_state_ptr: AtomicPtr<u8>,
+    mat_state_len: AtomicU64,
+    mat_data_base: AtomicU64,
+    mat_mem_top: AtomicU64,
+    mat_code_base: AtomicU64,
+    mat_code_top: AtomicU64,
+    mat_code_pa: AtomicU64,
+    mat_ro_units_sink: AtomicPtr<alloc::vec::Vec<u32>>,
+    overlay_sink: AtomicPtr<javm_cap::DataCap>,
+    active_pt_pml4_kva: AtomicU64,
+    owned_vec_ptr: AtomicU64,
+}
+
+impl LaneJitState {
+    const fn new() -> Self {
+        Self {
+            active_cr3: AtomicU64::new(0),
+            jit_code_base: AtomicU64::new(0),
+            jit_code_len: AtomicU64::new(0),
+            exit_label_va: AtomicU64::new(0),
+            trap_table_ptr: AtomicPtr::new(core::ptr::null_mut()),
+            trap_table_len: AtomicU64::new(0),
+            ctx_kva: AtomicU64::new(0),
+            mat_ranges_ptr: AtomicPtr::new(core::ptr::null_mut()),
+            mat_ranges_len: AtomicU64::new(0),
+            mat_zero_pa: AtomicU64::new(0),
+            mat_state_ptr: AtomicPtr::new(core::ptr::null_mut()),
+            mat_state_len: AtomicU64::new(0),
+            mat_data_base: AtomicU64::new(0),
+            mat_mem_top: AtomicU64::new(0),
+            mat_code_base: AtomicU64::new(0),
+            mat_code_top: AtomicU64::new(0),
+            mat_code_pa: AtomicU64::new(0),
+            mat_ro_units_sink: AtomicPtr::new(core::ptr::null_mut()),
+            overlay_sink: AtomicPtr::new(core::ptr::null_mut()),
+            active_pt_pml4_kva: AtomicU64::new(0),
+            owned_vec_ptr: AtomicU64::new(0),
+        }
+    }
+
+    fn clear(&self) {
+        self.active_cr3.store(0, Ordering::SeqCst);
+        self.trap_table_ptr
+            .store(core::ptr::null_mut(), Ordering::SeqCst);
+        self.trap_table_len.store(0, Ordering::SeqCst);
+        self.jit_code_len.store(0, Ordering::SeqCst);
+        self.mat_ranges_ptr
+            .store(core::ptr::null_mut(), Ordering::SeqCst);
+        self.mat_ranges_len.store(0, Ordering::SeqCst);
+        self.mat_zero_pa.store(0, Ordering::SeqCst);
+        self.mat_state_ptr
+            .store(core::ptr::null_mut(), Ordering::SeqCst);
+        self.mat_state_len.store(0, Ordering::SeqCst);
+        self.mat_mem_top.store(0, Ordering::SeqCst);
+        self.mat_code_top.store(0, Ordering::SeqCst);
+        self.mat_ro_units_sink
+            .store(core::ptr::null_mut(), Ordering::SeqCst);
+        self.overlay_sink
+            .store(core::ptr::null_mut(), Ordering::SeqCst);
+        self.active_pt_pml4_kva.store(0, Ordering::SeqCst);
+        self.owned_vec_ptr.store(0, Ordering::SeqCst);
+    }
+}
+
+static LANE_JIT_STATE: [LaneJitState; MAX_EXECUTION_LANES] =
+    [const { LaneJitState::new() }; MAX_EXECUTION_LANES];
+
+fn lane_jit_state(lane: ExecutionLane) -> &'static LaneJitState {
+    lane.assert_in_range();
+    &LANE_JIT_STATE[lane.index()]
+}
+
+fn current_cr3_jit_state() -> Option<&'static LaneJitState> {
+    let cr3 = crate::paging::read_cr3();
+    LANE_JIT_STATE
+        .iter()
+        .find(|state| state.active_cr3.load(Ordering::SeqCst) == cr3)
+}
 static LAST_GLOBAL_ARENA_TOKEN: [AtomicU64; MAX_EXECUTION_LANES] =
     [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
 static LAST_GLOBAL_ARENA_PAGES: [AtomicU64; MAX_EXECUTION_LANES] =
@@ -141,61 +224,6 @@ fn global_pd_pa(slot: &AtomicU64, va: u64, page_pa: u64) -> u64 {
     pa
 }
 
-static MAT_RANGES_PTR: AtomicPtr<crate::call_loop::MatRange> =
-    AtomicPtr::new(core::ptr::null_mut());
-static MAT_RANGES_LEN: AtomicU64 = AtomicU64::new(0);
-/// Physical address of the process-global shared zero page ([`ZERO_PAGE`]) — the
-/// source an `Empty` (absent / zero) data page resolves to (mapped RO on read,
-/// CoW-from-zero on write). Republished each `enter_frame` so the #PF handler
-/// reads it with one atomic load. Per-page cap source PAs are resolved **lazily**
-/// on fault from the frame's `mem` DataCap (see [`mem_source_pa`]); there is no
-/// eager per-page PA arena, so demand paging materializes only touched pages.
-static MAT_ZERO_PA: AtomicU64 = AtomicU64::new(0);
-/// Per-page [`javm_exec::mat::PageState`] (one byte/page), len =
-/// `(mem_top - data_base) / PAGE_SIZE`. Mutated in place by the handler.
-static MAT_STATE_PTR: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
-static MAT_STATE_LEN: AtomicU64 = AtomicU64::new(0);
-/// Guest VA bounds of the lazily-materialized data extent.
-static MAT_DATA_BASE: AtomicU64 = AtomicU64::new(0);
-static MAT_MEM_TOP: AtomicU64 = AtomicU64::new(0);
-/// Read-only CODE region `[code_base, code_top)` (page-rounded). A
-/// `PinnedCapRo` region: guest PIC data reads page each touched code page
-/// in RO on first read (charging #3 page-in, identical to the interp),
-/// writes hard-fault. `MAT_CODE_PA` is the source PA of code page 0.
-static MAT_CODE_BASE: AtomicU64 = AtomicU64::new(0);
-static MAT_CODE_TOP: AtomicU64 = AtomicU64::new(0);
-static MAT_CODE_PA: AtomicU64 = AtomicU64::new(0);
-/// Per-2 MiB-cluster materialization flag for **read-only** regions, namely
-/// code and `PinnedCapRo` data caps, indexed by absolute cluster
-/// ([`javm_exec::mat::cluster_of`]). The first RO fault in a cluster pays
-/// one `page_in` and fault-arounds the cluster's RO pages; the interpreter
-/// tracks the same per-cluster flag, so both charge a cluster exactly once.
-/// Materialized read-only **units** — pointer to the running frame's sorted
-/// `Vec<u32>` of [`javm_exec::mat::unit_base`] values (one per `cap ∩ 2 MiB
-/// cluster` paged in). The handler binary-searches/inserts here so each RO
-/// unit is charged one `page_in` exactly once, matching the interpreter. A
-/// `Vec` (not a fixed bitmap) because the unit set is keyed by `unit_base`,
-/// not a dense cluster index, and it grows in the handler (realloc-safe via
-/// the `&mut Vec` indirection, like `OVERLAY_SINK`'s `&mut DataCap`).
-static MAT_RO_UNITS_SINK: AtomicPtr<alloc::vec::Vec<u32>> = AtomicPtr::new(core::ptr::null_mut());
-/// Pointer to the running frame's `mem` DataCap (`KernelFrame.mem`). The #PF
-/// handler copy-on-writes each guest write into a fresh page and inserts it
-/// into this cap's `overlay` (keyed by data-extent page index) — so the cap
-/// carries the frame's writes across any future runtime reclamation (host-backed
-/// swap: a rebuilt runtime sources the overlay page, not the immutable backing)
-/// and, in Phase 3, a frame-to-frame move at HALT. Re-published every
-/// `enter_frame`. The Arc
-/// pointee of each inserted page is address-stable across `BTreeMap` realloc,
-/// so the PA mapped into the guest PT stays valid (same guarantee the old
-/// per-frame dirty-page `Vec` relied on).
-static OVERLAY_SINK: AtomicPtr<javm_cap::DataCap> = AtomicPtr::new(core::ptr::null_mut());
-static ACTIVE_PT_PML4_KVA: AtomicU64 = AtomicU64::new(0);
-/// Type-erased pointer ([`crate::paging::PageTable::owned_vec_ptr`]) to
-/// the active PT's `owned` table list — the handler's `pt_map_leaf`
-/// records fault-allocated intermediate tables here (freed at `Drop`),
-/// enabling true zero-setup demand paging (PML4[0] empty at entry).
-static OWNED_VEC_PTR: AtomicU64 = AtomicU64::new(0);
-
 /// Hyperlight-chained #PF handler. Fires AFTER Hyperlight's own
 /// stack-growth handler has declined to handle the fault.
 ///
@@ -215,17 +243,20 @@ fn jit_pf_handler(
     ctx: *mut Context,
     gva: u64,
 ) -> bool {
+    let Some(state) = current_cr3_jit_state() else {
+        return false;
+    };
     // SAFETY: Hyperlight passes a valid pointer to the iretq frame.
     let saved_rip = unsafe { (&raw const (*info).rip).read_volatile() };
-    let code_base = JIT_CODE_BASE.load(Ordering::SeqCst);
-    let code_len = JIT_CODE_LEN.load(Ordering::SeqCst);
+    let code_base = state.jit_code_base.load(Ordering::SeqCst);
+    let code_len = state.jit_code_len.load(Ordering::SeqCst);
     if code_len == 0 || saved_rip < code_base || saved_rip >= code_base + code_len {
         return false;
     }
 
     // Resolve the faulting PVM PC + access width from the trap table.
     let offset = (saved_rip - code_base) as u32;
-    let (pvm_pc, width) = trap_lookup(offset);
+    let (pvm_pc, width) = trap_lookup(state, offset);
 
     // Category #3: try lazy materialization (page-in / CoW) of the
     // faulting access's page set, charging gas. The error code's write
@@ -234,13 +265,13 @@ fn jit_pf_handler(
     // SAFETY: `info` is the valid iretq frame Hyperlight passed.
     let error_code = unsafe { (&raw const (*info).error_code).read_volatile() };
     let is_write = (error_code & 0x2) != 0;
-    if width != 0 && try_materialize(gva, width, is_write, ctx) {
+    if width != 0 && try_materialize(state, gva, width, is_write, ctx) {
         return true;
     }
 
     // Not materializable (outside the declared region, or a write to a
     // pinned read-only page) → a PVM-level PageFault, charging nothing.
-    let ctx_kva = CTX_KVA.load(Ordering::SeqCst);
+    let ctx_kva = state.ctx_kva.load(Ordering::SeqCst);
     // SAFETY: ctx_kva is the kernel VA of the JitContext page for the
     // current invocation; valid while the handler runs.
     unsafe {
@@ -250,7 +281,7 @@ fn jit_pf_handler(
         (*jc).pc = pvm_pc;
     }
 
-    let exit_va = EXIT_LABEL_VA.load(Ordering::SeqCst);
+    let exit_va = state.exit_label_va.load(Ordering::SeqCst);
     // SAFETY: info is a valid pointer to a writable iretq frame.
     unsafe {
         (&raw mut (*info).rip).write_volatile(exit_va);
@@ -261,9 +292,9 @@ fn jit_pf_handler(
 /// Resolve a faulting native offset to its `(pvm_pc, access_width)` via
 /// the trap table. Returns `(0, 0)` when no entry covers the offset
 /// (not a guest memory op → width 0 → caller treats as a PageFault).
-fn trap_lookup(offset: u32) -> (u32, u32) {
-    let tt_ptr = TRAP_TABLE_PTR.load(Ordering::SeqCst);
-    let tt_len = TRAP_TABLE_LEN.load(Ordering::SeqCst) as usize;
+fn trap_lookup(state: &LaneJitState, offset: u32) -> (u32, u32) {
+    let tt_ptr = state.trap_table_ptr.load(Ordering::SeqCst);
+    let tt_len = state.trap_table_len.load(Ordering::SeqCst) as usize;
     if tt_ptr.is_null() || tt_len == 0 {
         return (0, 0);
     }
@@ -295,9 +326,9 @@ fn mat_range_for_in(
 /// Find the cap-backed [`crate::call_loop::MatRange`] covering page
 /// `page_va` (page-aligned) in the running frame's published `mat_ranges`, or
 /// `None` for an ephemeral page.
-fn mat_range_for(page_va: u32) -> Option<crate::call_loop::MatRange> {
-    let ptr = MAT_RANGES_PTR.load(Ordering::SeqCst);
-    let len = MAT_RANGES_LEN.load(Ordering::SeqCst) as usize;
+fn mat_range_for(state: &LaneJitState, page_va: u32) -> Option<crate::call_loop::MatRange> {
+    let ptr = state.mat_ranges_ptr.load(Ordering::SeqCst);
+    let len = state.mat_ranges_len.load(Ordering::SeqCst) as usize;
     if ptr.is_null() || len == 0 {
         return None;
     }
@@ -318,16 +349,21 @@ fn mat_range_for(page_va: u32) -> Option<crate::call_loop::MatRange> {
 /// Reading `mem` through `OVERLAY_SINK` is sound: the guest is single-threaded,
 /// and this shared read returns a `u64` (the borrow ends) before any `&mut`
 /// write to the same cap in [`cow_into_fresh`].
-fn mem_source_pa(page_va: u64) -> Option<u64> {
-    let data_base = MAT_DATA_BASE.load(Ordering::SeqCst);
-    let sink = OVERLAY_SINK.load(Ordering::SeqCst);
+fn mem_source_pa(state: &LaneJitState, page_va: u64) -> Option<u64> {
+    let data_base = state.mat_data_base.load(Ordering::SeqCst);
+    let sink = state.overlay_sink.load(Ordering::SeqCst);
     if sink.is_null() {
         return None;
     }
     // SAFETY: OVERLAY_SINK is the running frame's `mem` DataCap, exclusively
     // ours under Hyperlight serialisation; borrowed read-only here.
     let mem = unsafe { &*sink };
-    mem_source_pa_in(mem, data_base, page_va, MAT_ZERO_PA.load(Ordering::SeqCst))
+    mem_source_pa_in(
+        mem,
+        data_base,
+        page_va,
+        state.mat_zero_pa.load(Ordering::SeqCst),
+    )
 }
 
 /// Core of [`mem_source_pa`] over an explicit `mem` / `data_base` / `zero_pa`.
@@ -354,8 +390,8 @@ fn mem_source_pa_in(
 /// on an already-private page (its leaf re-armed read-only at the previous
 /// HALT) only needs its leaf W bit flipped back, whereas a write to a shared
 /// backing page must CoW a fresh private copy.
-fn overlay_has_page(page_va: u64, data_base: u64) -> bool {
-    let sink = OVERLAY_SINK.load(Ordering::SeqCst);
+fn overlay_has_page(state: &LaneJitState, page_va: u64, data_base: u64) -> bool {
+    let sink = state.overlay_sink.load(Ordering::SeqCst);
     if sink.is_null() {
         return false;
     }
@@ -376,8 +412,8 @@ enum RoSrc {
 /// The static [`javm_exec::mat::PageKind`] of guest page `page_va`:
 /// cap-backed pages take their kind from the matching `MatRange`; every
 /// other page in the declared extent is ephemeral.
-fn page_kind(page_va: u32) -> javm_exec::mat::PageKind {
-    match mat_range_for(page_va) {
+fn page_kind(state: &LaneJitState, page_va: u32) -> javm_exec::mat::PageKind {
+    match mat_range_for(state, page_va) {
         Some(r) => javm_exec::mat::PageKind::from_u8(r.kind)
             .unwrap_or(javm_exec::mat::PageKind::PinnedCapRo),
         None => javm_exec::mat::PageKind::EphemeralZero,
@@ -397,14 +433,20 @@ fn page_kind(page_va: u32) -> javm_exec::mat::PageKind {
 /// page — the caller then raises a PVM PageFault. Uses the *same*
 /// [`javm_exec::mat`] state machine + page-set rule as the interpreter,
 /// so both engines charge bit-identically (gas-cost.md §3).
-fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> bool {
-    let data_base = MAT_DATA_BASE.load(Ordering::SeqCst);
-    let mem_top = MAT_MEM_TOP.load(Ordering::SeqCst);
-    let code_base = MAT_CODE_BASE.load(Ordering::SeqCst);
-    let code_top = MAT_CODE_TOP.load(Ordering::SeqCst);
-    let code_pa = MAT_CODE_PA.load(Ordering::SeqCst);
-    let pml4 = ACTIVE_PT_PML4_KVA.load(Ordering::SeqCst);
-    let owned_vec = OWNED_VEC_PTR.load(Ordering::SeqCst);
+fn try_materialize(
+    state: &LaneJitState,
+    gva: u64,
+    width: u32,
+    is_write: bool,
+    ctx: *mut Context,
+) -> bool {
+    let data_base = state.mat_data_base.load(Ordering::SeqCst);
+    let mem_top = state.mat_mem_top.load(Ordering::SeqCst);
+    let code_base = state.mat_code_base.load(Ordering::SeqCst);
+    let code_top = state.mat_code_top.load(Ordering::SeqCst);
+    let code_pa = state.mat_code_pa.load(Ordering::SeqCst);
+    let pml4 = state.active_pt_pml4_kva.load(Ordering::SeqCst);
+    let owned_vec = state.owned_vec_ptr.load(Ordering::SeqCst);
     if pml4 == 0 || owned_vec == 0 {
         return false;
     }
@@ -437,7 +479,9 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
             }
         } else {
             // DATA region: every page must be a data page; pinned write faults.
-            if !in_data(pv) || (is_write && page_kind(p) == javm_exec::mat::PageKind::PinnedCapRo) {
+            if !in_data(pv)
+                || (is_write && page_kind(state, p) == javm_exec::mat::PageKind::PinnedCapRo)
+            {
                 return false;
             }
         }
@@ -445,9 +489,9 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
 
     // Per-region state arrays. Null only when a region is undeclared, in
     // which case no page of `set` lies in it (guarded by in_code/in_data).
-    let dstate_ptr = MAT_STATE_PTR.load(Ordering::SeqCst);
-    let dstate_len = MAT_STATE_LEN.load(Ordering::SeqCst) as usize;
-    let ro_units_ptr = MAT_RO_UNITS_SINK.load(Ordering::SeqCst);
+    let dstate_ptr = state.mat_state_ptr.load(Ordering::SeqCst);
+    let dstate_len = state.mat_state_len.load(Ordering::SeqCst) as usize;
+    let ro_units_ptr = state.mat_ro_units_sink.load(Ordering::SeqCst);
     // SAFETY: each ptr describes the running FrameRuntime's state
     // (single-threaded → exclusive); empty slice / scratch Vec if undeclared.
     let dstate: &mut [u8] = if dstate_ptr.is_null() {
@@ -475,7 +519,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
             // Code is a single contiguous slab: page PA = code_pa + offset.
             Some((code_base, code_top, RoSrc::Contig { base_pa: code_pa }))
         } else {
-            match mat_range_for(p) {
+            match mat_range_for(state, p) {
                 Some(r) if r.kind == javm_exec::mat::PageKind::PinnedCapRo.as_u8() => {
                     Some((r.start as u64, r.end as u64, RoSrc::Mem))
                 }
@@ -483,7 +527,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
             }
         };
         if let Some((r_start, r_end, src)) = ro_range {
-            match materialize_ro_unit(pv, r_start, r_end, src, ro_units, pml4, owned_vec) {
+            match materialize_ro_unit(state, pv, r_start, r_end, src, ro_units, pml4, owned_vec) {
                 Some(c) => total = total.saturating_add(c),
                 None => return false,
             }
@@ -497,7 +541,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
         // in-data, so it faults.
         let idx = ((pv - data_base) / PAGE_SIZE as u64) as usize;
         let cur = javm_exec::mat::PageState::from_u8(dstate[idx]);
-        let kind = match mat_range_for(p) {
+        let kind = match mat_range_for(state, p) {
             Some(r) => javm_exec::mat::PageKind::from_u8(r.kind)
                 .unwrap_or(javm_exec::mat::PageKind::PinnedCapRo),
             None => return false,
@@ -511,7 +555,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
                 if cur == javm_exec::mat::PageState::NotPresent {
                     // Page-in: map the page RO at its source PA (resolved lazily
                     // from the frame's `mem`; `None`/`Missing` → fault).
-                    let Some(src_pa) = mem_source_pa(pv) else {
+                    let Some(src_pa) = mem_source_pa(state, pv) else {
                         return false;
                     };
                     // SAFETY: live PT, single writer; builds the path.
@@ -551,7 +595,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
                     // overlay, so it correctly falls through to a real CoW.) The
                     // RO translation may be TLB-cached by the faulting write, so
                     // invlpg after the flip.
-                    let flipped = overlay_has_page(pv, data_base)
+                    let flipped = overlay_has_page(state, pv, data_base)
                         && unsafe { crate::paging::pt_set_leaf_w(pml4, pv, true) };
                     if flipped {
                         crate::paging::invlpg(pv);
@@ -566,10 +610,10 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
                         // `Loaded` cap slab, or the shared zero page for an
                         // ephemeral page (so the CoW yields a fresh zeroed page).
                         // `None` (a `Missing` page) → fault.
-                        let Some(src_pa) = mem_source_pa(pv) else {
+                        let Some(src_pa) = mem_source_pa(state, pv) else {
                             return false;
                         };
-                        if !cow_into_fresh(pv, src_pa, pml4, owned_vec, data_base, flush) {
+                        if !cow_into_fresh(state, pv, src_pa, pml4, owned_vec, data_base, flush) {
                             // Allocation / remap failure → fault (nothing charged
                             // yet for THIS page, but earlier pages of a straddle
                             // were already advanced; an OOM here is fatal anyway).
@@ -614,6 +658,7 @@ fn try_materialize(gva: u64, width: u32, is_write: bool, ctx: *mut Context) -> b
 /// CoW, where the page was mapped RO and may be cached); a first-touch write
 /// (the page was `NotPresent`) needs no flush.
 fn cow_into_fresh(
+    state: &LaneJitState,
     page_va: u64,
     src_pa: u64,
     pml4: u64,
@@ -653,7 +698,7 @@ fn cow_into_fresh(
         crate::paging::invlpg(page_va);
     }
 
-    let sink_ptr = OVERLAY_SINK.load(Ordering::SeqCst);
+    let sink_ptr = state.overlay_sink.load(Ordering::SeqCst);
     if !sink_ptr.is_null() {
         // SAFETY: sink_ptr is the running frame's `mem` DataCap, re-published
         // each enter_frame; exclusively ours (single-threaded) for the
@@ -684,7 +729,9 @@ fn cow_into_fresh(
 /// No `invlpg`: every page mapped here goes `NotPresent → present`, which is
 /// not TLB-cached, so the faulting retry walks the fresh entries. Returns
 /// `Some(0)` on success, or `None` on a page-table allocation failure.
+#[allow(clippy::too_many_arguments)]
 fn materialize_ro_unit(
+    state: &LaneJitState,
     pv: u64,
     r_start: u64,
     r_end: u64,
@@ -711,7 +758,7 @@ fn materialize_ro_unit(
         // cap's pages each resolve their own slab PA lazily from the frame mem.
         let page_pa = match &src {
             RoSrc::Contig { base_pa } => base_pa + (q - r_start),
-            RoSrc::Mem => mem_source_pa(q)?,
+            RoSrc::Mem => mem_source_pa(state, q)?,
         };
         // SAFETY: live PT, single writer; builds the path (zero-setup).
         unsafe {
@@ -1090,29 +1137,55 @@ pub unsafe fn enter_frame(
     // current vCPU worker.
     unsafe { ring3::prepare_ring3_entry(lane) };
 
-    JIT_CODE_BASE.store(rt.jit_va, Ordering::SeqCst);
-    JIT_CODE_LEN.store(rt.jit_size, Ordering::SeqCst);
-    EXIT_LABEL_VA.store(rt.exit_label_va, Ordering::SeqCst);
-    TRAP_TABLE_PTR.store(rt.trap_table_ptr as *mut (u32, u32, u32), Ordering::SeqCst);
-    TRAP_TABLE_LEN.store(rt.trap_table_len, Ordering::SeqCst);
-    CTX_KVA.store(ctx_kva, Ordering::SeqCst);
-    MAT_RANGES_PTR.store(
+    let state = lane_jit_state(lane);
+    state.clear();
+    state.jit_code_base.store(rt.jit_va, Ordering::SeqCst);
+    state.jit_code_len.store(rt.jit_size, Ordering::SeqCst);
+    state
+        .exit_label_va
+        .store(rt.exit_label_va, Ordering::SeqCst);
+    state
+        .trap_table_ptr
+        .store(rt.trap_table_ptr as *mut (u32, u32, u32), Ordering::SeqCst);
+    state
+        .trap_table_len
+        .store(rt.trap_table_len, Ordering::SeqCst);
+    state.ctx_kva.store(ctx_kva, Ordering::SeqCst);
+    state.mat_ranges_ptr.store(
         rt.mat_ranges.as_ptr() as *mut crate::call_loop::MatRange,
         Ordering::SeqCst,
     );
-    MAT_RANGES_LEN.store(rt.mat_ranges.len() as u64, Ordering::SeqCst);
-    MAT_ZERO_PA.store(ZERO_PAGE.pa(), Ordering::SeqCst);
-    MAT_STATE_PTR.store(mat_state_ptr, Ordering::SeqCst);
-    MAT_STATE_LEN.store(mat_state_len, Ordering::SeqCst);
-    MAT_DATA_BASE.store(rt.data_base as u64, Ordering::SeqCst);
-    MAT_MEM_TOP.store(rt.mem_top as u64, Ordering::SeqCst);
-    MAT_CODE_BASE.store(rt.code_base as u64, Ordering::SeqCst);
-    MAT_CODE_TOP.store(rt.code_top as u64, Ordering::SeqCst);
-    MAT_CODE_PA.store(rt.code_pa, Ordering::SeqCst);
-    MAT_RO_UNITS_SINK.store(ro_units, Ordering::SeqCst);
-    OVERLAY_SINK.store(overlay_sink, Ordering::SeqCst);
-    ACTIVE_PT_PML4_KVA.store(rt.pt.pml4_kva(), Ordering::SeqCst);
-    OWNED_VEC_PTR.store(rt.pt.owned_vec_ptr(), Ordering::SeqCst);
+    state
+        .mat_ranges_len
+        .store(rt.mat_ranges.len() as u64, Ordering::SeqCst);
+    state.mat_zero_pa.store(ZERO_PAGE.pa(), Ordering::SeqCst);
+    state.mat_state_ptr.store(mat_state_ptr, Ordering::SeqCst);
+    state.mat_state_len.store(mat_state_len, Ordering::SeqCst);
+    state
+        .mat_data_base
+        .store(rt.data_base as u64, Ordering::SeqCst);
+    state.mat_mem_top.store(rt.mem_top as u64, Ordering::SeqCst);
+    state
+        .mat_code_base
+        .store(rt.code_base as u64, Ordering::SeqCst);
+    state
+        .mat_code_top
+        .store(rt.code_top as u64, Ordering::SeqCst);
+    state.mat_code_pa.store(rt.code_pa, Ordering::SeqCst);
+    state.mat_ro_units_sink.store(ro_units, Ordering::SeqCst);
+    state.overlay_sink.store(overlay_sink, Ordering::SeqCst);
+    state
+        .active_pt_pml4_kva
+        .store(rt.pt.pml4_kva(), Ordering::SeqCst);
+    state
+        .owned_vec_ptr
+        .store(rt.pt.owned_vec_ptr(), Ordering::SeqCst);
+    // Publish the CR3 last: the #PF handler finds this lane by current CR3, so
+    // matching the CR3 implies every other field above is initialized.
+    state.active_cr3.store(rt.new_cr3, Ordering::SeqCst);
+    // Shared handler, lane-local state: leave the function installed across
+    // exits so one lane cannot clear another lane's #PF hook. The handler
+    // returns `false` for non-JIT CR3s.
     HANDLERS[14].store(jit_pf_handler as *const () as u64, Ordering::Release);
 
     crate::paging::enable_global_pages();
@@ -1123,21 +1196,7 @@ pub unsafe fn enter_frame(
     // new_cr3 carries kernel half.
     let _user_rax = unsafe { ring3::nub_enter_ring3(rt.tramp_va, user_stack_top, rt.new_cr3) };
 
-    HANDLERS[14].store(0, Ordering::Release);
-    TRAP_TABLE_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);
-    TRAP_TABLE_LEN.store(0, Ordering::SeqCst);
-    JIT_CODE_LEN.store(0, Ordering::SeqCst);
-    MAT_RANGES_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);
-    MAT_RANGES_LEN.store(0, Ordering::SeqCst);
-    MAT_ZERO_PA.store(0, Ordering::SeqCst);
-    MAT_STATE_PTR.store(core::ptr::null_mut(), Ordering::SeqCst);
-    MAT_STATE_LEN.store(0, Ordering::SeqCst);
-    MAT_MEM_TOP.store(0, Ordering::SeqCst);
-    MAT_CODE_TOP.store(0, Ordering::SeqCst);
-    MAT_RO_UNITS_SINK.store(core::ptr::null_mut(), Ordering::SeqCst);
-    OVERLAY_SINK.store(core::ptr::null_mut(), Ordering::SeqCst);
-    ACTIVE_PT_PML4_KVA.store(0, Ordering::SeqCst);
-    OWNED_VEC_PTR.store(0, Ordering::SeqCst);
+    state.clear();
 
     // Suppress unused-field warning: `pt` is referenced indirectly via
     // `new_cr3` (the PML4's PA) and kept alive by owning the page tables.

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -54,7 +54,7 @@ use crate::cached_cap::CachedCap;
 use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 use crate::jit_cache;
 use crate::page_alloc::GlobalPage;
-use crate::paging::{PAGE_SIZE, PageTable};
+use crate::paging::{PAGE_SIZE, PageTable, Pml4SlotTemplate};
 use crate::ring3;
 use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
@@ -64,9 +64,9 @@ use javm_recompiler_x86::codegen::HelperFns;
 // === Per-invocation context for the #PF handler ===========================
 //
 // Set by `enter_frame` immediately before `enter_ring3`, read by
-// `jit_pf_handler` if a #PF fires from inside the JIT'd code window.
-// Single-threaded (Hyperlight serialises calls), so unsynchronised
-// statics are safe — we use atomics for `&'static mut` avoidance only.
+// `jit_pf_handler` if a #PF fires from inside the JIT'd code window. The
+// handler finds the active lane by the current CR3, then reads that lane's
+// atomics; there is no process-global active frame.
 
 struct LaneJitState {
     active_cr3: AtomicU64,
@@ -195,20 +195,38 @@ static ZERO_PAGE: GlobalPage = GlobalPage::new();
 /// `dispatch_table`/`code_base`); the ring-3 stack is reset to its top every
 /// entry; `host_rsp_base` and the spilled x3/x4 are per-execution scratch the
 /// guest re-initialises. This removes the per-frame CTX + STACK `PageBuf`s.
-static CTX_PAGE: GlobalPage = GlobalPage::new();
-static STACK_PAGE: GlobalPage = GlobalPage::new();
+static CTX_PAGES: [GlobalPage; MAX_EXECUTION_LANES] =
+    [const { GlobalPage::new() }; MAX_EXECUTION_LANES];
+static STACK_PAGES: [GlobalPage; MAX_EXECUTION_LANES] =
+    [const { GlobalPage::new() }; MAX_EXECUTION_LANES];
 
-/// PD physical addresses of the process-global CTX / STACK 1 GiB PD subtrees
-/// (PD -> PT -> the shared CTX/STACK page above), built + leaked once and
-/// borrowed as the CTX/STACK entries of *every* Image's `Pml4SlotTemplate`, so
-/// those identical tables are not duplicated per Image.
-static CTX_PD_PA: AtomicU64 = AtomicU64::new(0);
-static STACK_PD_PA: AtomicU64 = AtomicU64::new(0);
+/// PD physical addresses of the lane-local CTX / STACK 1 GiB PD subtrees
+/// (PD -> PT -> the lane's CTX/STACK page), built + leaked once per lane and
+/// borrowed by every frame runtime assigned to that lane.
+static CTX_PD_PA: [AtomicU64; MAX_EXECUTION_LANES] =
+    [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
+static STACK_PD_PA: [AtomicU64; MAX_EXECUTION_LANES] =
+    [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
 static GLOBAL_PD_INIT: spin::Mutex<()> = spin::Mutex::new(());
 
 /// Resolve a global CTX/STACK PD PA, building + leaking the PD subtree mapping
 /// `page_pa` at `va` on first call.
-fn global_pd_pa(slot: &AtomicU64, va: u64, page_pa: u64) -> u64 {
+fn lane_page(
+    pages: &'static [GlobalPage; MAX_EXECUTION_LANES],
+    lane: ExecutionLane,
+) -> &'static GlobalPage {
+    lane.assert_in_range();
+    &pages[lane.index()]
+}
+
+fn lane_pd_pa(
+    slots: &'static [AtomicU64; MAX_EXECUTION_LANES],
+    lane: ExecutionLane,
+    va: u64,
+    page_pa: u64,
+) -> u64 {
+    lane.assert_in_range();
+    let slot = &slots[lane.index()];
     let cur = slot.load(Ordering::Acquire);
     if cur != 0 {
         return cur;
@@ -811,15 +829,15 @@ pub struct ExitInfo {
 /// PML4 slot so the per-Image template PT can own the META PD without
 /// colliding with the CTX/STACK PDs.
 ///
-/// CTX and STACK are process-global shared pages ([`CTX_PAGE`] /
-/// [`STACK_PAGE`]) mapped at the fixed VAs below in every frame's PT — only
-/// one frame runs in ring 3 at a time, so they need no per-call copy.
+/// CTX and STACK are lane-local pages mapped at the fixed VAs below in every
+/// frame's PT. A frame runtime owns the small PDPT that joins those lane-local
+/// pages with the per-Image META arena.
 ///
 /// ```text
 ///   PML4[1] (512..1024 GiB)
-///     PDPT[0] (512..513 GiB)  ← CTX, global shared page
+///     PDPT[0] (512..513 GiB)  ← CTX, lane-local page
 ///     PDPT[1] (513..514 GiB)  ← META arena, template-owned
-///     PDPT[2] (514..515 GiB)  ← STACK, global shared page
+///     PDPT[2] (514..515 GiB)  ← STACK, lane-local page
 /// ```
 const META_PML4_BASE: u64 = 1u64 << 39; // 512 GiB
 /// CTX sits at the slot base. CTX_VA_M must match
@@ -841,10 +859,8 @@ const STACK_SIZE: u64 = PAGE_SIZE as u64;
 /// to publish #PF-handler atomics on every entry. Built once per `KernelFrame`
 /// (lazily on first [`enter_frame`]) and reused across every re-entry on the
 /// same frame — it is **not** evicted (the synchronous call stack is bounded
-/// structurally, so all live page tables stay resident). The CTX, STACK, and
-/// zero scratch pages are process-global ([`CTX_PAGE`] / [`STACK_PAGE`] /
-/// [`ZERO_PAGE`]), shared by every frame (only one runs in ring 3 at a time),
-/// so the page table is the bulk of a frame's footprint.
+/// structurally, so all live page tables stay resident). CTX and STACK are
+/// lane-local scratch pages; the zero scratch page remains process-global.
 ///
 /// The category-#3 materialization *bookkeeping* (`mat_state` / `ro_units`)
 /// lives on the [`KernelFrame`](crate::call_loop), not here — it is gas history
@@ -859,6 +875,11 @@ const STACK_SIZE: u64 = PAGE_SIZE as u64;
 pub struct FrameRuntime {
     lane: ExecutionLane,
     pt: PageTable,
+    /// Per-frame PDPT joining lane-local CTX, per-image META arena, and
+    /// lane-local STACK. The page table borrows this PDPT at PML4[1], so this
+    /// owner must live as long as `pt`.
+    #[allow(dead_code)]
+    meta_slot_template: Pml4SlotTemplate,
     jit_va: u64,
     jit_size: u64,
     /// Dispatch-table VA (`META_BASE_M + dispatch_offset`) — re-stamped into
@@ -953,9 +974,9 @@ impl FrameRuntime {
 /// `PinnedCapRo` region lazily paged in RO on guest PIC reads.
 ///
 /// # Safety
-/// The guest runs single-threaded (Hyperlight serialises calls); the
-/// `code` / overlay slices and `code_pa` / cap PAs must outlive the
-/// returned [`FrameRuntime`], which owns the per-call page table.
+/// The `code` / overlay slices and `code_pa` / cap PAs must outlive the
+/// returned [`FrameRuntime`], which owns the per-call page table and borrows
+/// the cached Image arena PD.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn build_frame_runtime(
     lane: ExecutionLane,
@@ -993,9 +1014,6 @@ pub unsafe fn build_frame_runtime(
         code_base,
         META_BASE_M,
         CTX_VA_M,
-        STACK_VA_M,
-        global_pd_pa(&CTX_PD_PA, CTX_VA_M, CTX_PAGE.pa()),
-        global_pd_pa(&STACK_PD_PA, STACK_VA_M, STACK_PAGE.pa()),
         mem_cycles,
         helpers,
         |cached| {
@@ -1019,9 +1037,9 @@ pub unsafe fn build_frame_runtime(
             // Memory is sourced lazily from the Instance's `mem` DataCap via
             // `mat_ranges`: every data page is covered by a `MatRange` (initial/pinned
             // slabs or the shared zero page), so there is NO eager flat buffer. CTX and
-            // STACK are process-global shared pages ([`CTX_PAGE`] / [`STACK_PAGE`]) —
-            // nothing is allocated per call but the page table itself. The shared ctx's
-            // frame-constant fields (`dispatch_table` / `code_base`) are re-stamped by
+            // STACK are lane-local shared pages, so each frame allocates only its page
+            // table plus the small CTX|META|STACK PDPT. The ctx's frame-constant
+            // fields (`dispatch_table` / `code_base`) are re-stamped by
             // [`enter_frame`] each entry (the page is shared, the image differs).
 
             let mut pt = PageTable::new()?;
@@ -1043,16 +1061,30 @@ pub unsafe fn build_frame_runtime(
             // is safe.
             let code_bytes_rounded = code.len().next_multiple_of(PAGE_SIZE);
             let code_top = code_base.saturating_add(code_bytes_rounded as u32);
-            // Install the entire PML4 slot-1 subtree (CTX | META arena | STACK) with a
-            // single borrowed PML4 write. CTX/STACK are the global shared pages and the
-            // arena PD is per-Image, so the whole PDPT is an Image constant built once
-            // in `with_compiled_image` — no per-frame CTX/STACK PDPT/PD/PT allocation.
-            pt.install_borrowed_pdpt(META_PML4_BASE, cached.template_pdpt_pa)?;
+            let meta_slot_template = Pml4SlotTemplate::new(
+                CTX_VA_M,
+                lane_pd_pa(&CTX_PD_PA, lane, CTX_VA_M, lane_page(&CTX_PAGES, lane).pa()),
+                META_BASE_M,
+                cached.template_pd_pa,
+                STACK_VA_M,
+                lane_pd_pa(
+                    &STACK_PD_PA,
+                    lane,
+                    STACK_VA_M,
+                    lane_page(&STACK_PAGES, lane).pa(),
+                ),
+            )?;
+            let template_pdpt_pa = meta_slot_template.pdpt_pa()?;
+            // Install the PML4 slot-1 subtree (CTX | META arena | STACK) with
+            // one borrowed PML4 write. CTX/STACK are lane-local; META is the
+            // per-Image cached arena PD.
+            pt.install_borrowed_pdpt(META_PML4_BASE, template_pdpt_pa)?;
             let new_cr3 = pt.cr3()?;
 
             Some(FrameRuntime {
                 lane,
                 pt,
+                meta_slot_template,
                 jit_va,
                 jit_size: cached.jit_size as u64,
                 dispatch_va,
@@ -1106,10 +1138,10 @@ pub unsafe fn enter_frame(
     ro_units: *mut alloc::vec::Vec<u32>,
 ) -> ExitInfo {
     assert_eq!(rt.lane, lane, "FrameRuntime entered on the wrong lane");
-    let ctx_kva = CTX_PAGE.kva();
+    let ctx_kva = lane_page(&CTX_PAGES, lane).kva();
     let ctx = ctx_kva as *mut JitContext;
-    // SAFETY: CTX_PAGE is the process-global ring-3 ctx page, leaked for the
-    // kernel's lifetime; mapped at CTX_VA_M in this frame's PT.
+    // SAFETY: the lane-local CTX page is leaked for the kernel's lifetime and
+    // mapped at CTX_VA_M in this frame's PT.
     unsafe {
         // The persisted register file is the 13 host-mapped slots; the two
         // spilled slots (x3/x4) are invocation-local and start at 0, matching

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -54,7 +54,7 @@ use crate::cached_cap::CachedCap;
 use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 use crate::jit_cache;
 use crate::page_alloc::GlobalPage;
-use crate::paging::{PAGE_SIZE, PageTable, Pml4SlotTemplate};
+use crate::paging::{PAGE_SIZE, PageTable};
 use crate::ring3;
 use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
@@ -120,31 +120,17 @@ impl LaneJitState {
     }
 
     fn clear(&self) {
-        self.active_cr3.store(0, Ordering::SeqCst);
-        self.trap_table_ptr
-            .store(core::ptr::null_mut(), Ordering::SeqCst);
-        self.trap_table_len.store(0, Ordering::SeqCst);
-        self.jit_code_len.store(0, Ordering::SeqCst);
-        self.mat_ranges_ptr
-            .store(core::ptr::null_mut(), Ordering::SeqCst);
-        self.mat_ranges_len.store(0, Ordering::SeqCst);
-        self.mat_zero_pa.store(0, Ordering::SeqCst);
-        self.mat_state_ptr
-            .store(core::ptr::null_mut(), Ordering::SeqCst);
-        self.mat_state_len.store(0, Ordering::SeqCst);
-        self.mat_mem_top.store(0, Ordering::SeqCst);
-        self.mat_code_top.store(0, Ordering::SeqCst);
-        self.mat_ro_units_sink
-            .store(core::ptr::null_mut(), Ordering::SeqCst);
-        self.overlay_sink
-            .store(core::ptr::null_mut(), Ordering::SeqCst);
-        self.active_pt_pml4_kva.store(0, Ordering::SeqCst);
-        self.owned_vec_ptr.store(0, Ordering::SeqCst);
+        // `active_cr3` is the publication sentinel. Once it is zero, the #PF
+        // handler will not use this lane state; the remaining fields may stay
+        // stale until the next `enter_frame` overwrites them before publishing a
+        // new CR3.
+        self.active_cr3.store(0, Ordering::Release);
     }
 }
 
 static LANE_JIT_STATE: [LaneJitState; MAX_EXECUTION_LANES] =
     [const { LaneJitState::new() }; MAX_EXECUTION_LANES];
+static LAST_ACTIVE_JIT_LANE: AtomicU64 = AtomicU64::new(u64::MAX);
 
 fn lane_jit_state(lane: ExecutionLane) -> &'static LaneJitState {
     lane.assert_in_range();
@@ -153,9 +139,16 @@ fn lane_jit_state(lane: ExecutionLane) -> &'static LaneJitState {
 
 fn current_cr3_jit_state() -> Option<&'static LaneJitState> {
     let cr3 = crate::paging::read_cr3();
+    let hint = LAST_ACTIVE_JIT_LANE.load(Ordering::Relaxed) as usize;
+    if hint < MAX_EXECUTION_LANES {
+        let state = &LANE_JIT_STATE[hint];
+        if state.active_cr3.load(Ordering::Acquire) == cr3 {
+            return Some(state);
+        }
+    }
     LANE_JIT_STATE
         .iter()
-        .find(|state| state.active_cr3.load(Ordering::SeqCst) == cr3)
+        .find(|state| state.active_cr3.load(Ordering::Acquire) == cr3)
 }
 static LAST_GLOBAL_ARENA_TOKEN: [AtomicU64; MAX_EXECUTION_LANES] =
     [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
@@ -266,8 +259,8 @@ fn jit_pf_handler(
     };
     // SAFETY: Hyperlight passes a valid pointer to the iretq frame.
     let saved_rip = unsafe { (&raw const (*info).rip).read_volatile() };
-    let code_base = state.jit_code_base.load(Ordering::SeqCst);
-    let code_len = state.jit_code_len.load(Ordering::SeqCst);
+    let code_base = state.jit_code_base.load(Ordering::Relaxed);
+    let code_len = state.jit_code_len.load(Ordering::Relaxed);
     if code_len == 0 || saved_rip < code_base || saved_rip >= code_base + code_len {
         return false;
     }
@@ -289,7 +282,7 @@ fn jit_pf_handler(
 
     // Not materializable (outside the declared region, or a write to a
     // pinned read-only page) → a PVM-level PageFault, charging nothing.
-    let ctx_kva = state.ctx_kva.load(Ordering::SeqCst);
+    let ctx_kva = state.ctx_kva.load(Ordering::Relaxed);
     // SAFETY: ctx_kva is the kernel VA of the JitContext page for the
     // current invocation; valid while the handler runs.
     unsafe {
@@ -299,7 +292,7 @@ fn jit_pf_handler(
         (*jc).pc = pvm_pc;
     }
 
-    let exit_va = state.exit_label_va.load(Ordering::SeqCst);
+    let exit_va = state.exit_label_va.load(Ordering::Relaxed);
     // SAFETY: info is a valid pointer to a writable iretq frame.
     unsafe {
         (&raw mut (*info).rip).write_volatile(exit_va);
@@ -311,8 +304,8 @@ fn jit_pf_handler(
 /// the trap table. Returns `(0, 0)` when no entry covers the offset
 /// (not a guest memory op → width 0 → caller treats as a PageFault).
 fn trap_lookup(state: &LaneJitState, offset: u32) -> (u32, u32) {
-    let tt_ptr = state.trap_table_ptr.load(Ordering::SeqCst);
-    let tt_len = state.trap_table_len.load(Ordering::SeqCst) as usize;
+    let tt_ptr = state.trap_table_ptr.load(Ordering::Relaxed);
+    let tt_len = state.trap_table_len.load(Ordering::Relaxed) as usize;
     if tt_ptr.is_null() || tt_len == 0 {
         return (0, 0);
     }
@@ -345,8 +338,8 @@ fn mat_range_for_in(
 /// `page_va` (page-aligned) in the running frame's published `mat_ranges`, or
 /// `None` for an ephemeral page.
 fn mat_range_for(state: &LaneJitState, page_va: u32) -> Option<crate::call_loop::MatRange> {
-    let ptr = state.mat_ranges_ptr.load(Ordering::SeqCst);
-    let len = state.mat_ranges_len.load(Ordering::SeqCst) as usize;
+    let ptr = state.mat_ranges_ptr.load(Ordering::Relaxed);
+    let len = state.mat_ranges_len.load(Ordering::Relaxed) as usize;
     if ptr.is_null() || len == 0 {
         return None;
     }
@@ -368,8 +361,8 @@ fn mat_range_for(state: &LaneJitState, page_va: u32) -> Option<crate::call_loop:
 /// and this shared read returns a `u64` (the borrow ends) before any `&mut`
 /// write to the same cap in [`cow_into_fresh`].
 fn mem_source_pa(state: &LaneJitState, page_va: u64) -> Option<u64> {
-    let data_base = state.mat_data_base.load(Ordering::SeqCst);
-    let sink = state.overlay_sink.load(Ordering::SeqCst);
+    let data_base = state.mat_data_base.load(Ordering::Relaxed);
+    let sink = state.overlay_sink.load(Ordering::Relaxed);
     if sink.is_null() {
         return None;
     }
@@ -380,7 +373,7 @@ fn mem_source_pa(state: &LaneJitState, page_va: u64) -> Option<u64> {
         mem,
         data_base,
         page_va,
-        state.mat_zero_pa.load(Ordering::SeqCst),
+        state.mat_zero_pa.load(Ordering::Relaxed),
     )
 }
 
@@ -409,7 +402,7 @@ fn mem_source_pa_in(
 /// HALT) only needs its leaf W bit flipped back, whereas a write to a shared
 /// backing page must CoW a fresh private copy.
 fn overlay_has_page(state: &LaneJitState, page_va: u64, data_base: u64) -> bool {
-    let sink = state.overlay_sink.load(Ordering::SeqCst);
+    let sink = state.overlay_sink.load(Ordering::Relaxed);
     if sink.is_null() {
         return false;
     }
@@ -458,13 +451,13 @@ fn try_materialize(
     is_write: bool,
     ctx: *mut Context,
 ) -> bool {
-    let data_base = state.mat_data_base.load(Ordering::SeqCst);
-    let mem_top = state.mat_mem_top.load(Ordering::SeqCst);
-    let code_base = state.mat_code_base.load(Ordering::SeqCst);
-    let code_top = state.mat_code_top.load(Ordering::SeqCst);
-    let code_pa = state.mat_code_pa.load(Ordering::SeqCst);
-    let pml4 = state.active_pt_pml4_kva.load(Ordering::SeqCst);
-    let owned_vec = state.owned_vec_ptr.load(Ordering::SeqCst);
+    let data_base = state.mat_data_base.load(Ordering::Relaxed);
+    let mem_top = state.mat_mem_top.load(Ordering::Relaxed);
+    let code_base = state.mat_code_base.load(Ordering::Relaxed);
+    let code_top = state.mat_code_top.load(Ordering::Relaxed);
+    let code_pa = state.mat_code_pa.load(Ordering::Relaxed);
+    let pml4 = state.active_pt_pml4_kva.load(Ordering::Relaxed);
+    let owned_vec = state.owned_vec_ptr.load(Ordering::Relaxed);
     if pml4 == 0 || owned_vec == 0 {
         return false;
     }
@@ -507,9 +500,9 @@ fn try_materialize(
 
     // Per-region state arrays. Null only when a region is undeclared, in
     // which case no page of `set` lies in it (guarded by in_code/in_data).
-    let dstate_ptr = state.mat_state_ptr.load(Ordering::SeqCst);
-    let dstate_len = state.mat_state_len.load(Ordering::SeqCst) as usize;
-    let ro_units_ptr = state.mat_ro_units_sink.load(Ordering::SeqCst);
+    let dstate_ptr = state.mat_state_ptr.load(Ordering::Relaxed);
+    let dstate_len = state.mat_state_len.load(Ordering::Relaxed) as usize;
+    let ro_units_ptr = state.mat_ro_units_sink.load(Ordering::Relaxed);
     // SAFETY: each ptr describes the running FrameRuntime's state
     // (single-threaded → exclusive); empty slice / scratch Vec if undeclared.
     let dstate: &mut [u8] = if dstate_ptr.is_null() {
@@ -716,7 +709,7 @@ fn cow_into_fresh(
         crate::paging::invlpg(page_va);
     }
 
-    let sink_ptr = state.overlay_sink.load(Ordering::SeqCst);
+    let sink_ptr = state.overlay_sink.load(Ordering::Relaxed);
     if !sink_ptr.is_null() {
         // SAFETY: sink_ptr is the running frame's `mem` DataCap, re-published
         // each enter_frame; exclusively ours (single-threaded) for the
@@ -875,11 +868,6 @@ const STACK_SIZE: u64 = PAGE_SIZE as u64;
 pub struct FrameRuntime {
     lane: ExecutionLane,
     pt: PageTable,
-    /// Per-frame PDPT joining lane-local CTX, per-image META arena, and
-    /// lane-local STACK. The page table borrows this PDPT at PML4[1], so this
-    /// owner must live as long as `pt`.
-    #[allow(dead_code)]
-    meta_slot_template: Pml4SlotTemplate,
     jit_va: u64,
     jit_size: u64,
     /// Dispatch-table VA (`META_BASE_M + dispatch_offset`) — re-stamped into
@@ -1061,11 +1049,11 @@ pub unsafe fn build_frame_runtime(
             // is safe.
             let code_bytes_rounded = code.len().next_multiple_of(PAGE_SIZE);
             let code_top = code_base.saturating_add(code_bytes_rounded as u32);
-            let meta_slot_template = Pml4SlotTemplate::new(
+            let template_pdpt_pa = cached.template_pdpt_pa_for_lane(
+                lane,
                 CTX_VA_M,
                 lane_pd_pa(&CTX_PD_PA, lane, CTX_VA_M, lane_page(&CTX_PAGES, lane).pa()),
                 META_BASE_M,
-                cached.template_pd_pa,
                 STACK_VA_M,
                 lane_pd_pa(
                     &STACK_PD_PA,
@@ -1074,7 +1062,6 @@ pub unsafe fn build_frame_runtime(
                     lane_page(&STACK_PAGES, lane).pa(),
                 ),
             )?;
-            let template_pdpt_pa = meta_slot_template.pdpt_pa()?;
             // Install the PML4 slot-1 subtree (CTX | META arena | STACK) with
             // one borrowed PML4 write. CTX/STACK are lane-local; META is the
             // per-Image cached arena PD.
@@ -1084,7 +1071,6 @@ pub unsafe fn build_frame_runtime(
             Some(FrameRuntime {
                 lane,
                 pt,
-                meta_slot_template,
                 jit_va,
                 jit_size: cached.jit_size as u64,
                 dispatch_va,
@@ -1170,51 +1156,53 @@ pub unsafe fn enter_frame(
     unsafe { ring3::prepare_ring3_entry(lane) };
 
     let state = lane_jit_state(lane);
-    state.clear();
-    state.jit_code_base.store(rt.jit_va, Ordering::SeqCst);
-    state.jit_code_len.store(rt.jit_size, Ordering::SeqCst);
+    state.jit_code_base.store(rt.jit_va, Ordering::Relaxed);
+    state.jit_code_len.store(rt.jit_size, Ordering::Relaxed);
     state
         .exit_label_va
-        .store(rt.exit_label_va, Ordering::SeqCst);
+        .store(rt.exit_label_va, Ordering::Relaxed);
     state
         .trap_table_ptr
-        .store(rt.trap_table_ptr as *mut (u32, u32, u32), Ordering::SeqCst);
+        .store(rt.trap_table_ptr as *mut (u32, u32, u32), Ordering::Relaxed);
     state
         .trap_table_len
-        .store(rt.trap_table_len, Ordering::SeqCst);
-    state.ctx_kva.store(ctx_kva, Ordering::SeqCst);
+        .store(rt.trap_table_len, Ordering::Relaxed);
+    state.ctx_kva.store(ctx_kva, Ordering::Relaxed);
     state.mat_ranges_ptr.store(
         rt.mat_ranges.as_ptr() as *mut crate::call_loop::MatRange,
-        Ordering::SeqCst,
+        Ordering::Relaxed,
     );
     state
         .mat_ranges_len
-        .store(rt.mat_ranges.len() as u64, Ordering::SeqCst);
-    state.mat_zero_pa.store(ZERO_PAGE.pa(), Ordering::SeqCst);
-    state.mat_state_ptr.store(mat_state_ptr, Ordering::SeqCst);
-    state.mat_state_len.store(mat_state_len, Ordering::SeqCst);
+        .store(rt.mat_ranges.len() as u64, Ordering::Relaxed);
+    state.mat_zero_pa.store(ZERO_PAGE.pa(), Ordering::Relaxed);
+    state.mat_state_ptr.store(mat_state_ptr, Ordering::Relaxed);
+    state.mat_state_len.store(mat_state_len, Ordering::Relaxed);
     state
         .mat_data_base
-        .store(rt.data_base as u64, Ordering::SeqCst);
-    state.mat_mem_top.store(rt.mem_top as u64, Ordering::SeqCst);
+        .store(rt.data_base as u64, Ordering::Relaxed);
+    state
+        .mat_mem_top
+        .store(rt.mem_top as u64, Ordering::Relaxed);
     state
         .mat_code_base
-        .store(rt.code_base as u64, Ordering::SeqCst);
+        .store(rt.code_base as u64, Ordering::Relaxed);
     state
         .mat_code_top
-        .store(rt.code_top as u64, Ordering::SeqCst);
-    state.mat_code_pa.store(rt.code_pa, Ordering::SeqCst);
-    state.mat_ro_units_sink.store(ro_units, Ordering::SeqCst);
-    state.overlay_sink.store(overlay_sink, Ordering::SeqCst);
+        .store(rt.code_top as u64, Ordering::Relaxed);
+    state.mat_code_pa.store(rt.code_pa, Ordering::Relaxed);
+    state.mat_ro_units_sink.store(ro_units, Ordering::Relaxed);
+    state.overlay_sink.store(overlay_sink, Ordering::Relaxed);
     state
         .active_pt_pml4_kva
-        .store(rt.pt.pml4_kva(), Ordering::SeqCst);
+        .store(rt.pt.pml4_kva(), Ordering::Relaxed);
     state
         .owned_vec_ptr
-        .store(rt.pt.owned_vec_ptr(), Ordering::SeqCst);
+        .store(rt.pt.owned_vec_ptr(), Ordering::Relaxed);
     // Publish the CR3 last: the #PF handler finds this lane by current CR3, so
     // matching the CR3 implies every other field above is initialized.
-    state.active_cr3.store(rt.new_cr3, Ordering::SeqCst);
+    state.active_cr3.store(rt.new_cr3, Ordering::Release);
+    LAST_ACTIVE_JIT_LANE.store(lane.index() as u64, Ordering::Relaxed);
     // Shared handler, lane-local state: leave the function installed across
     // exits so one lane cannot clear another lane's #PF hook. The handler
     // returns `false` for non-JIT CR3s.
@@ -1254,13 +1242,13 @@ pub unsafe fn enter_frame(
 fn flush_global_arena_on_image_switch(lane: ExecutionLane, next_token: u64, next_pages: u64) {
     let idx = lane.index();
     lane.assert_in_range();
-    let prev_token = LAST_GLOBAL_ARENA_TOKEN[idx].load(Ordering::SeqCst);
+    let prev_token = LAST_GLOBAL_ARENA_TOKEN[idx].load(Ordering::Relaxed);
     if prev_token != 0 && prev_token != next_token {
-        let prev_pages = LAST_GLOBAL_ARENA_PAGES[idx].load(Ordering::SeqCst);
+        let prev_pages = LAST_GLOBAL_ARENA_PAGES[idx].load(Ordering::Relaxed);
         for page in 0..prev_pages {
             crate::paging::invlpg(META_BASE_M + page * PAGE_SIZE as u64);
         }
     }
-    LAST_GLOBAL_ARENA_PAGES[idx].store(next_pages, Ordering::SeqCst);
-    LAST_GLOBAL_ARENA_TOKEN[idx].store(next_token, Ordering::SeqCst);
+    LAST_GLOBAL_ARENA_PAGES[idx].store(next_pages, Ordering::Relaxed);
+    LAST_GLOBAL_ARENA_TOKEN[idx].store(next_token, Ordering::Relaxed);
 }

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -60,6 +60,28 @@ use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
 use javm_recompiler_x86::JitContext;
 use javm_recompiler_x86::codegen::HelperFns;
 
+/// Maximum fixed execution lanes the guest runtime can address. The production
+/// default vCPU pool is capped at 8; this leaves room for explicit overrides
+/// while keeping lane-local hot state static and allocation-free.
+pub const MAX_EXECUTION_LANES: usize = 64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExecutionLane {
+    index: usize,
+}
+
+impl ExecutionLane {
+    pub const PRIMARY: Self = Self { index: 0 };
+
+    pub const fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub const fn index(self) -> usize {
+        self.index
+    }
+}
+
 // === Per-invocation context for the #PF handler ===========================
 //
 // Set by `enter_frame` immediately before `enter_ring3`, read by
@@ -73,8 +95,10 @@ static EXIT_LABEL_VA: AtomicU64 = AtomicU64::new(0);
 static TRAP_TABLE_PTR: AtomicPtr<(u32, u32, u32)> = AtomicPtr::new(core::ptr::null_mut());
 static TRAP_TABLE_LEN: AtomicU64 = AtomicU64::new(0);
 static CTX_KVA: AtomicU64 = AtomicU64::new(0);
-static LAST_GLOBAL_ARENA_TOKEN: AtomicU64 = AtomicU64::new(0);
-static LAST_GLOBAL_ARENA_PAGES: AtomicU64 = AtomicU64::new(0);
+static LAST_GLOBAL_ARENA_TOKEN: [AtomicU64; MAX_EXECUTION_LANES] =
+    [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
+static LAST_GLOBAL_ARENA_PAGES: [AtomicU64; MAX_EXECUTION_LANES] =
+    [const { AtomicU64::new(0) }; MAX_EXECUTION_LANES];
 
 // === Per-invocation category-#3 materialization state =====================
 //
@@ -807,6 +831,7 @@ const STACK_SIZE: u64 = PAGE_SIZE as u64;
 /// re-stamped by [`enter_frame`] each entry (they differ per image, and the
 /// ctx page is shared), alongside the per-entry regs/pc/gas/exit_*.
 pub struct FrameRuntime {
+    lane: ExecutionLane,
     pt: PageTable,
     jit_va: u64,
     jit_size: u64,
@@ -907,6 +932,7 @@ impl FrameRuntime {
 /// returned [`FrameRuntime`], which owns the per-call page table.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn build_frame_runtime(
+    lane: ExecutionLane,
     image_cap: &CachedCap,
     image_hash: &javm_cap::CapHash,
     code: &[u8],
@@ -999,6 +1025,7 @@ pub unsafe fn build_frame_runtime(
             let new_cr3 = pt.cr3()?;
 
             Some(FrameRuntime {
+                lane,
                 pt,
                 jit_va,
                 jit_size: cached.jit_size as u64,
@@ -1042,6 +1069,7 @@ pub unsafe fn build_frame_runtime(
 /// `mat_state_len` bytes), and `ro_units` must outlive the call.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn enter_frame(
+    lane: ExecutionLane,
     rt: &mut FrameRuntime,
     initial_gas: i64,
     entry_pc: u32,
@@ -1051,6 +1079,7 @@ pub unsafe fn enter_frame(
     mat_state_len: u64,
     ro_units: *mut alloc::vec::Vec<u32>,
 ) -> ExitInfo {
+    assert_eq!(rt.lane, lane, "FrameRuntime entered on the wrong lane");
     let ctx_kva = CTX_PAGE.kva();
     let ctx = ctx_kva as *mut JitContext;
     // SAFETY: CTX_PAGE is the process-global ring-3 ctx page, leaked for the
@@ -1107,7 +1136,7 @@ pub unsafe fn enter_frame(
     HANDLERS[14].store(jit_pf_handler as *const () as u64, Ordering::Release);
 
     crate::paging::enable_global_pages();
-    flush_global_arena_on_image_switch(rt.global_arena_token, rt.global_arena_pages);
+    flush_global_arena_on_image_switch(lane, rt.global_arena_token, rt.global_arena_pages);
 
     let user_stack_top = STACK_VA_M + STACK_SIZE;
     // SAFETY: trampoline (inside the Image arena) + stack mapped above;
@@ -1151,14 +1180,19 @@ pub unsafe fn enter_frame(
     }
 }
 
-fn flush_global_arena_on_image_switch(next_token: u64, next_pages: u64) {
-    let prev_token = LAST_GLOBAL_ARENA_TOKEN.load(Ordering::SeqCst);
+fn flush_global_arena_on_image_switch(lane: ExecutionLane, next_token: u64, next_pages: u64) {
+    let idx = lane.index();
+    assert!(
+        idx < MAX_EXECUTION_LANES,
+        "execution lane index exceeds guest lane table"
+    );
+    let prev_token = LAST_GLOBAL_ARENA_TOKEN[idx].load(Ordering::SeqCst);
     if prev_token != 0 && prev_token != next_token {
-        let prev_pages = LAST_GLOBAL_ARENA_PAGES.load(Ordering::SeqCst);
+        let prev_pages = LAST_GLOBAL_ARENA_PAGES[idx].load(Ordering::SeqCst);
         for page in 0..prev_pages {
             crate::paging::invlpg(META_BASE_M + page * PAGE_SIZE as u64);
         }
     }
-    LAST_GLOBAL_ARENA_PAGES.store(next_pages, Ordering::SeqCst);
-    LAST_GLOBAL_ARENA_TOKEN.store(next_token, Ordering::SeqCst);
+    LAST_GLOBAL_ARENA_PAGES[idx].store(next_pages, Ordering::SeqCst);
+    LAST_GLOBAL_ARENA_TOKEN[idx].store(next_token, Ordering::SeqCst);
 }

--- a/rust/nub-arch-x86/src/jit_run.rs
+++ b/rust/nub-arch-x86/src/jit_run.rs
@@ -51,6 +51,7 @@
 extern crate alloc;
 
 use crate::cached_cap::CachedCap;
+use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 use crate::jit_cache;
 use crate::page_alloc::GlobalPage;
 use crate::paging::{PAGE_SIZE, PageTable};
@@ -59,28 +60,6 @@ use core::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo, HANDLERS};
 use javm_recompiler_x86::JitContext;
 use javm_recompiler_x86::codegen::HelperFns;
-
-/// Maximum fixed execution lanes the guest runtime can address. The production
-/// default vCPU pool is capped at 8; this leaves room for explicit overrides
-/// while keeping lane-local hot state static and allocation-free.
-pub const MAX_EXECUTION_LANES: usize = 64;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ExecutionLane {
-    index: usize,
-}
-
-impl ExecutionLane {
-    pub const PRIMARY: Self = Self { index: 0 };
-
-    pub const fn new(index: usize) -> Self {
-        Self { index }
-    }
-
-    pub const fn index(self) -> usize {
-        self.index
-    }
-}
 
 // === Per-invocation context for the #PF handler ===========================
 //
@@ -1106,9 +1085,10 @@ pub unsafe fn enter_frame(
         (*ctx).code_base = rt.jit_va;
     }
 
-    // ---- install ring-3 GDT/IDT + JIT #PF handler ------------------------
-    // SAFETY: ring-0 mutation of GDT/IDT; serialised by Hyperlight.
-    unsafe { ring3::install_ring3_exit_gate() };
+    // ---- install ring-3 GDT/IDT + select lane-local exit state ------------
+    // SAFETY: ring-0 mutation of GDT/IDT/GS base; `lane` is owned by the
+    // current vCPU worker.
+    unsafe { ring3::prepare_ring3_entry(lane) };
 
     JIT_CODE_BASE.store(rt.jit_va, Ordering::SeqCst);
     JIT_CODE_LEN.store(rt.jit_size, Ordering::SeqCst);
@@ -1182,10 +1162,7 @@ pub unsafe fn enter_frame(
 
 fn flush_global_arena_on_image_switch(lane: ExecutionLane, next_token: u64, next_pages: u64) {
     let idx = lane.index();
-    assert!(
-        idx < MAX_EXECUTION_LANES,
-        "execution lane index exceeds guest lane table"
-    );
+    lane.assert_in_range();
     let prev_token = LAST_GLOBAL_ARENA_TOKEN[idx].load(Ordering::SeqCst);
     if prev_token != 0 && prev_token != next_token {
         let prev_pages = LAST_GLOBAL_ARENA_PAGES[idx].load(Ordering::SeqCst);

--- a/rust/nub-arch-x86/src/lib.rs
+++ b/rust/nub-arch-x86/src/lib.rs
@@ -31,6 +31,8 @@ pub mod cached_cap;
 #[cfg(target_os = "none")]
 pub mod call_loop;
 #[cfg(target_os = "none")]
+pub mod execution_lane;
+#[cfg(target_os = "none")]
 pub mod jit_cache;
 #[cfg(target_os = "none")]
 pub mod jit_run;

--- a/rust/nub-arch-x86/src/page_alloc.rs
+++ b/rust/nub-arch-x86/src/page_alloc.rs
@@ -80,9 +80,9 @@ impl Drop for PageBuf {
 /// nesting; each `host_call` fully exits to ring 0), so a single physical page
 /// backs them all without any per-frame state leaking between frames.
 ///
-/// The guest is single-threaded (Hyperlight serialises calls), so the
-/// lazy-init load/store needs no compare-exchange; the [`AtomicU64`] is only to
-/// avoid `&'static mut`.
+/// Lazy init uses a compare-exchange so future multi-vCPU workers can race on
+/// first touch safely; the winning page is leaked, and any losing allocation is
+/// dropped immediately.
 pub struct GlobalPage {
     /// Kernel VA of the leaked page, or 0 before first init.
     kva: AtomicU64,
@@ -107,13 +107,21 @@ impl GlobalPage {
         if cur != 0 {
             return cur;
         }
-        // First touch: allocate a zeroed page and leak it (never freed).
-        // Single-threaded guest → no race on the store.
+        // First touch: allocate a zeroed page and try to publish it. If another
+        // lane wins the race, this `PageBuf` drops normally at the end of the
+        // function and frees the unused page.
         let buf = PageBuf::new(PAGE_SIZE).expect("global page alloc");
         let kva = buf.kva();
-        core::mem::forget(buf);
-        self.kva.store(kva, Ordering::Release);
-        kva
+        match self
+            .kva
+            .compare_exchange(0, kva, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => {
+                core::mem::forget(buf);
+                kva
+            }
+            Err(existing) => existing,
+        }
     }
 
     /// Physical address of the page (allocating it on first call).

--- a/rust/nub-arch-x86/src/ring3.rs
+++ b/rust/nub-arch-x86/src/ring3.rs
@@ -21,13 +21,14 @@
 //!                                                    mov rax, <retval>
 //!                                                    int 0x81
 //!     ring3_exit_stub:  (CPU loads IST1 stack)       .
-//!       mov [USER_RAX], rax                          .
-//!       mov rsp, [KERNEL_RESUME_RSP]                 .
-//!       mov cr3, [SAVED_CR3]                         .
+//!       swapgs                                       .
+//!       mov gs:[USER_RAX], rax                       .
+//!       mov rsp, gs:[KERNEL_RESUME_RSP]              .
+//!       mov cr3, gs:[SAVED_CR3]                      .
 //!       jmp resume                                   .
 //!     resume:                                        .
 //!       pop callee-saved                             .
-//!       mov rax, [USER_RAX]                          .
+//!       mov rax, gs:[USER_RAX]                       .
 //!       ret
 //! ```
 //!
@@ -38,34 +39,124 @@
 //!   and points TSS.IST1 at it. Using IST=1 means we don't need to
 //!   touch TSS.RSP0; the interrupt frame lands on the exception
 //!   stack and we abandon it after copying RAX out.
-//! * **Single-shot.** The static `KERNEL_RESUME_RSP` / `SAVED_CR3` /
-//!   `USER_EXIT_RAX` are global and so this code is *not* reentrant.
-//!   Stage 2.2 only has one active invocation at a time (Hyperlight
-//!   serialises host calls), but if we later add nested PVM
-//!   invocations we'll need to thread these through a per-call
-//!   context.
+//! * **Lane-local state.** [`prepare_ring3_entry`] points GS at the active
+//!   lane's [`Ring3LaneRaw`]. The entry/exit assembly stores its saved kernel
+//!   RSP, saved CR3, and user RAX through GS, so two vCPUs can take the exit
+//!   gate without racing on a process-global slot. Both `GSBase` and
+//!   `KernelGSBase` are set to the same state pointer, and the exit stub starts
+//!   with `swapgs`, because Hyperlight's exception path can leave the active GS
+//!   side swapped before the final `int 0x81`.
 
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::cell::UnsafeCell;
+use core::mem::offset_of;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 
 /// Vector for the ring-3 exit gate.
 pub const RING3_EXIT_VECTOR: u8 = 0x81;
 
-/// Saved kernel RSP at the point of `iretq` in [`enter_ring3`].
-/// The exit stub overwrites RSP with this value before jumping to
-/// the resume label.
-#[unsafe(no_mangle)]
-pub static KERNEL_RESUME_RSP: AtomicU64 = AtomicU64::new(0);
+#[repr(C, align(64))]
+struct Ring3LaneRaw {
+    lane_index: u64,
+    /// Saved kernel RSP at the point of `iretq` in [`nub_enter_ring3`].
+    kernel_resume_rsp: u64,
+    /// Saved kernel CR3 at the point of CR3 swap in [`nub_enter_ring3`].
+    saved_cr3: u64,
+    /// Ring-3 RAX at the moment of the exit trap.
+    user_exit_rax: u64,
+}
 
-/// Saved kernel CR3 at the point of CR3 swap in [`enter_ring3`].
-/// The exit stub restores this before jumping to resume.
-#[unsafe(no_mangle)]
-pub static SAVED_CR3: AtomicU64 = AtomicU64::new(0);
+struct Ring3LaneState {
+    raw: UnsafeCell<Ring3LaneRaw>,
+}
 
-/// Ring-3 RAX at the moment of the exit trap. Copied out by the
-/// exit stub before the kernel reentry path tears down the
-/// interrupt frame.
-#[unsafe(no_mangle)]
-pub static USER_EXIT_RAX: AtomicU64 = AtomicU64::new(0);
+// SAFETY: each lane writes only its own slot after `prepare_ring3_entry`
+// selects it, and the assembly accesses the selected slot through GS on that
+// same vCPU. Cross-lane sharing is by static address only.
+unsafe impl Sync for Ring3LaneState {}
+
+impl Ring3LaneState {
+    const fn new() -> Self {
+        Self {
+            raw: UnsafeCell::new(Ring3LaneRaw {
+                lane_index: u64::MAX,
+                kernel_resume_rsp: 0,
+                saved_cr3: 0,
+                user_exit_rax: 0,
+            }),
+        }
+    }
+
+    fn ptr(&self) -> *mut Ring3LaneRaw {
+        self.raw.get()
+    }
+
+    /// # Safety
+    /// The caller must ensure this state belongs to the currently entering
+    /// vCPU lane, so no other CPU is concurrently mutating the same raw fields.
+    unsafe fn reset_for_entry(&self, lane: ExecutionLane) {
+        let raw = self.raw.get();
+        unsafe {
+            (*raw).lane_index = lane.index() as u64;
+            (*raw).kernel_resume_rsp = 0;
+            (*raw).saved_cr3 = 0;
+            (*raw).user_exit_rax = 0;
+        }
+    }
+}
+
+static RING3_LANES: [Ring3LaneState; MAX_EXECUTION_LANES] =
+    [const { Ring3LaneState::new() }; MAX_EXECUTION_LANES];
+
+const LANE_INDEX_OFFSET: usize = offset_of!(Ring3LaneRaw, lane_index);
+const KERNEL_RESUME_RSP_OFFSET: usize = offset_of!(Ring3LaneRaw, kernel_resume_rsp);
+const SAVED_CR3_OFFSET: usize = offset_of!(Ring3LaneRaw, saved_cr3);
+const USER_EXIT_RAX_OFFSET: usize = offset_of!(Ring3LaneRaw, user_exit_rax);
+
+const IA32_GS_BASE: u32 = 0xC000_0101;
+const IA32_KERNEL_GS_BASE: u32 = 0xC000_0102;
+
+unsafe fn write_msr(msr: u32, value: u64) {
+    let lo = value as u32;
+    let hi = (value >> 32) as u32;
+    unsafe {
+        core::arch::asm!(
+            "wrmsr",
+            in("ecx") msr,
+            in("eax") lo,
+            in("edx") hi,
+            options(nostack, preserves_flags)
+        );
+    }
+}
+
+unsafe fn write_gs_bases(base: u64) {
+    unsafe {
+        write_msr(IA32_GS_BASE, base);
+        // Hyperlight exception machinery may use `swapgs` while handling a
+        // ring3 #PF. Keep both sides pointed at the same lane state; the
+        // int-0x81 stub still starts with `swapgs`, which makes the active side
+        // correct even if a prior exception left it swapped.
+        write_msr(IA32_KERNEL_GS_BASE, base);
+    }
+}
+
+/// Return the lane selected by the current GS base. Valid while running in the
+/// ring3 entry/exit path or its exception handlers after [`prepare_ring3_entry`]
+/// has run on this vCPU.
+pub fn current_execution_lane() -> ExecutionLane {
+    let lane: u64;
+    unsafe {
+        core::arch::asm!(
+            "mov {}, qword ptr gs:[{offset}]",
+            out(reg) lane,
+            offset = const LANE_INDEX_OFFSET,
+            options(nostack, preserves_flags, readonly)
+        );
+    }
+    ExecutionLane::new(lane as usize)
+}
 
 unsafe extern "C" {
     /// Drop to ring 3 at `entry_va`, on stack `stack_va`, with page
@@ -95,9 +186,9 @@ unsafe extern "C" {
 //     at the `int 0x81` instruction in ring-3 — so it does a
 //     `mov rsp, ...; jmp resume` longjmp instead.
 //
-// The two halves communicate via the three `AtomicU64` statics
-// above; we use `mov [sym + rip]` (RIP-relative) for `pic`-correct
-// addressing.
+// The two halves communicate through the active lane's GS-base state. Rust sets
+// GS to a `Ring3LaneRaw` before entry; the interrupt gate runs on the same vCPU
+// and therefore sees the same GS base.
 core::arch::global_asm!(
     ".global nub_enter_ring3",
     ".global nub_ring3_exit_stub",
@@ -111,8 +202,8 @@ core::arch::global_asm!(
     "    push r15",
     // Snapshot current cr3 + rsp so the exit stub can restore.
     "    mov rax, cr3",
-    "    mov qword ptr [rip + {saved_cr3}], rax",
-    "    mov qword ptr [rip + {resume_rsp}], rsp",
+    "    mov qword ptr gs:[{saved_cr3}], rax",
+    "    mov qword ptr gs:[{resume_rsp}], rsp",
     // Swap to the per-invocation page table.
     "    mov cr3, rdx",
     // Push iretq frame: SS, RSP, RFLAGS, CS, RIP (last push popped first).
@@ -124,13 +215,16 @@ core::arch::global_asm!(
     "    iretq",
     "nub_ring3_exit_stub:",
     // CPU just dispatched int 0x81 from ring 3 onto the IST1 stack.
+    // If an earlier exception path left GS swapped back to the user side, bring
+    // the lane state into active GS before touching gs:[...].
+    "    swapgs",
     // RAX still holds the ring-3 value; persist it.
-    "    mov qword ptr [rip + {user_rax}], rax",
+    "    mov qword ptr gs:[{user_rax}], rax",
     // Restore the kernel context and longjmp back to the resume label
     // inside nub_enter_ring3.
-    "    mov rax, qword ptr [rip + {saved_cr3}]",
+    "    mov rax, qword ptr gs:[{saved_cr3}]",
     "    mov cr3, rax",
-    "    mov rsp, qword ptr [rip + {resume_rsp}]",
+    "    mov rsp, qword ptr gs:[{resume_rsp}]",
     "    jmp 2f",
     // Resume label: pop callee-saved, load user RAX, return.
     "2:",
@@ -140,14 +234,33 @@ core::arch::global_asm!(
     "    pop r12",
     "    pop rbp",
     "    pop rbx",
-    "    mov rax, qword ptr [rip + {user_rax}]",
+    "    mov rax, qword ptr gs:[{user_rax}]",
     "    ret",
-    saved_cr3 = sym SAVED_CR3,
-    resume_rsp = sym KERNEL_RESUME_RSP,
-    user_rax = sym USER_EXIT_RAX,
+    saved_cr3 = const SAVED_CR3_OFFSET,
+    resume_rsp = const KERNEL_RESUME_RSP_OFFSET,
+    user_rax = const USER_EXIT_RAX_OFFSET,
     user_cs = const crate::segments::USER_CODE_SEL as u64,
     user_ss = const crate::segments::USER_DATA_SEL as u64,
 );
+
+/// Prepare the current vCPU to enter ring 3 on `lane`.
+///
+/// Installs the shared exit gate once, resets the selected lane's scratch
+/// fields, and points GS at that lane's state so the assembly entry/exit path
+/// is reentrant across vCPUs.
+///
+/// # Safety
+/// Safe to call from kernel mode (CPL=0). The caller must pass the lane owned
+/// by the currently running vCPU.
+pub unsafe fn prepare_ring3_entry(lane: ExecutionLane) {
+    lane.assert_in_range();
+    unsafe { install_ring3_exit_gate() };
+    let state = &RING3_LANES[lane.index()];
+    unsafe {
+        state.reset_for_entry(lane);
+        write_gs_bases(state.ptr() as u64);
+    }
+}
 
 /// Install the ring-3 exit gate at vector 0x81 (DPL=3, IST=1).
 ///
@@ -181,8 +294,4 @@ pub unsafe fn install_ring3_exit_gate() {
             );
         }
     }
-    // Reset captured state from any prior call.
-    KERNEL_RESUME_RSP.store(0, Ordering::SeqCst);
-    SAVED_CR3.store(0, Ordering::SeqCst);
-    USER_EXIT_RAX.store(0, Ordering::SeqCst);
 }

--- a/rust/nub-arch-x86/src/ring3.rs
+++ b/rust/nub-arch-x86/src/ring3.rs
@@ -239,6 +239,8 @@ static LANE_CPU: [LaneCpuControlCell; MAX_EXECUTION_LANES] =
     [const { LaneCpuControlCell::new() }; MAX_EXECUTION_LANES];
 static LANE_CPU_READY: [AtomicBool; MAX_EXECUTION_LANES] =
     [const { AtomicBool::new(false) }; MAX_EXECUTION_LANES];
+static RING3_LANE_READY: [AtomicBool; MAX_EXECUTION_LANES] =
+    [const { AtomicBool::new(false) }; MAX_EXECUTION_LANES];
 
 const TSS_SEL: u16 = 0x18;
 
@@ -443,13 +445,20 @@ core::arch::global_asm!(
 /// by the currently running vCPU.
 pub unsafe fn prepare_ring3_entry(lane: ExecutionLane) {
     lane.assert_in_range();
-    unsafe {
-        install_lane_cpu_control(lane);
-        install_ring3_exit_gate();
-    }
     let state = &RING3_LANES[lane.index()];
+    if !RING3_LANE_READY[lane.index()].load(Ordering::Acquire) {
+        unsafe {
+            install_lane_cpu_control(lane);
+            install_ring3_exit_gate();
+            write_gs_bases(state.ptr() as u64);
+        }
+        RING3_LANE_READY[lane.index()].store(true, Ordering::Release);
+    }
     unsafe {
         state.reset_for_entry(lane);
+        // GS base is not persistent across top-level guest entries in the
+        // Hyperlight/KVM path, so refresh it every time even though the
+        // lane-local GDT/TSS/IDT setup above is stable.
         write_gs_bases(state.ptr() as u64);
     }
 }

--- a/rust/nub-arch-x86/src/ring3.rs
+++ b/rust/nub-arch-x86/src/ring3.rs
@@ -34,11 +34,11 @@
 //!
 //! Notes:
 //!
-//! * **IST=1 for vector 0x81.** Hyperlight already sets up an
-//!   exception stack at `MAX_GVA - SCRATCH_TOP_EXN_STACK_OFFSET + 1`
-//!   and points TSS.IST1 at it. Using IST=1 means we don't need to
-//!   touch TSS.RSP0; the interrupt frame lands on the exception
-//!   stack and we abandon it after copying RAX out.
+//! * **IST=1 for vector 0x81.** [`prepare_ring3_entry`] installs a
+//!   lane-local TSS whose IST1 points at the active vCPU lane's private
+//!   exception stack. Using IST=1 means we don't need to touch TSS.RSP0;
+//!   the interrupt frame lands on that lane's exception stack and we abandon
+//!   it after copying RAX out.
 //! * **Lane-local state.** [`prepare_ring3_entry`] points GS at the active
 //!   lane's [`Ring3LaneRaw`]. The entry/exit assembly stores its saved kernel
 //!   RSP, saved CR3, and user RAX through GS, so two vCPUs can take the exit
@@ -48,8 +48,10 @@
 //!   side swapped before the final `int 0x81`.
 
 use core::cell::UnsafeCell;
-use core::mem::offset_of;
+use core::mem::{offset_of, size_of};
+use core::ptr;
 use core::sync::atomic::{AtomicBool, Ordering};
+use spin::Once;
 
 use crate::execution_lane::{ExecutionLane, MAX_EXECUTION_LANES};
 
@@ -109,6 +111,137 @@ impl Ring3LaneState {
 static RING3_LANES: [Ring3LaneState; MAX_EXECUTION_LANES] =
     [const { Ring3LaneState::new() }; MAX_EXECUTION_LANES];
 
+#[repr(C, align(8))]
+#[derive(Clone, Copy)]
+struct GdtEntry {
+    limit_low: u16,
+    base_low: u16,
+    base_middle: u8,
+    access: u8,
+    flags_limit: u8,
+    base_high: u8,
+}
+
+impl GdtEntry {
+    const fn new(base: u32, limit: u32, access: u8, flags: u8) -> Self {
+        Self {
+            limit_low: (limit & 0xffff) as u16,
+            base_low: (base & 0xffff) as u16,
+            base_middle: ((base >> 16) & 0xff) as u8,
+            access,
+            flags_limit: (((limit >> 16) & 0x0f) as u8) | ((flags & 0x0f) << 4),
+            base_high: ((base >> 24) & 0xff) as u8,
+        }
+    }
+
+    const fn user(access: u8, flags: u8) -> Self {
+        Self {
+            limit_low: 0,
+            base_low: 0,
+            base_middle: 0,
+            access,
+            flags_limit: (flags & 0x0f) << 4,
+            base_high: 0,
+        }
+    }
+
+    const fn tss(base: u64, limit: u32) -> [Self; 2] {
+        [
+            Self {
+                limit_low: (limit & 0xffff) as u16,
+                base_low: (base & 0xffff) as u16,
+                base_middle: ((base >> 16) & 0xff) as u8,
+                access: 0x89,
+                flags_limit: ((limit >> 16) & 0x0f) as u8,
+                base_high: ((base >> 24) & 0xff) as u8,
+            },
+            Self {
+                limit_low: ((base >> 32) & 0xffff) as u16,
+                base_low: ((base >> 48) & 0xffff) as u16,
+                base_middle: 0,
+                access: 0,
+                flags_limit: 0,
+                base_high: 0,
+            },
+        ]
+    }
+}
+
+#[repr(C, packed)]
+struct Tss {
+    _rsvd0: [u8; 4],
+    _rsp0: u64,
+    _rsp1: u64,
+    _rsp2: u64,
+    _rsvd1: [u8; 8],
+    ist1: u64,
+    _ist2: u64,
+    _ist3: u64,
+    _ist4: u64,
+    _ist5: u64,
+    _ist6: u64,
+    _ist7: u64,
+    _rsvd2: [u8; 10],
+    _iomap_base: u16,
+}
+
+impl Tss {
+    const fn new() -> Self {
+        Self {
+            _rsvd0: [0; 4],
+            _rsp0: 0,
+            _rsp1: 0,
+            _rsp2: 0,
+            _rsvd1: [0; 8],
+            ist1: 0,
+            _ist2: 0,
+            _ist3: 0,
+            _ist4: 0,
+            _ist5: 0,
+            _ist6: 0,
+            _ist7: 0,
+            _rsvd2: [0; 10],
+            _iomap_base: size_of::<Tss>() as u16,
+        }
+    }
+}
+
+#[repr(C, align(16))]
+struct LaneCpuControl {
+    gdt: [GdtEntry; 7],
+    tss: Tss,
+}
+
+impl LaneCpuControl {
+    const fn new() -> Self {
+        Self {
+            gdt: [GdtEntry::new(0, 0, 0, 0); 7],
+            tss: Tss::new(),
+        }
+    }
+}
+
+struct LaneCpuControlCell {
+    raw: UnsafeCell<LaneCpuControl>,
+}
+
+unsafe impl Sync for LaneCpuControlCell {}
+
+impl LaneCpuControlCell {
+    const fn new() -> Self {
+        Self {
+            raw: UnsafeCell::new(LaneCpuControl::new()),
+        }
+    }
+}
+
+static LANE_CPU: [LaneCpuControlCell; MAX_EXECUTION_LANES] =
+    [const { LaneCpuControlCell::new() }; MAX_EXECUTION_LANES];
+static LANE_CPU_READY: [AtomicBool; MAX_EXECUTION_LANES] =
+    [const { AtomicBool::new(false) }; MAX_EXECUTION_LANES];
+
+const TSS_SEL: u16 = 0x18;
+
 const LANE_INDEX_OFFSET: usize = offset_of!(Ring3LaneRaw, lane_index);
 const KERNEL_RESUME_RSP_OFFSET: usize = offset_of!(Ring3LaneRaw, kernel_resume_rsp);
 const SAVED_CR3_OFFSET: usize = offset_of!(Ring3LaneRaw, saved_cr3);
@@ -140,6 +273,62 @@ unsafe fn write_gs_bases(base: u64) {
         // correct even if a prior exception left it swapped.
         write_msr(IA32_KERNEL_GS_BASE, base);
     }
+}
+
+fn lane_exception_stack_top(lane: usize) -> u64 {
+    nub_host_common::layout::MAX_GVA as u64 - nub_host_common::layout::SCRATCH_TOP_EXN_STACK_OFFSET
+        + 1
+        - lane as u64 * nub_host_common::layout::VCPU_EXCEPTION_STACK_STRIDE
+}
+
+/// Install the lane-local GDT/TSS for the current vCPU.
+///
+/// Hyperlight's boot path starts every vCPU with lane 0's post-boot SREGs, so
+/// all lanes initially share one TSS and therefore one IST1 stack. Concurrent
+/// ring-3 exits and page faults need independent IST storage; otherwise two
+/// vCPUs can scribble over the same interrupt frames. We keep the selector
+/// layout identical to the boot GDT, but point the TSS descriptor at
+/// per-lane storage and load TR once for that lane.
+///
+/// # Safety
+/// Must run in ring 0 on the vCPU represented by `lane`, before that lane
+/// enters ring 3. A lane must not call this concurrently with itself.
+unsafe fn install_lane_cpu_control(lane: ExecutionLane) {
+    let idx = lane.index();
+    if LANE_CPU_READY[idx].load(Ordering::Acquire) {
+        return;
+    }
+
+    let ctrl = LANE_CPU[idx].raw.get();
+    let tss_ptr = unsafe { ptr::addr_of_mut!((*ctrl).tss) };
+    unsafe {
+        ptr::write(tss_ptr, Tss::new());
+        ptr::addr_of_mut!((*tss_ptr).ist1).write_unaligned(lane_exception_stack_top(idx));
+    }
+
+    let tss_base = tss_ptr as u64;
+    let tss_limit = (size_of::<Tss>() - 1) as u32;
+    let tss = GdtEntry::tss(tss_base, tss_limit);
+    let gdt = [
+        GdtEntry::new(0, 0, 0, 0),
+        GdtEntry::new(0, 0, 0x9A, 0xA),
+        GdtEntry::new(0, 0, 0x92, 0xC),
+        tss[0],
+        tss[1],
+        GdtEntry::user(0xFA, 0xA),
+        GdtEntry::user(0xF2, 0xC),
+    ];
+    unsafe {
+        ptr::addr_of_mut!((*ctrl).gdt).write(gdt);
+        let gdtr = crate::segments::GdtDescriptor {
+            limit: (size_of::<[GdtEntry; 7]>() - 1) as u16,
+            base: ptr::addr_of!((*ctrl).gdt) as u64,
+        };
+        crate::segments::lgdt(&gdtr);
+        core::arch::asm!("ltr ax", in("ax") TSS_SEL, options(nostack, preserves_flags));
+    }
+
+    LANE_CPU_READY[idx].store(true, Ordering::Release);
 }
 
 /// Return the lane selected by the current GS base. Valid while running in the
@@ -254,7 +443,10 @@ core::arch::global_asm!(
 /// by the currently running vCPU.
 pub unsafe fn prepare_ring3_entry(lane: ExecutionLane) {
     lane.assert_in_range();
-    unsafe { install_ring3_exit_gate() };
+    unsafe {
+        install_lane_cpu_control(lane);
+        install_ring3_exit_gate();
+    }
     let state = &RING3_LANES[lane.index()];
     unsafe {
         state.reset_for_entry(lane);
@@ -275,23 +467,22 @@ pub unsafe fn prepare_ring3_entry(lane: ExecutionLane) {
 /// this from an interrupt handler (which would race against the
 /// current CPU's GDTR/IDTR pointer).
 pub unsafe fn install_ring3_exit_gate() {
-    // First-call-only: install GDT user segments + patch IDT entry
-    // for the ring-3 exit vector. Both `install_user_segments` and
-    // `install_dpl3_handler` `Box::leak` ~4 KiB of memory (the new
-    // IDT + descriptor) on every call — re-running them per
-    // invocation leaked 4106 B/iter (confirmed via `talc::counters`).
-    // The installed IDT is shared across all invocations; nothing
-    // about it depends on per-call state.
-    static INSTALLED: AtomicBool = AtomicBool::new(false);
-    if !INSTALLED.swap(true, Ordering::AcqRel) {
-        // SAFETY: ring-0 GDT/IDT mutation; see module-level docs.
-        unsafe {
-            crate::segments::install_user_segments();
-            let _ = crate::segments::install_dpl3_handler(
+    // The IDT storage allocation is process-global, but GDTR/IDTR are vCPU
+    // registers. Every lane must reload its GDT limit (for USER_CS/USER_DS)
+    // and IDT base (for vector 0x81), while the ~4 KiB IDT buffer is created
+    // only once.
+    static RING3_IDT: Once<&'static crate::segments::IdtDescriptor> = Once::new();
+
+    // SAFETY: ring-0 GDT/IDT mutation; see module-level docs.
+    unsafe {
+        crate::segments::install_user_segments();
+        let descriptor = RING3_IDT.call_once(|| {
+            crate::segments::install_dpl3_handler(
                 RING3_EXIT_VECTOR,
                 nub_ring3_exit_stub as *const () as u64,
-                1, // IST=1, run on the pre-existing exception stack
-            );
-        }
+                1, // IST=1, run on the lane-local exception stack
+            )
+        });
+        crate::segments::lidt(descriptor);
     }
 }

--- a/rust/nub-arch-x86/src/test_abi.rs
+++ b/rust/nub-arch-x86/src/test_abi.rs
@@ -9,6 +9,10 @@
 /// Smoke probe — returns 42u64 rkyv-encoded.
 pub const FN_ID_TEST_SMOKE: u32 = 100;
 
+/// Test-only scheduler probe. Payload is two raw `InvokePacket`s concatenated;
+/// output is rkyv-encoded `[InvocationResult; 2]`.
+pub const FN_ID_TEST_INVOKE_TWO_SERIAL: u32 = 101;
+
 /// Bench: allocate `N` × `Arc<Page>` where `Page` is a 4 KiB
 /// page-aligned block.
 ///

--- a/rust/nub-host-common/src/layout.rs
+++ b/rust/nub-host-common/src/layout.rs
@@ -117,6 +117,21 @@ pub const SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET: u64 = 0x18;
 pub const SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET: u64 = 0x20;
 pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x30;
 
+/// Bytes reserved for each vCPU's ring-0 exception/interrupt stack. The stack
+/// top for lane `n` is below the legacy Hyperlight exception-stack top by
+/// `n * VCPU_EXCEPTION_STACK_STRIDE`.
+pub const VCPU_EXCEPTION_STACK_STRIDE: u64 = 64 * 1024;
+
+/// Bytes reserved for each vCPU's host-dispatch stack. These stacks are used
+/// while executing guest function dispatchers and long-lived invoke workers,
+/// not for ring-3 PVM execution.
+pub const VCPU_DISPATCH_STACK_STRIDE: u64 = 64 * 1024;
+
+/// Fixed number of dispatch-stack lanes mapped by the guest at boot. The
+/// public Nub default caps at 8 vCPUs, but this leaves headroom for explicit
+/// test/bench overrides without needing a guest ABI field during phase 1.
+pub const VCPU_DISPATCH_STACK_LANES: u64 = 64;
+
 pub fn scratch_base_gpa(size: usize) -> u64 {
     (MAX_GPA - size + 1) as u64
 }

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 mod x86_64;
 
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use nub_host_common::log_level::GuestLogFilter;
@@ -374,7 +375,7 @@ pub(crate) struct HyperlightVm {
 
     pub(super) mmap_regions: Vec<(u32, MemoryRegion)>, // Later mapped regions (slot number, region)
 
-    pub(super) pending_tlb_flush: bool,
+    pub(super) pending_tlb_flush: AtomicBool,
 }
 
 impl HyperlightVm {

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
@@ -107,6 +107,8 @@ pub enum DispatchGuestCallError {
     Run(#[from] RunVmError),
     #[error("Failed to setup registers: {0}")]
     SetupRegs(RegisterError),
+    #[error("Invalid dispatch stack for vCPU lane {lane}: base rsp={rsp:#x}")]
+    InvalidLaneStack { lane: usize, rsp: u64 },
     #[error("VM was uninitialized")]
     Uninitialized,
 }
@@ -118,7 +120,9 @@ impl DispatchGuestCallError {
             // These errors poison the sandbox because they can leave it in an inconsistent state
             // by returning before the guest can unwind properly
             DispatchGuestCallError::Run(_) => true,
-            DispatchGuestCallError::SetupRegs(_) | DispatchGuestCallError::Uninitialized => false,
+            DispatchGuestCallError::SetupRegs(_)
+            | DispatchGuestCallError::InvalidLaneStack { .. }
+            | DispatchGuestCallError::Uninitialized => false,
         }
     }
 
@@ -196,6 +200,8 @@ pub enum RunVmError {
 pub enum HandleIoError {
     #[error("No data was given in IO interrupt")]
     NoData,
+    #[error("sandbox memory manager mutex poisoned")]
+    MemoryManagerPoisoned,
     #[error("{0}")]
     Outb(#[from] HandleOutbError),
 }
@@ -479,6 +485,30 @@ impl HyperlightVm {
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
     ) -> std::result::Result<(), RunVmError> {
+        self.run_on_with_io(lane, |port, data| {
+            self.handle_io(mem_mgr, host_funcs, port, data)
+        })
+    }
+
+    pub(super) fn run_on_shared(
+        &self,
+        lane: VcpuLane,
+        mem_mgr: &Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
+        host_funcs: &Arc<Mutex<FunctionRegistry>>,
+    ) -> std::result::Result<(), RunVmError> {
+        self.run_on_with_io(lane, |port, data| {
+            let mut mem_mgr = mem_mgr
+                .lock()
+                .map_err(|_| HandleIoError::MemoryManagerPoisoned)?;
+            self.handle_io(&mut mem_mgr, host_funcs, port, data)
+        })
+    }
+
+    fn run_on_with_io(
+        &self,
+        lane: VcpuLane,
+        mut handle_io: impl FnMut(u16, Vec<u8>) -> std::result::Result<(), HandleIoError>,
+    ) -> std::result::Result<(), RunVmError> {
         let interrupt_handle = self
             .interrupt_handles
             .get(lane.index())
@@ -532,7 +562,7 @@ impl HyperlightVm {
                     break Ok(());
                 }
                 Ok(VmExit::IoOut(port, data)) => {
-                    self.handle_io(mem_mgr, host_funcs, port, data)?;
+                    handle_io(port, data)?;
                 }
                 Ok(VmExit::MmioRead(addr)) => {
                     let all_regions = self.get_mapped_regions();

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
@@ -27,7 +27,7 @@ use crate::hypervisor::virtual_machine::{
     MapMemoryError, RegisterError, RunVcpuError, UnmapMemoryError, VmError, VmExit,
 };
 use crate::hypervisor::virtual_machine::{VcpuLane, VirtualMachine};
-use crate::hypervisor::{InterruptHandle, InterruptHandleImpl};
+use crate::hypervisor::{InterruptHandle, InterruptHandleImpl, MultiLaneInterruptHandle};
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags, MemoryRegionType};
 use crate::mem::mgr::{SandboxMemoryManager, SnapshotSharedMemory};
 use crate::mem::shared_mem::{GuestSharedMemory, HostSharedMemory, SharedMemory};
@@ -446,7 +446,16 @@ impl HyperlightVm {
     }
 
     pub(crate) fn interrupt_handle(&self) -> Arc<dyn InterruptHandle> {
-        self.interrupt_handles[VcpuLane::PRIMARY.index()].clone()
+        if self.interrupt_handles.len() == 1 {
+            self.interrupt_handles[VcpuLane::PRIMARY.index()].clone()
+        } else {
+            Arc::new(MultiLaneInterruptHandle::new(
+                self.interrupt_handles
+                    .iter()
+                    .map(|handle| handle.clone() as Arc<dyn InterruptHandle>)
+                    .collect(),
+            ))
+        }
     }
 
     pub(crate) fn clear_cancel(&self) {

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/mod.rs
@@ -23,10 +23,10 @@ use nub_host_common::log_level::GuestLogFilter;
 use tracing_core::LevelFilter;
 
 use crate::HyperlightError;
-use crate::hypervisor::virtual_machine::VirtualMachine;
 use crate::hypervisor::virtual_machine::{
     MapMemoryError, RegisterError, RunVcpuError, UnmapMemoryError, VmError, VmExit,
 };
+use crate::hypervisor::virtual_machine::{VcpuLane, VirtualMachine};
 use crate::hypervisor::{InterruptHandle, InterruptHandleImpl};
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags, MemoryRegionType};
 use crate::mem::mgr::{SandboxMemoryManager, SnapshotSharedMemory};
@@ -356,7 +356,7 @@ pub(crate) struct HyperlightVm {
     pub(super) vm: Box<dyn VirtualMachine>,
     pub(super) entrypoint: NextAction, // only present if this vm has not yet been initialised
     pub(super) rsp_gva: u64,
-    pub(super) interrupt_handle: Arc<dyn InterruptHandleImpl>,
+    pub(super) interrupt_handles: Vec<Arc<dyn InterruptHandleImpl>>,
 
     pub(super) snapshot_slot: u32,
     // The current snapshot region, used to keep it alive as long as
@@ -446,51 +446,72 @@ impl HyperlightVm {
     }
 
     pub(crate) fn interrupt_handle(&self) -> Arc<dyn InterruptHandle> {
-        self.interrupt_handle.clone()
+        self.interrupt_handles[VcpuLane::PRIMARY.index()].clone()
     }
 
     pub(crate) fn clear_cancel(&self) {
-        self.interrupt_handle.clear_cancel();
+        for handle in &self.interrupt_handles {
+            handle.clear_cancel();
+        }
     }
 
     pub(super) fn run(
-        &mut self,
+        &self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
     ) -> std::result::Result<(), RunVmError> {
+        self.run_on(VcpuLane::PRIMARY, mem_mgr, host_funcs)
+    }
+
+    pub(super) fn run_on(
+        &self,
+        lane: VcpuLane,
+        mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
+        host_funcs: &Arc<Mutex<FunctionRegistry>>,
+    ) -> std::result::Result<(), RunVmError> {
+        let interrupt_handle = self
+            .interrupt_handles
+            .get(lane.index())
+            .ok_or_else(|| {
+                RunVmError::UnexpectedVmExit(format!("invalid vCPU lane {}", lane.index()))
+            })?
+            .clone();
         let result = loop {
             // ===== KILL() TIMING POINT 2: Before set_tid() =====
             // If kill() is called and ran to completion BEFORE this line executes:
             //    - CANCEL_BIT will be set and we will return an early VmExit::Cancelled()
             //      without sending any signals/WHV api calls
-            self.interrupt_handle.set_tid();
-            self.interrupt_handle.set_running();
+            interrupt_handle.set_tid();
+            interrupt_handle.set_running();
             // NOTE: `set_running()`` must be called before checking `is_cancelled()`
             // otherwise we risk missing a call to `kill()` because the vcpu would not be marked as running yet so signals won't be sent
 
-            let exit_reason = if self.interrupt_handle.is_cancelled()
-                || self.interrupt_handle.is_debug_interrupted()
-            {
-                Ok(VmExit::Cancelled())
-            } else {
-                // ==== KILL() TIMING POINT 3: Before calling run() ====
-                // If kill() is called and ran to completion BEFORE this line executes:
-                //    - Will still do a VM entry, but signals will be sent until VM exits
-                self.vm.run_vcpu()
-            };
+            let exit_reason =
+                if interrupt_handle.is_cancelled() || interrupt_handle.is_debug_interrupted() {
+                    Ok(VmExit::Cancelled())
+                } else {
+                    // ==== KILL() TIMING POINT 3: Before calling run() ====
+                    // If kill() is called and ran to completion BEFORE this line executes:
+                    //    - Will still do a VM entry, but signals will be sent until VM exits
+                    if lane == VcpuLane::PRIMARY {
+                        self.vm.run_vcpu()
+                    } else {
+                        self.vm.run_vcpu_on(lane)
+                    }
+                };
 
             // ===== KILL() TIMING POINT 4: Before clear_running() =====
             // If kill() is called and ran to completion BEFORE this line executes:
             //    - CANCEL_BIT will be set. Cancellation is deferred to the next iteration.
             //    - Signals will be sent until `clear_running()` is called, which is ok
-            self.interrupt_handle.clear_running();
+            interrupt_handle.clear_running();
 
             // ===== KILL() TIMING POINT 5: Before capturing cancel_requested =====
             // If kill() is called and ran to completion BEFORE this line executes:
             //    - CANCEL_BIT will be set. Cancellation is deferred to the next iteration.
             //    - Signals will not be sent
-            let cancel_requested = self.interrupt_handle.is_cancelled();
-            let debug_interrupted = self.interrupt_handle.is_debug_interrupted();
+            let cancel_requested = interrupt_handle.is_cancelled();
+            let debug_interrupted = interrupt_handle.is_debug_interrupted();
 
             // ===== KILL() TIMING POINT 6: Before checking exit_reason =====
             // If kill() is called and ran to completion BEFORE this line executes:
@@ -577,7 +598,7 @@ impl HyperlightVm {
 
     /// Handle an IO exit
     fn handle_io(
-        &mut self,
+        &self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
         port: u16,
@@ -603,7 +624,9 @@ impl HyperlightVm {
 
 impl Drop for HyperlightVm {
     fn drop(&mut self) {
-        self.interrupt_handle.set_dropped();
+        for handle in &self.interrupt_handles {
+            handle.set_dropped();
+        }
     }
 }
 

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -26,9 +26,9 @@ use super::*;
 use crate::hypervisor::InterruptHandleImpl;
 use crate::hypervisor::LinuxInterruptHandle;
 use crate::hypervisor::regs::{CommonFpu, CommonRegisters, CommonSpecialRegisters};
-use crate::hypervisor::virtual_machine::VirtualMachine;
 use crate::hypervisor::virtual_machine::kvm::KvmVm;
 use crate::hypervisor::virtual_machine::{HypervisorType, VmError, get_available_hypervisor};
+use crate::hypervisor::virtual_machine::{VcpuLane, VirtualMachine};
 use crate::mem::mgr::SandboxMemoryManager;
 use crate::mem::ptr::RawPtr;
 use crate::mem::shared_mem::{GuestSharedMemory, HostSharedMemory};
@@ -58,31 +58,37 @@ impl HyperlightVm {
             None => return Err(CreateHyperlightVmError::NoHypervisorFound),
         };
 
-        vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(
-            root_pt_addr,
-        ))
-        .map_err(VmError::Register)?;
+        let sregs = CommonSpecialRegisters::standard_64bit_defaults(root_pt_addr);
+        vm.set_sregs(&sregs).map_err(VmError::Register)?;
+        for lane in 1..vm.vcpu_count() {
+            vm.set_sregs_on(VcpuLane::new(lane), &sregs)
+                .map_err(VmError::Register)?;
+        }
 
-        let interrupt_handle: Arc<dyn InterruptHandleImpl> = Arc::new(LinuxInterruptHandle {
-            state: AtomicU8::new(0),
-            #[cfg(all(
-                target_arch = "x86_64",
-                target_vendor = "unknown",
-                target_os = "linux",
-                target_env = "musl"
-            ))]
-            tid: AtomicU64::new(unsafe { libc::pthread_self() as u64 }),
-            #[cfg(not(all(
-                target_arch = "x86_64",
-                target_vendor = "unknown",
-                target_os = "linux",
-                target_env = "musl"
-            )))]
-            tid: AtomicU64::new(unsafe { libc::pthread_self() }),
-            retry_delay: config.get_interrupt_retry_delay(),
-            sig_rt_min_offset: config.get_interrupt_vcpu_sigrtmin_offset(),
-            dropped: AtomicBool::new(false),
-        });
+        let interrupt_handles: Vec<Arc<dyn InterruptHandleImpl>> = (0..vm.vcpu_count())
+            .map(|_| {
+                Arc::new(LinuxInterruptHandle {
+                    state: AtomicU8::new(0),
+                    #[cfg(all(
+                        target_arch = "x86_64",
+                        target_vendor = "unknown",
+                        target_os = "linux",
+                        target_env = "musl"
+                    ))]
+                    tid: AtomicU64::new(unsafe { libc::pthread_self() as u64 }),
+                    #[cfg(not(all(
+                        target_arch = "x86_64",
+                        target_vendor = "unknown",
+                        target_os = "linux",
+                        target_env = "musl"
+                    )))]
+                    tid: AtomicU64::new(unsafe { libc::pthread_self() }),
+                    retry_delay: config.get_interrupt_retry_delay(),
+                    sig_rt_min_offset: config.get_interrupt_vcpu_sigrtmin_offset(),
+                    dropped: AtomicBool::new(false),
+                }) as Arc<dyn InterruptHandleImpl>
+            })
+            .collect();
 
         let snapshot_slot = 0u32;
         let scratch_slot = 1u32;
@@ -90,7 +96,7 @@ impl HyperlightVm {
             vm,
             entrypoint,
             rsp_gva,
-            interrupt_handle,
+            interrupt_handles,
 
             snapshot_slot,
             snapshot_memory: None,

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -180,6 +180,20 @@ impl HyperlightVm {
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
     ) -> std::result::Result<(), DispatchGuestCallError> {
+        self.dispatch_call_from_host_on(VcpuLane::PRIMARY, mem_mgr, host_funcs)
+    }
+
+    /// Dispatch a host call on a selected vCPU lane. The old shared input/output
+    /// ring is still serialized by the caller, so this is not a concurrent hot
+    /// path yet; it proves that non-primary vCPUs can enter the guest and gives
+    /// the future worker queue a lane-addressed entry primitive.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
+    pub(crate) fn dispatch_call_from_host_on(
+        &mut self,
+        lane: VcpuLane,
+        mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
+        host_funcs: &Arc<Mutex<FunctionRegistry>>,
+    ) -> std::result::Result<(), DispatchGuestCallError> {
         let NextAction::Call(dispatch_func_addr) = self.entrypoint else {
             return Err(DispatchGuestCallError::Uninitialized);
         };
@@ -204,16 +218,22 @@ impl HyperlightVm {
             ..Default::default()
         };
         self.vm
-            .set_regs(&regs)
+            .set_regs_on(lane, &regs)
             .map_err(DispatchGuestCallError::SetupRegs)?;
 
         // reset fpu
-        self.vm
-            .set_fpu(&CommonFpu::default())
-            .map_err(DispatchGuestCallError::SetupRegs)?;
+        if lane == VcpuLane::PRIMARY {
+            self.vm
+                .set_fpu(&CommonFpu::default())
+                .map_err(DispatchGuestCallError::SetupRegs)?;
+        } else {
+            self.vm
+                .set_fpu_on(lane, &CommonFpu::default())
+                .map_err(DispatchGuestCallError::SetupRegs)?;
+        }
 
         let result = self
-            .run(mem_mgr, host_funcs)
+            .run_on(lane, mem_mgr, host_funcs)
             .map_err(DispatchGuestCallError::Run);
 
         // Clear the TLB flush flag only after run() returns. The guest

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tracing::{Span, instrument};
@@ -106,7 +106,7 @@ impl HyperlightVm {
 
             mmap_regions: Vec::new(),
 
-            pending_tlb_flush: false,
+            pending_tlb_flush: AtomicBool::new(false),
         };
 
         ret.install_snapshot_mapping(snapshot_mem)?;
@@ -176,7 +176,7 @@ impl HyperlightVm {
     /// Returns `Ok` if the call succeeded, and an `Err` if it failed
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
     pub(crate) fn dispatch_call_from_host(
-        &mut self,
+        &self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
     ) -> std::result::Result<(), DispatchGuestCallError> {
@@ -189,7 +189,7 @@ impl HyperlightVm {
     /// the future worker queue a lane-addressed entry primitive.
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
     pub(crate) fn dispatch_call_from_host_on(
-        &mut self,
+        &self,
         lane: VcpuLane,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
@@ -198,7 +198,7 @@ impl HyperlightVm {
             return Err(DispatchGuestCallError::Uninitialized);
         };
         let mut rflags = 1 << 1; // RFLAGS.1 is RES1
-        if self.pending_tlb_flush {
+        if self.pending_tlb_flush.load(Ordering::Acquire) {
             rflags |= 1 << 6; // set ZF if we need a tlb flush done before anything else executes
         }
         // set RIP and RSP, reset others
@@ -238,7 +238,7 @@ impl HyperlightVm {
 
         // Clear the TLB flush flag only after run() returns. The guest
         // may have been cancelled before it executed the flush.
-        self.pending_tlb_flush = false;
+        self.pending_tlb_flush.store(false, Ordering::Release);
 
         result
     }

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -52,7 +52,9 @@ impl HyperlightVm {
         type VmType = Box<dyn VirtualMachine>;
 
         let vm: VmType = match get_available_hypervisor() {
-            Some(HypervisorType::Kvm) => Box::new(KvmVm::new().map_err(VmError::CreateVm)?),
+            Some(HypervisorType::Kvm) => {
+                Box::new(KvmVm::new(config.get_vcpu_count()).map_err(VmError::CreateVm)?)
+            }
             None => return Err(CreateHyperlightVmError::NoHypervisorFound),
         };
 

--- a/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -163,6 +163,10 @@ impl HyperlightVm {
         }
         self.rsp_gva = regs.rsp;
         self.entrypoint = NextAction::Call(regs.rax);
+        let sregs = self.vm.sregs()?;
+        for lane in 1..self.vm.vcpu_count() {
+            self.vm.set_sregs_on(VcpuLane::new(lane), &sregs)?;
+        }
 
         Ok(())
     }
@@ -184,9 +188,8 @@ impl HyperlightVm {
     }
 
     /// Dispatch a host call on a selected vCPU lane. The old shared input/output
-    /// ring is still serialized by the caller, so this is not a concurrent hot
-    /// path yet; it proves that non-primary vCPUs can enter the guest and gives
-    /// the future worker queue a lane-addressed entry primitive.
+    /// ring is still serialized by the caller; the concurrent invoke workers
+    /// use this only as their long-lived entry into the guest.
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
     pub(crate) fn dispatch_call_from_host_on(
         &self,
@@ -194,9 +197,55 @@ impl HyperlightVm {
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
     ) -> std::result::Result<(), DispatchGuestCallError> {
+        self.prepare_dispatch_call_from_host(lane)?;
+        let result = self
+            .run_on(lane, mem_mgr, host_funcs)
+            .map_err(DispatchGuestCallError::Run);
+
+        // Clear the TLB flush flag only after run() returns. The guest
+        // may have been cancelled before it executed the flush.
+        self.pending_tlb_flush.store(false, Ordering::Release);
+
+        result
+    }
+
+    /// Dispatch a host call while sharing the sandbox memory manager with
+    /// other host threads. The run loop takes the memory-manager mutex only
+    /// around IO exits; slot-based invoke workers use this so KVM can keep
+    /// running while callers post jobs into scratch.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
+    pub(crate) fn dispatch_call_from_host_on_shared(
+        &self,
+        lane: VcpuLane,
+        mem_mgr: &Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
+        host_funcs: &Arc<Mutex<FunctionRegistry>>,
+    ) -> std::result::Result<(), DispatchGuestCallError> {
+        self.prepare_dispatch_call_from_host(lane)?;
+        let result = self
+            .run_on_shared(lane, mem_mgr, host_funcs)
+            .map_err(DispatchGuestCallError::Run);
+
+        // Clear the TLB flush flag only after run() returns. The guest
+        // may have been cancelled before it executed the flush.
+        self.pending_tlb_flush.store(false, Ordering::Release);
+
+        result
+    }
+
+    fn prepare_dispatch_call_from_host(
+        &self,
+        lane: VcpuLane,
+    ) -> std::result::Result<(), DispatchGuestCallError> {
         let NextAction::Call(dispatch_func_addr) = self.entrypoint else {
             return Err(DispatchGuestCallError::Uninitialized);
         };
+        let rsp_gva = self
+            .rsp_gva
+            .checked_sub(lane.index() as u64 * nub_host_common::layout::VCPU_DISPATCH_STACK_STRIDE)
+            .ok_or(DispatchGuestCallError::InvalidLaneStack {
+                lane: lane.index(),
+                rsp: self.rsp_gva,
+            })?;
         let mut rflags = 1 << 1; // RFLAGS.1 is RES1
         if self.pending_tlb_flush.load(Ordering::Acquire) {
             rflags |= 1 << 6; // set ZF if we need a tlb flush done before anything else executes
@@ -213,7 +262,7 @@ impl HyperlightVm {
             // address).  However, the x64 entry stub in
             // hyperlight_guest::arch::dispatch handles this itself,
             // so we do use the aligned address here.
-            rsp: self.rsp_gva,
+            rsp: rsp_gva,
             rflags,
             ..Default::default()
         };
@@ -232,14 +281,6 @@ impl HyperlightVm {
                 .map_err(DispatchGuestCallError::SetupRegs)?;
         }
 
-        let result = self
-            .run_on(lane, mem_mgr, host_funcs)
-            .map_err(DispatchGuestCallError::Run);
-
-        // Clear the TLB flush flag only after run() returns. The guest
-        // may have been cancelled before it executed the flush.
-        self.pending_tlb_flush.store(false, Ordering::Release);
-
-        result
+        Ok(())
     }
 }

--- a/rust/nub-host-kvm/src/hypervisor/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/mod.rs
@@ -207,3 +207,28 @@ impl InterruptHandle for LinuxInterruptHandle {
         self.dropped.load(Ordering::Acquire)
     }
 }
+
+#[derive(Debug)]
+pub(super) struct MultiLaneInterruptHandle {
+    handles: Vec<std::sync::Arc<dyn InterruptHandle>>,
+}
+
+impl MultiLaneInterruptHandle {
+    pub(super) fn new(handles: Vec<std::sync::Arc<dyn InterruptHandle>>) -> Self {
+        Self { handles }
+    }
+}
+
+impl InterruptHandle for MultiLaneInterruptHandle {
+    fn kill(&self) -> bool {
+        let mut interrupted = false;
+        for handle in &self.handles {
+            interrupted = handle.kill() || interrupted;
+        }
+        interrupted
+    }
+
+    fn dropped(&self) -> bool {
+        self.handles.iter().all(|handle| handle.dropped())
+    }
+}

--- a/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use std::sync::LazyLock;
+use std::sync::{Mutex, MutexGuard};
 
 use kvm_bindings::{kvm_fpu, kvm_regs, kvm_sregs, kvm_userspace_memory_region};
 use kvm_ioctls::Cap::UserMemory;
@@ -24,7 +25,7 @@ use tracing::{Span, instrument};
 
 use crate::hypervisor::regs::{CommonFpu, CommonRegisters, CommonSpecialRegisters};
 use crate::hypervisor::virtual_machine::{
-    CreateVmError, MapMemoryError, RegisterError, RunVcpuError, VirtualMachine, VmExit,
+    CreateVmError, MapMemoryError, RegisterError, RunVcpuError, VcpuLane, VirtualMachine, VmExit,
 };
 use crate::mem::memory_region::MemoryRegion;
 
@@ -70,13 +71,13 @@ pub(crate) fn is_hypervisor_present() -> bool {
 
 /// A KVM implementation with a fixed vCPU pool.
 ///
-/// The legacy `VirtualMachine` trait still drives only lane 0. Creating the
+/// The legacy control path still drives only lane 0. Creating the
 /// whole pool up front mirrors the fixed KVM memory-region model and gives the
 /// parallel invoke worker ABI stable vCPU identities to attach to later.
 #[derive(Debug)]
 pub(crate) struct KvmVm {
     vm_fd: VmFd,
-    vcpu_fds: Vec<VcpuFd>,
+    vcpu_fds: Vec<Mutex<VcpuFd>>,
 }
 
 static KVM: LazyLock<std::result::Result<Kvm, CreateVmError>> =
@@ -114,23 +115,39 @@ impl KvmVm {
             vcpu_fd
                 .set_cpuid2(&kvm_cpuid)
                 .map_err(|e| CreateVmError::InitializeVm(e.into()))?;
-            vcpu_fds.push(vcpu_fd);
+            vcpu_fds.push(Mutex::new(vcpu_fd));
         }
 
         Ok(Self { vm_fd, vcpu_fds })
     }
 
-    fn primary_vcpu(&self) -> &VcpuFd {
-        &self.vcpu_fds[0]
+    fn vcpu_for_register(
+        &self,
+        lane: VcpuLane,
+    ) -> std::result::Result<MutexGuard<'_, VcpuFd>, RegisterError> {
+        let idx = lane.index();
+        self.vcpu_fds
+            .get(idx)
+            .ok_or(RegisterError::InvalidVcpuLane(idx))?
+            .lock()
+            .map_err(|_| RegisterError::VcpuLanePoisoned(idx))
     }
 
-    fn primary_vcpu_mut(&mut self) -> &mut VcpuFd {
-        &mut self.vcpu_fds[0]
+    fn vcpu_for_run(
+        &self,
+        lane: VcpuLane,
+    ) -> std::result::Result<MutexGuard<'_, VcpuFd>, RunVcpuError> {
+        let idx = lane.index();
+        self.vcpu_fds
+            .get(idx)
+            .ok_or(RunVcpuError::InvalidVcpuLane(idx))?
+            .lock()
+            .map_err(|_| RunVcpuError::VcpuLanePoisoned(idx))
     }
 
     /// Run the vCPU once without hardware interrupt support (default path).
-    fn run_vcpu_default(&mut self) -> std::result::Result<VmExit, RunVcpuError> {
-        match self.primary_vcpu_mut().run() {
+    fn run_vcpu_default(&self, lane: VcpuLane) -> std::result::Result<VmExit, RunVcpuError> {
+        match self.vcpu_for_run(lane)?.run() {
             Ok(VcpuExit::Hlt) => Ok(VmExit::Halt()),
             Ok(VcpuExit::IoOut(port, _)) if port == VmAction::Halt as u16 => Ok(VmExit::Halt()),
             Ok(VcpuExit::IoOut(port, data)) => Ok(VmExit::IoOut(port, data.to_vec())),
@@ -161,39 +178,55 @@ impl VirtualMachine for KvmVm {
             .map_err(|e| MapMemoryError::Hypervisor(e.into()))
     }
 
-    fn run_vcpu(&mut self) -> std::result::Result<VmExit, RunVcpuError> {
-        self.run_vcpu_default()
+    fn vcpu_count(&self) -> usize {
+        self.vcpu_fds.len()
     }
 
-    fn regs(&self) -> std::result::Result<CommonRegisters, RegisterError> {
+    fn run_vcpu_on(&self, lane: VcpuLane) -> std::result::Result<VmExit, RunVcpuError> {
+        self.run_vcpu_default(lane)
+    }
+
+    fn regs_on(&self, lane: VcpuLane) -> std::result::Result<CommonRegisters, RegisterError> {
         let kvm_regs = self
-            .primary_vcpu()
+            .vcpu_for_register(lane)?
             .get_regs()
             .map_err(|e| RegisterError::GetRegs(e.into()))?;
         Ok((&kvm_regs).into())
     }
 
-    fn set_regs(&self, regs: &CommonRegisters) -> std::result::Result<(), RegisterError> {
+    fn set_regs_on(
+        &self,
+        lane: VcpuLane,
+        regs: &CommonRegisters,
+    ) -> std::result::Result<(), RegisterError> {
         let kvm_regs: kvm_regs = regs.into();
-        self.primary_vcpu()
+        self.vcpu_for_register(lane)?
             .set_regs(&kvm_regs)
             .map_err(|e| RegisterError::SetRegs(e.into()))?;
         Ok(())
     }
 
-    fn set_fpu(&self, fpu: &CommonFpu) -> std::result::Result<(), RegisterError> {
+    fn set_fpu_on(
+        &self,
+        lane: VcpuLane,
+        fpu: &CommonFpu,
+    ) -> std::result::Result<(), RegisterError> {
         let kvm_fpu: kvm_fpu = fpu.into();
         // Note: On KVM this ignores MXCSR.
         // See https://github.com/torvalds/linux/blob/d358e5254674b70f34c847715ca509e46eb81e6f/arch/x86/kvm/x86.c#L12554-L12599
-        self.primary_vcpu()
+        self.vcpu_for_register(lane)?
             .set_fpu(&kvm_fpu)
             .map_err(|e| RegisterError::SetFpu(e.into()))?;
         Ok(())
     }
 
-    fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError> {
+    fn set_sregs_on(
+        &self,
+        lane: VcpuLane,
+        sregs: &CommonSpecialRegisters,
+    ) -> std::result::Result<(), RegisterError> {
         let kvm_sregs: kvm_sregs = sregs.into();
-        self.primary_vcpu()
+        self.vcpu_for_register(lane)?
             .set_sregs(&kvm_sregs)
             .map_err(|e| RegisterError::SetSregs(e.into()))?;
         Ok(())

--- a/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
@@ -68,11 +68,15 @@ pub(crate) fn is_hypervisor_present() -> bool {
     }
 }
 
-/// A KVM implementation of a single-vcpu VM
+/// A KVM implementation with a fixed vCPU pool.
+///
+/// The legacy `VirtualMachine` trait still drives only lane 0. Creating the
+/// whole pool up front mirrors the fixed KVM memory-region model and gives the
+/// parallel invoke worker ABI stable vCPU identities to attach to later.
 #[derive(Debug)]
 pub(crate) struct KvmVm {
     vm_fd: VmFd,
-    vcpu_fd: VcpuFd,
+    vcpu_fds: Vec<VcpuFd>,
 }
 
 static KVM: LazyLock<std::result::Result<Kvm, CreateVmError>> =
@@ -81,16 +85,12 @@ static KVM: LazyLock<std::result::Result<Kvm, CreateVmError>> =
 impl KvmVm {
     /// Create a new instance of a `KvmVm`
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
-    pub(crate) fn new() -> std::result::Result<Self, CreateVmError> {
+    pub(crate) fn new(vcpu_count: usize) -> std::result::Result<Self, CreateVmError> {
         let hv = KVM.as_ref().map_err(|e| e.clone())?;
 
         let vm_fd = hv
             .create_vm_with_type(0)
             .map_err(|e| CreateVmError::CreateVmFd(e.into()))?;
-
-        let vcpu_fd = vm_fd
-            .create_vcpu(0)
-            .map_err(|e| CreateVmError::CreateVcpuFd(e.into()))?;
 
         // Set the CPUID leaf for MaxPhysAddr. KVM allows this to
         // easily be overridden by the hypervisor and defaults it very
@@ -106,16 +106,31 @@ impl KvmVm {
                 entry.eax |= nub_host_common::layout::MAX_GPA.ilog2() + 1;
             }
         }
-        vcpu_fd
-            .set_cpuid2(&kvm_cpuid)
-            .map_err(|e| CreateVmError::InitializeVm(e.into()))?;
+        let mut vcpu_fds = Vec::with_capacity(vcpu_count.max(1));
+        for vcpu_id in 0..vcpu_count.max(1) {
+            let vcpu_fd = vm_fd
+                .create_vcpu(vcpu_id as u64)
+                .map_err(|e| CreateVmError::CreateVcpuFd(e.into()))?;
+            vcpu_fd
+                .set_cpuid2(&kvm_cpuid)
+                .map_err(|e| CreateVmError::InitializeVm(e.into()))?;
+            vcpu_fds.push(vcpu_fd);
+        }
 
-        Ok(Self { vm_fd, vcpu_fd })
+        Ok(Self { vm_fd, vcpu_fds })
+    }
+
+    fn primary_vcpu(&self) -> &VcpuFd {
+        &self.vcpu_fds[0]
+    }
+
+    fn primary_vcpu_mut(&mut self) -> &mut VcpuFd {
+        &mut self.vcpu_fds[0]
     }
 
     /// Run the vCPU once without hardware interrupt support (default path).
     fn run_vcpu_default(&mut self) -> std::result::Result<VmExit, RunVcpuError> {
-        match self.vcpu_fd.run() {
+        match self.primary_vcpu_mut().run() {
             Ok(VcpuExit::Hlt) => Ok(VmExit::Halt()),
             Ok(VcpuExit::IoOut(port, _)) if port == VmAction::Halt as u16 => Ok(VmExit::Halt()),
             Ok(VcpuExit::IoOut(port, data)) => Ok(VmExit::IoOut(port, data.to_vec())),
@@ -152,7 +167,7 @@ impl VirtualMachine for KvmVm {
 
     fn regs(&self) -> std::result::Result<CommonRegisters, RegisterError> {
         let kvm_regs = self
-            .vcpu_fd
+            .primary_vcpu()
             .get_regs()
             .map_err(|e| RegisterError::GetRegs(e.into()))?;
         Ok((&kvm_regs).into())
@@ -160,7 +175,7 @@ impl VirtualMachine for KvmVm {
 
     fn set_regs(&self, regs: &CommonRegisters) -> std::result::Result<(), RegisterError> {
         let kvm_regs: kvm_regs = regs.into();
-        self.vcpu_fd
+        self.primary_vcpu()
             .set_regs(&kvm_regs)
             .map_err(|e| RegisterError::SetRegs(e.into()))?;
         Ok(())
@@ -170,7 +185,7 @@ impl VirtualMachine for KvmVm {
         let kvm_fpu: kvm_fpu = fpu.into();
         // Note: On KVM this ignores MXCSR.
         // See https://github.com/torvalds/linux/blob/d358e5254674b70f34c847715ca509e46eb81e6f/arch/x86/kvm/x86.c#L12554-L12599
-        self.vcpu_fd
+        self.primary_vcpu()
             .set_fpu(&kvm_fpu)
             .map_err(|e| RegisterError::SetFpu(e.into()))?;
         Ok(())
@@ -178,7 +193,7 @@ impl VirtualMachine for KvmVm {
 
     fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError> {
         let kvm_sregs: kvm_sregs = sregs.into();
-        self.vcpu_fd
+        self.primary_vcpu()
             .set_sregs(&kvm_sregs)
             .map_err(|e| RegisterError::SetSregs(e.into()))?;
         Ok(())

--- a/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
+++ b/rust/nub-host-kvm/src/hypervisor/virtual_machine/kvm/x86_64.rs
@@ -73,7 +73,7 @@ pub(crate) fn is_hypervisor_present() -> bool {
 ///
 /// The legacy control path still drives only lane 0. Creating the
 /// whole pool up front mirrors the fixed KVM memory-region model and gives the
-/// parallel invoke worker ABI stable vCPU identities to attach to later.
+/// parallel invoke workers stable vCPU identities for the sandbox lifetime.
 #[derive(Debug)]
 pub(crate) struct KvmVm {
     vm_fd: VmFd,
@@ -230,5 +230,16 @@ impl VirtualMachine for KvmVm {
             .set_sregs(&kvm_sregs)
             .map_err(|e| RegisterError::SetSregs(e.into()))?;
         Ok(())
+    }
+
+    fn sregs_on(
+        &self,
+        lane: VcpuLane,
+    ) -> std::result::Result<CommonSpecialRegisters, RegisterError> {
+        let kvm_sregs = self
+            .vcpu_for_register(lane)?
+            .get_sregs()
+            .map_err(|e| RegisterError::GetRegs(e.into()))?;
+        Ok((&kvm_sregs).into())
     }
 }

--- a/rust/nub-host-kvm/src/hypervisor/virtual_machine/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/virtual_machine/mod.rs
@@ -84,6 +84,23 @@ pub(crate) enum VmExit {
     Retry(),
 }
 
+/// Stable index of a vCPU in the VM's fixed vCPU pool.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct VcpuLane(usize);
+
+impl VcpuLane {
+    /// The legacy control lane used by the existing host dispatch path.
+    pub(crate) const PRIMARY: Self = Self(0);
+
+    pub(crate) fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    pub(crate) fn index(self) -> usize {
+        self.0
+    }
+}
+
 /// VM error
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum VmError {
@@ -117,6 +134,10 @@ pub enum CreateVmError {
 /// RunVCPU error
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RunVcpuError {
+    #[error("Invalid vCPU lane: {0}")]
+    InvalidVcpuLane(usize),
+    #[error("vCPU lane lock poisoned: {0}")]
+    VcpuLanePoisoned(usize),
     #[error("Failed to decode message type: {0}")]
     DecodeIOMessage(u32),
     #[error("Increment RIP failed: {0}")]
@@ -130,6 +151,10 @@ pub enum RunVcpuError {
 /// Register error
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RegisterError {
+    #[error("Invalid vCPU lane: {0}")]
+    InvalidVcpuLane(usize),
+    #[error("vCPU lane lock poisoned: {0}")]
+    VcpuLanePoisoned(usize),
     #[error("Failed to get registers: {0}")]
     GetRegs(HypervisorError),
     #[error("Failed to set registers: {0}")]
@@ -162,9 +187,8 @@ pub enum HypervisorError {
     KvmError(#[from] kvm_ioctls::Error),
 }
 
-/// Trait for single-vCPU VMs. Provides a common interface for basic VM operations.
-/// Common interface for the single-vCPU KVM VM.
-pub(crate) trait VirtualMachine: Debug + Send {
+/// Common interface for a VM with a fixed vCPU pool.
+pub(crate) trait VirtualMachine: Debug + Send + Sync {
     /// Map memory region into this VM
     ///
     /// # Safety
@@ -178,19 +202,59 @@ pub(crate) trait VirtualMachine: Debug + Send {
         region: (u32, &MemoryRegion),
     ) -> std::result::Result<(), MapMemoryError>;
 
-    /// Runs the vCPU until it exits.
+    /// Number of vCPU lanes created for this VM.
+    fn vcpu_count(&self) -> usize;
+
+    /// Runs the selected vCPU until it exits.
     /// Note: this function emits traces spans for guests;
     /// the span setup is called right before the KVM run-vcpu ioctl.
-    fn run_vcpu(&mut self) -> std::result::Result<VmExit, RunVcpuError>;
+    fn run_vcpu_on(&self, lane: VcpuLane) -> std::result::Result<VmExit, RunVcpuError>;
+
+    /// Runs the primary control vCPU until it exits.
+    fn run_vcpu(&self) -> std::result::Result<VmExit, RunVcpuError> {
+        self.run_vcpu_on(VcpuLane::PRIMARY)
+    }
 
     /// Get regs
-    fn regs(&self) -> std::result::Result<CommonRegisters, RegisterError>;
+    fn regs_on(&self, lane: VcpuLane) -> std::result::Result<CommonRegisters, RegisterError>;
+
+    /// Get regs on the primary control vCPU.
+    fn regs(&self) -> std::result::Result<CommonRegisters, RegisterError> {
+        self.regs_on(VcpuLane::PRIMARY)
+    }
+
     /// Set regs
-    fn set_regs(&self, regs: &CommonRegisters) -> std::result::Result<(), RegisterError>;
+    fn set_regs_on(
+        &self,
+        lane: VcpuLane,
+        regs: &CommonRegisters,
+    ) -> std::result::Result<(), RegisterError>;
+
+    /// Set regs on the primary control vCPU.
+    fn set_regs(&self, regs: &CommonRegisters) -> std::result::Result<(), RegisterError> {
+        self.set_regs_on(VcpuLane::PRIMARY, regs)
+    }
+
     /// Set fpu regs
-    fn set_fpu(&self, fpu: &CommonFpu) -> std::result::Result<(), RegisterError>;
+    fn set_fpu_on(&self, lane: VcpuLane, fpu: &CommonFpu)
+    -> std::result::Result<(), RegisterError>;
+
+    /// Set fpu regs on the primary control vCPU.
+    fn set_fpu(&self, fpu: &CommonFpu) -> std::result::Result<(), RegisterError> {
+        self.set_fpu_on(VcpuLane::PRIMARY, fpu)
+    }
+
     /// Set special regs
-    fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError>;
+    fn set_sregs_on(
+        &self,
+        lane: VcpuLane,
+        sregs: &CommonSpecialRegisters,
+    ) -> std::result::Result<(), RegisterError>;
+
+    /// Set special regs on the primary control vCPU.
+    fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError> {
+        self.set_sregs_on(VcpuLane::PRIMARY, sregs)
+    }
 }
 
 #[cfg(test)]

--- a/rust/nub-host-kvm/src/hypervisor/virtual_machine/mod.rs
+++ b/rust/nub-host-kvm/src/hypervisor/virtual_machine/mod.rs
@@ -255,6 +255,17 @@ pub(crate) trait VirtualMachine: Debug + Send + Sync {
     fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError> {
         self.set_sregs_on(VcpuLane::PRIMARY, sregs)
     }
+
+    /// Get special regs
+    fn sregs_on(
+        &self,
+        lane: VcpuLane,
+    ) -> std::result::Result<CommonSpecialRegisters, RegisterError>;
+
+    /// Get special regs on the primary control vCPU.
+    fn sregs(&self) -> std::result::Result<CommonSpecialRegisters, RegisterError> {
+        self.sregs_on(VcpuLane::PRIMARY)
+    }
 }
 
 #[cfg(test)]

--- a/rust/nub-host-kvm/src/mem/layout.rs
+++ b/rust/nub-host-kvm/src/mem/layout.rs
@@ -63,6 +63,7 @@ limitations under the License.
 use std::fmt::Debug;
 use std::mem::{offset_of, size_of};
 
+use nub_arch_x86_abi::PARALLEL_INVOKE_SLOT_BYTES;
 use nub_host_common::mem::{HyperlightPEB, PAGE_SIZE_USIZE};
 use tracing::{Span, instrument};
 
@@ -207,7 +208,7 @@ impl SandboxMemoryLayout {
         let min_scratch_size = nub_host_common::layout::min_scratch_size(
             cfg.get_input_data_size(),
             cfg.get_output_data_size(),
-        );
+        ) + Self::parallel_invoke_slots_size(cfg.get_vcpu_count());
         if scratch_size < min_scratch_size {
             return Err(MemoryRequestTooSmall(scratch_size, min_scratch_size));
         }
@@ -331,12 +332,38 @@ impl SandboxMemoryLayout {
         0
     }
 
+    pub(crate) fn parallel_invoke_slots_size(vcpu_count: usize) -> usize {
+        (vcpu_count.max(1) * PARALLEL_INVOKE_SLOT_BYTES)
+            .next_multiple_of(nub_host_common::vmem::PAGE_SIZE)
+    }
+
+    pub(crate) fn get_parallel_invoke_slots_size(&self) -> usize {
+        Self::parallel_invoke_slots_size(self.sandbox_memory_config.get_vcpu_count())
+    }
+
+    pub(crate) fn get_parallel_invoke_slots_scratch_host_offset(&self) -> usize {
+        self.sandbox_memory_config.get_input_data_size()
+            + self.sandbox_memory_config.get_output_data_size()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn get_parallel_invoke_slot_scratch_host_offset(&self, lane: usize) -> usize {
+        self.get_parallel_invoke_slots_scratch_host_offset() + lane * PARALLEL_INVOKE_SLOT_BYTES
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn get_parallel_invoke_slots_gva(&self) -> u64 {
+        nub_host_common::layout::scratch_base_gva(self.scratch_size)
+            + self.get_parallel_invoke_slots_scratch_host_offset() as u64
+    }
+
     /// Get the offset from the beginning of the scratch region to the
     /// location where page tables will be eagerly copied on restore
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn get_pt_base_scratch_offset(&self) -> usize {
         (self.sandbox_memory_config.get_input_data_size()
-            + self.sandbox_memory_config.get_output_data_size())
+            + self.sandbox_memory_config.get_output_data_size()
+            + self.get_parallel_invoke_slots_size())
         .next_multiple_of(nub_host_common::vmem::PAGE_SIZE)
     }
 
@@ -416,7 +443,7 @@ impl SandboxMemoryLayout {
         let min_fixed_scratch = nub_host_common::layout::min_scratch_size(
             self.sandbox_memory_config.get_input_data_size(),
             self.sandbox_memory_config.get_output_data_size(),
-        );
+        ) + self.get_parallel_invoke_slots_size();
         let min_scratch = min_fixed_scratch + size;
         if self.scratch_size < min_scratch {
             return Err(MemoryRequestTooSmall(self.scratch_size, min_scratch));

--- a/rust/nub-host-kvm/src/mem/layout.rs
+++ b/rust/nub-host-kvm/src/mem/layout.rs
@@ -208,7 +208,8 @@ impl SandboxMemoryLayout {
         let min_scratch_size = nub_host_common::layout::min_scratch_size(
             cfg.get_input_data_size(),
             cfg.get_output_data_size(),
-        ) + Self::parallel_invoke_slots_size(cfg.get_vcpu_count());
+        ) + Self::parallel_invoke_slots_size(cfg.get_vcpu_count())
+            + Self::exception_stack_size(cfg.get_vcpu_count());
         if scratch_size < min_scratch_size {
             return Err(MemoryRequestTooSmall(scratch_size, min_scratch_size));
         }
@@ -337,8 +338,16 @@ impl SandboxMemoryLayout {
             .next_multiple_of(nub_host_common::vmem::PAGE_SIZE)
     }
 
+    pub(crate) fn exception_stack_size(vcpu_count: usize) -> usize {
+        (vcpu_count.max(1) as u64 * nub_host_common::layout::VCPU_EXCEPTION_STACK_STRIDE) as usize
+    }
+
     pub(crate) fn get_parallel_invoke_slots_size(&self) -> usize {
         Self::parallel_invoke_slots_size(self.sandbox_memory_config.get_vcpu_count())
+    }
+
+    pub(crate) fn get_vcpu_count(&self) -> usize {
+        self.sandbox_memory_config.get_vcpu_count()
     }
 
     pub(crate) fn get_parallel_invoke_slots_scratch_host_offset(&self) -> usize {
@@ -443,7 +452,8 @@ impl SandboxMemoryLayout {
         let min_fixed_scratch = nub_host_common::layout::min_scratch_size(
             self.sandbox_memory_config.get_input_data_size(),
             self.sandbox_memory_config.get_output_data_size(),
-        ) + self.get_parallel_invoke_slots_size();
+        ) + self.get_parallel_invoke_slots_size()
+            + Self::exception_stack_size(self.sandbox_memory_config.get_vcpu_count());
         let min_scratch = min_fixed_scratch + size;
         if self.scratch_size < min_scratch {
             return Err(MemoryRequestTooSmall(self.scratch_size, min_scratch));

--- a/rust/nub-host-kvm/src/mem/mgr.rs
+++ b/rust/nub-host-kvm/src/mem/mgr.rs
@@ -250,6 +250,17 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
 }
 
 impl SandboxMemoryManager<HostSharedMemory> {
+    #[allow(dead_code)]
+    pub(crate) fn parallel_invoke_slots_gva(&self) -> u64 {
+        self.layout.get_parallel_invoke_slots_gva()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn parallel_invoke_slot_scratch_host_offset(&self, lane: usize) -> usize {
+        self.layout
+            .get_parallel_invoke_slot_scratch_host_offset(lane)
+    }
+
     /// Push raw bytes (e.g. a rkyv-archived `Request` envelope) onto
     /// the guest's input data ring.
     #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
@@ -364,6 +375,12 @@ impl SandboxMemoryManager<HostSharedMemory> {
             self.layout.get_output_data_buffer_scratch_host_offset(),
             SandboxMemoryLayout::STACK_POINTER_SIZE_BYTES,
         )?;
+
+        let slot_start = self.layout.get_parallel_invoke_slots_scratch_host_offset();
+        let slot_end = slot_start + self.layout.get_parallel_invoke_slots_size();
+        self.scratch_mem.with_exclusivity(|scratch| {
+            scratch.as_mut_slice()[slot_start..slot_end].fill(0);
+        })?;
 
         // Copy page tables from `shared_mem` into scratch. PT bytes
         // are appended to the snapshot blob at build time and live

--- a/rust/nub-host-kvm/src/mem/mgr.rs
+++ b/rust/nub-host-kvm/src/mem/mgr.rs
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
+use nub_arch_x86_abi::{InvocationResult, InvokePacket, ParallelInvokeSlot};
 use nub_host_common::vmem::{self, PAGE_TABLE_SIZE};
+use std::mem::{MaybeUninit, offset_of, size_of};
 use tracing::{Span, instrument};
 
 use super::layout::SandboxMemoryLayout;
@@ -255,10 +257,65 @@ impl SandboxMemoryManager<HostSharedMemory> {
         self.layout.get_parallel_invoke_slots_gva()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn parallel_invoke_slot_scratch_host_offset(&self, lane: usize) -> usize {
         self.layout
             .get_parallel_invoke_slot_scratch_host_offset(lane)
+    }
+
+    fn parallel_invoke_slot_field_offset(&self, lane: usize, field_offset: usize) -> usize {
+        self.parallel_invoke_slot_scratch_host_offset(lane) + field_offset
+    }
+
+    pub(crate) fn read_parallel_invoke_status(&self, lane: usize) -> Result<u32> {
+        self.scratch_mem.read::<u32>(
+            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, status)),
+        )
+    }
+
+    pub(crate) fn write_parallel_invoke_status(&self, lane: usize, status: u32) -> Result<()> {
+        self.scratch_mem.write::<u32>(
+            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, status)),
+            status,
+        )
+    }
+
+    pub(crate) fn write_parallel_invoke_job_id(&self, lane: usize, job_id: u64) -> Result<()> {
+        self.scratch_mem.write::<u64>(
+            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, job_id)),
+            job_id,
+        )
+    }
+
+    pub(crate) fn write_parallel_invoke_packet(
+        &self,
+        lane: usize,
+        packet: &InvokePacket,
+    ) -> Result<()> {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                packet as *const InvokePacket as *const u8,
+                size_of::<InvokePacket>(),
+            )
+        };
+        self.scratch_mem.copy_from_slice(
+            bytes,
+            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, packet)),
+        )
+    }
+
+    pub(crate) fn read_parallel_invoke_result(&self, lane: usize) -> Result<InvocationResult> {
+        let mut result = MaybeUninit::<InvocationResult>::uninit();
+        let bytes = unsafe {
+            std::slice::from_raw_parts_mut(
+                result.as_mut_ptr() as *mut u8,
+                size_of::<InvocationResult>(),
+            )
+        };
+        self.scratch_mem.copy_to_slice(
+            bytes,
+            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, result)),
+        )?;
+        Ok(unsafe { result.assume_init() })
     }
 
     /// Push raw bytes (e.g. a rkyv-archived `Request` envelope) onto

--- a/rust/nub-host-kvm/src/mem/mgr.rs
+++ b/rust/nub-host-kvm/src/mem/mgr.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
-use nub_arch_x86_abi::{InvocationResult, InvokePacket, ParallelInvokeSlot};
+use nub_arch_x86_abi::ParallelInvokeSlot;
 use nub_host_common::vmem::{self, PAGE_TABLE_SIZE};
-use std::mem::{MaybeUninit, offset_of, size_of};
+use std::mem::{align_of, offset_of, size_of};
 use tracing::{Span, instrument};
 
 use super::layout::SandboxMemoryLayout;
@@ -262,6 +262,30 @@ impl SandboxMemoryManager<HostSharedMemory> {
             .get_parallel_invoke_slot_scratch_host_offset(lane)
     }
 
+    pub(crate) fn parallel_invoke_slot_host_ptr(
+        &self,
+        lane: usize,
+    ) -> Result<*mut ParallelInvokeSlot> {
+        let offset = self.parallel_invoke_slot_scratch_host_offset(lane);
+        let len = size_of::<ParallelInvokeSlot>();
+        if offset
+            .checked_add(len)
+            .is_none_or(|end| end > self.scratch_mem.mem_size())
+        {
+            return Err(crate::new_error!(
+                "parallel invoke slot {} is outside scratch memory",
+                lane
+            ));
+        }
+        let ptr = self.scratch_mem.base_ptr().wrapping_add(offset) as *mut ParallelInvokeSlot;
+        debug_assert_eq!(
+            (ptr as usize) % align_of::<ParallelInvokeSlot>(),
+            0,
+            "parallel invoke slot is not ABI-aligned"
+        );
+        Ok(ptr)
+    }
+
     fn parallel_invoke_slot_field_offset(&self, lane: usize, field_offset: usize) -> usize {
         self.parallel_invoke_slot_scratch_host_offset(lane) + field_offset
     }
@@ -277,45 +301,6 @@ impl SandboxMemoryManager<HostSharedMemory> {
             self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, status)),
             status,
         )
-    }
-
-    pub(crate) fn write_parallel_invoke_job_id(&self, lane: usize, job_id: u64) -> Result<()> {
-        self.scratch_mem.write::<u64>(
-            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, job_id)),
-            job_id,
-        )
-    }
-
-    pub(crate) fn write_parallel_invoke_packet(
-        &self,
-        lane: usize,
-        packet: &InvokePacket,
-    ) -> Result<()> {
-        let bytes = unsafe {
-            std::slice::from_raw_parts(
-                packet as *const InvokePacket as *const u8,
-                size_of::<InvokePacket>(),
-            )
-        };
-        self.scratch_mem.copy_from_slice(
-            bytes,
-            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, packet)),
-        )
-    }
-
-    pub(crate) fn read_parallel_invoke_result(&self, lane: usize) -> Result<InvocationResult> {
-        let mut result = MaybeUninit::<InvocationResult>::uninit();
-        let bytes = unsafe {
-            std::slice::from_raw_parts_mut(
-                result.as_mut_ptr() as *mut u8,
-                size_of::<InvocationResult>(),
-            )
-        };
-        self.scratch_mem.copy_to_slice(
-            bytes,
-            self.parallel_invoke_slot_field_offset(lane, offset_of!(ParallelInvokeSlot, result)),
-        )?;
-        Ok(unsafe { result.assume_init() })
     }
 
     /// Push raw bytes (e.g. a rkyv-archived `Request` envelope) onto

--- a/rust/nub-host-kvm/src/mem/shared_mem.rs
+++ b/rust/nub-host-kvm/src/mem/shared_mem.rs
@@ -127,7 +127,15 @@ pub struct GuestSharedMemory {
     /// is mapped in to the VM at VM creation time.
     pub lock: Arc<RwLock<()>>,
 }
+// SAFETY: `GuestSharedMemory` is the KVM-facing handle for a mapping whose
+// lifetime is owned by `Arc<HostMapping>`. The wrapper exposes no direct Rust
+// slice access except through `SharedMemory::with_exclusivity`, which takes the
+// shared RwLock's write side and therefore excludes host-side volatile access
+// while exclusive remapping/snapshotting is in progress. Sharing this handle
+// between host worker threads only shares the registered mapping/lifetime
+// handle; synchronized host reads/writes still go through `HostSharedMemory`.
 unsafe impl Send for GuestSharedMemory {}
+unsafe impl Sync for GuestSharedMemory {}
 
 /// A HostSharedMemory allows synchronized accesses to guest
 /// communication buffers, allowing it to be used concurrently with a

--- a/rust/nub-host-kvm/src/sandbox/config.rs
+++ b/rust/nub-host-kvm/src/sandbox/config.rs
@@ -55,9 +55,9 @@ pub struct SandboxConfiguration {
     interrupt_vcpu_sigrtmin_offset: u8,
     /// How much writable memory to offer the guest
     scratch_size: usize,
-    /// Fixed vCPU pool size for this sandbox. The current call_raw control path
-    /// uses vCPU 0; future parallel invoke lanes consume the remaining stable
-    /// pool without resizing the VM.
+    /// Fixed vCPU pool size for this sandbox. The serialized control plane uses
+    /// one selected lane at a time; parallel invokes attach one hot worker to
+    /// each stable vCPU lane.
     vcpu_count: usize,
 }
 

--- a/rust/nub-host-kvm/src/sandbox/config.rs
+++ b/rust/nub-host-kvm/src/sandbox/config.rs
@@ -55,6 +55,10 @@ pub struct SandboxConfiguration {
     interrupt_vcpu_sigrtmin_offset: u8,
     /// How much writable memory to offer the guest
     scratch_size: usize,
+    /// Fixed vCPU pool size for this sandbox. The current call_raw control path
+    /// uses vCPU 0; future parallel invoke lanes consume the remaining stable
+    /// pool without resizing the VM.
+    vcpu_count: usize,
 }
 
 impl SandboxConfiguration {
@@ -83,6 +87,7 @@ impl SandboxConfiguration {
         output_data_size: usize,
         heap_size_override: Option<u64>,
         scratch_size: usize,
+        vcpu_count: usize,
         interrupt_retry_delay: Duration,
         interrupt_vcpu_sigrtmin_offset: u8,
     ) -> Self {
@@ -91,6 +96,7 @@ impl SandboxConfiguration {
             output_data_size: max(output_data_size, Self::MIN_OUTPUT_SIZE),
             heap_size_override: heap_size_override.unwrap_or(0),
             scratch_size,
+            vcpu_count: vcpu_count.max(1),
             interrupt_retry_delay,
             interrupt_vcpu_sigrtmin_offset,
         }
@@ -174,6 +180,15 @@ impl SandboxConfiguration {
         self.scratch_size = scratch_size;
     }
 
+    /// Set the fixed vCPU pool size for this sandbox.
+    pub fn set_vcpu_count(&mut self, vcpu_count: usize) {
+        self.vcpu_count = vcpu_count.max(1);
+    }
+
+    pub(crate) fn get_vcpu_count(&self) -> usize {
+        self.vcpu_count
+    }
+
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn heap_size_override_opt(&self) -> Option<u64> {
         (self.heap_size_override > 0).then_some(self.heap_size_override)
@@ -196,6 +211,7 @@ impl Default for SandboxConfiguration {
             Self::DEFAULT_OUTPUT_SIZE,
             None,
             Self::DEFAULT_SCRATCH_SIZE,
+            1,
             Self::DEFAULT_INTERRUPT_RETRY_DELAY,
             Self::INTERRUPT_VCPU_SIGRTMIN_OFFSET,
         )

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -29,6 +29,7 @@ use crate::HyperlightError;
 use crate::Result;
 use crate::hypervisor::InterruptHandle;
 use crate::hypervisor::hyperlight_vm::HyperlightVm;
+use crate::hypervisor::virtual_machine::VcpuLane;
 use crate::mem::mgr::SandboxMemoryManager;
 use crate::mem::shared_mem::HostSharedMemory;
 use crate::metrics::{
@@ -113,11 +114,33 @@ impl MultiUseSandbox {
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
     pub fn call_raw(&mut self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
         maybe_time_and_emit_guest_call("call_raw", || {
-            self.call_guest_function_by_id(fn_id, payload)
+            self.call_guest_function_by_id_on(VcpuLane::PRIMARY, fn_id, payload)
         })
     }
 
-    fn call_guest_function_by_id(&mut self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
+    /// Serialized control-plane call on a selected vCPU lane. This still uses
+    /// the legacy shared input/output rings and therefore must not be used as
+    /// the concurrent invoke mechanism; it exists to validate and bootstrap
+    /// non-primary lanes before the shared job queue lands.
+    #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
+    pub fn call_raw_on_vcpu(
+        &mut self,
+        vcpu_index: usize,
+        fn_id: u32,
+        payload: &[u8],
+    ) -> Result<Vec<u8>> {
+        let lane = VcpuLane::new(vcpu_index);
+        maybe_time_and_emit_guest_call("call_raw_on_vcpu", || {
+            self.call_guest_function_by_id_on(lane, fn_id, payload)
+        })
+    }
+
+    fn call_guest_function_by_id_on(
+        &mut self,
+        lane: VcpuLane,
+        fn_id: u32,
+        payload: &[u8],
+    ) -> Result<Vec<u8>> {
         // ===== KILL() TIMING POINT 1 =====
         // Clear any stale cancellation from a previous guest function call or if kill() was called too early.
         // Any kill() that completed (even partially) BEFORE this line has NO effect on this call.
@@ -134,9 +157,13 @@ impl MultiUseSandbox {
             self.mem_mgr
                 .write_guest_function_call_raw(req_bytes.as_slice())?;
 
-            let dispatch_res = self
-                .vm
-                .dispatch_call_from_host(&mut self.mem_mgr, &self.host_funcs);
+            let dispatch_res = if lane == VcpuLane::PRIMARY {
+                self.vm
+                    .dispatch_call_from_host(&mut self.mem_mgr, &self.host_funcs)
+            } else {
+                self.vm
+                    .dispatch_call_from_host_on(lane, &mut self.mem_mgr, &self.host_funcs)
+            };
 
             if let Err(e) = dispatch_res {
                 let (error, _should_poison) = e.promote();

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -259,6 +259,9 @@ impl MultiUseSandbox {
     ///
     /// Workers are started lazily and remain hot for subsequent invoke calls.
     /// The legacy raw RPC channel remains the serialized control plane.
+    /// User job waits deliberately have no host-side timeout; without a
+    /// cancellation API, the lane must stay reserved until the guest reports
+    /// completion or the worker exits.
     pub fn invoke_cached_parallel(
         &self,
         job_id: u64,
@@ -272,7 +275,6 @@ impl MultiUseSandbox {
             thread::yield_now();
         };
         let lane_idx = lane.index();
-        let deadline = Instant::now() + Duration::from_secs(30);
 
         {
             let mem_mgr = self
@@ -330,19 +332,6 @@ impl MultiUseSandbox {
                     lane_idx,
                     job_id,
                     detail
-                ));
-            }
-            if Instant::now() >= deadline {
-                let status = self
-                    .mem_mgr
-                    .lock()
-                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?
-                    .read_parallel_invoke_status(lane_idx)?;
-                return Err(crate::new_error!(
-                    "parallel invoke lane {} timed out waiting for job {} (status={})",
-                    lane_idx,
-                    job_id,
-                    status
                 ));
             }
             thread::yield_now();

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -48,8 +48,8 @@ pub struct MultiUseSandbox {
     /// Unique identifier for this sandbox instance
     id: u64,
     pub(crate) host_funcs: Arc<Mutex<FunctionRegistry>>,
-    pub(crate) mem_mgr: SandboxMemoryManager<HostSharedMemory>,
-    vm: HyperlightVm,
+    pub(crate) mem_mgr: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
+    vm: Arc<HyperlightVm>,
     /// Host-side record of every blob hash this sandbox has successfully
     /// published, so `put_cap_with_hash` can short-circuit an idempotent
     /// re-put without a roundtrip + merkle walk through the guest.
@@ -71,7 +71,7 @@ pub struct MultiUseSandbox {
     /// tier is swept). A miss falls through to the idempotent `put_cap` RPC,
     /// so even blobs the guest published on its own (e.g. via `derive_spawn`)
     /// are handled correctly — just without the short-circuit.
-    published_blobs: HashSet<AbiCapHash>,
+    published_blobs: Mutex<HashSet<AbiCapHash>>,
 }
 
 impl MultiUseSandbox {
@@ -89,9 +89,9 @@ impl MultiUseSandbox {
         Self {
             id: super::snapshot::SANDBOX_CONFIGURATION_COUNTER.fetch_add(1, Ordering::Relaxed),
             host_funcs,
-            mem_mgr: mgr,
-            vm,
-            published_blobs: HashSet::new(),
+            mem_mgr: Arc::new(Mutex::new(mgr)),
+            vm: Arc::new(vm),
+            published_blobs: Mutex::new(HashSet::new()),
         }
     }
 
@@ -112,7 +112,7 @@ impl MultiUseSandbox {
     /// Changes made to the sandbox during execution are persisted.
     /// On failure the sandbox should be dropped and rebuilt.
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
-    pub fn call_raw(&mut self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
+    pub fn call_raw(&self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
         maybe_time_and_emit_guest_call("call_raw", || {
             self.call_guest_function_by_id_on(VcpuLane::PRIMARY, fn_id, payload)
         })
@@ -124,7 +124,7 @@ impl MultiUseSandbox {
     /// non-primary lanes before the shared job queue lands.
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
     pub fn call_raw_on_vcpu(
-        &mut self,
+        &self,
         vcpu_index: usize,
         fn_id: u32,
         payload: &[u8],
@@ -136,7 +136,7 @@ impl MultiUseSandbox {
     }
 
     fn call_guest_function_by_id_on(
-        &mut self,
+        &self,
         lane: VcpuLane,
         fn_id: u32,
         payload: &[u8],
@@ -154,15 +154,19 @@ impl MultiUseSandbox {
             let req_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&req)
                 .map_err(|e| crate::new_error!("rkyv-serialize Request: {e}"))?;
 
-            self.mem_mgr
-                .write_guest_function_call_raw(req_bytes.as_slice())?;
+            let mut mem_mgr = self
+                .mem_mgr
+                .lock()
+                .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+
+            mem_mgr.write_guest_function_call_raw(req_bytes.as_slice())?;
 
             let dispatch_res = if lane == VcpuLane::PRIMARY {
                 self.vm
-                    .dispatch_call_from_host(&mut self.mem_mgr, &self.host_funcs)
+                    .dispatch_call_from_host(&mut mem_mgr, &self.host_funcs)
             } else {
                 self.vm
-                    .dispatch_call_from_host_on(lane, &mut self.mem_mgr, &self.host_funcs)
+                    .dispatch_call_from_host_on(lane, &mut mem_mgr, &self.host_funcs)
             };
 
             if let Err(e) = dispatch_res {
@@ -170,7 +174,7 @@ impl MultiUseSandbox {
                 return Err(error);
             }
 
-            let raw_resp = self.mem_mgr.read_guest_function_call_result_raw()?;
+            let raw_resp = mem_mgr.read_guest_function_call_result_raw()?;
 
             let mut aligned = AlignedVec::<16>::with_capacity(raw_resp.len());
             aligned.extend_from_slice(&raw_resp);
@@ -200,10 +204,14 @@ impl MultiUseSandbox {
         })();
 
         // Clear partial abort bytes so they don't leak across calls.
-        self.mem_mgr.abort_buffer.clear();
+        let mut mem_mgr = self
+            .mem_mgr
+            .lock()
+            .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+        mem_mgr.abort_buffer.clear();
 
         if res.is_err() {
-            self.mem_mgr.clear_io_buffers();
+            mem_mgr.clear_io_buffers();
         }
 
         res
@@ -225,7 +233,7 @@ impl MultiUseSandbox {
     /// rancor error chain. Other encode/decode failures are surfaced
     /// as `HyperlightError::Error`. A sentinel response (all-`0xFF`
     /// hash) from the guest is also turned into an error.
-    pub fn put_cap(&mut self, cap: &Cap) -> Result<AbiCapHash> {
+    pub fn put_cap(&self, cap: &Cap) -> Result<AbiCapHash> {
         let cap_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(cap)
             .map_err(|e| crate::new_error!("put_cap: rkyv encode (or Ref present): {e}"))?;
         let resp = self.call_raw(FN_ID_NUB_PUT_CAP, cap_bytes.as_slice())?;
@@ -267,16 +275,27 @@ impl MultiUseSandbox {
     /// the guest's `CacheDirectory` is a hashbrown table built with a
     /// different SIMD `Group` width than the host's hashbrown (see
     /// `published_blobs`), so a host-side deref of it is unsound.
-    pub fn put_cap_with_hash(&mut self, hash: AbiCapHash, cap: &Cap) -> Result<()> {
-        if self.published_blobs.contains(&hash) {
-            return Ok(());
+    pub fn put_cap_with_hash(&self, hash: AbiCapHash, cap: &Cap) -> Result<()> {
+        {
+            let published_blobs = self
+                .published_blobs
+                .lock()
+                .map_err(|_| crate::new_error!("published blob set mutex poisoned"))?;
+            if published_blobs.contains(&hash) {
+                return Ok(());
+            }
         }
+
         let got = self.put_cap(cap)?;
         debug_assert_eq!(
             got, hash,
             "put_cap_with_hash: guest-computed hash differs from claimed hash"
         );
-        self.published_blobs.insert(hash);
+
+        self.published_blobs
+            .lock()
+            .map_err(|_| crate::new_error!("published blob set mutex poisoned"))?
+            .insert(hash);
         Ok(())
     }
 

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -269,10 +269,22 @@ impl MultiUseSandbox {
     ) -> Result<InvocationResult> {
         let (workers, lane) = loop {
             let workers = self.ensure_invoke_workers()?;
+            if let Some(lane) = workers.try_acquire_lane()? {
+                break (workers, lane);
+            }
+            if let Some(lane_idx) = workers.reserve_unstarted_lane()? {
+                match self.start_invoke_worker_lane(lane_idx) {
+                    Ok(handle) => workers.install_started_lane(lane_idx, handle)?,
+                    Err(e) => {
+                        workers.release_start_reservation(lane_idx)?;
+                        return Err(e);
+                    }
+                }
+                continue;
+            }
             if let Some(lane) = workers.acquire_lane()? {
                 break (workers, lane);
             }
-            thread::yield_now();
         };
         let lane_idx = lane.index();
 
@@ -429,22 +441,8 @@ impl MultiUseSandbox {
         }
 
         let vcpu_count = self.vcpu_count()?;
-        let mut handles = Vec::with_capacity(vcpu_count);
-        for lane in 0..vcpu_count {
-            match self.start_invoke_worker_lane(lane) {
-                Ok(handle) => handles.push(handle),
-                Err(start_err) => {
-                    if let Err(cleanup_err) = self.stop_started_invoke_worker_handles(handles) {
-                        return Err(crate::new_error!(
-                            "failed to start invoke worker pool: {start_err}; \
-                             additionally failed to stop partially started workers: {cleanup_err}"
-                        ));
-                    }
-                    return Err(start_err);
-                }
-            }
-        }
-        let workers = Arc::new(ParallelInvokeWorkers::new(vcpu_count, handles));
+        let first_handle = self.start_invoke_worker_lane(0)?;
+        let workers = Arc::new(ParallelInvokeWorkers::new(vcpu_count, 0, first_handle));
         *guard = Some(workers.clone());
         Ok(workers)
     }
@@ -457,8 +455,8 @@ impl MultiUseSandbox {
             return Ok(());
         };
 
-        workers.mark_stopping_and_wait_idle()?;
-        for lane in 0..workers.lane_count() {
+        let started_lanes = workers.mark_stopping_and_wait_idle()?;
+        for lane in started_lanes {
             {
                 let mem_mgr = self
                     .mem_mgr
@@ -548,22 +546,6 @@ impl MultiUseSandbox {
             }
             thread::yield_now();
         }
-    }
-
-    fn stop_started_invoke_worker_handles(&self, handles: Vec<InvokeWorkerHandle>) -> Result<()> {
-        for (lane, handle) in handles.into_iter().enumerate() {
-            {
-                let mem_mgr = self
-                    .mem_mgr
-                    .lock()
-                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
-                mem_mgr.write_parallel_invoke_status(lane, PARALLEL_INVOKE_STATUS_STOP)?;
-            }
-            join_invoke_worker_handle(lane, handle, Duration::from_secs(5))?
-                .map_err(|e| crate::new_error!("parallel invoke worker lane {lane}: {e}"))?;
-        }
-
-        Ok(())
     }
 
     /// Publish a [`Cap`] into the guest's heap-resident cap
@@ -666,6 +648,7 @@ struct ParallelInvokeWorkers {
 
 struct ParallelInvokeWorkerState {
     available: Vec<usize>,
+    started: Vec<bool>,
     stopping: bool,
 }
 
@@ -675,24 +658,43 @@ struct LaneLease {
 }
 
 impl ParallelInvokeWorkers {
-    fn new(lane_count: usize, handles: Vec<InvokeWorkerHandle>) -> Self {
+    fn new(lane_count: usize, first_lane: usize, first_handle: InvokeWorkerHandle) -> Self {
+        let mut handles = Vec::with_capacity(lane_count);
+        handles.resize_with(lane_count, || None);
+        handles[first_lane] = Some(first_handle);
+        let mut started = vec![false; lane_count];
+        started[first_lane] = true;
         Self {
             lane_count,
             state: Mutex::new(ParallelInvokeWorkerState {
-                available: (0..lane_count).rev().collect(),
+                available: vec![first_lane],
+                started,
                 stopping: false,
             }),
             ready: Condvar::new(),
-            handles: Mutex::new(handles.into_iter().map(Some).collect()),
+            handles: Mutex::new(handles),
         }
     }
 
-    fn lane_count(&self) -> usize {
-        self.lane_count
+    fn try_acquire_lane(self: &Arc<Self>) -> Result<Option<LaneLease>> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        if state.stopping {
+            return Ok(None);
+        }
+        Ok(state.available.pop().map(|lane| LaneLease {
+            lane,
+            workers: self.clone(),
+        }))
     }
 
     fn acquire_lane(self: &Arc<Self>) -> Result<Option<LaneLease>> {
-        let mut state = self.state.lock().expect("parallel worker mutex poisoned");
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         loop {
             if state.stopping {
                 return Ok(None);
@@ -706,8 +708,55 @@ impl ParallelInvokeWorkers {
             state = self
                 .ready
                 .wait(state)
-                .expect("parallel worker mutex poisoned");
+                .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         }
+    }
+
+    fn reserve_unstarted_lane(&self) -> Result<Option<usize>> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        if state.stopping {
+            return Ok(None);
+        }
+        for lane in 0..self.lane_count {
+            if !state.started[lane] {
+                state.started[lane] = true;
+                return Ok(Some(lane));
+            }
+        }
+        Ok(None)
+    }
+
+    fn install_started_lane(&self, lane: usize, handle: InvokeWorkerHandle) -> Result<()> {
+        {
+            let mut handles = self
+                .handles
+                .lock()
+                .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+            if lane >= handles.len() || handles[lane].is_some() {
+                return Err(crate::new_error!(
+                    "parallel invoke worker lane {} already has a handle",
+                    lane
+                ));
+            }
+            handles[lane] = Some(handle);
+        }
+        self.release_lane(lane);
+        Ok(())
+    }
+
+    fn release_start_reservation(&self, lane: usize) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        if lane < state.started.len() {
+            state.started[lane] = false;
+        }
+        self.ready.notify_all();
+        Ok(())
     }
 
     fn acquire_all_lanes(self: &Arc<Self>) -> Result<Vec<LaneLease>> {
@@ -719,7 +768,8 @@ impl ParallelInvokeWorkers {
             if state.stopping {
                 return Err(crate::new_error!("parallel invoke workers are stopping"));
             }
-            if state.available.len() == self.lane_count {
+            let started_count = state.started.iter().filter(|&&started| started).count();
+            if state.available.len() == started_count {
                 return Ok(state
                     .available
                     .drain(..)
@@ -742,20 +792,26 @@ impl ParallelInvokeWorkers {
         self.ready.notify_all();
     }
 
-    fn mark_stopping_and_wait_idle(&self) -> Result<()> {
+    fn mark_stopping_and_wait_idle(&self) -> Result<Vec<usize>> {
         let mut state = self
             .state
             .lock()
             .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         state.stopping = true;
         self.ready.notify_all();
-        while state.available.len() != self.lane_count {
+        let started_count = state.started.iter().filter(|&&started| started).count();
+        while state.available.len() != started_count {
             state = self
                 .ready
                 .wait(state)
                 .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         }
-        Ok(())
+        Ok(state
+            .started
+            .iter()
+            .enumerate()
+            .filter_map(|(lane, &started)| started.then_some(lane))
+            .collect())
     }
 
     fn take_finished_result(&self, lane: usize) -> Option<InvokeWorkerResult> {

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -350,7 +350,18 @@ impl MultiUseSandbox {
         let vcpu_count = self.vcpu_count()?;
         let mut handles = Vec::with_capacity(vcpu_count);
         for lane in 0..vcpu_count {
-            handles.push(self.start_invoke_worker_lane(lane)?);
+            match self.start_invoke_worker_lane(lane) {
+                Ok(handle) => handles.push(handle),
+                Err(start_err) => {
+                    if let Err(cleanup_err) = self.stop_started_invoke_worker_handles(handles) {
+                        return Err(crate::new_error!(
+                            "failed to start invoke worker pool: {start_err}; \
+                             additionally failed to stop partially started workers: {cleanup_err}"
+                        ));
+                    }
+                    return Err(start_err);
+                }
+            }
         }
         let workers = Arc::new(ParallelInvokeWorkers::new(vcpu_count, handles));
         *guard = Some(workers.clone());
@@ -456,6 +467,22 @@ impl MultiUseSandbox {
             }
             thread::yield_now();
         }
+    }
+
+    fn stop_started_invoke_worker_handles(&self, handles: Vec<InvokeWorkerHandle>) -> Result<()> {
+        for (lane, handle) in handles.into_iter().enumerate() {
+            {
+                let mem_mgr = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+                mem_mgr.write_parallel_invoke_status(lane, PARALLEL_INVOKE_STATUS_STOP)?;
+            }
+            join_invoke_worker_handle(lane, handle, Duration::from_secs(5))?
+                .map_err(|e| crate::new_error!("parallel invoke worker lane {lane}: {e}"))?;
+        }
+
+        Ok(())
     }
 
     /// Publish a [`Cap`] into the guest's heap-resident cap
@@ -634,41 +661,39 @@ impl ParallelInvokeWorkers {
     }
 
     fn join_lane(&self, lane: usize, timeout: Duration) -> Result<InvokeWorkerResult> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            {
-                let handles = self
-                    .handles
-                    .lock()
-                    .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
-                let Some(Some(handle)) = handles.get(lane) else {
-                    return Ok(Ok(()));
-                };
-                if handle.is_finished() {
-                    break;
-                }
-            }
-            if Instant::now() >= deadline {
-                return Err(crate::new_error!(
-                    "parallel invoke worker lane {} timed out during stop",
-                    lane
-                ));
-            }
-            thread::yield_now();
-        }
-
         let handle = self
             .handles
             .lock()
             .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?
             .get_mut(lane)
-            .and_then(Option::take)
-            .ok_or_else(|| crate::new_error!("parallel invoke worker lane {} missing", lane))?;
-        Ok(match handle.join() {
-            Ok(result) => result,
-            Err(_) => Err("worker thread panicked".to_string()),
-        })
+            .and_then(Option::take);
+        let Some(handle) = handle else {
+            return Ok(Ok(()));
+        };
+        join_invoke_worker_handle(lane, handle, timeout)
     }
+}
+
+fn join_invoke_worker_handle(
+    lane: usize,
+    handle: InvokeWorkerHandle,
+    timeout: Duration,
+) -> Result<InvokeWorkerResult> {
+    let deadline = Instant::now() + timeout;
+    while !handle.is_finished() {
+        if Instant::now() >= deadline {
+            return Err(crate::new_error!(
+                "parallel invoke worker lane {} timed out during stop",
+                lane
+            ));
+        }
+        thread::yield_now();
+    }
+
+    Ok(match handle.join() {
+        Ok(result) => result,
+        Err(_) => Err("worker thread panicked".to_string()),
+    })
 }
 
 impl LaneLease {

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -134,8 +134,16 @@ impl MultiUseSandbox {
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
     pub fn call_raw(&self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
         maybe_time_and_emit_guest_call("call_raw", || {
-            self.stop_invoke_workers()?;
-            self.call_guest_function_by_id_on(VcpuLane::PRIMARY, fn_id, payload)
+            let mut workers = self
+                .invoke_workers
+                .lock()
+                .map_err(|_| crate::new_error!("parallel invoke worker mutex poisoned"))?;
+            self.stop_invoke_workers_locked(&mut workers)?;
+            let _control = self
+                .control_lock
+                .lock()
+                .map_err(|_| crate::new_error!("sandbox control mutex poisoned"))?;
+            self.call_guest_function_by_id_on_locked(VcpuLane::PRIMARY, fn_id, payload)
         })
     }
 
@@ -152,12 +160,20 @@ impl MultiUseSandbox {
     ) -> Result<Vec<u8>> {
         let lane = VcpuLane::new(vcpu_index);
         maybe_time_and_emit_guest_call("call_raw_on_vcpu", || {
-            self.stop_invoke_workers()?;
-            self.call_guest_function_by_id_on(lane, fn_id, payload)
+            let mut workers = self
+                .invoke_workers
+                .lock()
+                .map_err(|_| crate::new_error!("parallel invoke worker mutex poisoned"))?;
+            self.stop_invoke_workers_locked(&mut workers)?;
+            let _control = self
+                .control_lock
+                .lock()
+                .map_err(|_| crate::new_error!("sandbox control mutex poisoned"))?;
+            self.call_guest_function_by_id_on_locked(lane, fn_id, payload)
         })
     }
 
-    fn call_guest_function_by_id_on(
+    fn call_guest_function_by_id_on_locked(
         &self,
         lane: VcpuLane,
         fn_id: u32,
@@ -167,10 +183,6 @@ impl MultiUseSandbox {
         // Clear any stale cancellation from a previous guest function call or if kill() was called too early.
         // Any kill() that completed (even partially) BEFORE this line has NO effect on this call.
         self.vm.clear_cancel();
-        let _control = self
-            .control_lock
-            .lock()
-            .map_err(|_| crate::new_error!("sandbox control mutex poisoned"))?;
 
         let res = (|| {
             let req = Request {
@@ -252,8 +264,13 @@ impl MultiUseSandbox {
         job_id: u64,
         packet: &InvokePacket,
     ) -> Result<InvocationResult> {
-        let workers = self.ensure_invoke_workers()?;
-        let lane = workers.acquire_lane()?;
+        let (workers, lane) = loop {
+            let workers = self.ensure_invoke_workers()?;
+            if let Some(lane) = workers.acquire_lane()? {
+                break (workers, lane);
+            }
+            thread::yield_now();
+        };
         let lane_idx = lane.index();
         let deadline = Instant::now() + Duration::from_secs(30);
 
@@ -351,16 +368,12 @@ impl MultiUseSandbox {
         Ok(workers)
     }
 
-    fn stop_invoke_workers(&self) -> Result<()> {
-        let workers = {
-            let mut guard = self
-                .invoke_workers
-                .lock()
-                .map_err(|_| crate::new_error!("parallel invoke worker mutex poisoned"))?;
-            let Some(workers) = guard.take() else {
-                return Ok(());
-            };
-            workers
+    fn stop_invoke_workers_locked(
+        &self,
+        guard: &mut Option<Arc<ParallelInvokeWorkers>>,
+    ) -> Result<()> {
+        let Some(workers) = guard.as_ref().cloned() else {
+            return Ok(());
         };
 
         workers.mark_stopping_and_wait_idle()?;
@@ -377,6 +390,7 @@ impl MultiUseSandbox {
                 .map_err(|e| crate::new_error!("parallel invoke worker lane {lane}: {e}"))?;
         }
 
+        *guard = None;
         Ok(())
     }
 
@@ -580,19 +594,17 @@ impl ParallelInvokeWorkers {
         self.lane_count
     }
 
-    fn acquire_lane(self: &Arc<Self>) -> Result<LaneLease> {
+    fn acquire_lane(self: &Arc<Self>) -> Result<Option<LaneLease>> {
         let mut state = self.state.lock().expect("parallel worker mutex poisoned");
         loop {
             if state.stopping {
-                return Err(crate::new_error!(
-                    "parallel invoke workers are stopping for a control-plane call"
-                ));
+                return Ok(None);
             }
             if let Some(lane) = state.available.pop() {
-                return Ok(LaneLease {
+                return Ok(Some(LaneLease {
                     lane,
                     workers: self.clone(),
-                });
+                }));
             }
             state = self
                 .ready
@@ -613,6 +625,7 @@ impl ParallelInvokeWorkers {
             .lock()
             .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         state.stopping = true;
+        self.ready.notify_all();
         while state.available.len() != self.lane_count {
             state = self
                 .ready

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -23,8 +23,8 @@ use javm_cap::cap::Cap;
 use nub_arch_x86_abi::{
     CapHash as AbiCapHash, FN_ID_NUB_INVOKE_WORKER, FN_ID_NUB_PUT_CAP, InvocationResult,
     InvokePacket, PARALLEL_INVOKE_STATUS_DONE, PARALLEL_INVOKE_STATUS_EMPTY,
-    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING,
-    PARALLEL_INVOKE_STATUS_STOP,
+    PARALLEL_INVOKE_STATUS_EVICT_JIT_READY, PARALLEL_INVOKE_STATUS_READY,
+    PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING, PARALLEL_INVOKE_STATUS_STOP,
 };
 use nub_host_common::rpc::{ArchivedResponse, Request};
 use rkyv::util::AlignedVec;
@@ -338,6 +338,87 @@ impl MultiUseSandbox {
         }
     }
 
+    /// Bench-only: evict guest JIT caches while keeping the hot invoke worker
+    /// pool alive. The legacy raw RPC path stops workers before entering the
+    /// shared control ring; cold benchmarks call this every iteration, so using
+    /// the worker slot protocol avoids measuring worker teardown/startup.
+    ///
+    /// All lanes are reserved first. That preserves the eviction invariant: no
+    /// frame runtime can be live while image arenas and templates are dropped.
+    pub fn evict_jit_all_parallel(&self) -> Result<()> {
+        maybe_time_and_emit_guest_call("evict_jit_all_parallel", || {
+            let workers = self.ensure_invoke_workers()?;
+            let lanes = workers.acquire_all_lanes()?;
+            let Some(control_lane) = lanes.first().map(LaneLease::index) else {
+                return Ok(());
+            };
+
+            {
+                let mem_mgr = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+                let status = mem_mgr.read_parallel_invoke_status(control_lane)?;
+                if status != PARALLEL_INVOKE_STATUS_EMPTY {
+                    return Err(crate::new_error!(
+                        "parallel control lane {} was not empty before evict (status={})",
+                        control_lane,
+                        status
+                    ));
+                }
+                mem_mgr.write_parallel_invoke_job_id(control_lane, 0)?;
+                fence(Ordering::Release);
+                mem_mgr.write_parallel_invoke_status(
+                    control_lane,
+                    PARALLEL_INVOKE_STATUS_EVICT_JIT_READY,
+                )?;
+            }
+
+            loop {
+                let done =
+                    {
+                        let mem_mgr = self.mem_mgr.lock().map_err(|_| {
+                            crate::new_error!("sandbox memory manager mutex poisoned")
+                        })?;
+                        match mem_mgr.read_parallel_invoke_status(control_lane)? {
+                            PARALLEL_INVOKE_STATUS_DONE => {
+                                fence(Ordering::Acquire);
+                                mem_mgr.write_parallel_invoke_status(
+                                    control_lane,
+                                    PARALLEL_INVOKE_STATUS_EMPTY,
+                                )?;
+                                true
+                            }
+                            PARALLEL_INVOKE_STATUS_EVICT_JIT_READY
+                            | PARALLEL_INVOKE_STATUS_RUNNING => false,
+                            other => {
+                                return Err(crate::new_error!(
+                                    "parallel control lane {} entered unexpected status {}",
+                                    control_lane,
+                                    other
+                                ));
+                            }
+                        }
+                    };
+                if done {
+                    return Ok(());
+                }
+                if let Some(worker_result) = workers.take_finished_result(control_lane) {
+                    let detail = match worker_result {
+                        Ok(()) => "clean worker exit".to_string(),
+                        Err(e) => e,
+                    };
+                    return Err(crate::new_error!(
+                        "parallel invoke worker lane {} exited during evict_jit_all: {}",
+                        control_lane,
+                        detail
+                    ));
+                }
+                thread::yield_now();
+            }
+        })
+    }
+
     fn ensure_invoke_workers(&self) -> Result<Arc<ParallelInvokeWorkers>> {
         let mut guard = self
             .invoke_workers
@@ -626,6 +707,32 @@ impl ParallelInvokeWorkers {
                 .ready
                 .wait(state)
                 .expect("parallel worker mutex poisoned");
+        }
+    }
+
+    fn acquire_all_lanes(self: &Arc<Self>) -> Result<Vec<LaneLease>> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        loop {
+            if state.stopping {
+                return Err(crate::new_error!("parallel invoke workers are stopping"));
+            }
+            if state.available.len() == self.lane_count {
+                return Ok(state
+                    .available
+                    .drain(..)
+                    .map(|lane| LaneLease {
+                        lane,
+                        workers: self.clone(),
+                    })
+                    .collect());
+            }
+            state = self
+                .ready
+                .wait(state)
+                .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
         }
     }
 

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -150,7 +150,7 @@ impl MultiUseSandbox {
     /// Serialized control-plane call on a selected vCPU lane. This still uses
     /// the legacy shared input/output rings and therefore must not be used as
     /// the concurrent invoke mechanism; it exists to validate and bootstrap
-    /// non-primary lanes before the shared job queue lands.
+    /// non-primary lanes. Concurrent invokes use the per-lane worker slots.
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
     pub fn call_raw_on_vcpu(
         &self,

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -288,12 +288,19 @@ impl MultiUseSandbox {
         };
         let lane_idx = lane.index();
 
-        {
+        let slot = {
             let mem_mgr = self
                 .mem_mgr
                 .lock()
                 .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
-            let status = mem_mgr.read_parallel_invoke_status(lane_idx)?;
+            mem_mgr.parallel_invoke_slot_host_ptr(lane_idx)?
+        };
+
+        // SAFETY: `lane` is a live `LaneLease`, so this host thread has
+        // exclusive host ownership of the slot until the function returns. The
+        // guest worker communicates through the ABI atomics in the same slot.
+        unsafe {
+            let status = (*slot).status.load(Ordering::Acquire);
             if status != PARALLEL_INVOKE_STATUS_EMPTY {
                 return Err(crate::new_error!(
                     "parallel invoke lane {} was not empty before submit (status={})",
@@ -301,24 +308,23 @@ impl MultiUseSandbox {
                     status
                 ));
             }
-            mem_mgr.write_parallel_invoke_job_id(lane_idx, job_id)?;
-            mem_mgr.write_parallel_invoke_packet(lane_idx, packet)?;
+            (*slot).job_id.store(job_id, Ordering::Relaxed);
+            core::ptr::addr_of_mut!((*slot).packet).write_volatile(*packet);
             fence(Ordering::Release);
-            mem_mgr.write_parallel_invoke_status(lane_idx, PARALLEL_INVOKE_STATUS_READY)?;
+            (*slot)
+                .status
+                .store(PARALLEL_INVOKE_STATUS_READY, Ordering::Release);
         }
 
         loop {
-            let done = {
-                let mem_mgr = self
-                    .mem_mgr
-                    .lock()
-                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
-                match mem_mgr.read_parallel_invoke_status(lane_idx)? {
+            let done = unsafe {
+                match (*slot).status.load(Ordering::Acquire) {
                     PARALLEL_INVOKE_STATUS_DONE => {
                         fence(Ordering::Acquire);
-                        let result = mem_mgr.read_parallel_invoke_result(lane_idx)?;
-                        mem_mgr
-                            .write_parallel_invoke_status(lane_idx, PARALLEL_INVOKE_STATUS_EMPTY)?;
+                        let result = core::ptr::addr_of!((*slot).result).read_volatile();
+                        (*slot)
+                            .status
+                            .store(PARALLEL_INVOKE_STATUS_EMPTY, Ordering::Release);
                         Some(result)
                     }
                     PARALLEL_INVOKE_STATUS_READY | PARALLEL_INVOKE_STATUS_RUNNING => None,
@@ -365,12 +371,19 @@ impl MultiUseSandbox {
                 return Ok(());
             };
 
-            {
+            let slot = {
                 let mem_mgr = self
                     .mem_mgr
                     .lock()
                     .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
-                let status = mem_mgr.read_parallel_invoke_status(control_lane)?;
+                mem_mgr.parallel_invoke_slot_host_ptr(control_lane)?
+            };
+
+            // SAFETY: `lanes` contains a live lease for every started lane, so
+            // no host invoke can use `control_lane` while this control command
+            // is in flight. The guest worker observes the ABI atomic status.
+            unsafe {
+                let status = (*slot).status.load(Ordering::Acquire);
                 if status != PARALLEL_INVOKE_STATUS_EMPTY {
                     return Err(crate::new_error!(
                         "parallel control lane {} was not empty before evict (status={})",
@@ -378,40 +391,35 @@ impl MultiUseSandbox {
                         status
                     ));
                 }
-                mem_mgr.write_parallel_invoke_job_id(control_lane, 0)?;
+                (*slot).job_id.store(0, Ordering::Relaxed);
                 fence(Ordering::Release);
-                mem_mgr.write_parallel_invoke_status(
-                    control_lane,
-                    PARALLEL_INVOKE_STATUS_EVICT_JIT_READY,
-                )?;
+                (*slot)
+                    .status
+                    .store(PARALLEL_INVOKE_STATUS_EVICT_JIT_READY, Ordering::Release);
             }
 
             loop {
-                let done =
-                    {
-                        let mem_mgr = self.mem_mgr.lock().map_err(|_| {
-                            crate::new_error!("sandbox memory manager mutex poisoned")
-                        })?;
-                        match mem_mgr.read_parallel_invoke_status(control_lane)? {
-                            PARALLEL_INVOKE_STATUS_DONE => {
-                                fence(Ordering::Acquire);
-                                mem_mgr.write_parallel_invoke_status(
-                                    control_lane,
-                                    PARALLEL_INVOKE_STATUS_EMPTY,
-                                )?;
-                                true
-                            }
-                            PARALLEL_INVOKE_STATUS_EVICT_JIT_READY
-                            | PARALLEL_INVOKE_STATUS_RUNNING => false,
-                            other => {
-                                return Err(crate::new_error!(
-                                    "parallel control lane {} entered unexpected status {}",
-                                    control_lane,
-                                    other
-                                ));
-                            }
+                let done = unsafe {
+                    match (*slot).status.load(Ordering::Acquire) {
+                        PARALLEL_INVOKE_STATUS_DONE => {
+                            fence(Ordering::Acquire);
+                            (*slot)
+                                .status
+                                .store(PARALLEL_INVOKE_STATUS_EMPTY, Ordering::Release);
+                            true
                         }
-                    };
+                        PARALLEL_INVOKE_STATUS_EVICT_JIT_READY | PARALLEL_INVOKE_STATUS_RUNNING => {
+                            false
+                        }
+                        other => {
+                            return Err(crate::new_error!(
+                                "parallel control lane {} entered unexpected status {}",
+                                control_lane,
+                                other
+                            ));
+                        }
+                    }
+                };
                 if done {
                     return Ok(());
                 }

--- a/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
+++ b/rust/nub-host-kvm/src/sandbox/initialized_multi_use.rs
@@ -14,11 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{Ordering, fence};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use javm_cap::cap::Cap;
-use nub_arch_x86_abi::{CapHash as AbiCapHash, FN_ID_NUB_PUT_CAP};
+use nub_arch_x86_abi::{
+    CapHash as AbiCapHash, FN_ID_NUB_INVOKE_WORKER, FN_ID_NUB_PUT_CAP, InvocationResult,
+    InvokePacket, PARALLEL_INVOKE_STATUS_DONE, PARALLEL_INVOKE_STATUS_EMPTY,
+    PARALLEL_INVOKE_STATUS_READY, PARALLEL_INVOKE_STATUS_RUNNING, PARALLEL_INVOKE_STATUS_STARTING,
+    PARALLEL_INVOKE_STATUS_STOP,
+};
 use nub_host_common::rpc::{ArchivedResponse, Request};
 use rkyv::util::AlignedVec;
 use std::collections::HashSet;
@@ -50,6 +57,8 @@ pub struct MultiUseSandbox {
     pub(crate) host_funcs: Arc<Mutex<FunctionRegistry>>,
     pub(crate) mem_mgr: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     vm: Arc<HyperlightVm>,
+    control_lock: Mutex<()>,
+    invoke_workers: Mutex<Option<Arc<ParallelInvokeWorkers>>>,
     /// Host-side record of every blob hash this sandbox has successfully
     /// published, so `put_cap_with_hash` can short-circuit an idempotent
     /// re-put without a roundtrip + merkle walk through the guest.
@@ -91,6 +100,8 @@ impl MultiUseSandbox {
             host_funcs,
             mem_mgr: Arc::new(Mutex::new(mgr)),
             vm: Arc::new(vm),
+            control_lock: Mutex::new(()),
+            invoke_workers: Mutex::new(None),
             published_blobs: Mutex::new(HashSet::new()),
         }
     }
@@ -98,6 +109,15 @@ impl MultiUseSandbox {
     /// Returns this sandbox's unique id.
     pub fn id(&self) -> u64 {
         self.id
+    }
+
+    /// Fixed vCPU pool size configured for this sandbox.
+    pub fn vcpu_count(&self) -> Result<usize> {
+        let mem_mgr = self
+            .mem_mgr
+            .lock()
+            .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+        Ok(mem_mgr.layout.get_vcpu_count())
     }
 
     /// Call a guest function by `fn_id` with a raw byte payload.
@@ -114,6 +134,7 @@ impl MultiUseSandbox {
     #[instrument(err(Debug), skip(self, payload), parent = Span::current())]
     pub fn call_raw(&self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
         maybe_time_and_emit_guest_call("call_raw", || {
+            self.stop_invoke_workers()?;
             self.call_guest_function_by_id_on(VcpuLane::PRIMARY, fn_id, payload)
         })
     }
@@ -131,6 +152,7 @@ impl MultiUseSandbox {
     ) -> Result<Vec<u8>> {
         let lane = VcpuLane::new(vcpu_index);
         maybe_time_and_emit_guest_call("call_raw_on_vcpu", || {
+            self.stop_invoke_workers()?;
             self.call_guest_function_by_id_on(lane, fn_id, payload)
         })
     }
@@ -145,6 +167,10 @@ impl MultiUseSandbox {
         // Clear any stale cancellation from a previous guest function call or if kill() was called too early.
         // Any kill() that completed (even partially) BEFORE this line has NO effect on this call.
         self.vm.clear_cancel();
+        let _control = self
+            .control_lock
+            .lock()
+            .map_err(|_| crate::new_error!("sandbox control mutex poisoned"))?;
 
         let res = (|| {
             let req = Request {
@@ -215,6 +241,218 @@ impl MultiUseSandbox {
         }
 
         res
+    }
+
+    /// Submit an invoke packet through the per-lane parallel worker slots.
+    ///
+    /// Workers are started lazily and remain hot for subsequent invoke calls.
+    /// The legacy raw RPC channel remains the serialized control plane.
+    pub fn invoke_cached_parallel(
+        &self,
+        job_id: u64,
+        packet: &InvokePacket,
+    ) -> Result<InvocationResult> {
+        let workers = self.ensure_invoke_workers()?;
+        let lane = workers.acquire_lane()?;
+        let lane_idx = lane.index();
+        let deadline = Instant::now() + Duration::from_secs(30);
+
+        {
+            let mem_mgr = self
+                .mem_mgr
+                .lock()
+                .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+            let status = mem_mgr.read_parallel_invoke_status(lane_idx)?;
+            if status != PARALLEL_INVOKE_STATUS_EMPTY {
+                return Err(crate::new_error!(
+                    "parallel invoke lane {} was not empty before submit (status={})",
+                    lane_idx,
+                    status
+                ));
+            }
+            mem_mgr.write_parallel_invoke_job_id(lane_idx, job_id)?;
+            mem_mgr.write_parallel_invoke_packet(lane_idx, packet)?;
+            fence(Ordering::Release);
+            mem_mgr.write_parallel_invoke_status(lane_idx, PARALLEL_INVOKE_STATUS_READY)?;
+        }
+
+        loop {
+            let done = {
+                let mem_mgr = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+                match mem_mgr.read_parallel_invoke_status(lane_idx)? {
+                    PARALLEL_INVOKE_STATUS_DONE => {
+                        fence(Ordering::Acquire);
+                        let result = mem_mgr.read_parallel_invoke_result(lane_idx)?;
+                        mem_mgr
+                            .write_parallel_invoke_status(lane_idx, PARALLEL_INVOKE_STATUS_EMPTY)?;
+                        Some(result)
+                    }
+                    PARALLEL_INVOKE_STATUS_READY | PARALLEL_INVOKE_STATUS_RUNNING => None,
+                    other => {
+                        return Err(crate::new_error!(
+                            "parallel invoke lane {} entered unexpected status {}",
+                            lane_idx,
+                            other
+                        ));
+                    }
+                }
+            };
+            if let Some(result) = done {
+                return Ok(result);
+            }
+            if let Some(worker_result) = workers.take_finished_result(lane_idx) {
+                let detail = match worker_result {
+                    Ok(()) => "clean worker exit".to_string(),
+                    Err(e) => e,
+                };
+                return Err(crate::new_error!(
+                    "parallel invoke worker lane {} exited while job {} was pending: {}",
+                    lane_idx,
+                    job_id,
+                    detail
+                ));
+            }
+            if Instant::now() >= deadline {
+                let status = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?
+                    .read_parallel_invoke_status(lane_idx)?;
+                return Err(crate::new_error!(
+                    "parallel invoke lane {} timed out waiting for job {} (status={})",
+                    lane_idx,
+                    job_id,
+                    status
+                ));
+            }
+            thread::yield_now();
+        }
+    }
+
+    fn ensure_invoke_workers(&self) -> Result<Arc<ParallelInvokeWorkers>> {
+        let mut guard = self
+            .invoke_workers
+            .lock()
+            .map_err(|_| crate::new_error!("parallel invoke worker mutex poisoned"))?;
+        if let Some(workers) = guard.as_ref().cloned() {
+            return Ok(workers);
+        }
+
+        let vcpu_count = self.vcpu_count()?;
+        let mut handles = Vec::with_capacity(vcpu_count);
+        for lane in 0..vcpu_count {
+            handles.push(self.start_invoke_worker_lane(lane)?);
+        }
+        let workers = Arc::new(ParallelInvokeWorkers::new(vcpu_count, handles));
+        *guard = Some(workers.clone());
+        Ok(workers)
+    }
+
+    fn stop_invoke_workers(&self) -> Result<()> {
+        let workers = {
+            let mut guard = self
+                .invoke_workers
+                .lock()
+                .map_err(|_| crate::new_error!("parallel invoke worker mutex poisoned"))?;
+            let Some(workers) = guard.take() else {
+                return Ok(());
+            };
+            workers
+        };
+
+        workers.mark_stopping_and_wait_idle()?;
+        for lane in 0..workers.lane_count() {
+            {
+                let mem_mgr = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+                mem_mgr.write_parallel_invoke_status(lane, PARALLEL_INVOKE_STATUS_STOP)?;
+            }
+            workers
+                .join_lane(lane, Duration::from_secs(5))?
+                .map_err(|e| crate::new_error!("parallel invoke worker lane {lane}: {e}"))?;
+        }
+
+        Ok(())
+    }
+
+    fn start_invoke_worker_lane(&self, lane: usize) -> Result<InvokeWorkerHandle> {
+        let _control = self
+            .control_lock
+            .lock()
+            .map_err(|_| crate::new_error!("sandbox control mutex poisoned"))?;
+
+        {
+            let mut mem_mgr = self
+                .mem_mgr
+                .lock()
+                .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+            mem_mgr.write_parallel_invoke_status(lane, PARALLEL_INVOKE_STATUS_STARTING)?;
+            let req = Request {
+                fn_id: FN_ID_NUB_INVOKE_WORKER,
+                payload: (lane as u32).to_le_bytes().to_vec(),
+            };
+            let req_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&req)
+                .map_err(|e| crate::new_error!("rkyv-serialize worker Request: {e}"))?;
+            mem_mgr.write_guest_function_call_raw(req_bytes.as_slice())?;
+        }
+
+        let vm = self.vm.clone();
+        let mem_mgr = self.mem_mgr.clone();
+        let host_funcs = self.host_funcs.clone();
+        let handle = thread::Builder::new()
+            .name(format!("nub-vcpu-worker-{lane}"))
+            .spawn(move || {
+                let lane = VcpuLane::new(lane);
+                vm.dispatch_call_from_host_on_shared(lane, &mem_mgr, &host_funcs)
+                    .map_err(|e| format!("dispatch worker lane {}: {e}", lane.index()))?;
+                let mut mem_mgr = mem_mgr
+                    .lock()
+                    .map_err(|_| "sandbox memory manager mutex poisoned".to_string())?;
+                let _ = mem_mgr
+                    .read_guest_function_call_result_raw()
+                    .map_err(|e| format!("read worker shutdown response: {e}"))?;
+                Ok(())
+            })
+            .map_err(|e| crate::new_error!("spawn invoke worker lane {lane}: {e}"))?;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = {
+                let mem_mgr = self
+                    .mem_mgr
+                    .lock()
+                    .map_err(|_| crate::new_error!("sandbox memory manager mutex poisoned"))?;
+                mem_mgr.read_parallel_invoke_status(lane)?
+            };
+            if status == PARALLEL_INVOKE_STATUS_EMPTY {
+                return Ok(handle);
+            }
+            if handle.is_finished() {
+                let worker_result = handle
+                    .join()
+                    .map_err(|_| crate::new_error!("invoke worker lane {lane} panicked"))?;
+                return Err(crate::new_error!(
+                    "invoke worker lane {} exited during startup: {}",
+                    lane,
+                    worker_result
+                        .err()
+                        .unwrap_or_else(|| "clean exit before startup handshake".to_string())
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(crate::new_error!(
+                    "invoke worker lane {} timed out during startup (status={})",
+                    lane,
+                    status
+                ));
+            }
+            thread::yield_now();
+        }
     }
 
     /// Publish a [`Cap`] into the guest's heap-resident cap
@@ -302,6 +540,144 @@ impl MultiUseSandbox {
     /// Returns a handle for interrupting guest execution.
     pub fn interrupt_handle(&self) -> Arc<dyn InterruptHandle> {
         self.vm.interrupt_handle()
+    }
+}
+
+type InvokeWorkerResult = std::result::Result<(), String>;
+type InvokeWorkerHandle = JoinHandle<InvokeWorkerResult>;
+
+struct ParallelInvokeWorkers {
+    lane_count: usize,
+    state: Mutex<ParallelInvokeWorkerState>,
+    ready: Condvar,
+    handles: Mutex<Vec<Option<InvokeWorkerHandle>>>,
+}
+
+struct ParallelInvokeWorkerState {
+    available: Vec<usize>,
+    stopping: bool,
+}
+
+struct LaneLease {
+    lane: usize,
+    workers: Arc<ParallelInvokeWorkers>,
+}
+
+impl ParallelInvokeWorkers {
+    fn new(lane_count: usize, handles: Vec<InvokeWorkerHandle>) -> Self {
+        Self {
+            lane_count,
+            state: Mutex::new(ParallelInvokeWorkerState {
+                available: (0..lane_count).rev().collect(),
+                stopping: false,
+            }),
+            ready: Condvar::new(),
+            handles: Mutex::new(handles.into_iter().map(Some).collect()),
+        }
+    }
+
+    fn lane_count(&self) -> usize {
+        self.lane_count
+    }
+
+    fn acquire_lane(self: &Arc<Self>) -> Result<LaneLease> {
+        let mut state = self.state.lock().expect("parallel worker mutex poisoned");
+        loop {
+            if state.stopping {
+                return Err(crate::new_error!(
+                    "parallel invoke workers are stopping for a control-plane call"
+                ));
+            }
+            if let Some(lane) = state.available.pop() {
+                return Ok(LaneLease {
+                    lane,
+                    workers: self.clone(),
+                });
+            }
+            state = self
+                .ready
+                .wait(state)
+                .expect("parallel worker mutex poisoned");
+        }
+    }
+
+    fn release_lane(&self, lane: usize) {
+        let mut state = self.state.lock().expect("parallel worker mutex poisoned");
+        state.available.push(lane);
+        self.ready.notify_all();
+    }
+
+    fn mark_stopping_and_wait_idle(&self) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        state.stopping = true;
+        while state.available.len() != self.lane_count {
+            state = self
+                .ready
+                .wait(state)
+                .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+        }
+        Ok(())
+    }
+
+    fn take_finished_result(&self, lane: usize) -> Option<InvokeWorkerResult> {
+        let mut handles = self.handles.lock().expect("parallel worker mutex poisoned");
+        let handle = handles.get_mut(lane)?.take_if(|h| h.is_finished())?;
+        Some(match handle.join() {
+            Ok(result) => result,
+            Err(_) => Err("worker thread panicked".to_string()),
+        })
+    }
+
+    fn join_lane(&self, lane: usize, timeout: Duration) -> Result<InvokeWorkerResult> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            {
+                let handles = self
+                    .handles
+                    .lock()
+                    .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?;
+                let Some(Some(handle)) = handles.get(lane) else {
+                    return Ok(Ok(()));
+                };
+                if handle.is_finished() {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(crate::new_error!(
+                    "parallel invoke worker lane {} timed out during stop",
+                    lane
+                ));
+            }
+            thread::yield_now();
+        }
+
+        let handle = self
+            .handles
+            .lock()
+            .map_err(|_| crate::new_error!("parallel worker mutex poisoned"))?
+            .get_mut(lane)
+            .and_then(Option::take)
+            .ok_or_else(|| crate::new_error!("parallel invoke worker lane {} missing", lane))?;
+        Ok(match handle.join() {
+            Ok(result) => result,
+            Err(_) => Err("worker thread panicked".to_string()),
+        })
+    }
+}
+
+impl LaneLease {
+    fn index(&self) -> usize {
+        self.lane
+    }
+}
+
+impl Drop for LaneLease {
+    fn drop(&mut self) {
+        self.workers.release_lane(self.lane);
     }
 }
 

--- a/rust/nub/Cargo.toml
+++ b/rust/nub/Cargo.toml
@@ -46,7 +46,7 @@ nub-build = { path = "../nub-build" }
 # Self-reference so `cargo test -p nub` and `cargo bench -p nub`
 # automatically enable the `test-support` feature, which in turn
 # builds the test/bench guest binaries and exposes the
-# `Nub::new_hyperlight_tests` / `new_hyperlight_benches` constructors.
+# `Nub::hyperlight_tests` / `hyperlight_benches` constructors.
 nub = { path = ".", features = ["test-support"] }
 criterion = "0.5"
 

--- a/rust/nub/benches/arc_page_alloc.rs
+++ b/rust/nub/benches/arc_page_alloc.rs
@@ -18,24 +18,18 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use nub::Nub;
 use nub_arch_x86::test_abi::FN_ID_BENCH_ARC_PAGE_ALLOC;
-use std::sync::{Mutex, OnceLock};
-
-fn nub_handle() -> &'static Mutex<Nub> {
-    static NUB: OnceLock<Mutex<Nub>> = OnceLock::new();
-    NUB.get_or_init(|| Mutex::new(Nub::new_hyperlight_benches().expect("bench guest binary")))
-}
 
 fn bench(c: &mut Criterion) {
     // Warm up: instantiate the Nub so the first sample doesn't pay
     // sandbox-boot cost.
-    drop(nub_handle().lock().expect("nub mutex"));
+    drop(Nub::hyperlight_benches().expect("bench guest binary"));
 
     let mut group = c.benchmark_group("arc_page_alloc");
     for &n in &[16u32, 256, 1024, 4096] {
         group.throughput(Throughput::Elements(u64::from(n)));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter(|| {
-                let mut nub = nub_handle().lock().expect("nub mutex");
+                let mut nub = Nub::hyperlight_benches().expect("bench guest binary");
                 let payload = n.to_le_bytes();
                 let bytes = nub
                     .call_raw(FN_ID_BENCH_ARC_PAGE_ALLOC, &payload)

--- a/rust/nub/benches/arc_page_alloc.rs
+++ b/rust/nub/benches/arc_page_alloc.rs
@@ -29,7 +29,7 @@ fn bench(c: &mut Criterion) {
         group.throughput(Throughput::Elements(u64::from(n)));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             b.iter(|| {
-                let mut nub = Nub::hyperlight_benches().expect("bench guest binary");
+                let nub = Nub::hyperlight_benches().expect("bench guest binary");
                 let payload = n.to_le_bytes();
                 let bytes = nub
                     .call_raw(FN_ID_BENCH_ARC_PAGE_ALLOC, &payload)

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -115,6 +115,38 @@ struct NubInner {
     next_job_id: AtomicU64,
 }
 
+struct MeterReservation {
+    inner: Arc<NubInner>,
+    key: Key,
+}
+
+impl MeterReservation {
+    fn reserve(inner: Arc<NubInner>, key: Key) -> Result<Self> {
+        {
+            let mut in_flight = inner
+                .in_flight_meters
+                .lock()
+                .expect("Nub meter reservation mutex poisoned");
+            if !in_flight.insert(key.clone()) {
+                return Err(anyhow::anyhow!(
+                    "invoke_cached: gas meter is already in flight"
+                ));
+            }
+        }
+        Ok(Self { inner, key })
+    }
+}
+
+impl Drop for MeterReservation {
+    fn drop(&mut self) {
+        self.inner
+            .in_flight_meters
+            .lock()
+            .expect("Nub meter reservation mutex poisoned")
+            .remove(&self.key);
+    }
+}
+
 /// Options used when constructing the process-wide Hyperlight Nub singleton.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NubOptions {
@@ -613,19 +645,14 @@ impl Nub {
             _ => (request.initial_gas, false),
         };
 
-        let reserved_meter = if used_meter { meter_key.clone() } else { None };
-        if let Some(k) = &reserved_meter {
-            let mut in_flight = self
-                .inner
-                .in_flight_meters
-                .lock()
-                .expect("Nub meter reservation mutex poisoned");
-            if !in_flight.insert(k.clone()) {
-                return Err(anyhow::anyhow!(
-                    "invoke_cached: gas meter is already in flight"
-                ));
-            }
-        }
+        let _meter_reservation = if used_meter {
+            meter_key
+                .clone()
+                .map(|k| MeterReservation::reserve(self.inner.clone(), k))
+                .transpose()?
+        } else {
+            None
+        };
 
         let result = self.invoke_cached_raw(
             job_id,
@@ -634,13 +661,6 @@ impl Nub {
             request.args,
             budget,
         );
-        if let Some(k) = &reserved_meter {
-            self.inner
-                .in_flight_meters
-                .lock()
-                .expect("Nub meter reservation mutex poisoned")
-                .remove(k);
-        }
         let result = result?;
         if used_meter && let Some(k) = meter_key {
             self.inner
@@ -777,4 +797,27 @@ fn resolve_meter_key_from(cache: &CacheDirectory, instance_hash: AbiCapHash) -> 
         return Some(key_from_regs(g.regs[0], g.regs[1]));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meter_reservation_rejects_duplicate_and_releases_on_drop() {
+        let nub = Nub::new_local();
+        let key = Key::from(&[0xCA, 0xFE][..]);
+
+        let first =
+            MeterReservation::reserve(nub.inner.clone(), key.clone()).expect("first reservation");
+        assert!(
+            MeterReservation::reserve(nub.inner.clone(), key.clone()).is_err(),
+            "a duplicate in-flight meter reservation must be rejected"
+        );
+
+        drop(first);
+        let second = MeterReservation::reserve(nub.inner.clone(), key)
+            .expect("reservation should be released on drop");
+        drop(second);
+    }
 }

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -118,9 +118,9 @@ struct NubInner {
 /// Options used when constructing the process-wide Hyperlight Nub singleton.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NubOptions {
-    /// Fixed vCPU pool size for the backing sandbox. The current hot path still
-    /// enters lane 0; the value is plumbed through the host substrate so the
-    /// multi-lane worker ABI can attach to the same stable pool.
+    /// Fixed vCPU pool size for the backing sandbox. Multi-vCPU Hyperlight
+    /// sandboxes keep one hot worker per lane and route top-level invokes
+    /// through those workers.
     pub vcpu_count: usize,
 }
 
@@ -237,7 +237,7 @@ enum Backend {
     /// hashes host-side to short-circuit idempotent re-puts (it does
     /// *not* dereference the guest's hashbrown — see
     /// `MultiUseSandbox::published_blobs` for why that is unsound).
-    Hyperlight(Box<HyperlightDriver>),
+    Hyperlight(Arc<HyperlightDriver>),
 }
 
 /// Host-side RPC stub for the Hyperlight backend. The real kernel
@@ -251,7 +251,7 @@ struct HyperlightDriver {
     /// authoritative cap directory lives guest-side). This is the host's own
     /// `CacheDirectory` — not a deref of the guest's hashbrown (which is
     /// unsound across the SIMD-width boundary; see `MultiUseSandbox`).
-    host_cache: CacheDirectory,
+    host_cache: Mutex<CacheDirectory>,
 }
 
 impl Nub {
@@ -339,10 +339,10 @@ impl Nub {
         let sandbox = uninit.evolve()?;
         Ok(Self {
             inner: Arc::new(NubInner {
-                backend: Mutex::new(Backend::Hyperlight(Box::new(HyperlightDriver {
+                backend: Mutex::new(Backend::Hyperlight(Arc::new(HyperlightDriver {
                     sandbox,
                     state_root_cache: [0; 32],
-                    host_cache: CacheDirectory::new(),
+                    host_cache: Mutex::new(CacheDirectory::new()),
                 }))),
                 meters: Mutex::new(HashMap::new()),
                 quotas: Mutex::new(HashMap::new()),
@@ -435,7 +435,11 @@ impl Nub {
                 // Mirror into the host-side cache so `invoke_cached` can resolve
                 // gas_slots → meter_key host-side (best-effort; the guest cache
                 // is authoritative for execution).
-                let _ = h.host_cache.put_cap(cap);
+                let _ = h
+                    .host_cache
+                    .lock()
+                    .expect("Hyperlight host cache mutex poisoned")
+                    .put_cap(cap);
                 h.sandbox
                     .put_cap(cap)
                     .map_err(|e| anyhow::anyhow!("put_cap: {e}"))
@@ -469,7 +473,11 @@ impl Nub {
                 .put_cap_with_hash(hash, cap)
                 .map_err(|e| anyhow::anyhow!("put_cap_with_hash (local): {e}")),
             Backend::Hyperlight(h) => {
-                let _ = h.host_cache.put_cap_with_hash(hash, cap);
+                let _ = h
+                    .host_cache
+                    .lock()
+                    .expect("Hyperlight host cache mutex poisoned")
+                    .put_cap_with_hash(hash, cap);
                 h.sandbox
                     .put_cap_with_hash(hash, cap)
                     .map_err(|e| anyhow::anyhow!("put_cap_with_hash: {e}"))
@@ -535,15 +543,20 @@ impl Nub {
             .expect("Nub backend mutex poisoned");
         let cache = match &*backend {
             Backend::Local { cache, .. } => cache,
-            Backend::Hyperlight(h) => &h.host_cache,
+            Backend::Hyperlight(h) => {
+                let cache = h
+                    .host_cache
+                    .lock()
+                    .expect("Hyperlight host cache mutex poisoned");
+                return resolve_meter_key_from(&cache, instance_hash);
+            }
         };
         resolve_meter_key_from(cache, instance_hash)
     }
 
-    /// Submit an invocation to the singleton Nub and return a job handle. This
-    /// compatibility implementation uses a host worker thread per submitted
-    /// job; the KVM backend still serializes at the sandbox boundary until the
-    /// guest multi-lane worker ABI lands.
+    /// Submit an invocation to the singleton Nub and return a job handle. The
+    /// Hyperlight backend uses a host-side waiter thread for the job while the
+    /// actual guest execution runs on the sandbox's fixed vCPU worker lanes.
     pub fn submit_invoke(&self, request: InvokeRequest) -> Result<InvokeJob> {
         let id = InvokeJobId(self.inner.next_job_id.fetch_add(1, Ordering::Relaxed));
         let state = Arc::new(InvokeJobState::new());
@@ -553,7 +566,7 @@ impl Nub {
             .name(format!("nub-invoke-{}", id.0))
             .spawn(move || {
                 let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    nub.invoke_request_blocking(request)
+                    nub.invoke_request_blocking(request, id.0)
                 }))
                 .map_err(|_| "invoke worker panicked".to_string())
                 .and_then(|r| r.map_err(|e| format!("{e:#}")));
@@ -579,15 +592,23 @@ impl Nub {
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        self.invoke_request_blocking(InvokeRequest {
-            instance_hash,
-            endpoint_idx,
-            args,
-            initial_gas,
-        })
+        let job_id = self.inner.next_job_id.fetch_add(1, Ordering::Relaxed);
+        self.invoke_request_blocking(
+            InvokeRequest {
+                instance_hash,
+                endpoint_idx,
+                args,
+                initial_gas,
+            },
+            job_id,
+        )
     }
 
-    fn invoke_request_blocking(&self, request: InvokeRequest) -> Result<InvocationResult> {
+    fn invoke_request_blocking(
+        &self,
+        request: InvokeRequest,
+        job_id: u64,
+    ) -> Result<InvocationResult> {
         let meter_key = self.resolve_gas_meter_key(request.instance_hash);
         let meter_balance = meter_key.as_ref().map(|k| self.get_meter(k)).unwrap_or(0);
         let (budget, used_meter) = match &meter_key {
@@ -610,6 +631,7 @@ impl Nub {
         }
 
         let result = self.invoke_cached_raw(
+            job_id,
             request.instance_hash,
             request.endpoint_idx,
             request.args,
@@ -637,81 +659,93 @@ impl Nub {
     /// already resolved (meter-seeded or call-supplied).
     fn invoke_cached_raw(
         &self,
+        job_id: u64,
         instance_hash: AbiCapHash,
         endpoint_idx: u8,
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        let mut backend = self
-            .inner
-            .backend
-            .lock()
-            .expect("Nub backend mutex poisoned");
-        match &mut *backend {
-            Backend::Local { cache, .. } => {
-                // Resolve the instance + image from the in-process
-                // cache and drive the PVM2 (RISC-V) interpreter.
-                let instance_cap = cache
-                    .get(CapHashOrRef::Hash(instance_hash))
-                    .ok_or_else(|| anyhow::anyhow!("invoke_cached: instance not published"))?;
-                let inst = match &*instance_cap {
-                    Cap::Instance(i) => i.clone(),
-                    _ => {
-                        return Err(anyhow::anyhow!(
-                            "invoke_cached: cap at hash is not an Instance"
-                        ));
-                    }
-                };
-                let image_cap = cache
-                    .get(CapHashOrRef::Hash(inst.image_hash))
-                    .ok_or_else(|| anyhow::anyhow!("invoke_cached: image not in cache"))?;
-                let img = match &*image_cap {
-                    Cap::Image(i) => i.clone(),
-                    _ => {
-                        return Err(anyhow::anyhow!(
-                            "invoke_cached: cap at image_hash is not an Image"
-                        ));
-                    }
-                };
-                Ok(nub_arch_local::run_instance(
-                    &inst,
-                    &img,
-                    endpoint_idx,
-                    args,
-                    initial_gas,
-                ))
+        let hyperlight = {
+            let mut backend = self
+                .inner
+                .backend
+                .lock()
+                .expect("Nub backend mutex poisoned");
+            match &mut *backend {
+                Backend::Local { cache, .. } => {
+                    // Resolve the instance + image from the in-process
+                    // cache and drive the PVM2 (RISC-V) interpreter.
+                    let instance_cap = cache
+                        .get(CapHashOrRef::Hash(instance_hash))
+                        .ok_or_else(|| anyhow::anyhow!("invoke_cached: instance not published"))?;
+                    let inst = match &*instance_cap {
+                        Cap::Instance(i) => i.clone(),
+                        _ => {
+                            return Err(anyhow::anyhow!(
+                                "invoke_cached: cap at hash is not an Instance"
+                            ));
+                        }
+                    };
+                    let image_cap = cache
+                        .get(CapHashOrRef::Hash(inst.image_hash))
+                        .ok_or_else(|| anyhow::anyhow!("invoke_cached: image not in cache"))?;
+                    let img = match &*image_cap {
+                        Cap::Image(i) => i.clone(),
+                        _ => {
+                            return Err(anyhow::anyhow!(
+                                "invoke_cached: cap at image_hash is not an Image"
+                            ));
+                        }
+                    };
+                    return Ok(nub_arch_local::run_instance(
+                        &inst,
+                        &img,
+                        endpoint_idx,
+                        args,
+                        initial_gas,
+                    ));
+                }
+                Backend::Hyperlight(h) => h.clone(),
             }
-            Backend::Hyperlight(h) => {
-                // No host-side pin/unpin — the cap is owned by the
-                // guest's heap-resident DIRECTORY; there's nothing for
-                // the host to lock against (the guest doesn't evict).
-                let packet = InvokePacket {
-                    instance_hash,
-                    endpoint_idx: endpoint_idx as u32,
-                    _pad: 0,
-                    args,
-                    initial_gas,
-                };
-                let result_bytes = h
-                    .sandbox
-                    .call_raw(FN_ID_NUB_INVOKE_CACHED, packet.as_bytes())?;
+        };
 
-                let mut aligned = AlignedVec::<16>::with_capacity(result_bytes.len());
-                aligned.extend_from_slice(&result_bytes);
-                let archived = rkyv::access::<ArchivedInvocationResult, rkyv::rancor::Error>(
-                    aligned.as_slice(),
-                )
-                .map_err(|e| anyhow::anyhow!("rkyv-access InvocationResult: {e}"))?;
-                Ok(InvocationResult {
-                    exit_reason: archived.exit_reason.to_native(),
-                    exit_arg: archived.exit_arg.to_native(),
-                    return_value: archived.return_value.to_native(),
-                    gas_remaining: archived.gas_remaining.to_native(),
-                    // `[u8; N]` archives byte-identically (u8 has no endianness).
-                    scratchpad_head: archived.scratchpad_head,
-                })
-            }
+        // No host-side pin/unpin — the cap is owned by the guest's
+        // heap-resident DIRECTORY; there's nothing for the host to lock against
+        // (the guest doesn't evict). Multi-vCPU sandboxes use the per-lane worker
+        // slots; the single-vCPU case keeps the legacy RPC path so control-only
+        // tests do not start a permanent worker on lane 0.
+        let packet = InvokePacket {
+            instance_hash,
+            endpoint_idx: endpoint_idx as u32,
+            _pad: 0,
+            args,
+            initial_gas,
+        };
+
+        if hyperlight.sandbox.vcpu_count()? > 1 {
+            return hyperlight
+                .sandbox
+                .invoke_cached_parallel(job_id, &packet)
+                .map_err(|e| anyhow::anyhow!("invoke_cached_parallel: {e}"));
         }
+
+        let result_bytes = hyperlight
+            .sandbox
+            .call_raw(FN_ID_NUB_INVOKE_CACHED, packet.as_bytes())?;
+
+        let mut aligned = AlignedVec::<16>::with_capacity(result_bytes.len());
+        aligned.extend_from_slice(&result_bytes);
+        let archived =
+            rkyv::access::<ArchivedInvocationResult, rkyv::rancor::Error>(aligned.as_slice())
+                .map_err(|e| anyhow::anyhow!("rkyv-access InvocationResult: {e}"))?;
+        Ok(InvocationResult {
+            exit_reason: archived.exit_reason.to_native(),
+            exit_arg: archived.exit_arg.to_native(),
+            return_value: archived.return_value.to_native(),
+            gas_remaining: archived.gas_remaining.to_native(),
+            // `[u8; N]` archives byte-identically (u8 has no endianness).
+            scratchpad_head: archived.scratchpad_head,
+        })
     }
 }
 

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -123,10 +123,10 @@ struct MeterReservation {
 impl MeterReservation {
     fn reserve(inner: Arc<NubInner>, key: Key) -> Result<Self> {
         {
-            let mut in_flight = inner
-                .in_flight_meters
-                .lock()
-                .expect("Nub meter reservation mutex poisoned");
+            let mut in_flight = match inner.in_flight_meters.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
             if !in_flight.insert(key.clone()) {
                 return Err(anyhow::anyhow!(
                     "invoke_cached: gas meter is already in flight"
@@ -139,11 +139,11 @@ impl MeterReservation {
 
 impl Drop for MeterReservation {
     fn drop(&mut self) {
-        self.inner
-            .in_flight_meters
-            .lock()
-            .expect("Nub meter reservation mutex poisoned")
-            .remove(&self.key);
+        let mut in_flight = match self.inner.in_flight_meters.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        in_flight.remove(&self.key);
     }
 }
 
@@ -818,6 +818,28 @@ mod tests {
         drop(first);
         let second = MeterReservation::reserve(nub.inner.clone(), key)
             .expect("reservation should be released on drop");
+        drop(second);
+    }
+
+    #[test]
+    fn meter_reservation_drop_tolerates_poisoned_mutex() {
+        let nub = Nub::new_local();
+        let key = Key::from(&[0xBA, 0xAD][..]);
+        let reservation =
+            MeterReservation::reserve(nub.inner.clone(), key.clone()).expect("reservation");
+
+        let inner = nub.inner.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = inner
+                .in_flight_meters
+                .lock()
+                .expect("lock before intentional panic");
+            panic!("poison meter reservation mutex");
+        });
+
+        drop(reservation);
+        let second = MeterReservation::reserve(nub.inner.clone(), key)
+            .expect("drop should release even after poison");
         drop(second);
     }
 }

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -39,13 +39,9 @@ use nub_kernel::Kernel;
 
 #[cfg(feature = "heap-diag")]
 use nub_arch_x86_abi::FN_ID_NUB_HEAP_STATS;
-use nub_arch_x86_abi::{
-    ArchivedInvocationResult, FN_ID_NUB_EVICT_JIT_ALL, FN_ID_NUB_INVOKE_CACHED, InvokePacket,
-};
 pub use nub_arch_x86_abi::{CapHash as AbiCapHash, InvocationResult, SCRATCHPAD_HEAD_LEN};
+use nub_arch_x86_abi::{FN_ID_NUB_EVICT_JIT_ALL, InvokePacket};
 pub use nub_kernel::{CapHash, InstanceRef, InvokeOptions, InvokeOutcome};
-
-use rkyv::util::AlignedVec;
 
 /// Snapshot of the guest's talc allocation state. Returned by
 /// [`Nub::heap_stats`].
@@ -883,9 +879,9 @@ impl Nub {
 
         // No host-side pin/unpin — the cap is owned by the guest's
         // heap-resident DIRECTORY; there's nothing for the host to lock against
-        // (the guest doesn't evict). Multi-vCPU sandboxes use the per-lane worker
-        // slots; the single-vCPU case keeps the legacy RPC path so control-only
-        // tests do not start a permanent worker on lane 0.
+        // (the guest doesn't evict). Hyperlight invokes always go through the
+        // fixed per-lane worker pool; serialized `call_raw` remains only for the
+        // control plane and stops idle workers before using the legacy RPC ring.
         let packet = InvokePacket {
             instance_hash,
             endpoint_idx: endpoint_idx as u32,
@@ -894,30 +890,10 @@ impl Nub {
             initial_gas,
         };
 
-        if hyperlight.sandbox.vcpu_count()? > 1 {
-            return hyperlight
-                .sandbox
-                .invoke_cached_parallel(job_id, &packet)
-                .map_err(|e| anyhow::anyhow!("invoke_cached_parallel: {e}"));
-        }
-
-        let result_bytes = hyperlight
+        hyperlight
             .sandbox
-            .call_raw(FN_ID_NUB_INVOKE_CACHED, packet.as_bytes())?;
-
-        let mut aligned = AlignedVec::<16>::with_capacity(result_bytes.len());
-        aligned.extend_from_slice(&result_bytes);
-        let archived =
-            rkyv::access::<ArchivedInvocationResult, rkyv::rancor::Error>(aligned.as_slice())
-                .map_err(|e| anyhow::anyhow!("rkyv-access InvocationResult: {e}"))?;
-        Ok(InvocationResult {
-            exit_reason: archived.exit_reason.to_native(),
-            exit_arg: archived.exit_arg.to_native(),
-            return_value: archived.return_value.to_native(),
-            gas_remaining: archived.gas_remaining.to_native(),
-            // `[u8; N]` archives byte-identically (u8 has no endianness).
-            scratchpad_head: archived.scratchpad_head,
-        })
+            .invoke_cached_parallel(job_id, &packet)
+            .map_err(|e| anyhow::anyhow!("invoke_cached_parallel: {e}"))
     }
 }
 

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -20,9 +20,12 @@
 #[cfg(feature = "test-support")]
 pub mod test_support;
 
-use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
-use std::sync::{Mutex, MutexGuard};
+use std::collections::{BTreeSet, HashMap};
+use std::num::NonZeroUsize;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
 
 use anyhow::Result;
 use javm_cap::{
@@ -75,61 +78,149 @@ pub(crate) struct HyperlightBlob {
 
 struct HyperlightSingleton {
     blob: HyperlightBlob,
+    options: NubOptions,
     nub: Nub,
 }
 
 static HYPERLIGHT_NUB: Mutex<Option<HyperlightSingleton>> = Mutex::new(None);
 
-/// Guard for the process-wide Hyperlight-backed [`Nub`].
-///
-/// The KVM backend maps the guest at fixed host virtual addresses, so the high
-/// level `nub` API exposes exactly one live Hyperlight sandbox per process. The
-/// guard serializes access to that singleton and dereferences to [`Nub`] for the
-/// normal publish/invoke methods.
-///
-/// TODO(parallel-nub): future parallel execution should keep this single host
-/// Nub and schedule parallel work inside the guest microkernel, not by creating
-/// multiple KVM sandboxes in one host process.
-pub struct HyperlightNubGuard {
-    guard: MutexGuard<'static, Option<HyperlightSingleton>>,
-}
-
-impl Deref for HyperlightNubGuard {
-    type Target = Nub;
-
-    fn deref(&self) -> &Self::Target {
-        &self
-            .guard
-            .as_ref()
-            .expect("Hyperlight Nub singleton initialized")
-            .nub
-    }
-}
-
-impl DerefMut for HyperlightNubGuard {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self
-            .guard
-            .as_mut()
-            .expect("Hyperlight Nub singleton initialized")
-            .nub
-    }
-}
+/// Compatibility alias for older tests/benches that named the returned
+/// Hyperlight singleton borrow. `Nub` is now a cloneable handle; synchronization
+/// lives inside the handle instead of in an outer mutex guard.
+pub type HyperlightNubGuard = Nub;
 
 /// Uniform handle to the nub microkernel.
+#[derive(Clone)]
 pub struct Nub {
-    backend: Backend,
+    inner: Arc<NubInner>,
+}
+
+struct NubInner {
+    backend: Mutex<Backend>,
     /// The kernel-maintained gas meter mapping (`meter_key -> remaining gas`).
     /// The interim "static meter mapping" of the kernel-assisted GasMeter
     /// design — a later spec change moves it behind a YieldCatcher. At top-level
     /// invoke the host resolves the running Instance's primary usable gas slot
     /// (first non-empty valid `Gas{meter_key}`), seeds the run from this map
     /// when non-zero, and writes the remaining primary balance back here.
-    meters: HashMap<Key, u64>,
+    meters: Mutex<HashMap<Key, u64>>,
     /// The kernel-maintained storage quota mapping (`quota_key -> remaining`).
     /// Symmetric to [`Self::meters`]; quota *charging* is not yet wired (V1),
     /// so this is seeded/observed but not yet debited per dirty page.
-    quotas: HashMap<Key, u64>,
+    quotas: Mutex<HashMap<Key, u64>>,
+    /// Host-side guard for top-level invokes that seed from the same kernel gas
+    /// meter. The first parallel milestone rejects concurrent reuse instead of
+    /// racing two writers on one balance.
+    in_flight_meters: Mutex<BTreeSet<Key>>,
+    next_job_id: AtomicU64,
+}
+
+/// Options used when constructing the process-wide Hyperlight Nub singleton.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NubOptions {
+    /// Fixed vCPU pool size for the backing sandbox. The current hot path still
+    /// enters lane 0; the value is plumbed through the host substrate so the
+    /// multi-lane worker ABI can attach to the same stable pool.
+    pub vcpu_count: usize,
+}
+
+impl NubOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_vcpu_count(mut self, vcpu_count: usize) -> Self {
+        self.vcpu_count = vcpu_count.max(1);
+        self
+    }
+}
+
+impl Default for NubOptions {
+    fn default() -> Self {
+        let default = thread::available_parallelism()
+            .map(NonZeroUsize::get)
+            .unwrap_or(1)
+            .clamp(1, 8);
+        let vcpu_count = std::env::var("JAR_NUB_VCPUS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(default);
+        Self { vcpu_count }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvokeRequest {
+    pub instance_hash: AbiCapHash,
+    pub endpoint_idx: u8,
+    pub args: [u64; 4],
+    pub initial_gas: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InvokeJobId(pub u64);
+
+pub struct InvokeJob {
+    id: InvokeJobId,
+    state: Arc<InvokeJobState>,
+}
+
+struct InvokeJobState {
+    result: Mutex<Option<Result<InvocationResult, String>>>,
+    ready: Condvar,
+}
+
+impl InvokeJob {
+    pub fn id(&self) -> InvokeJobId {
+        self.id
+    }
+
+    pub fn try_wait(&self) -> Option<Result<InvocationResult>> {
+        let guard = self
+            .state
+            .result
+            .lock()
+            .expect("InvokeJob result mutex poisoned");
+        guard.as_ref().map(|r| match r {
+            Ok(v) => Ok(*v),
+            Err(e) => Err(anyhow::anyhow!(e.clone())),
+        })
+    }
+
+    pub fn wait(self) -> Result<InvocationResult> {
+        let mut guard = self
+            .state
+            .result
+            .lock()
+            .expect("InvokeJob result mutex poisoned");
+        while guard.is_none() {
+            guard = self
+                .state
+                .ready
+                .wait(guard)
+                .expect("InvokeJob result mutex poisoned");
+        }
+        match guard.take().expect("checked is_some") {
+            Ok(v) => Ok(v),
+            Err(e) => Err(anyhow::anyhow!(e)),
+        }
+    }
+}
+
+impl InvokeJobState {
+    fn new() -> Self {
+        Self {
+            result: Mutex::new(None),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn complete(&self, result: Result<InvocationResult, String>) {
+        let mut guard = self.result.lock().expect("InvokeJob result mutex poisoned");
+        *guard = Some(result);
+        self.ready.notify_all();
+    }
 }
 
 enum Backend {
@@ -167,30 +258,49 @@ impl Nub {
     /// Construct a Nub backed by the in-process [`LocalArch`].
     pub fn new_local() -> Self {
         Self {
-            backend: Backend::Local {
-                kernel: Kernel::new(LocalArch::new()),
-                cache: CacheDirectory::new(),
-            },
-            meters: HashMap::new(),
-            quotas: HashMap::new(),
+            inner: Arc::new(NubInner {
+                backend: Mutex::new(Backend::Local {
+                    kernel: Kernel::new(LocalArch::new()),
+                    cache: CacheDirectory::new(),
+                }),
+                meters: Mutex::new(HashMap::new()),
+                quotas: Mutex::new(HashMap::new()),
+                in_flight_meters: Mutex::new(BTreeSet::new()),
+                next_job_id: AtomicU64::new(1),
+            }),
         }
     }
 
     /// Borrow the process-wide Hyperlight-backed Nub loaded from the
     /// `nub-arch-x86` guest blob.
     pub fn hyperlight() -> Result<HyperlightNubGuard> {
-        Self::hyperlight_with_blob(HyperlightBlob {
-            label: "production",
-            path: NUB_ARCH_X86_BLOB_PATH,
-        })
+        Self::hyperlight_with_options(NubOptions::default())
     }
 
-    pub(crate) fn hyperlight_with_blob(blob: HyperlightBlob) -> Result<HyperlightNubGuard> {
+    pub fn hyperlight_with_options(options: NubOptions) -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(
+            HyperlightBlob {
+                label: "production",
+                path: NUB_ARCH_X86_BLOB_PATH,
+            },
+            options,
+        )
+    }
+
+    pub(crate) fn hyperlight_with_blob(blob: HyperlightBlob, options: NubOptions) -> Result<Nub> {
         let mut guard = HYPERLIGHT_NUB
             .lock()
             .map_err(|_| anyhow::anyhow!("Hyperlight Nub singleton mutex poisoned"))?;
         match guard.as_ref() {
-            Some(existing) if existing.blob.path == blob.path => {}
+            Some(existing) if existing.blob.path == blob.path && existing.options == options => {}
+            Some(existing) if existing.blob.path == blob.path => {
+                return Err(anyhow::anyhow!(
+                    "Hyperlight Nub singleton already initialized with {} vCPU(s); \
+                     cannot reconfigure it to {} vCPU(s)",
+                    existing.options.vcpu_count,
+                    options.vcpu_count,
+                ));
+            }
             Some(existing) => {
                 return Err(anyhow::anyhow!(
                     "Hyperlight Nub singleton already initialized with {} guest ({:?}); \
@@ -202,11 +312,15 @@ impl Nub {
                 ));
             }
             None => {
-                let nub = Self::create_hyperlight_with_blob_path(blob.path)?;
-                *guard = Some(HyperlightSingleton { blob, nub });
+                let nub = Self::create_hyperlight_with_blob_path(blob.path, options)?;
+                *guard = Some(HyperlightSingleton { blob, options, nub });
             }
         }
-        Ok(HyperlightNubGuard { guard })
+        Ok(guard
+            .as_ref()
+            .expect("Hyperlight Nub singleton initialized")
+            .nub
+            .clone())
     }
 
     /// Create the backing sandbox for the process-wide Hyperlight singleton
@@ -214,8 +328,9 @@ impl Nub {
     ///
     /// This is intentionally private: high-level callers must go through the
     /// process singleton returned by [`Self::hyperlight`].
-    fn create_hyperlight_with_blob_path(path: &str) -> Result<Self> {
+    fn create_hyperlight_with_blob_path(path: &str, options: NubOptions) -> Result<Self> {
         let mut cfg = SandboxConfiguration::default();
+        cfg.set_vcpu_count(options.vcpu_count);
         cfg.set_scratch_size(512 * 1024 * 1024);
         cfg.set_input_data_size(16 * 1024 * 1024);
         cfg.set_output_data_size(16 * 1024 * 1024);
@@ -223,19 +338,28 @@ impl Nub {
         let uninit = UninitializedSandbox::new(GuestBinary::FilePath(path.to_string()), Some(cfg))?;
         let sandbox = uninit.evolve()?;
         Ok(Self {
-            backend: Backend::Hyperlight(Box::new(HyperlightDriver {
-                sandbox,
-                state_root_cache: [0; 32],
-                host_cache: CacheDirectory::new(),
-            })),
-            meters: HashMap::new(),
-            quotas: HashMap::new(),
+            inner: Arc::new(NubInner {
+                backend: Mutex::new(Backend::Hyperlight(Box::new(HyperlightDriver {
+                    sandbox,
+                    state_root_cache: [0; 32],
+                    host_cache: CacheDirectory::new(),
+                }))),
+                meters: Mutex::new(HashMap::new()),
+                quotas: Mutex::new(HashMap::new()),
+                in_flight_meters: Mutex::new(BTreeSet::new()),
+                next_job_id: AtomicU64::new(1),
+            }),
         })
     }
 
     /// Current state root.
     pub fn state_root(&self) -> CapHash {
-        match &self.backend {
+        let backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &*backend {
             Backend::Local { kernel, .. } => kernel.state_root(),
             Backend::Hyperlight(h) => h.state_root_cache,
         }
@@ -244,8 +368,13 @@ impl Nub {
     /// Bench-only: clear the guest's JIT compile cache so the next
     /// `invoke_cached` pays a full recompile. No-op on the Local
     /// backend (which uses the interpreter and has no JIT cache).
-    pub fn evict_jit_all(&mut self) -> Result<()> {
-        match &mut self.backend {
+    pub fn evict_jit_all(&self) -> Result<()> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Local { .. } => Ok(()),
             Backend::Hyperlight(h) => {
                 let _ = h.sandbox.call_raw(FN_ID_NUB_EVICT_JIT_ALL, &[])?;
@@ -257,8 +386,13 @@ impl Nub {
     /// Diagnostic: read the guest's talc allocation counters.
     /// Hyperlight backend only. Requires the `heap-diag` feature.
     #[cfg(feature = "heap-diag")]
-    pub fn heap_stats(&mut self) -> Result<HeapStats> {
-        match &mut self.backend {
+    pub fn heap_stats(&self) -> Result<HeapStats> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Local { .. } => Err(anyhow::anyhow!(
                 "heap_stats: Local backend has no guest heap"
             )),
@@ -287,8 +421,13 @@ impl Nub {
     /// Put a caller-built `Cap` into the active cache. Computes
     /// the cap's content hash and either clones the cap on first put or
     /// bumps refcount on idempotent re-put. Returns the cap's content hash.
-    pub fn put_cap(&mut self, cap: &javm_cap::Cap) -> Result<AbiCapHash> {
-        match &mut self.backend {
+    pub fn put_cap(&self, cap: &javm_cap::Cap) -> Result<AbiCapHash> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Local { cache, .. } => cache
                 .put_cap(cap)
                 .map_err(|e| anyhow::anyhow!("put_cap (local): {e}")),
@@ -319,8 +458,13 @@ impl Nub {
     /// table built with a different SIMD `Group` width than the host's,
     /// so a cross-binary deref is unsound — see
     /// `nub-host-kvm::MultiUseSandbox::published_blobs`.)
-    pub fn put_cap_with_hash(&mut self, hash: AbiCapHash, cap: &javm_cap::Cap) -> Result<()> {
-        match &mut self.backend {
+    pub fn put_cap_with_hash(&self, hash: AbiCapHash, cap: &javm_cap::Cap) -> Result<()> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Local { cache, .. } => cache
                 .put_cap_with_hash(hash, cap)
                 .map_err(|e| anyhow::anyhow!("put_cap_with_hash (local): {e}")),
@@ -337,23 +481,45 @@ impl Nub {
 
     /// Set the kernel gas meter `meter_key` to `value`; returns the previous
     /// value (0 if absent). The chain-side topup / harvest primitive.
-    pub fn set_meter(&mut self, meter_key: Key, value: u64) -> u64 {
-        self.meters.insert(meter_key, value).unwrap_or(0)
+    pub fn set_meter(&self, meter_key: Key, value: u64) -> u64 {
+        self.inner
+            .meters
+            .lock()
+            .expect("Nub meter mutex poisoned")
+            .insert(meter_key, value)
+            .unwrap_or(0)
     }
 
     /// Read the kernel gas meter `meter_key` (0 if absent).
     pub fn get_meter(&self, meter_key: &Key) -> u64 {
-        self.meters.get(meter_key).copied().unwrap_or(0)
+        self.inner
+            .meters
+            .lock()
+            .expect("Nub meter mutex poisoned")
+            .get(meter_key)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Set the kernel storage quota `quota_key`; returns the previous value.
-    pub fn set_quota(&mut self, quota_key: Key, value: u64) -> u64 {
-        self.quotas.insert(quota_key, value).unwrap_or(0)
+    pub fn set_quota(&self, quota_key: Key, value: u64) -> u64 {
+        self.inner
+            .quotas
+            .lock()
+            .expect("Nub quota mutex poisoned")
+            .insert(quota_key, value)
+            .unwrap_or(0)
     }
 
     /// Read the kernel storage quota `quota_key` (0 if absent).
     pub fn get_quota(&self, quota_key: &Key) -> u64 {
-        self.quotas.get(quota_key).copied().unwrap_or(0)
+        self.inner
+            .quotas
+            .lock()
+            .expect("Nub quota mutex poisoned")
+            .get(quota_key)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Resolve the running Instance's primary usable gas `meter_key` from its
@@ -362,11 +528,39 @@ impl Nub {
     /// is only for budget seeding; guest-side execution still performs the strict
     /// invalid-slot checks.
     fn resolve_gas_meter_key(&self, instance_hash: AbiCapHash) -> Option<Key> {
-        let cache = match &self.backend {
+        let backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        let cache = match &*backend {
             Backend::Local { cache, .. } => cache,
             Backend::Hyperlight(h) => &h.host_cache,
         };
         resolve_meter_key_from(cache, instance_hash)
+    }
+
+    /// Submit an invocation to the singleton Nub and return a job handle. This
+    /// compatibility implementation uses a host worker thread per submitted
+    /// job; the KVM backend still serializes at the sandbox boundary until the
+    /// guest multi-lane worker ABI lands.
+    pub fn submit_invoke(&self, request: InvokeRequest) -> Result<InvokeJob> {
+        let id = InvokeJobId(self.inner.next_job_id.fetch_add(1, Ordering::Relaxed));
+        let state = Arc::new(InvokeJobState::new());
+        let worker_state = state.clone();
+        let nub = self.clone();
+        thread::Builder::new()
+            .name(format!("nub-invoke-{}", id.0))
+            .spawn(move || {
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    nub.invoke_request_blocking(request)
+                }))
+                .map_err(|_| "invoke worker panicked".to_string())
+                .and_then(|r| r.map_err(|e| format!("{e:#}")));
+                worker_state.complete(result);
+            })
+            .map_err(|e| anyhow::anyhow!("submit_invoke: spawn worker: {e}"))?;
+        Ok(InvokeJob { id, state })
     }
 
     /// Invoke a previously-published `Cap::Instance` by hash. V0 args
@@ -379,20 +573,62 @@ impl Nub {
     /// exit. Otherwise the call-supplied `initial_gas` is used (and the meter is
     /// left untouched), preserving the bare-budget path.
     pub fn invoke_cached(
-        &mut self,
+        &self,
         instance_hash: AbiCapHash,
         endpoint_idx: u8,
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        let meter_key = self.resolve_gas_meter_key(instance_hash);
+        self.invoke_request_blocking(InvokeRequest {
+            instance_hash,
+            endpoint_idx,
+            args,
+            initial_gas,
+        })
+    }
+
+    fn invoke_request_blocking(&self, request: InvokeRequest) -> Result<InvocationResult> {
+        let meter_key = self.resolve_gas_meter_key(request.instance_hash);
+        let meter_balance = meter_key.as_ref().map(|k| self.get_meter(k)).unwrap_or(0);
         let (budget, used_meter) = match &meter_key {
-            Some(k) if self.get_meter(k) > 0 => (self.get_meter(k), true),
-            _ => (initial_gas, false),
+            Some(_) if meter_balance > 0 => (meter_balance, true),
+            _ => (request.initial_gas, false),
         };
-        let result = self.invoke_cached_raw(instance_hash, endpoint_idx, args, budget)?;
+
+        let reserved_meter = if used_meter { meter_key.clone() } else { None };
+        if let Some(k) = &reserved_meter {
+            let mut in_flight = self
+                .inner
+                .in_flight_meters
+                .lock()
+                .expect("Nub meter reservation mutex poisoned");
+            if !in_flight.insert(k.clone()) {
+                return Err(anyhow::anyhow!(
+                    "invoke_cached: gas meter is already in flight"
+                ));
+            }
+        }
+
+        let result = self.invoke_cached_raw(
+            request.instance_hash,
+            request.endpoint_idx,
+            request.args,
+            budget,
+        );
+        if let Some(k) = &reserved_meter {
+            self.inner
+                .in_flight_meters
+                .lock()
+                .expect("Nub meter reservation mutex poisoned")
+                .remove(k);
+        }
+        let result = result?;
         if used_meter && let Some(k) = meter_key {
-            self.meters.insert(k, result.gas_remaining);
+            self.inner
+                .meters
+                .lock()
+                .expect("Nub meter mutex poisoned")
+                .insert(k, result.gas_remaining);
         }
         Ok(result)
     }
@@ -400,13 +636,18 @@ impl Nub {
     /// The backend dispatch for [`Self::invoke_cached`], with the gas budget
     /// already resolved (meter-seeded or call-supplied).
     fn invoke_cached_raw(
-        &mut self,
+        &self,
         instance_hash: AbiCapHash,
         endpoint_idx: u8,
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        match &mut self.backend {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Local { cache, .. } => {
                 // Resolve the instance + image from the in-process
                 // cache and drive the PVM2 (RISC-V) interpreter.

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -272,6 +272,14 @@ enum Backend {
     Hyperlight(Arc<HyperlightDriver>),
 }
 
+enum InvokeBackendTarget {
+    Local {
+        inst: Box<javm_cap::InstanceCap>,
+        img: Box<javm_cap::ImageCap>,
+    },
+    Hyperlight(Arc<HyperlightDriver>),
+}
+
 /// Host-side RPC stub for the Hyperlight backend. The real kernel
 /// lives guest-side; this wrapper just ships invocations into the
 /// sandbox.
@@ -682,7 +690,7 @@ impl Nub {
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        let hyperlight = {
+        let target = {
             let mut backend = self
                 .inner
                 .backend
@@ -714,16 +722,26 @@ impl Nub {
                             ));
                         }
                     };
-                    return Ok(nub_arch_local::run_instance(
-                        &inst,
-                        &img,
-                        endpoint_idx,
-                        args,
-                        initial_gas,
-                    ));
+                    InvokeBackendTarget::Local {
+                        inst: Box::new(inst),
+                        img: Box::new(img),
+                    }
                 }
-                Backend::Hyperlight(h) => h.clone(),
+                Backend::Hyperlight(h) => InvokeBackendTarget::Hyperlight(h.clone()),
             }
+        };
+
+        let hyperlight = match target {
+            InvokeBackendTarget::Local { inst, img } => {
+                return Ok(nub_arch_local::run_instance(
+                    &inst,
+                    &img,
+                    endpoint_idx,
+                    args,
+                    initial_gas,
+                ));
+            }
+            InvokeBackendTarget::Hyperlight(h) => h,
         };
 
         // No host-side pin/unpin — the cap is owned by the guest's

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -592,16 +592,13 @@ impl Nub {
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        let job_id = self.inner.next_job_id.fetch_add(1, Ordering::Relaxed);
-        self.invoke_request_blocking(
-            InvokeRequest {
-                instance_hash,
-                endpoint_idx,
-                args,
-                initial_gas,
-            },
-            job_id,
-        )
+        self.submit_invoke(InvokeRequest {
+            instance_hash,
+            endpoint_idx,
+            args,
+            initial_gas,
+        })?
+        .wait()
     }
 
     fn invoke_request_blocking(

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -37,8 +37,8 @@ use nub_kernel::Kernel;
 
 #[cfg(feature = "heap-diag")]
 use nub_arch_x86_abi::FN_ID_NUB_HEAP_STATS;
+use nub_arch_x86_abi::InvokePacket;
 pub use nub_arch_x86_abi::{CapHash as AbiCapHash, InvocationResult, SCRATCHPAD_HEAD_LEN};
-use nub_arch_x86_abi::{FN_ID_NUB_EVICT_JIT_ALL, InvokePacket};
 pub use nub_kernel::{CapHash, InstanceRef, InvokeOptions, InvokeOutcome};
 
 pub const MAX_HYPERLIGHT_VCPUS: usize = nub_arch_x86_abi::MAX_EXECUTION_LANES;
@@ -509,7 +509,7 @@ impl Nub {
         match &mut *backend {
             Backend::Local { .. } => Ok(()),
             Backend::Hyperlight(h) => {
-                let _ = h.sandbox.call_raw(FN_ID_NUB_EVICT_JIT_ALL, &[])?;
+                h.sandbox.evict_jit_all_parallel()?;
                 Ok(())
             }
         }

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -630,13 +630,19 @@ impl Nub {
         args: [u64; 4],
         initial_gas: u64,
     ) -> Result<InvocationResult> {
-        self.submit_invoke(InvokeRequest {
-            instance_hash,
-            endpoint_idx,
-            args,
-            initial_gas,
-        })?
-        .wait()
+        // The blocking API can go straight to the KVM lane pool: each caller
+        // blocks on its own lane lease. `submit_invoke` keeps the host-side job
+        // queue for callers that explicitly want an async handle.
+        let id = self.inner.next_job_id.fetch_add(1, Ordering::Relaxed);
+        self.invoke_request_blocking(
+            InvokeRequest {
+                instance_hash,
+                endpoint_idx,
+                args,
+                initial_gas,
+            },
+            id,
+        )
     }
 
     fn invoke_request_blocking(

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -43,6 +43,8 @@ pub use nub_arch_x86_abi::{CapHash as AbiCapHash, InvocationResult, SCRATCHPAD_H
 use nub_arch_x86_abi::{FN_ID_NUB_EVICT_JIT_ALL, InvokePacket};
 pub use nub_kernel::{CapHash, InstanceRef, InvokeOptions, InvokeOutcome};
 
+pub const MAX_HYPERLIGHT_VCPUS: usize = nub_arch_x86_abi::MAX_EXECUTION_LANES;
+
 /// Snapshot of the guest's talc allocation state. Returned by
 /// [`Nub::heap_stats`].
 #[cfg(feature = "heap-diag")]
@@ -162,6 +164,20 @@ impl NubOptions {
     pub fn with_vcpu_count(mut self, vcpu_count: usize) -> Self {
         self.vcpu_count = vcpu_count.max(1);
         self
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.vcpu_count == 0 {
+            return Err(anyhow::anyhow!("NubOptions.vcpu_count must be at least 1"));
+        }
+        if self.vcpu_count > MAX_HYPERLIGHT_VCPUS {
+            return Err(anyhow::anyhow!(
+                "NubOptions.vcpu_count={} exceeds guest lane capacity {}",
+                self.vcpu_count,
+                MAX_HYPERLIGHT_VCPUS
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -463,6 +479,7 @@ impl Nub {
     }
 
     pub(crate) fn hyperlight_with_blob(blob: HyperlightBlob, options: NubOptions) -> Result<Nub> {
+        options.validate()?;
         let mut guard = HYPERLIGHT_NUB
             .lock()
             .map_err(|_| anyhow::anyhow!("Hyperlight Nub singleton mutex poisoned"))?;

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -21,6 +21,8 @@
 pub mod test_support;
 
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Mutex, MutexGuard};
 
 use anyhow::Result;
 use javm_cap::{
@@ -64,6 +66,55 @@ pub struct HeapStats {
 /// Path to the cross-compiled Hyperlight guest blob. Set by
 /// `build.rs` via [`nub_build::build`].
 const NUB_ARCH_X86_BLOB_PATH: &str = env!("NUB_ARCH_X86_BLOB");
+
+#[derive(Clone, Copy)]
+pub(crate) struct HyperlightBlob {
+    pub(crate) label: &'static str,
+    pub(crate) path: &'static str,
+}
+
+struct HyperlightSingleton {
+    blob: HyperlightBlob,
+    nub: Nub,
+}
+
+static HYPERLIGHT_NUB: Mutex<Option<HyperlightSingleton>> = Mutex::new(None);
+
+/// Guard for the process-wide Hyperlight-backed [`Nub`].
+///
+/// The KVM backend maps the guest at fixed host virtual addresses, so the high
+/// level `nub` API exposes exactly one live Hyperlight sandbox per process. The
+/// guard serializes access to that singleton and dereferences to [`Nub`] for the
+/// normal publish/invoke methods.
+///
+/// TODO(parallel-nub): future parallel execution should keep this single host
+/// Nub and schedule parallel work inside the guest microkernel, not by creating
+/// multiple KVM sandboxes in one host process.
+pub struct HyperlightNubGuard {
+    guard: MutexGuard<'static, Option<HyperlightSingleton>>,
+}
+
+impl Deref for HyperlightNubGuard {
+    type Target = Nub;
+
+    fn deref(&self) -> &Self::Target {
+        &self
+            .guard
+            .as_ref()
+            .expect("Hyperlight Nub singleton initialized")
+            .nub
+    }
+}
+
+impl DerefMut for HyperlightNubGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self
+            .guard
+            .as_mut()
+            .expect("Hyperlight Nub singleton initialized")
+            .nub
+    }
+}
 
 /// Uniform handle to the nub microkernel.
 pub struct Nub {
@@ -125,17 +176,45 @@ impl Nub {
         }
     }
 
-    /// Construct a Nub backed by a fresh Hyperlight sandbox loaded
-    /// from the `nub-arch-x86` guest blob.
-    pub fn new_hyperlight() -> Result<Self> {
-        Self::new_hyperlight_with_blob_path(NUB_ARCH_X86_BLOB_PATH)
+    /// Borrow the process-wide Hyperlight-backed Nub loaded from the
+    /// `nub-arch-x86` guest blob.
+    pub fn hyperlight() -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(HyperlightBlob {
+            label: "production",
+            path: NUB_ARCH_X86_BLOB_PATH,
+        })
     }
 
-    /// Construct a Nub backed by a fresh Hyperlight sandbox loaded
-    /// from an arbitrary guest ELF on disk. Used by `test_support`
-    /// to swap in the test/bench binaries; production callers should
-    /// use [`Self::new_hyperlight`].
-    pub(crate) fn new_hyperlight_with_blob_path(path: &str) -> Result<Self> {
+    pub(crate) fn hyperlight_with_blob(blob: HyperlightBlob) -> Result<HyperlightNubGuard> {
+        let mut guard = HYPERLIGHT_NUB
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Hyperlight Nub singleton mutex poisoned"))?;
+        match guard.as_ref() {
+            Some(existing) if existing.blob.path == blob.path => {}
+            Some(existing) => {
+                return Err(anyhow::anyhow!(
+                    "Hyperlight Nub singleton already initialized with {} guest ({:?}); \
+                     cannot switch to {} guest ({:?})",
+                    existing.blob.label,
+                    existing.blob.path,
+                    blob.label,
+                    blob.path,
+                ));
+            }
+            None => {
+                let nub = Self::create_hyperlight_with_blob_path(blob.path)?;
+                *guard = Some(HyperlightSingleton { blob, nub });
+            }
+        }
+        Ok(HyperlightNubGuard { guard })
+    }
+
+    /// Create the backing sandbox for the process-wide Hyperlight singleton
+    /// from an arbitrary guest ELF on disk.
+    ///
+    /// This is intentionally private: high-level callers must go through the
+    /// process singleton returned by [`Self::hyperlight`].
+    fn create_hyperlight_with_blob_path(path: &str) -> Result<Self> {
         let mut cfg = SandboxConfiguration::default();
         cfg.set_scratch_size(512 * 1024 * 1024);
         cfg.set_input_data_size(16 * 1024 * 1024);

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -20,7 +20,7 @@
 #[cfg(feature = "test-support")]
 pub mod test_support;
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -28,9 +28,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 
 use anyhow::Result;
-use javm_cap::{
-    CacheDirectory, CapHashOrRef, KernelImage, Key, cap::Cap, key_from_regs, recognize_kernel_image,
-};
+use javm_cap::{CacheDirectory, CapHashOrRef, cap::Cap};
 use nub_arch_local::LocalArch;
 use nub_host_kvm::sandbox::{
     GuestBinary, MultiUseSandbox, SandboxConfiguration, UninitializedSandbox,
@@ -95,56 +93,9 @@ pub struct Nub {
 
 struct NubInner {
     backend: Mutex<Backend>,
-    /// The kernel-maintained gas meter mapping (`meter_key -> remaining gas`).
-    /// The interim "static meter mapping" of the kernel-assisted GasMeter
-    /// design — a later spec change moves it behind a YieldCatcher. At top-level
-    /// invoke the host resolves the running Instance's primary usable gas slot
-    /// (first non-empty valid `Gas{meter_key}`), seeds the run from this map
-    /// when non-zero, and writes the remaining primary balance back here.
-    meters: Mutex<HashMap<Key, u64>>,
-    /// The kernel-maintained storage quota mapping (`quota_key -> remaining`).
-    /// Symmetric to [`Self::meters`]; quota *charging* is not yet wired (V1),
-    /// so this is seeded/observed but not yet debited per dirty page.
-    quotas: Mutex<HashMap<Key, u64>>,
-    /// Host-side guard for top-level invokes that seed from the same kernel gas
-    /// meter. The first parallel milestone rejects concurrent reuse instead of
-    /// racing two writers on one balance.
-    in_flight_meters: Mutex<BTreeSet<Key>>,
     next_job_id: AtomicU64,
     invoke_executor: Arc<InvokeExecutor>,
     invoke_worker_count: usize,
-}
-
-struct MeterReservation {
-    inner: Arc<NubInner>,
-    key: Key,
-}
-
-impl MeterReservation {
-    fn reserve(inner: Arc<NubInner>, key: Key) -> Result<Self> {
-        {
-            let mut in_flight = match inner.in_flight_meters.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            if !in_flight.insert(key.clone()) {
-                return Err(anyhow::anyhow!(
-                    "invoke_cached: gas meter is already in flight"
-                ));
-            }
-        }
-        Ok(Self { inner, key })
-    }
-}
-
-impl Drop for MeterReservation {
-    fn drop(&mut self) {
-        let mut in_flight = match self.inner.in_flight_meters.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        in_flight.remove(&self.key);
-    }
 }
 
 /// Options used when constructing the process-wide Hyperlight Nub singleton.
@@ -431,12 +382,6 @@ enum InvokeBackendTarget {
 struct HyperlightDriver {
     sandbox: MultiUseSandbox,
     state_root_cache: CapHash,
-    /// Host-side mirror of the published cap graph, used **only** to resolve an
-    /// Instance's primary usable gas slot → `Gas{meter_key}` handle host-side (the
-    /// authoritative cap directory lives guest-side). This is the host's own
-    /// `CacheDirectory` — not a deref of the guest's hashbrown (which is
-    /// unsound across the SIMD-width boundary; see `MultiUseSandbox`).
-    host_cache: Mutex<CacheDirectory>,
 }
 
 impl Nub {
@@ -452,9 +397,6 @@ impl Nub {
                     kernel: Kernel::new(LocalArch::new()),
                     cache: CacheDirectory::new(),
                 }),
-                meters: Mutex::new(HashMap::new()),
-                quotas: Mutex::new(HashMap::new()),
-                in_flight_meters: Mutex::new(BTreeSet::new()),
                 next_job_id: AtomicU64::new(1),
                 invoke_executor: Arc::new(InvokeExecutor::new()),
                 invoke_worker_count,
@@ -534,11 +476,7 @@ impl Nub {
                 backend: Mutex::new(Backend::Hyperlight(Arc::new(HyperlightDriver {
                     sandbox,
                     state_root_cache: [0; 32],
-                    host_cache: Mutex::new(CacheDirectory::new()),
                 }))),
-                meters: Mutex::new(HashMap::new()),
-                quotas: Mutex::new(HashMap::new()),
-                in_flight_meters: Mutex::new(BTreeSet::new()),
                 next_job_id: AtomicU64::new(1),
                 invoke_executor: Arc::new(InvokeExecutor::new()),
                 invoke_worker_count: options.vcpu_count.max(1),
@@ -625,19 +563,10 @@ impl Nub {
             Backend::Local { cache, .. } => cache
                 .put_cap(cap)
                 .map_err(|e| anyhow::anyhow!("put_cap (local): {e}")),
-            Backend::Hyperlight(h) => {
-                // Mirror into the host-side cache so `invoke_cached` can resolve
-                // gas_slots → meter_key host-side (best-effort; the guest cache
-                // is authoritative for execution).
-                let _ = h
-                    .host_cache
-                    .lock()
-                    .expect("Hyperlight host cache mutex poisoned")
-                    .put_cap(cap);
-                h.sandbox
-                    .put_cap(cap)
-                    .map_err(|e| anyhow::anyhow!("put_cap: {e}"))
-            }
+            Backend::Hyperlight(h) => h
+                .sandbox
+                .put_cap(cap)
+                .map_err(|e| anyhow::anyhow!("put_cap: {e}")),
         }
     }
 
@@ -666,86 +595,11 @@ impl Nub {
             Backend::Local { cache, .. } => cache
                 .put_cap_with_hash(hash, cap)
                 .map_err(|e| anyhow::anyhow!("put_cap_with_hash (local): {e}")),
-            Backend::Hyperlight(h) => {
-                let _ = h
-                    .host_cache
-                    .lock()
-                    .expect("Hyperlight host cache mutex poisoned")
-                    .put_cap_with_hash(hash, cap);
-                h.sandbox
-                    .put_cap_with_hash(hash, cap)
-                    .map_err(|e| anyhow::anyhow!("put_cap_with_hash: {e}"))
-            }
+            Backend::Hyperlight(h) => h
+                .sandbox
+                .put_cap_with_hash(hash, cap)
+                .map_err(|e| anyhow::anyhow!("put_cap_with_hash: {e}")),
         }
-    }
-
-    // --- Kernel gas/quota meter mapping (`SetGasMeter` / `SetStorageQuota`) ---
-
-    /// Set the kernel gas meter `meter_key` to `value`; returns the previous
-    /// value (0 if absent). The chain-side topup / harvest primitive.
-    pub fn set_meter(&self, meter_key: Key, value: u64) -> u64 {
-        self.inner
-            .meters
-            .lock()
-            .expect("Nub meter mutex poisoned")
-            .insert(meter_key, value)
-            .unwrap_or(0)
-    }
-
-    /// Read the kernel gas meter `meter_key` (0 if absent).
-    pub fn get_meter(&self, meter_key: &Key) -> u64 {
-        self.inner
-            .meters
-            .lock()
-            .expect("Nub meter mutex poisoned")
-            .get(meter_key)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    /// Set the kernel storage quota `quota_key`; returns the previous value.
-    pub fn set_quota(&self, quota_key: Key, value: u64) -> u64 {
-        self.inner
-            .quotas
-            .lock()
-            .expect("Nub quota mutex poisoned")
-            .insert(quota_key, value)
-            .unwrap_or(0)
-    }
-
-    /// Read the kernel storage quota `quota_key` (0 if absent).
-    pub fn get_quota(&self, quota_key: &Key) -> u64 {
-        self.inner
-            .quotas
-            .lock()
-            .expect("Nub quota mutex poisoned")
-            .get(quota_key)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    /// Resolve the running Instance's primary usable gas `meter_key` from its
-    /// Image gas slots, via the appropriate host-side cache (the Local cache, or
-    /// the Hyperlight host mirror). Empty slots are skipped. This host-side path
-    /// is only for budget seeding; guest-side execution still performs the strict
-    /// invalid-slot checks.
-    fn resolve_gas_meter_key(&self, instance_hash: AbiCapHash) -> Option<Key> {
-        let backend = self
-            .inner
-            .backend
-            .lock()
-            .expect("Nub backend mutex poisoned");
-        let cache = match &*backend {
-            Backend::Local { cache, .. } => cache,
-            Backend::Hyperlight(h) => {
-                let cache = h
-                    .host_cache
-                    .lock()
-                    .expect("Hyperlight host cache mutex poisoned");
-                return resolve_meter_key_from(&cache, instance_hash);
-            }
-        };
-        resolve_meter_key_from(cache, instance_hash)
     }
 
     /// Submit an invocation to the singleton Nub and return a job handle. Jobs
@@ -769,12 +623,6 @@ impl Nub {
     /// Invoke a previously-published `Cap::Instance` by hash. V0 args
     /// are 4 u64s laid into φ[7..=10] on top of the published
     /// endpoint's `initial_regs` baseline.
-    ///
-    /// Meter-driven gas: if the Instance's primary usable gas slot names a `Gas`
-    /// handle whose `meter_key` has a non-zero entry in the kernel meter mapping,
-    /// the run is seeded from that meter and the remaining gas is written back at
-    /// exit. Otherwise the call-supplied `initial_gas` is used (and the meter is
-    /// left untouched), preserving the bare-budget path.
     pub fn invoke_cached(
         &self,
         instance_hash: AbiCapHash,
@@ -796,42 +644,16 @@ impl Nub {
         request: InvokeRequest,
         job_id: u64,
     ) -> Result<InvocationResult> {
-        let meter_key = self.resolve_gas_meter_key(request.instance_hash);
-        let meter_balance = meter_key.as_ref().map(|k| self.get_meter(k)).unwrap_or(0);
-        let (budget, used_meter) = match &meter_key {
-            Some(_) if meter_balance > 0 => (meter_balance, true),
-            _ => (request.initial_gas, false),
-        };
-
-        let _meter_reservation = if used_meter {
-            meter_key
-                .clone()
-                .map(|k| MeterReservation::reserve(self.inner.clone(), k))
-                .transpose()?
-        } else {
-            None
-        };
-
-        let result = self.invoke_cached_raw(
+        self.invoke_cached_raw(
             job_id,
             request.instance_hash,
             request.endpoint_idx,
             request.args,
-            budget,
-        );
-        let result = result?;
-        if used_meter && let Some(k) = meter_key {
-            self.inner
-                .meters
-                .lock()
-                .expect("Nub meter mutex poisoned")
-                .insert(k, result.gas_remaining);
-        }
-        Ok(result)
+            request.initial_gas,
+        )
     }
 
-    /// The backend dispatch for [`Self::invoke_cached`], with the gas budget
-    /// already resolved (meter-seeded or call-supplied).
+    /// The backend dispatch for [`Self::invoke_cached`].
     fn invoke_cached_raw(
         &self,
         job_id: u64,
@@ -911,83 +733,5 @@ impl Nub {
             .sandbox
             .invoke_cached_parallel(job_id, &packet)
             .map_err(|e| anyhow::anyhow!("invoke_cached_parallel: {e}"))
-    }
-}
-
-/// Walk `instance_hash → image.gas_slots[*] → cnode slot → Gas{meter_key}` in
-/// `cache`, returning the first valid non-empty `meter_key`. `None` if the
-/// Image declares no usable gas slot. This helper is intentionally soft: the
-/// guest-side kernel loop performs the strict invalid-slot hard faults.
-fn resolve_meter_key_from(cache: &CacheDirectory, instance_hash: AbiCapHash) -> Option<Key> {
-    let inst_cap = cache.get(CapHashOrRef::Hash(instance_hash))?;
-    let Cap::Instance(inst) = &*inst_cap else {
-        return None;
-    };
-    let img_cap = cache.get(CapHashOrRef::Hash(inst.image_hash))?;
-    let Cap::Image(img) = &*img_cap else {
-        return None;
-    };
-    let cnode_cap = cache.get(inst.root_cnode.clone())?;
-    let Cap::CNode(cnode) = &*cnode_cap else {
-        return None;
-    };
-    for slot in &img.gas_slots {
-        let Some(gas_ref) = cnode.get(slot) else {
-            continue;
-        };
-        let gas_cap = cache.get(gas_ref)?;
-        let Cap::Instance(g) = &*gas_cap else {
-            return None;
-        };
-        if recognize_kernel_image(g.image_hash_chain) != Some(KernelImage::Gas) {
-            return None;
-        }
-        return Some(key_from_regs(g.regs[0], g.regs[1]));
-    }
-    None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn meter_reservation_rejects_duplicate_and_releases_on_drop() {
-        let nub = Nub::new_local();
-        let key = Key::from(&[0xCA, 0xFE][..]);
-
-        let first =
-            MeterReservation::reserve(nub.inner.clone(), key.clone()).expect("first reservation");
-        assert!(
-            MeterReservation::reserve(nub.inner.clone(), key.clone()).is_err(),
-            "a duplicate in-flight meter reservation must be rejected"
-        );
-
-        drop(first);
-        let second = MeterReservation::reserve(nub.inner.clone(), key)
-            .expect("reservation should be released on drop");
-        drop(second);
-    }
-
-    #[test]
-    fn meter_reservation_drop_tolerates_poisoned_mutex() {
-        let nub = Nub::new_local();
-        let key = Key::from(&[0xBA, 0xAD][..]);
-        let reservation =
-            MeterReservation::reserve(nub.inner.clone(), key.clone()).expect("reservation");
-
-        let inner = nub.inner.clone();
-        let _ = std::panic::catch_unwind(move || {
-            let _guard = inner
-                .in_flight_meters
-                .lock()
-                .expect("lock before intentional panic");
-            panic!("poison meter reservation mutex");
-        });
-
-        drop(reservation);
-        let second = MeterReservation::reserve(nub.inner.clone(), key)
-            .expect("drop should release even after poison");
-        drop(second);
     }
 }

--- a/rust/nub/src/lib.rs
+++ b/rust/nub/src/lib.rs
@@ -20,12 +20,12 @@
 #[cfg(feature = "test-support")]
 pub mod test_support;
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
-use std::thread;
+use std::thread::{self, JoinHandle};
 
 use anyhow::Result;
 use javm_cap::{
@@ -113,6 +113,8 @@ struct NubInner {
     /// racing two writers on one balance.
     in_flight_meters: Mutex<BTreeSet<Key>>,
     next_job_id: AtomicU64,
+    invoke_executor: Arc<InvokeExecutor>,
+    invoke_worker_count: usize,
 }
 
 struct MeterReservation {
@@ -203,6 +205,24 @@ struct InvokeJobState {
     ready: Condvar,
 }
 
+struct QueuedInvoke {
+    nub: Nub,
+    id: InvokeJobId,
+    request: InvokeRequest,
+    state: Arc<InvokeJobState>,
+}
+
+struct InvokeExecutor {
+    state: Mutex<InvokeExecutorState>,
+    ready: Condvar,
+    handles: Mutex<Vec<JoinHandle<()>>>,
+}
+
+struct InvokeExecutorState {
+    queue: VecDeque<QueuedInvoke>,
+    stopping: bool,
+}
+
 impl InvokeJob {
     pub fn id(&self) -> InvokeJobId {
         self.id
@@ -255,6 +275,119 @@ impl InvokeJobState {
     }
 }
 
+impl InvokeExecutor {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(InvokeExecutorState {
+                queue: VecDeque::new(),
+                stopping: false,
+            }),
+            ready: Condvar::new(),
+            handles: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn ensure_started(self: &Arc<Self>, worker_count: usize) -> Result<()> {
+        let mut handles = self
+            .handles
+            .lock()
+            .expect("InvokeExecutor handles mutex poisoned");
+        if !handles.is_empty() {
+            return Ok(());
+        }
+
+        for worker in 0..worker_count.max(1) {
+            let executor = self.clone();
+            let handle = thread::Builder::new()
+                .name(format!("nub-invoke-worker-{worker}"))
+                .spawn(move || executor.worker_loop())
+                .map_err(|e| anyhow::anyhow!("submit_invoke: spawn worker: {e}"))?;
+            handles.push(handle);
+        }
+        Ok(())
+    }
+
+    fn enqueue(&self, job: QueuedInvoke) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("InvokeExecutor state mutex poisoned");
+        if state.stopping {
+            return Err(anyhow::anyhow!(
+                "submit_invoke: Nub invoke executor is stopping"
+            ));
+        }
+        state.queue.push_back(job);
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    fn worker_loop(self: Arc<Self>) {
+        while let Some(job) = self.next_job() {
+            let id = job.id.0;
+            let nub = job.nub;
+            let request = job.request;
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                nub.invoke_request_blocking(request, id)
+            }))
+            .map_err(|_| "invoke worker panicked".to_string())
+            .and_then(|r| r.map_err(|e| format!("{e:#}")));
+            job.state.complete(result);
+        }
+    }
+
+    fn next_job(&self) -> Option<QueuedInvoke> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("InvokeExecutor state mutex poisoned");
+        loop {
+            if let Some(job) = state.queue.pop_front() {
+                return Some(job);
+            }
+            if state.stopping {
+                return None;
+            }
+            state = self
+                .ready
+                .wait(state)
+                .expect("InvokeExecutor state mutex poisoned");
+        }
+    }
+
+    fn stop_and_join(&self) {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .expect("InvokeExecutor state mutex poisoned");
+            state.stopping = true;
+            self.ready.notify_all();
+        }
+
+        let current = thread::current().id();
+        let handles = {
+            let mut handles = self
+                .handles
+                .lock()
+                .expect("InvokeExecutor handles mutex poisoned");
+            core::mem::take(&mut *handles)
+        };
+        for handle in handles {
+            if handle.thread().id() == current {
+                continue;
+            }
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for NubInner {
+    fn drop(&mut self) {
+        self.invoke_executor.stop_and_join();
+    }
+}
+
 enum Backend {
     /// In-process backend: the PVM2 (RISC-V) interpreter plus its own
     /// cap directory. `cache` is the source of truth for caps published
@@ -297,6 +430,10 @@ struct HyperlightDriver {
 impl Nub {
     /// Construct a Nub backed by the in-process [`LocalArch`].
     pub fn new_local() -> Self {
+        let invoke_worker_count = thread::available_parallelism()
+            .map(NonZeroUsize::get)
+            .unwrap_or(2)
+            .clamp(2, 8);
         Self {
             inner: Arc::new(NubInner {
                 backend: Mutex::new(Backend::Local {
@@ -307,6 +444,8 @@ impl Nub {
                 quotas: Mutex::new(HashMap::new()),
                 in_flight_meters: Mutex::new(BTreeSet::new()),
                 next_job_id: AtomicU64::new(1),
+                invoke_executor: Arc::new(InvokeExecutor::new()),
+                invoke_worker_count,
             }),
         }
     }
@@ -388,6 +527,8 @@ impl Nub {
                 quotas: Mutex::new(HashMap::new()),
                 in_flight_meters: Mutex::new(BTreeSet::new()),
                 next_job_id: AtomicU64::new(1),
+                invoke_executor: Arc::new(InvokeExecutor::new()),
+                invoke_worker_count: options.vcpu_count.max(1),
             }),
         })
     }
@@ -594,25 +735,21 @@ impl Nub {
         resolve_meter_key_from(cache, instance_hash)
     }
 
-    /// Submit an invocation to the singleton Nub and return a job handle. The
-    /// Hyperlight backend uses a host-side waiter thread for the job while the
-    /// actual guest execution runs on the sandbox's fixed vCPU worker lanes.
+    /// Submit an invocation to the singleton Nub and return a job handle. Jobs
+    /// are queued onto a fixed Nub-owned host executor; Hyperlight execution then
+    /// runs on the sandbox's fixed vCPU worker lanes.
     pub fn submit_invoke(&self, request: InvokeRequest) -> Result<InvokeJob> {
         let id = InvokeJobId(self.inner.next_job_id.fetch_add(1, Ordering::Relaxed));
         let state = Arc::new(InvokeJobState::new());
-        let worker_state = state.clone();
-        let nub = self.clone();
-        thread::Builder::new()
-            .name(format!("nub-invoke-{}", id.0))
-            .spawn(move || {
-                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    nub.invoke_request_blocking(request, id.0)
-                }))
-                .map_err(|_| "invoke worker panicked".to_string())
-                .and_then(|r| r.map_err(|e| format!("{e:#}")));
-                worker_state.complete(result);
-            })
-            .map_err(|e| anyhow::anyhow!("submit_invoke: spawn worker: {e}"))?;
+        self.inner
+            .invoke_executor
+            .ensure_started(self.inner.invoke_worker_count)?;
+        self.inner.invoke_executor.enqueue(QueuedInvoke {
+            nub: self.clone(),
+            id,
+            request,
+            state: state.clone(),
+        })?;
         Ok(InvokeJob { id, state })
     }
 

--- a/rust/nub/src/test_support.rs
+++ b/rust/nub/src/test_support.rs
@@ -16,7 +16,7 @@
 
 use anyhow::Result;
 
-use crate::{Backend, HyperlightBlob, HyperlightNubGuard, Nub};
+use crate::{Backend, HyperlightBlob, HyperlightNubGuard, Nub, NubOptions};
 
 const TESTS_BLOB_PATH: &str = env!("NUB_ARCH_X86_TESTS_BLOB");
 const BENCHES_BLOB_PATH: &str = env!("NUB_ARCH_X86_BENCHES_BLOB");
@@ -27,10 +27,17 @@ impl Nub {
     /// [`Nub::hyperlight`] plus the test-only guest functions
     /// (whose FN_IDs live in [`nub_arch_x86::test_abi`]).
     pub fn hyperlight_tests() -> Result<HyperlightNubGuard> {
-        Self::hyperlight_with_blob(HyperlightBlob {
-            label: "test",
-            path: TESTS_BLOB_PATH,
-        })
+        Self::hyperlight_tests_with_options(NubOptions::default())
+    }
+
+    pub fn hyperlight_tests_with_options(options: NubOptions) -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(
+            HyperlightBlob {
+                label: "test",
+                path: TESTS_BLOB_PATH,
+            },
+            options,
+        )
     }
 
     /// Borrow the Hyperlight-backed singleton running the
@@ -38,18 +45,30 @@ impl Nub {
     /// [`Nub::hyperlight`] plus the bench probes (FN_IDs in
     /// [`nub_arch_x86::test_abi`]).
     pub fn hyperlight_benches() -> Result<HyperlightNubGuard> {
-        Self::hyperlight_with_blob(HyperlightBlob {
-            label: "bench",
-            path: BENCHES_BLOB_PATH,
-        })
+        Self::hyperlight_benches_with_options(NubOptions::default())
+    }
+
+    pub fn hyperlight_benches_with_options(options: NubOptions) -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(
+            HyperlightBlob {
+                label: "bench",
+                path: BENCHES_BLOB_PATH,
+            },
+            options,
+        )
     }
 
     /// Raw RPC dispatch. Sends `payload` to the guest's `fn_id`
     /// handler and returns the response bytes verbatim. Test/bench
     /// callers use this for FN_IDs not exposed through the typed
     /// API. Returns `Err` for the Local backend (no guest to call).
-    pub fn call_raw(&mut self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
-        match &mut self.backend {
+    pub fn call_raw(&self, fn_id: u32, payload: &[u8]) -> Result<Vec<u8>> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
             Backend::Hyperlight(h) => h
                 .sandbox
                 .call_raw(fn_id, payload)

--- a/rust/nub/src/test_support.rs
+++ b/rust/nub/src/test_support.rs
@@ -78,4 +78,29 @@ impl Nub {
             }
         }
     }
+
+    /// Test-only raw RPC dispatch on a selected vCPU lane. This is still the
+    /// serialized control-plane ring path, not the production concurrent invoke
+    /// queue.
+    pub fn call_raw_on_vcpu(
+        &self,
+        vcpu_index: usize,
+        fn_id: u32,
+        payload: &[u8],
+    ) -> Result<Vec<u8>> {
+        let mut backend = self
+            .inner
+            .backend
+            .lock()
+            .expect("Nub backend mutex poisoned");
+        match &mut *backend {
+            Backend::Hyperlight(h) => h
+                .sandbox
+                .call_raw_on_vcpu(vcpu_index, fn_id, payload)
+                .map_err(|e| anyhow::anyhow!("call_raw_on_vcpu: {e}")),
+            Backend::Local { .. } => Err(anyhow::anyhow!(
+                "call_raw_on_vcpu not supported on Local backend"
+            )),
+        }
+    }
 }

--- a/rust/nub/src/test_support.rs
+++ b/rust/nub/src/test_support.rs
@@ -1,10 +1,10 @@
 //! Test/bench driver infra for [`Nub`].
 //!
 //! Provides:
-//! - [`Nub::new_hyperlight_tests`]: load the `nub-arch-x86-tests`
+//! - [`Nub::hyperlight_tests`]: borrow the singleton `nub-arch-x86-tests`
 //!   guest binary (production RPCs + test-only fns like
 //!   `nub_smoke`).
-//! - [`Nub::new_hyperlight_benches`]: load the `nub-arch-x86-benches`
+//! - [`Nub::hyperlight_benches`]: borrow the singleton `nub-arch-x86-benches`
 //!   guest binary (production RPCs + bench probes like
 //!   `bench_arc_page_alloc`).
 //! - [`Nub::call_raw`]: raw RPC dispatch for fn_ids not exposed
@@ -16,26 +16,32 @@
 
 use anyhow::Result;
 
-use crate::{Backend, Nub};
+use crate::{Backend, HyperlightBlob, HyperlightNubGuard, Nub};
 
 const TESTS_BLOB_PATH: &str = env!("NUB_ARCH_X86_TESTS_BLOB");
 const BENCHES_BLOB_PATH: &str = env!("NUB_ARCH_X86_BENCHES_BLOB");
 
 impl Nub {
-    /// Construct a Hyperlight-backed `Nub` running the
+    /// Borrow the Hyperlight-backed singleton running the
     /// `nub-arch-x86-tests` guest binary. Same production RPCs as
-    /// [`Nub::new_hyperlight`] plus the test-only guest functions
+    /// [`Nub::hyperlight`] plus the test-only guest functions
     /// (whose FN_IDs live in [`nub_arch_x86::test_abi`]).
-    pub fn new_hyperlight_tests() -> Result<Self> {
-        Self::new_hyperlight_with_blob_path(TESTS_BLOB_PATH)
+    pub fn hyperlight_tests() -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(HyperlightBlob {
+            label: "test",
+            path: TESTS_BLOB_PATH,
+        })
     }
 
-    /// Construct a Hyperlight-backed `Nub` running the
+    /// Borrow the Hyperlight-backed singleton running the
     /// `nub-arch-x86-benches` guest binary. Same production RPCs as
-    /// [`Nub::new_hyperlight`] plus the bench probes (FN_IDs in
+    /// [`Nub::hyperlight`] plus the bench probes (FN_IDs in
     /// [`nub_arch_x86::test_abi`]).
-    pub fn new_hyperlight_benches() -> Result<Self> {
-        Self::new_hyperlight_with_blob_path(BENCHES_BLOB_PATH)
+    pub fn hyperlight_benches() -> Result<HyperlightNubGuard> {
+        Self::hyperlight_with_blob(HyperlightBlob {
+            label: "bench",
+            path: BENCHES_BLOB_PATH,
+        })
     }
 
     /// Raw RPC dispatch. Sends `payload` to the guest's `fn_id`

--- a/rust/nub/tests/bootstrap_timing.rs
+++ b/rust/nub/tests/bootstrap_timing.rs
@@ -1,15 +1,12 @@
-//! Standalone timing for `Nub::new_hyperlight()` boot. Run with:
+//! Standalone timing for the `Nub::hyperlight()` singleton. Run with:
 //!
 //! ```bash
 //! cargo test -p nub --release --test bootstrap_timing -- --ignored --nocapture
 //! ```
 //!
-//! `#[ignore]` because it's a manual measurement, not a CI gate: each
-//! sandbox allocates ~768 MiB of mmap'd address space (the
-//! `Nub::new_hyperlight()` config = 512 MiB scratch + 256 MiB heap) and
-//! runs the guest's init function, so 10 iterations cost ~7.5 GiB of
-//! VA + several seconds of wall time. Plenty to be visible in `top`
-//! but well within a 32 GiB-RAM dev box.
+//! `#[ignore]` because it's a manual measurement, not a CI gate. The
+//! Hyperlight backend is a process singleton, so this measures the first
+//! singleton access separately from repeated cached borrows.
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
@@ -20,21 +17,27 @@ const N: usize = 10;
 
 #[test]
 #[ignore]
-fn nub_new_hyperlight_boot() {
-    // One warm-up so any first-time JIT / linker init lands outside
-    // the measurement window.
-    drop(Nub::new_hyperlight().expect("warm-up sandbox"));
+fn nub_hyperlight_boot() {
+    let t = Instant::now();
+    drop(Nub::hyperlight().expect("sandbox"));
+    let first = t.elapsed();
+    eprintln!(
+        "Nub::hyperlight() first singleton access: {:.3} ms",
+        first.as_secs_f64() * 1e3,
+    );
 
     let mut samples = Vec::with_capacity(N);
     for i in 0..N {
         let t = Instant::now();
-        let nub = Nub::new_hyperlight().expect("sandbox");
+        let nub = Nub::hyperlight().expect("sandbox");
         let elapsed = t.elapsed();
-        // Drop the sandbox AFTER capturing the boot time, so dealloc
-        // doesn't pollute the measurement.
         drop(nub);
         samples.push(elapsed);
-        eprintln!("iter {:2}: {:.3} ms", i, elapsed.as_secs_f64() * 1e3);
+        eprintln!(
+            "cached borrow {:2}: {:.3} us",
+            i,
+            elapsed.as_secs_f64() * 1e6
+        );
     }
 
     samples.sort();
@@ -42,15 +45,15 @@ fn nub_new_hyperlight_boot() {
     let p50 = samples[N / 2];
     let p90 = samples[N * 9 / 10];
     let max = samples[N - 1];
-    let mean_ms = samples.iter().map(|d| d.as_secs_f64()).sum::<f64>() / (N as f64) * 1e3;
+    let mean_us = samples.iter().map(|d| d.as_secs_f64()).sum::<f64>() / (N as f64) * 1e6;
 
     eprintln!();
-    eprintln!("Nub::new_hyperlight() boot across {N} samples (post-warm-up):");
-    eprintln!("  min: {:.3} ms", min.as_secs_f64() * 1e3);
-    eprintln!("  p50: {:.3} ms", p50.as_secs_f64() * 1e3);
-    eprintln!("  p90: {:.3} ms", p90.as_secs_f64() * 1e3);
-    eprintln!("  max: {:.3} ms", max.as_secs_f64() * 1e3);
-    eprintln!("  avg: {mean_ms:.3} ms");
+    eprintln!("Nub::hyperlight() cached singleton borrow across {N} samples:");
+    eprintln!("  min: {:.3} us", min.as_secs_f64() * 1e6);
+    eprintln!("  p50: {:.3} us", p50.as_secs_f64() * 1e6);
+    eprintln!("  p90: {:.3} us", p90.as_secs_f64() * 1e6);
+    eprintln!("  max: {:.3} us", max.as_secs_f64() * 1e6);
+    eprintln!("  avg: {mean_us:.3} us");
 }
 
 #[test]

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -7,7 +7,7 @@ use javm_cap::{
     CNodeCap, Cap, CapHashOrRef, DataCap, KernelImage, Key, NUM_REGS, kernel_image_hash,
     key_to_regs,
 };
-use nub::{InvokeRequest, Nub};
+use nub::{InvokeRequest, Nub, NubOptions};
 use std::collections::BTreeMap;
 
 const GAS_SLOT: u8 = 5;
@@ -161,7 +161,8 @@ fn meter_drives_gas_local() {
 
 #[test]
 fn meter_drives_gas_hyperlight() {
-    let mut nub = Nub::hyperlight().expect("hyperlight");
+    let mut nub =
+        Nub::hyperlight_with_options(NubOptions::new().with_vcpu_count(2)).expect("hyperlight");
     meter_drives_gas(&mut nub);
 }
 
@@ -177,9 +178,20 @@ fn no_gas_slot_uses_call_budget() {
 #[test]
 fn concurrent_invokes_sharing_meter_are_rejected() {
     let nub = Nub::new_local();
+    concurrent_invokes_sharing_meter_are_rejected_for(&nub);
+}
+
+#[test]
+fn hyperlight_concurrent_invokes_sharing_meter_are_rejected() {
+    let nub =
+        Nub::hyperlight_with_options(NubOptions::new().with_vcpu_count(2)).expect("hyperlight");
+    concurrent_invokes_sharing_meter_are_rejected_for(&nub);
+}
+
+fn concurrent_invokes_sharing_meter_are_rejected_for(nub: &Nub) {
     let meter_key = Key::from(&[0xAA, 0xBB, 0xCC][..]);
     nub.set_meter(meter_key.clone(), 20_000_000);
-    let metered = publish_metered_image(&nub, looping_image(true), &meter_key);
+    let metered = publish_metered_image(nub, looping_image(true), &meter_key);
 
     let jobs: Vec<_> = (0..16)
         .map(|_| {

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -94,12 +94,12 @@ fn publish_metered(nub: &mut Nub, meter_key: &Key) -> nub::AbiCapHash {
     nub.put_cap(&inst).unwrap()
 }
 
-fn meter_drives_gas(mut nub: Nub) {
+fn meter_drives_gas(nub: &mut Nub) {
     const BUDGET: u64 = 1_000_000;
     const WRONG: u64 = BUDGET + 5_000_000;
 
     // Reference: a plain instance run on `BUDGET` directly (no meter).
-    let plain = publish_plain(&mut nub);
+    let plain = publish_plain(nub);
     let ref_run = nub.invoke_cached(plain, 0, [0; 4], BUDGET).unwrap();
     assert_eq!(ref_run.exit_reason, 4, "ecalli 42 → HostCall");
     let ref_remaining = ref_run.gas_remaining;
@@ -110,7 +110,7 @@ fn meter_drives_gas(mut nub: Nub) {
     // at the same remaining as the reference.
     let meter_key = Key::from(&[0xAB, 0xCD, 0xEF][..]);
     nub.set_meter(meter_key.clone(), BUDGET);
-    let metered = publish_metered(&mut nub, &meter_key);
+    let metered = publish_metered(nub, &meter_key);
     let run = nub.invoke_cached(metered, 0, [0; 4], WRONG).unwrap();
 
     assert_eq!(
@@ -126,12 +126,14 @@ fn meter_drives_gas(mut nub: Nub) {
 
 #[test]
 fn meter_drives_gas_local() {
-    meter_drives_gas(Nub::new_local());
+    let mut nub = Nub::new_local();
+    meter_drives_gas(&mut nub);
 }
 
 #[test]
 fn meter_drives_gas_hyperlight() {
-    meter_drives_gas(Nub::new_hyperlight().expect("hyperlight"));
+    let mut nub = Nub::hyperlight().expect("hyperlight");
+    meter_drives_gas(&mut nub);
 }
 
 #[test]

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -1,6 +1,7 @@
-//! Kernel gas-meter mapping: `invoke_cached` resolves the running Instance's
-//! `gas_slots[0]` → `Gas{meter_key}` handle, seeds the run from the kernel meter
-//! mapping (not the call-supplied budget), and writes the remaining gas back.
+//! Top-level invocation gas is task-local: `invoke_cached` seeds the new kernel
+//! task from its call-supplied `initial_gas`. A published `Gas{meter_key}` handle
+//! in an image's `gas_slots` participates in guest-side meter routing, but the
+//! host `Nub` does not keep a shared meter map across invocations.
 
 use javm_cap::image::{EndpointDef, Image};
 use javm_cap::{
@@ -34,34 +35,8 @@ fn ecalli_42_image(with_gas_slot: bool) -> Image {
     img
 }
 
-fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
-    (((imm as u32) & 0x0fff) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
-}
-
-fn looping_image(with_gas_slot: bool) -> Image {
-    let mut img = Image::empty();
-    img.code.extend_from_slice(&addi(10, 10, 1).to_le_bytes());
-    img.code.extend_from_slice(&addi(11, 11, 1).to_le_bytes());
-    img.code.extend_from_slice(&0xFF9F_F06Fu32.to_le_bytes()); // jal x0, -8
-    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
-    endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            entry_pc: 0,
-            arg_registers: 0,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
-    img.endpoints = endpoints;
-    if with_gas_slot {
-        img.gas_slots = vec![Key::from(GAS_SLOT)];
-    }
-    img
-}
-
 /// Publish a plain instance (no gas slot) and return its hash.
-fn publish_plain(nub: &mut Nub) -> nub::AbiCapHash {
+fn publish_plain(nub: &Nub) -> nub::AbiCapHash {
     let img = ecalli_42_image(false);
     let image_h = nub
         .put_cap(&Cap::image_with_slots(&img, &[], &[]).unwrap())
@@ -123,103 +98,92 @@ fn publish_metered(nub: &Nub, meter_key: &Key) -> nub::AbiCapHash {
     publish_metered_image(nub, ecalli_42_image(true), meter_key)
 }
 
-fn meter_drives_gas(nub: &mut Nub) {
+fn initial_gas_funds_metered_invocation(nub: &Nub) {
     const BUDGET: u64 = 1_000_000;
-    const WRONG: u64 = BUDGET + 5_000_000;
+    const TOPPED_UP: u64 = BUDGET + 5_000_000;
 
-    // Reference: a plain instance run on `BUDGET` directly (no meter).
-    let plain = publish_plain(nub);
-    let ref_run = nub.invoke_cached(plain, 0, [0; 4], BUDGET).unwrap();
-    assert_eq!(ref_run.exit_reason, 4, "ecalli 42 → HostCall");
-    let ref_remaining = ref_run.gas_remaining;
-    assert!(ref_remaining < BUDGET, "the guest consumed some gas");
-
-    // Metered instance: seed the meter to BUDGET, but pass a deliberately wrong
-    // `initial_gas`. If the meter is consulted, the run ignores WRONG and lands
-    // at the same remaining as the reference.
     let meter_key = Key::from(&[0xAB, 0xCD, 0xEF][..]);
-    nub.set_meter(meter_key.clone(), BUDGET);
     let metered = publish_metered(nub, &meter_key);
-    let run = nub.invoke_cached(metered, 0, [0; 4], WRONG).unwrap();
+    let funded = nub.invoke_cached(metered, 0, [0; 4], BUDGET).unwrap();
+    let topped_up = nub.invoke_cached(metered, 0, [0; 4], TOPPED_UP).unwrap();
 
-    assert_eq!(
-        run.gas_remaining, ref_remaining,
-        "ran on the meter budget ({BUDGET}), not the call-supplied {WRONG}"
+    assert_eq!(funded.exit_reason, 4, "ecalli 42 -> HostCall");
+    assert_eq!(topped_up.exit_reason, 4, "ecalli 42 -> HostCall");
+    assert!(
+        funded.gas_remaining < BUDGET,
+        "the guest should consume gas from the call-supplied budget"
     );
     assert_eq!(
-        nub.get_meter(&meter_key),
-        run.gas_remaining,
-        "meter written back to the remaining gas at frame exit"
+        TOPPED_UP - topped_up.gas_remaining,
+        BUDGET - funded.gas_remaining,
+        "the same metered image should consume the same amount from each task-local budget"
     );
 }
 
 #[test]
-fn meter_drives_gas_local() {
-    let mut nub = Nub::new_local();
-    meter_drives_gas(&mut nub);
+fn initial_gas_funds_metered_invocation_local() {
+    let nub = Nub::new_local();
+    initial_gas_funds_metered_invocation(&nub);
 }
 
 #[test]
-fn meter_drives_gas_hyperlight() {
-    let mut nub =
+fn initial_gas_funds_metered_invocation_hyperlight() {
+    let nub =
         Nub::hyperlight_with_options(NubOptions::new().with_vcpu_count(2)).expect("hyperlight");
-    meter_drives_gas(&mut nub);
+    initial_gas_funds_metered_invocation(&nub);
 }
 
 #[test]
 fn no_gas_slot_uses_call_budget() {
     // Without a gas slot the call-supplied budget is used and no meter touched.
-    let mut nub = Nub::new_local();
-    let plain = publish_plain(&mut nub);
+    let nub = Nub::new_local();
+    let plain = publish_plain(&nub);
     let r = nub.invoke_cached(plain, 0, [0; 4], 1_000_000).unwrap();
     assert!(r.gas_remaining < 1_000_000 && r.gas_remaining > 0);
 }
 
 #[test]
-fn concurrent_invokes_sharing_meter_are_rejected() {
+fn concurrent_invokes_sharing_gas_handle_are_independent() {
     let nub = Nub::new_local();
-    concurrent_invokes_sharing_meter_are_rejected_for(&nub);
+    concurrent_invokes_sharing_gas_handle_are_independent_for(&nub);
 }
 
 #[test]
-fn hyperlight_concurrent_invokes_sharing_meter_are_rejected() {
+fn hyperlight_concurrent_invokes_sharing_gas_handle_are_independent() {
     let nub =
         Nub::hyperlight_with_options(NubOptions::new().with_vcpu_count(2)).expect("hyperlight");
-    concurrent_invokes_sharing_meter_are_rejected_for(&nub);
+    concurrent_invokes_sharing_gas_handle_are_independent_for(&nub);
 }
 
-fn concurrent_invokes_sharing_meter_are_rejected_for(nub: &Nub) {
+fn concurrent_invokes_sharing_gas_handle_are_independent_for(nub: &Nub) {
     let meter_key = Key::from(&[0xAA, 0xBB, 0xCC][..]);
-    nub.set_meter(meter_key.clone(), 20_000_000);
-    let metered = publish_metered_image(nub, looping_image(true), &meter_key);
+    let metered = publish_metered_image(nub, ecalli_42_image(true), &meter_key);
+    const BASE_BUDGET: u64 = 1_000_000;
 
     let jobs: Vec<_> = (0..16)
-        .map(|_| {
+        .map(|i| {
             nub.submit_invoke(InvokeRequest {
                 instance_hash: metered,
                 endpoint_idx: 0,
                 args: [0; 4],
-                initial_gas: 1,
+                initial_gas: BASE_BUDGET + i,
             })
             .expect("submit metered invoke")
         })
         .collect();
 
-    let mut saw_in_flight_rejection = false;
-    let mut completed = 0usize;
-    for job in jobs {
-        match job.wait() {
-            Ok(_) => completed += 1,
-            Err(e) if e.to_string().contains("gas meter is already in flight") => {
-                saw_in_flight_rejection = true;
-            }
-            Err(e) => panic!("unexpected invoke error: {e:#}"),
+    let mut consumed = None;
+    for (i, job) in jobs.into_iter().enumerate() {
+        let result = job.wait().expect("shared gas handle invoke");
+        assert_eq!(result.exit_reason, 4, "ecalli 42 -> HostCall");
+        let budget = BASE_BUDGET + i as u64;
+        let this_consumed = budget - result.gas_remaining;
+        match consumed {
+            Some(expected) => assert_eq!(
+                this_consumed, expected,
+                "each invoke should draw from its own task-local budget"
+            ),
+            None => consumed = Some(this_consumed),
         }
     }
-
-    assert!(completed >= 1, "at least one invoke should own the meter");
-    assert!(
-        saw_in_flight_rejection,
-        "a concurrent invoke sharing the same host meter must be rejected"
-    );
 }

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -7,7 +7,7 @@ use javm_cap::{
     CNodeCap, Cap, CapHashOrRef, DataCap, KernelImage, Key, NUM_REGS, kernel_image_hash,
     key_to_regs,
 };
-use nub::Nub;
+use nub::{InvokeRequest, Nub};
 use std::collections::BTreeMap;
 
 const GAS_SLOT: u8 = 5;
@@ -17,6 +17,32 @@ const GAS_SLOT: u8 = 5;
 fn ecalli_42_image(with_gas_slot: bool) -> Image {
     let mut img = Image::empty();
     img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
+    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    img.endpoints = endpoints;
+    if with_gas_slot {
+        img.gas_slots = vec![Key::from(GAS_SLOT)];
+    }
+    img
+}
+
+fn addi(rd: u8, rs1: u8, imm: i32) -> u32 {
+    (((imm as u32) & 0x0fff) << 20) | ((rs1 as u32) << 15) | ((rd as u32) << 7) | 0x13
+}
+
+fn looping_image(with_gas_slot: bool) -> Image {
+    let mut img = Image::empty();
+    img.code.extend_from_slice(&addi(10, 10, 1).to_le_bytes());
+    img.code.extend_from_slice(&addi(11, 11, 1).to_le_bytes());
+    img.code.extend_from_slice(&0xFF9F_F06Fu32.to_le_bytes()); // jal x0, -8
     let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     endpoints.insert(
         Key::from(0u8),
@@ -54,7 +80,7 @@ fn publish_plain(nub: &mut Nub) -> nub::AbiCapHash {
 }
 
 /// Publish an instance whose `gas_slots[0]` holds a `Gas{meter_key}` handle.
-fn publish_metered(nub: &mut Nub, meter_key: &Key) -> nub::AbiCapHash {
+fn publish_metered_image(nub: &Nub, img: Image, meter_key: &Key) -> nub::AbiCapHash {
     // Gas unit handle: a Cap::Instance with the well-known Gas image-hash chain
     // and the meter_key packed into regs[0..1].
     let (packed, len) = key_to_regs(meter_key);
@@ -78,7 +104,6 @@ fn publish_metered(nub: &mut Nub, meter_key: &Key) -> nub::AbiCapHash {
         .unwrap();
     let cnode_h = nub.put_cap(&Cap::CNode(cnode)).unwrap();
 
-    let img = ecalli_42_image(true);
     let image_h = nub
         .put_cap(&Cap::image_with_slots(&img, &[], &[]).unwrap())
         .unwrap();
@@ -92,6 +117,10 @@ fn publish_metered(nub: &mut Nub, meter_key: &Key) -> nub::AbiCapHash {
         0,
     );
     nub.put_cap(&inst).unwrap()
+}
+
+fn publish_metered(nub: &Nub, meter_key: &Key) -> nub::AbiCapHash {
+    publish_metered_image(nub, ecalli_42_image(true), meter_key)
 }
 
 fn meter_drives_gas(nub: &mut Nub) {
@@ -143,4 +172,42 @@ fn no_gas_slot_uses_call_budget() {
     let plain = publish_plain(&mut nub);
     let r = nub.invoke_cached(plain, 0, [0; 4], 1_000_000).unwrap();
     assert!(r.gas_remaining < 1_000_000 && r.gas_remaining > 0);
+}
+
+#[test]
+fn concurrent_invokes_sharing_meter_are_rejected() {
+    let nub = Nub::new_local();
+    let meter_key = Key::from(&[0xAA, 0xBB, 0xCC][..]);
+    nub.set_meter(meter_key.clone(), 20_000_000);
+    let metered = publish_metered_image(&nub, looping_image(true), &meter_key);
+
+    let jobs: Vec<_> = (0..16)
+        .map(|_| {
+            nub.submit_invoke(InvokeRequest {
+                instance_hash: metered,
+                endpoint_idx: 0,
+                args: [0; 4],
+                initial_gas: 1,
+            })
+            .expect("submit metered invoke")
+        })
+        .collect();
+
+    let mut saw_in_flight_rejection = false;
+    let mut completed = 0usize;
+    for job in jobs {
+        match job.wait() {
+            Ok(_) => completed += 1,
+            Err(e) if e.to_string().contains("gas meter is already in flight") => {
+                saw_in_flight_rejection = true;
+            }
+            Err(e) => panic!("unexpected invoke error: {e:#}"),
+        }
+    }
+
+    assert!(completed >= 1, "at least one invoke should own the meter");
+    assert!(
+        saw_in_flight_rejection,
+        "a concurrent invoke sharing the same host meter must be rejected"
+    );
 }

--- a/rust/nub/tests/parallel_api.rs
+++ b/rust/nub/tests/parallel_api.rs
@@ -1,0 +1,81 @@
+//! Cloneable Nub handle and invoke job API smoke tests.
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{Cap, DataCap, Key, NUM_REGS};
+use nub::{InvokeRequest, Nub};
+use std::collections::BTreeMap;
+use std::thread;
+
+fn ecalli_imm_image(imm: u32) -> Image {
+    let mut img = Image::empty();
+    let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
+    img.code = instr.to_le_bytes().to_vec();
+    img.endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    img
+}
+
+fn publish(nub: &Nub, imm: u32) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&ecalli_imm_image(imm), &[], &[]).expect("image"))
+        .expect("put image");
+    let cnode_h = nub.put_cap(&Cap::empty_cnode()).expect("put cnode");
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        DataCap::from_bytes_sized(&[], 4096),
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+#[test]
+fn cloned_local_nub_handles_can_blocking_invoke_from_many_threads() {
+    let nub = Nub::new_local();
+    let inst = publish(&nub, 42);
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let nub = nub.clone();
+            thread::spawn(move || {
+                nub.invoke_cached(inst, 0, [0; 4], 1_000)
+                    .expect("invoke_cached")
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let result = handle.join().expect("invoke thread");
+        assert_eq!(result.exit_reason, 4);
+        assert_eq!(result.exit_arg, 42);
+    }
+}
+
+#[test]
+fn invoke_job_wait_returns_result() {
+    let nub = Nub::new_local();
+    let inst = publish(&nub, 43);
+    let job = nub
+        .submit_invoke(InvokeRequest {
+            instance_hash: inst,
+            endpoint_idx: 0,
+            args: [0; 4],
+            initial_gas: 1_000,
+        })
+        .expect("submit invoke");
+
+    assert_eq!(job.id().0, 1);
+    let result = job.wait().expect("job wait");
+    assert_eq!(result.exit_reason, 4);
+    assert_eq!(result.exit_arg, 43);
+}

--- a/rust/nub/tests/parallel_api.rs
+++ b/rust/nub/tests/parallel_api.rs
@@ -2,7 +2,7 @@
 
 use javm_cap::image::{EndpointDef, Image};
 use javm_cap::{Cap, DataCap, Key, NUM_REGS};
-use nub::{InvokeRequest, Nub};
+use nub::{InvokeRequest, MAX_HYPERLIGHT_VCPUS, Nub, NubOptions};
 use std::collections::BTreeMap;
 use std::thread;
 
@@ -100,4 +100,18 @@ fn cloned_local_nub_handles_can_idempotently_publish_from_many_threads() {
     for handle in handles {
         handle.join().expect("put thread");
     }
+}
+
+#[test]
+fn hyperlight_options_reject_too_many_vcpus() {
+    let result = Nub::hyperlight_tests_with_options(NubOptions {
+        vcpu_count: MAX_HYPERLIGHT_VCPUS + 1,
+    });
+    let Err(err) = result else {
+        panic!("oversized vCPU pool must fail before sandbox boot");
+    };
+    assert!(
+        err.to_string().contains("exceeds guest lane capacity"),
+        "unexpected error: {err:#}"
+    );
 }

--- a/rust/nub/tests/parallel_api.rs
+++ b/rust/nub/tests/parallel_api.rs
@@ -79,3 +79,25 @@ fn invoke_job_wait_returns_result() {
     assert_eq!(result.exit_reason, 4);
     assert_eq!(result.exit_arg, 43);
 }
+
+#[test]
+fn cloned_local_nub_handles_can_idempotently_publish_from_many_threads() {
+    let nub = Nub::new_local();
+    let cap = Cap::empty_cnode();
+    let hash = nub.put_cap(&cap).expect("initial put");
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let nub = nub.clone();
+            let cap = cap.clone();
+            thread::spawn(move || {
+                nub.put_cap_with_hash(hash, &cap)
+                    .expect("idempotent put_cap_with_hash")
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("put thread");
+    }
+}

--- a/rust/nub/tests/parallel_kvm.rs
+++ b/rust/nub/tests/parallel_kvm.rs
@@ -94,3 +94,26 @@ fn hyperlight_parallel_workers_complete_two_simple_invokes() {
         assert_eq!((result.exit_reason, result.exit_arg), (4, 80 + i));
     }
 }
+
+#[test]
+fn cloned_hyperlight_nub_handles_can_idempotently_publish_from_many_threads() {
+    let nub = Nub::hyperlight_tests_with_options(NubOptions::new().with_vcpu_count(2))
+        .expect("Hyperlight test sandbox");
+    let cap = Cap::empty_cnode();
+    let hash = nub.put_cap(&cap).expect("initial put");
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let nub = nub.clone();
+            let cap = cap.clone();
+            thread::spawn(move || {
+                nub.put_cap_with_hash(hash, &cap)
+                    .expect("idempotent put_cap_with_hash")
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("put thread");
+    }
+}

--- a/rust/nub/tests/parallel_kvm.rs
+++ b/rust/nub/tests/parallel_kvm.rs
@@ -4,6 +4,7 @@ use javm_cap::image::{EndpointDef, Image};
 use javm_cap::{Cap, DataCap, Key, NUM_REGS};
 use nub::{InvokeRequest, Nub, NubOptions};
 use std::collections::BTreeMap;
+use std::thread;
 
 fn ecalli_imm_image(imm: u32) -> Image {
     let mut img = Image::empty();
@@ -72,4 +73,24 @@ fn hyperlight_parallel_workers_complete_two_simple_invokes() {
         .invoke_cached(c, 0, [0; 4], 1_000)
         .expect("invoke C after worker stop/restart");
     assert_eq!((result_c.exit_reason, result_c.exit_arg), (4, 73));
+
+    let threaded: Vec<_> = (0..4).map(|i| publish(&nub, 80 + i)).collect();
+    let handles: Vec<_> = threaded
+        .into_iter()
+        .enumerate()
+        .map(|(i, inst)| {
+            let nub = nub.clone();
+            thread::spawn(move || {
+                let result = nub
+                    .invoke_cached(inst, 0, [0; 4], 1_000)
+                    .expect("threaded invoke_cached");
+                (i as u32, result)
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let (i, result) = handle.join().expect("invoke thread");
+        assert_eq!((result.exit_reason, result.exit_arg), (4, 80 + i));
+    }
 }

--- a/rust/nub/tests/parallel_kvm.rs
+++ b/rust/nub/tests/parallel_kvm.rs
@@ -1,0 +1,75 @@
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{Cap, DataCap, Key, NUM_REGS};
+use nub::{InvokeRequest, Nub, NubOptions};
+use std::collections::BTreeMap;
+
+fn ecalli_imm_image(imm: u32) -> Image {
+    let mut img = Image::empty();
+    let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
+    img.code = instr.to_le_bytes().to_vec();
+    img.endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    img
+}
+
+fn publish(nub: &Nub, imm: u32) -> nub::AbiCapHash {
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&ecalli_imm_image(imm), &[], &[]).expect("image"))
+        .expect("put image");
+    let cnode_h = nub.put_cap(&Cap::empty_cnode()).expect("put cnode");
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        DataCap::from_bytes_sized(&[], 4096),
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+#[test]
+fn hyperlight_parallel_workers_complete_two_simple_invokes() {
+    let nub = Nub::hyperlight_tests_with_options(NubOptions::new().with_vcpu_count(2))
+        .expect("Hyperlight test sandbox");
+    let a = publish(&nub, 71);
+    let b = publish(&nub, 72);
+
+    let job_a = nub
+        .submit_invoke(InvokeRequest {
+            instance_hash: a,
+            endpoint_idx: 0,
+            args: [0; 4],
+            initial_gas: 1_000,
+        })
+        .expect("submit A");
+    let job_b = nub
+        .submit_invoke(InvokeRequest {
+            instance_hash: b,
+            endpoint_idx: 0,
+            args: [0; 4],
+            initial_gas: 1_000,
+        })
+        .expect("submit B");
+
+    let result_a = job_a.wait().expect("wait A");
+    let result_b = job_b.wait().expect("wait B");
+    assert_eq!((result_a.exit_reason, result_a.exit_arg), (4, 71));
+    assert_eq!((result_b.exit_reason, result_b.exit_arg), (4, 72));
+
+    let c = publish(&nub, 73);
+    let result_c = nub
+        .invoke_cached(c, 0, [0; 4], 1_000)
+        .expect("invoke C after worker stop/restart");
+    assert_eq!((result_c.exit_reason, result_c.exit_arg), (4, 73));
+}

--- a/rust/nub/tests/smoke.rs
+++ b/rust/nub/tests/smoke.rs
@@ -61,7 +61,7 @@ fn local_invoke_cached_ecalli_42() {
 
 #[test]
 fn hyperlight_invoke_cached_ecalli_42() {
-    let mut nub = Nub::new_hyperlight().expect("hyperlight");
+    let mut nub = Nub::hyperlight().expect("hyperlight");
     let result = publish_and_invoke(&mut nub);
     assert_eq!(result.exit_reason, 4, "expected HostCall");
     assert_eq!(result.exit_arg, 42, "expected ecalli imm");

--- a/rust/nub/tests/test_bin_smoke.rs
+++ b/rust/nub/tests/test_bin_smoke.rs
@@ -9,8 +9,13 @@
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
 use nub::Nub;
-use nub_arch_x86::test_abi::FN_ID_TEST_SMOKE;
+use nub_arch_x86::test_abi::{FN_ID_TEST_INVOKE_TWO_SERIAL, FN_ID_TEST_SMOKE};
+use nub_arch_x86_abi::{InvocationResult, InvokePacket};
 use rkyv::primitive::ArchivedU64;
+use std::collections::BTreeMap;
+
+use javm_cap::image::{EndpointDef, Image};
+use javm_cap::{Cap, DataCap, Key, NUM_REGS};
 
 #[test]
 fn test_bin_smoke_returns_42() {
@@ -21,4 +26,115 @@ fn test_bin_smoke_returns_42() {
     let archived =
         rkyv::access::<ArchivedU64, rkyv::rancor::Error>(aligned.as_slice()).expect("rkyv access");
     assert_eq!(archived.to_native(), 42);
+}
+
+fn ecalli_image(imm: u32) -> Image {
+    let mut img = Image::empty();
+    let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
+    img.code = instr.to_le_bytes().to_vec();
+    let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
+    endpoints.insert(
+        Key::from(0u8),
+        EndpointDef {
+            entry_pc: 0,
+            arg_registers: 0,
+            arg_cnode_size: 0,
+            initial_regs: BTreeMap::new(),
+        },
+    );
+    img.endpoints = endpoints;
+    img
+}
+
+fn publish_ecalli(nub: &mut Nub, imm: u32) -> nub::AbiCapHash {
+    let img = ecalli_image(imm);
+    let image_h = nub
+        .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image_with_slots"))
+        .expect("put image");
+    let cnode_h = nub.put_cap(&Cap::empty_cnode()).expect("put cnode");
+    nub.put_cap(&Cap::instance_with_mem(
+        [0u8; 32],
+        image_h,
+        cnode_h,
+        DataCap::from_bytes_sized(&[], 4096),
+        [0u64; NUM_REGS],
+        0,
+        0,
+    ))
+    .expect("put instance")
+}
+
+fn scheduler_probe(
+    nub: &mut Nub,
+    first: nub::AbiCapHash,
+    first_gas: u64,
+    second: nub::AbiCapHash,
+    second_gas: u64,
+) -> [InvocationResult; 2] {
+    let first = InvokePacket {
+        instance_hash: first,
+        endpoint_idx: 0,
+        _pad: 0,
+        args: [0; 4],
+        initial_gas: first_gas,
+    };
+    let second = InvokePacket {
+        instance_hash: second,
+        endpoint_idx: 0,
+        _pad: 0,
+        args: [0; 4],
+        initial_gas: second_gas,
+    };
+    let mut payload = Vec::with_capacity(InvokePacket::SIZE * 2);
+    payload.extend_from_slice(first.as_bytes());
+    payload.extend_from_slice(second.as_bytes());
+
+    let bytes = nub
+        .call_raw(FN_ID_TEST_INVOKE_TWO_SERIAL, &payload)
+        .expect("scheduler probe rpc");
+    let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
+    aligned.extend_from_slice(&bytes);
+    let archived = rkyv::access::<rkyv::Archived<[InvocationResult; 2]>, rkyv::rancor::Error>(
+        aligned.as_slice(),
+    )
+    .expect("rkyv access scheduler results");
+    [
+        InvocationResult {
+            exit_reason: archived[0].exit_reason.to_native(),
+            exit_arg: archived[0].exit_arg.to_native(),
+            return_value: archived[0].return_value.to_native(),
+            gas_remaining: archived[0].gas_remaining.to_native(),
+            scratchpad_head: archived[0].scratchpad_head,
+        },
+        InvocationResult {
+            exit_reason: archived[1].exit_reason.to_native(),
+            exit_arg: archived[1].exit_arg.to_native(),
+            return_value: archived[1].return_value.to_native(),
+            gas_remaining: archived[1].gas_remaining.to_native(),
+            scratchpad_head: archived[1].scratchpad_head,
+        },
+    ]
+}
+
+#[test]
+fn test_scheduler_probe_runs_two_tasks() {
+    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let first = publish_ecalli(&mut nub, 42);
+    let second = publish_ecalli(&mut nub, 43);
+    let results = scheduler_probe(&mut nub, first, 1_000, second, 1_000);
+    assert_eq!(results[0].exit_reason, 4);
+    assert_eq!(results[0].exit_arg, 42);
+    assert_eq!(results[1].exit_reason, 4);
+    assert_eq!(results[1].exit_arg, 43);
+}
+
+#[test]
+fn test_scheduler_probe_keeps_task_gas_local_after_oog() {
+    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let first = publish_ecalli(&mut nub, 42);
+    let second = publish_ecalli(&mut nub, 43);
+    let results = scheduler_probe(&mut nub, first, 0, second, 1_000);
+    assert_eq!(results[0].exit_reason, 2);
+    assert_eq!(results[1].exit_reason, 4);
+    assert_eq!(results[1].exit_arg, 43);
 }

--- a/rust/nub/tests/test_bin_smoke.rs
+++ b/rust/nub/tests/test_bin_smoke.rs
@@ -1,6 +1,6 @@
 //! End-to-end smoke for the `nub-arch-x86-tests` guest binary.
 //!
-//! Loads the test guest binary via [`Nub::new_hyperlight_tests`],
+//! Loads the test guest binary via [`Nub::hyperlight_tests`],
 //! calls the `nub_smoke` RPC, and verifies it returns `42u64`.
 //! Together with `tests/smoke.rs` (which exercises the production
 //! `invoke_cached` path), this gives us coverage of both the
@@ -14,7 +14,7 @@ use rkyv::primitive::ArchivedU64;
 
 #[test]
 fn test_bin_smoke_returns_42() {
-    let mut nub = Nub::new_hyperlight_tests().expect("hyperlight tests bin");
+    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
     let bytes = nub.call_raw(FN_ID_TEST_SMOKE, &[]).expect("smoke rpc");
     let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
     aligned.extend_from_slice(&bytes);

--- a/rust/nub/tests/test_bin_smoke.rs
+++ b/rust/nub/tests/test_bin_smoke.rs
@@ -19,7 +19,7 @@ use javm_cap::{Cap, DataCap, Key, NUM_REGS};
 
 #[test]
 fn test_bin_smoke_returns_42() {
-    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
     let bytes = nub.call_raw(FN_ID_TEST_SMOKE, &[]).expect("smoke rpc");
     let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
     aligned.extend_from_slice(&bytes);

--- a/rust/nub/tests/test_bin_smoke.rs
+++ b/rust/nub/tests/test_bin_smoke.rs
@@ -8,7 +8,7 @@
 
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use nub::Nub;
+use nub::{Nub, NubOptions};
 use nub_arch_x86::test_abi::{FN_ID_TEST_INVOKE_TWO_SERIAL, FN_ID_TEST_SMOKE};
 use nub_arch_x86_abi::{InvocationResult, InvokePacket};
 use rkyv::primitive::ArchivedU64;
@@ -17,10 +17,28 @@ use std::collections::BTreeMap;
 use javm_cap::image::{EndpointDef, Image};
 use javm_cap::{Cap, DataCap, Key, NUM_REGS};
 
+fn test_nub() -> Nub {
+    Nub::hyperlight_tests_with_options(NubOptions::new().with_vcpu_count(2))
+        .expect("hyperlight tests bin")
+}
+
 #[test]
 fn test_bin_smoke_returns_42() {
-    let nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let nub = test_nub();
     let bytes = nub.call_raw(FN_ID_TEST_SMOKE, &[]).expect("smoke rpc");
+    let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
+    aligned.extend_from_slice(&bytes);
+    let archived =
+        rkyv::access::<ArchivedU64, rkyv::rancor::Error>(aligned.as_slice()).expect("rkyv access");
+    assert_eq!(archived.to_native(), 42);
+}
+
+#[test]
+fn test_bin_smoke_returns_42_on_second_vcpu() {
+    let nub = test_nub();
+    let bytes = nub
+        .call_raw_on_vcpu(1, FN_ID_TEST_SMOKE, &[])
+        .expect("smoke rpc on vcpu 1");
     let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
     aligned.extend_from_slice(&bytes);
     let archived =
@@ -118,7 +136,7 @@ fn scheduler_probe(
 
 #[test]
 fn test_scheduler_probe_runs_two_tasks() {
-    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let mut nub = test_nub();
     let first = publish_ecalli(&mut nub, 42);
     let second = publish_ecalli(&mut nub, 43);
     let results = scheduler_probe(&mut nub, first, 1_000, second, 1_000);
@@ -130,7 +148,7 @@ fn test_scheduler_probe_runs_two_tasks() {
 
 #[test]
 fn test_scheduler_probe_keeps_task_gas_local_after_oog() {
-    let mut nub = Nub::hyperlight_tests().expect("hyperlight tests bin");
+    let mut nub = test_nub();
     let first = publish_ecalli(&mut nub, 42);
     let second = publish_ecalli(&mut nub, 43);
     let results = scheduler_probe(&mut nub, first, 0, second, 1_000);


### PR DESCRIPTION
## Summary

- make the high-level Nub API use the singleton Hyperlight/KVM backend with cloneable handles
- add the fixed-lane parallel KVM invoke path and keep blocking `invoke_cached` on the direct lane-pool path
- recover benchmark performance by removing the synchronous host executor hop, using the lane-slot ABI atomics directly, and narrowing JIT eviction to compiled-image artifacts
- preserve serial behavior and owner-edge/gas/pending-origin semantics

## Validation

- `cargo test -p nub -- --test-threads=1`
- `cargo test -p javm-guest-tests -- --test-threads=1`
- `cargo test -p javm-bench --test parallel_refine -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Benchmark Check

Final Criterion mean comparison against saved master baseline: no positive regression over 5%.

Warm/cold largest positive deltas:
- `poseidon2_perm` warm: +3.4%
- `poly_eval` cold: +1.9%
- `goldilocks_mul` cold: +0.6%

Recursive sweeps:
- `sub_vm_recurse/10`: +4.4%
- `sub_vm_recurse/100`: +0.9%
- `sub_vm_recurse/1000`: +0.1%
- `sub_vm_data_recurse/10`: +1.5%
- `sub_vm_data_recurse/100`: +0.7%
- `sub_vm_data_recurse/1000`: +3.9%
- `pt_cache_call/10`: +4.6%
- `pt_cache_call/100`: +1.9%
- `pt_cache_call/1000`: +0.6%
