### PR TITLE
javm-cap: page-granular arena Image wire format

### DIFF
--- a/rust/javm-bench/benches/bench.rs
+++ b/rust/javm-bench/benches/bench.rs
@@ -21,10 +21,7 @@ macro_rules! bench_workload {
             let (val, gas) = javm_bench::run_recompiler(&built);
             eprintln!(
                 "[{}] result = {:#x}, gas = {}, code = {}B",
-                $label,
-                val,
-                gas,
-                image.code.len(),
+                $label, val, gas, image.code.len,
             );
 
             let mut g = c.benchmark_group($label);

--- a/rust/javm-bench/examples/blob_anatomy.rs
+++ b/rust/javm-bench/examples/blob_anatomy.rs
@@ -1,0 +1,110 @@
+//! Throwaway diagnostic: decode each bench Image blob and break down where
+//! its bytes go, focusing on the page-granular arena (named vs elided pages).
+//! Run: cargo run -p javm-bench --release --example blob_anatomy
+
+use javm_cap::PAGE_SIZE;
+use javm_cap::image::{DataDesc, Image, PinnedCap};
+use ssz::{Decode, Encode};
+
+/// Stats on one data slot's page-granular [`DataDesc`].
+struct Anat {
+    /// Logical extent in bytes (`size`).
+    size: u64,
+    /// Logical page count (`size / PAGE_SIZE`).
+    logical_pages: u64,
+    /// Non-zero pages actually stored in the arena (`pages.len()`).
+    named_pages: usize,
+    /// Pages elided because they are all-zero (`logical - named`).
+    elided_pages: u64,
+    /// Bytes actually stored in the arena (sum of each named page's `len`).
+    stored_bytes: usize,
+}
+
+fn anat(desc: &DataDesc) -> Anat {
+    let logical_pages = desc.page_count();
+    let named_pages = desc.pages.len();
+    let elided_pages = logical_pages.saturating_sub(named_pages as u64);
+    let stored_bytes = desc.pages.iter().map(|pr| pr.len as usize).sum();
+    Anat {
+        size: desc.size,
+        logical_pages,
+        named_pages,
+        elided_pages,
+        stored_bytes,
+    }
+}
+
+fn report(label: &str, blob: &[u8]) {
+    let img = Image::from_ssz_bytes(blob).expect("decode Image");
+    println!("\n== {label} ==  full blob = {} B", blob.len());
+    println!(
+        "   arena = {} B (tightly packed); code = {} B",
+        img.arena.len(),
+        img.code.len,
+    );
+
+    let mut elided_pages = 0u64;
+    let mut named_pages = 0usize;
+
+    let print_slot = |kind: &str, k: &javm_cap::Key, a: &Anat| {
+        println!(
+            "   {kind:<7} slot={:>3?} size={:>7} logical_pages={:>5} named={:>5} elided={:>5} stored={:>6}B",
+            k, a.size, a.logical_pages, a.named_pages, a.elided_pages, a.stored_bytes,
+        );
+    };
+
+    for (k, p) in &img.pinned_slots {
+        if let PinnedCap::Data { desc } = p {
+            let a = anat(desc);
+            print_slot("pinned", k, &a);
+            elided_pages += a.elided_pages;
+            named_pages += a.named_pages;
+        }
+    }
+    for (k, desc) in &img.initial_slots {
+        let a = anat(desc);
+        print_slot("initial", k, &a);
+        elided_pages += a.elided_pages;
+        named_pages += a.named_pages;
+    }
+    println!(
+        "   >>> {} named pages stored, {} all-zero pages elided ({} B not inlined)",
+        named_pages,
+        elided_pages,
+        elided_pages * PAGE_SIZE as u64,
+    );
+    // sanity: serialized size of just initial_slots / pinned_slots / arena
+    println!(
+        "   (initial_slots ssz = {} B, pinned_slots ssz = {} B, arena ssz = {} B)",
+        img.initial_slots.as_ssz_bytes().len(),
+        img.pinned_slots.as_ssz_bytes().len(),
+        img.arena.as_ssz_bytes().len(),
+    );
+}
+
+fn main() {
+    report("prime_sieve", include_bytes!(env!("PRIME_SIEVE_BLOB")));
+    report("keccak", include_bytes!(env!("KECCAK_BLOB")));
+    report("blake2b", include_bytes!(env!("BLAKE2B_BLOB")));
+    report(
+        "goldilocks_mul",
+        include_bytes!(env!("GOLDILOCKS_MUL_BLOB")),
+    );
+    report(
+        "sub_vm_recurse",
+        include_bytes!(env!("SUB_VM_RECURSE_BLOB")),
+    );
+    report(
+        "sub_vm_data_recurse",
+        include_bytes!(env!("SUB_VM_DATA_RECURSE_BLOB")),
+    );
+    report("ed25519", include_bytes!(env!("ED25519_BLOB")));
+    report("ecrecover", include_bytes!(env!("ECRECOVER_BLOB")));
+    report(
+        "poseidon2_perm",
+        include_bytes!(env!("POSEIDON2_PERM_BLOB")),
+    );
+    report("mini_verifier", include_bytes!(env!("MINI_VERIFIER_BLOB")));
+    report("poly_eval", include_bytes!(env!("POLY_EVAL_BLOB")));
+    report("fri_fold_tree", include_bytes!(env!("FRI_FOLD_TREE_BLOB")));
+}

--- a/rust/javm-bench/examples/compile_profile.rs
+++ b/rust/javm-bench/examples/compile_profile.rs
@@ -37,7 +37,7 @@ mod imp {
 
     fn profile_one(name: &str, blob: &[u8]) {
         let image = Image::from_ssz_bytes(blob).expect("decode Image");
-        let code = image.code.as_slice();
+        let code = image.code_bytes();
         // Guest CODE_BASE (where the linker maps the code region).
         let code_base = javm_cap::layout::CODE_BASE;
 

--- a/rust/javm-bench/examples/disasm.rs
+++ b/rust/javm-bench/examples/disasm.rs
@@ -22,6 +22,6 @@ fn main() {
     let out = std::env::args()
         .nth(2)
         .unwrap_or_else(|| format!("/tmp/pvm2_{}.bin", which));
-    std::fs::write(&out, &img.code).unwrap();
-    println!("wrote {} bytes to {}", img.code.len(), out);
+    std::fs::write(&out, img.code_bytes()).unwrap();
+    println!("wrote {} bytes to {}", img.code.len, out);
 }

--- a/rust/javm-bench/examples/dump.rs
+++ b/rust/javm-bench/examples/dump.rs
@@ -8,8 +8,8 @@ use ssz::Decode;
 fn dump(name: &str, blob: &[u8]) {
     let img = Image::from_ssz_bytes(blob).expect("decode");
     println!("=== {} ===", name);
-    println!("code = {} bytes", img.code.len());
-    let pd = predecode(&img.code);
+    println!("code = {} bytes", img.code.len);
+    let pd = predecode(img.code_bytes());
     println!(
         "predecode: {} insts, decode_error_at = {:?}",
         pd.insts.len(),

--- a/rust/javm-bench/examples/opcode_stats.rs
+++ b/rust/javm-bench/examples/opcode_stats.rs
@@ -240,7 +240,7 @@ fn rs1_of(inst: &Inst) -> Option<u8> {
 
 fn profile_one(name: &str, blob: &[u8]) {
     let image = Image::from_ssz_bytes(blob).expect("decode Image");
-    let code = &image.code[..];
+    let code = image.code_bytes();
 
     let mut single: BTreeMap<&'static str, usize> = BTreeMap::new();
     let mut total = 0usize;

--- a/rust/javm-bench/examples/smoke.rs
+++ b/rust/javm-bench/examples/smoke.rs
@@ -103,7 +103,7 @@ mod imp {
         for w in WORKLOADS {
             eprintln!("=== {} ===", w.name);
             let img = Image::from_ssz_bytes(w.blob).expect("decode Image");
-            eprintln!("  code={}B", img.code.len());
+            eprintln!("  code={}B", img.code.len);
 
             let (er_r, ea_r, rv_r, gas_r) = run_one(w.blob, &mut recomp);
             let (er_i, ea_i, rv_i, gas_i) = run_one(w.blob, &mut interp);

--- a/rust/javm-bench/src/lib.rs
+++ b/rust/javm-bench/src/lib.rs
@@ -78,8 +78,8 @@ impl BuiltCaps {
 
         for (slot, pinned) in &image.pinned_slots {
             let (h, cap) = match pinned {
-                PinnedCap::Data { content, size } => {
-                    let cap = Cap::data_inline_with_size(content, *size);
+                PinnedCap::Data { desc } => {
+                    let cap = Cap::data_from_desc(&image.arena, desc);
                     let h = ssz::hash_tree_root(&cap);
                     (h, Some(cap))
                 }
@@ -94,8 +94,8 @@ impl BuiltCaps {
                 data_caps.push((h, c));
             }
         }
-        for (slot, init) in &image.initial_slots {
-            let cap = Cap::data_inline_with_size(&init.content, init.size);
+        for (slot, desc) in &image.initial_slots {
+            let cap = Cap::data_from_desc(&image.arena, desc);
             let h = ssz::hash_tree_root(&cap);
             initial_hashes.push((slot.clone(), h));
             data_caps.push((h, cap));
@@ -329,8 +329,8 @@ fn publish_image(nub: &mut Nub, image: &Image) -> CapHash {
     let mut initial_hashes: Vec<(Key, CapHash)> = Vec::new();
     for (slot, pinned) in &image.pinned_slots {
         let (h, maybe_cap) = match pinned {
-            PinnedCap::Data { content, size } => {
-                let cap = Cap::data_inline_with_size(content, *size);
+            PinnedCap::Data { desc } => {
+                let cap = Cap::data_from_desc(&image.arena, desc);
                 let h = ssz::hash_tree_root(&cap);
                 (h, Some(cap))
             }
@@ -341,8 +341,8 @@ fn publish_image(nub: &mut Nub, image: &Image) -> CapHash {
             data_caps.push((h, cap));
         }
     }
-    for (slot, init) in &image.initial_slots {
-        let cap = Cap::data_inline_with_size(&init.content, init.size);
+    for (slot, desc) in &image.initial_slots {
+        let cap = Cap::data_from_desc(&image.arena, desc);
         let h = ssz::hash_tree_root(&cap);
         initial_hashes.push((slot.clone(), h));
         data_caps.push((h, cap));

--- a/rust/javm-bench/tests/x3_x4_differential.rs
+++ b/rust/javm-bench/tests/x3_x4_differential.rs
@@ -57,8 +57,7 @@ fn enc(words: &[u32]) -> Vec<u8> {
 }
 
 fn image(code: Vec<u8>) -> Image {
-    let mut img = Image::empty();
-    img.code = code;
+    let mut img = Image::with_code(code);
     img.endpoints.insert(
         Key::from(0u8),
         EndpointDef {

--- a/rust/javm-cap/src/cap/data.rs
+++ b/rust/javm-cap/src/cap/data.rs
@@ -165,6 +165,42 @@ impl PageSlab {
         }
         PageSlab { size, pages }
     }
+
+    /// Build a slab of logical `size` (a [`PAGE_SIZE`] multiple) from sparse
+    /// named pages: `pages` yields `(page_index, content)` for the non-zero
+    /// pages (`content` ≤ `PAGE_SIZE`); every unnamed page is the canonical
+    /// zero page. Reuses `put_page_idx` so the result is the same canonical
+    /// form (all-zero → `Empty`, trailing `Empty` trimmed) a contiguous
+    /// `from_bytes_sized` build would produce — i.e. byte- and hash-identical
+    /// for equivalent logical content. The decode target for
+    /// [`crate::image::DataDesc`].
+    pub fn from_sparse_pages<'a>(
+        size: u64,
+        pages: impl IntoIterator<Item = (u32, &'a [u8])>,
+    ) -> Self {
+        // Mirror `from_bytes_sized`'s size flooring so the two constructors
+        // are equivalent for *every* input — including `size == 0`, which
+        // floors to one `Empty` page rather than a zero-extent slab. A
+        // non-page-multiple `size` rounds up identically. (The deblob
+        // validates `size` is a page multiple, so this only normalizes
+        // degenerate direct-caller input.)
+        let size = size
+            .next_multiple_of(PAGE_SIZE as u64)
+            .max(PAGE_SIZE as u64);
+        let mut slab = PageSlab {
+            size,
+            pages: Vec::new(),
+        };
+        let page_count = slab.page_count();
+        for (page_index, content) in pages {
+            debug_assert!(
+                (page_index as usize) < page_count,
+                "from_sparse_pages: page_index {page_index} >= page_count {page_count}",
+            );
+            slab.put_page_idx(page_index as usize, content);
+        }
+        slab
+    }
 }
 
 impl HashTreeRoot for PageSlab {
@@ -435,6 +471,21 @@ impl DataCap {
     pub fn from_bytes_sized(content: &[u8], target_size: u64) -> Self {
         DataCap {
             backing: Arc::new(PageSlab::from_bytes_sized(content, target_size)),
+            overlay: BTreeMap::new(),
+        }
+    }
+
+    /// Build a clean (overlay-free) `DataCap` from sparse named pages over a
+    /// logical `size`. See [`PageSlab::from_sparse_pages`]. This is the
+    /// decode target for [`crate::image::DataDesc::to_data_cap`]; the result
+    /// is byte- and hash-identical to a contiguous [`Self::from_bytes_sized`]
+    /// of equivalent logical content.
+    pub fn from_sparse_pages<'a>(
+        size: u64,
+        pages: impl IntoIterator<Item = (u32, &'a [u8])>,
+    ) -> Self {
+        DataCap {
+            backing: Arc::new(PageSlab::from_sparse_pages(size, pages)),
             overlay: BTreeMap::new(),
         }
     }

--- a/rust/javm-cap/src/cap/image.rs
+++ b/rust/javm-cap/src/cap/image.rs
@@ -217,6 +217,10 @@ pub struct ImageSlotEntry {
 pub enum ImageConvertError {
     #[error("code region {0} bytes exceeds MAX_CODE_SIZE ({1})")]
     CodeTooLarge(usize, u32),
+    #[error("code ref [{0}, {0}+{1}) out of arena bounds (arena {2} bytes)")]
+    CodeRefOutOfRange(u32, u32, usize),
+    #[error("data desc invalid: {0:?}")]
+    DataDesc(crate::image::DataDescError),
     #[error("memory mapping source path empty")]
     SourcePathEmpty,
     #[error("memory mapping source path too deep (steps={0} > MAX_SOURCE_DEPTH)")]
@@ -256,15 +260,41 @@ pub fn image_cap(
     // is checked lazily, at execution); only its size is a structural
     // bound. Checked before the page-aligned copy so an oversized blob
     // is rejected without allocating it.
-    if image.code.len() > crate::layout::MAX_CODE_SIZE as usize {
+    let code_len = image.code.len as usize;
+    if code_len > crate::layout::MAX_CODE_SIZE as usize {
         return Err(ImageConvertError::CodeTooLarge(
-            image.code.len(),
+            code_len,
             crate::layout::MAX_CODE_SIZE,
         ));
     }
+    // The code window `[arena_off, arena_off + len)` must lie within the
+    // arena (untrusted wire input — fail loud, never slice out of range).
+    let code_in_bounds = (image.code.arena_off as usize)
+        .checked_add(code_len)
+        .is_some_and(|end| end <= image.arena.len());
+    if !code_in_bounds {
+        return Err(ImageConvertError::CodeRefOutOfRange(
+            image.code.arena_off,
+            image.code.len,
+            image.arena.len(),
+        ));
+    }
+    // Every pinned/initial data descriptor must reference the arena
+    // soundly (page-aligned, in-bounds, page_index < page_count, canonical
+    // page order) before any downstream materialization slices the arena.
+    for slot in image.pinned_slots.values() {
+        if let crate::image::PinnedCap::Data { desc } = slot {
+            desc.validate(image.arena.len())
+                .map_err(ImageConvertError::DataDesc)?;
+        }
+    }
+    for desc in image.initial_slots.values() {
+        desc.validate(image.arena.len())
+            .map_err(ImageConvertError::DataDesc)?;
+    }
     // Code: page-aligned copy so the kernel can direct-map it RO at
     // `layout::CODE_BASE`.
-    let code = alloc_page_aligned_code(&image.code);
+    let code = alloc_page_aligned_code(image.code_bytes());
 
     // Endpoints: a sparse, sorted `Key -> EndpointDef` association list (no
     // fixed capacity, no dense `entry_pc == 0` sentinel — presence is what

--- a/rust/javm-cap/src/cap/mod.rs
+++ b/rust/javm-cap/src/cap/mod.rs
@@ -126,6 +126,17 @@ impl Cap {
         Cap::Data(DataCap::from_bytes_sized(bytes, target_size))
     }
 
+    /// Build a heap `Cap::Data` from a page-granular [`crate::image::DataDesc`]
+    /// over an Image `arena`: each named page is materialized from its `PAGE_SIZE`
+    /// arena window, omitted pages are the canonical zero page. The single
+    /// materialization point for Image data slots; the resulting cap hash
+    /// equals `data_inline_with_size(equivalent_contiguous_content, size)`.
+    /// The caller must have validated the descriptor
+    /// ([`crate::image::DataDesc::validate`]) against `arena.len()`.
+    pub fn data_from_desc(arena: &[u8], desc: &crate::image::DataDesc) -> Self {
+        Cap::Data(desc.to_data_cap(arena))
+    }
+
     /// Build an empty heap `Cap::CNode`. A CNode is an unbounded
     /// hash-keyed map (bounded by storage quota), so there is no
     /// `size_log` to declare.

--- a/rust/javm-cap/src/image.rs
+++ b/rust/javm-cap/src/image.rs
@@ -55,7 +55,7 @@ pub struct Image {
     /// Code is mapped RO into the guest address space so the guest can
     /// read its own bytes (AUIPC+load PIC); the JIT executes the native
     /// translation. Empty for codeless images (kernel placeholders).
-    pub code: Vec<u8>,
+    pub code: CodeRef,
     /// Endpoints addressable by a [`Key`] selector (the same byte-string key
     /// type as a cnode slot; in the V1 single-byte ABI the selector is one
     /// byte). Sparse — only declared endpoints are present, with no fixed
@@ -88,6 +88,17 @@ pub struct Image {
     /// Cnode slots holding the `Cap::Instance[Quota{quota_key}]` unit handles.
     /// Same convention as [`Self::gas_slots`].
     pub quota_slots: Vec<Key>,
+    /// Payload arena: a single byte pool holding the code region and every
+    /// data cap's non-zero pages, packed tightly. [`CodeRef`] indexes the
+    /// contiguous code slice; each [`ArenaPageRef`] indexes a window holding
+    /// one page's non-zero prefix (zero-padded back to `PAGE_SIZE` at decode).
+    /// All-zero pages are **never** stored — they are elided and materialize
+    /// as the canonical zero page at deblob, so blobs carry no `.bss`/
+    /// leading-gap zeros, and trailing zeros within a page are dropped too.
+    /// Identical pages may share one window (dedup); sharing is invisible to
+    /// cap identity. Trailing field so the structural header decodes without
+    /// touching the payload.
+    pub arena: Vec<u8>,
 }
 
 /// Endpoint definition: entry PC + register conventions.
@@ -127,10 +138,9 @@ pub struct MemoryMapping {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
 pub enum PinnedCap {
     #[ssz(selector = 0)]
-    /// Pinned `Cap::Data` with bytes baked into the Image. `size`
-    /// may be larger than `content.len()`; trailing bytes are
-    /// zero-filled per the DataCap canonical form.
-    Data { content: Vec<u8>, size: u64 },
+    /// Pinned `Cap::Data` as a page-granular [`DataDesc`] over the Image
+    /// [`arena`](Image::arena). All-zero pages are elided.
+    Data { desc: DataDesc },
     #[ssz(selector = 1)]
     /// Pinned `Cap::Image` by content hash. Cap::Image is itself
     /// content-addressed; inlining a whole sub-Image makes less
@@ -138,19 +148,58 @@ pub enum PinnedCap {
     Image { content_hash: [u8; 32] },
 }
 
-/// Initial `Cap::Data` content for a non-pinned mutable slot. Used
-/// at standalone (root) Instance bootstrap to seed the cnode. A
-/// parented Instance receives its slots from the spawner and
-/// ignores this field.
+/// Initial `Cap::Data` content for a non-pinned mutable slot. Used at
+/// standalone (root) Instance bootstrap to seed the cnode. A parented
+/// Instance receives its slots from the spawner and ignores this field.
+///
+/// Now a [`DataDesc`] (page-granular sparse content over the Image arena);
+/// a pure zero region (stack/heap) is `DataDesc { size, pages: [] }`.
+pub type InitialDataCap = DataDesc;
+
+/// A slice of the Image [`arena`](Image::arena) holding the contiguous
+/// code region: `arena[arena_off .. arena_off + len]` are the raw
+/// RV+C+custom-0 bytes, mapped RO at [`crate::layout::CODE_BASE`]. `len`
+/// is the *exact* (non-page-rounded) code length — the recompiler and
+/// `alloc_page_aligned_code` iterate exactly `len` bytes — while the arena
+/// window itself is page-rounded. `CodeRef::default()` (`{0, 0}`) is a
+/// codeless image.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
+pub struct CodeRef {
+    pub arena_off: u32,
+    pub len: u32,
+}
+
+/// One non-zero page of a [`DataDesc`]: logical page `page_index` is backed
+/// by the arena window `arena[arena_off .. arena_off + len]`, zero-padded to
+/// `PAGE_SIZE` when materialized. `len` (`1..=PAGE_SIZE`) stores only the
+/// page's meaningful prefix — trailing zeros *within* the page are dropped,
+/// so a sub-page-dense region costs `len` bytes, not a full page. Windows are
+/// packed tightly (no `arena_off` alignment). Pages not named by any
+/// `ArenaPageRef` are the canonical zero page (`PageSlot::Empty`).
+///
+/// Named distinctly from the cap-layer `PageRef = Arc<PageBytes>`: this is
+/// a wire descriptor (offsets), not a refcounted runtime page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
+pub struct ArenaPageRef {
+    pub page_index: u32,
+    pub arena_off: u32,
+    pub len: u32,
+}
+
+/// Page-granular sparse content of a data cap. `size` is the full logical
+/// extent in bytes (a `PAGE_SIZE` multiple); `pages` names only the
+/// non-zero pages, sorted by `page_index` (strictly ascending, unique), each
+/// backed by an arena window of its non-zero prefix (zero-padded back to
+/// `PAGE_SIZE` at decode) — see [`ArenaPageRef`].
+///
+/// Decodes (via [`DataDesc::to_data_cap`]) to a `DataCap` whose identity is
+/// over logical `{size, page_index -> content}` only — independent of arena
+/// layout, page ordering, or page sharing. So eliding zero pages and
+/// deduplicating identical pages never change a cap hash.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Encode, Decode, ssz_derive::HashTreeRoot)]
-pub struct InitialDataCap {
-    /// Initial bytes. May be empty for zero-filled regions like
-    /// stack and heap.
-    pub content: Vec<u8>,
-    /// Logical size of the cap. `size` may be larger than
-    /// `content.len()`; trailing bytes are zero-filled when the
-    /// cap is mapped.
+pub struct DataDesc {
     pub size: u64,
+    pub pages: Vec<ArenaPageRef>,
 }
 
 impl Image {
@@ -158,7 +207,7 @@ impl Image {
     /// Useful for tests and as a starting point.
     pub fn empty() -> Self {
         Self {
-            code: Vec::new(),
+            code: CodeRef::default(),
             endpoints: BTreeMap::new(),
             memory_mappings: Vec::new(),
             pinned_slots: BTreeMap::new(),
@@ -166,6 +215,27 @@ impl Image {
             yield_receiver_slot: None,
             gas_slots: Vec::new(),
             quota_slots: Vec::new(),
+            arena: Vec::new(),
+        }
+    }
+
+    /// An Image carrying only `code` (no slots/mappings/endpoints): the
+    /// arena holds the page-rounded code at offset 0. Convenience for the
+    /// test helpers that previously did `let mut img = Image::empty();
+    /// img.code = bytes;` — set the other structural fields after.
+    pub fn with_code(code: Vec<u8>) -> Self {
+        ImageBuilder::new().code(code).build()
+    }
+
+    /// The raw code bytes: the `arena` window `[code.arena_off,
+    /// code.arena_off + code.len)`. Empty slice for a codeless image (or
+    /// an out-of-range `CodeRef`, which the deblob rejects separately).
+    pub fn code_bytes(&self) -> &[u8] {
+        let off = self.code.arena_off as usize;
+        let len = self.code.len as usize;
+        match off.checked_add(len) {
+            Some(end) => self.arena.get(off..end).unwrap_or(&[]),
+            None => &[],
         }
     }
 
@@ -198,6 +268,13 @@ impl Image {
     ///
     /// Single source of truth for Instance memory layout: both engines seed
     /// from this backing, so they materialize byte-identical memory.
+    ///
+    /// **Precondition:** the Image must be deblob-validated
+    /// ([`crate::cap::image::image_cap`], which runs [`DataDesc::validate`] on
+    /// every slot) before this is called — it slices `self.arena` by each
+    /// page-ref's `arena_off`, so an out-of-range ref on an *unvalidated*
+    /// Image would panic. Producers ([`ImageBuilder`]) always emit in-bounds
+    /// page-refs, and the deblob rejects malformed ones loudly.
     pub fn instance_mem_backing(&self) -> crate::cap::data::DataCap {
         use crate::cap::data::{DataCap, PAGE_SIZE};
         let size = self.mem_extent().max(PAGE_SIZE as u64);
@@ -207,23 +284,262 @@ impl Image {
             let Some(target) = mapping.source.target() else {
                 continue;
             };
-            let content: &[u8] =
-                if let Some(PinnedCap::Data { content, .. }) = self.pinned_slots.get(target) {
-                    content
-                } else if let Some(init) = self.initial_slots.get(target) {
-                    &init.content
+            let desc: &DataDesc =
+                if let Some(PinnedCap::Data { desc }) = self.pinned_slots.get(target) {
+                    desc
+                } else if let Some(desc) = self.initial_slots.get(target) {
+                    desc
                 } else {
                     continue;
                 };
-            if content.is_empty() {
-                continue;
-            }
+            // Fold each named page at its absolute offset; omitted pages
+            // stay `PageSlot::Empty` (zero). `put_page` canonicalizes
+            // all-zero -> Empty, so this is byte-identical to the previous
+            // contiguous `content.chunks(PAGE_SIZE)` fold for equal content.
             let base_off = mapping.start.saturating_sub(data_base);
-            for (i, chunk) in content.chunks(PAGE_SIZE).enumerate() {
-                backing.put_page(base_off + (i * PAGE_SIZE) as u64, chunk);
+            for pr in &desc.pages {
+                let off = pr.arena_off as usize;
+                let slice = &self.arena[off..off + pr.len as usize];
+                backing.put_page(base_off + pr.page_index as u64 * PAGE_SIZE as u64, slice);
             }
         }
         backing
+    }
+}
+
+impl DataDesc {
+    /// Number of logical pages (`size / PAGE_SIZE`).
+    pub fn page_count(&self) -> u64 {
+        self.size / crate::cap::data::PAGE_SIZE as u64
+    }
+
+    /// Eagerly validate this descriptor against an arena of `arena_len`
+    /// bytes: `size` a `PAGE_SIZE` multiple; every page-ref page-aligned,
+    /// in-bounds, with `page_index < page_count`; pages strictly ascending
+    /// by `page_index` (canonical, no duplicates). Untrusted wire input is
+    /// checked here — a loud `Err`, never a panic — before any arena slice
+    /// is taken in [`to_data_cap`](Self::to_data_cap).
+    pub fn validate(&self, arena_len: usize) -> Result<(), DataDescError> {
+        use crate::cap::data::PAGE_SIZE;
+        if !self.size.is_multiple_of(PAGE_SIZE as u64) {
+            return Err(DataDescError::SizeNotPageMultiple(self.size));
+        }
+        let page_count = self.page_count();
+        let mut prev: Option<u32> = None;
+        for pr in &self.pages {
+            // A named page stores 1..=PAGE_SIZE non-zero-prefix bytes.
+            if pr.len == 0 || pr.len as usize > PAGE_SIZE {
+                return Err(DataDescError::BadLen(pr.len));
+            }
+            let end = (pr.arena_off as usize)
+                .checked_add(pr.len as usize)
+                .ok_or(DataDescError::OutOfRange(pr.arena_off))?;
+            if end > arena_len {
+                return Err(DataDescError::OutOfRange(pr.arena_off));
+            }
+            if pr.page_index as u64 >= page_count {
+                return Err(DataDescError::PageIndexOutOfRange {
+                    page_index: pr.page_index,
+                    page_count,
+                });
+            }
+            if prev.is_some_and(|p| pr.page_index <= p) {
+                return Err(DataDescError::NotCanonical(pr.page_index));
+            }
+            prev = Some(pr.page_index);
+        }
+        Ok(())
+    }
+
+    /// Materialize the runtime [`DataCap`](crate::cap::data::DataCap): each
+    /// named page is `Loaded` from its `PAGE_SIZE` arena window at its
+    /// absolute `page_index`; omitted pages are the canonical zero page.
+    /// The result is byte-identical (and hash-identical) to
+    /// `DataCap::from_bytes_sized(equivalent_contiguous_content, size)`.
+    ///
+    /// Assumes [`validate`](Self::validate) has passed (the deblob gate); an
+    /// out-of-range `arena_off` panics — the intended loud failure for a
+    /// producer bug.
+    pub fn to_data_cap(&self, arena: &[u8]) -> crate::cap::data::DataCap {
+        crate::cap::data::DataCap::from_sparse_pages(
+            self.size,
+            self.pages.iter().map(|pr| {
+                let off = pr.arena_off as usize;
+                // `len` bytes (the non-zero prefix); `from_content`/`put_page_idx`
+                // zero-pad back to a full `PAGE_SIZE` page.
+                (pr.page_index, &arena[off..off + pr.len as usize])
+            }),
+        )
+    }
+}
+
+/// Structural faults in a [`DataDesc`] relative to the Image arena,
+/// surfaced eagerly at deblob (per the strict-interface rule: fail loud).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataDescError {
+    /// `size` is not a `PAGE_SIZE` multiple.
+    SizeNotPageMultiple(u64),
+    /// A page-ref `len` is 0 or exceeds `PAGE_SIZE`.
+    BadLen(u32),
+    /// A page-ref window `[arena_off, arena_off + len)` exceeds the arena.
+    OutOfRange(u32),
+    /// A `page_index` is `>= size / PAGE_SIZE`.
+    PageIndexOutOfRange { page_index: u32, page_count: u64 },
+    /// Pages are not strictly ascending by `page_index` (unsorted or duplicate).
+    NotCanonical(u32),
+}
+
+/// Pack contiguous `content` (zero-filled to `target_size`) into a
+/// [`DataDesc`] over `arena`, reusing `DataCap::from_bytes_sized`'s exact
+/// canonicalization (all-zero pages elided, the `size` formula) so the
+/// descriptor round-trips to a byte-identical `DataCap`. Identical pages
+/// (keyed by content hash) share one `arena_off` via `dedup`.
+fn pack_data(
+    arena: &mut Vec<u8>,
+    dedup: &mut BTreeMap<[u8; 32], (u32, u32)>,
+    content: &[u8],
+    target_size: u64,
+) -> DataDesc {
+    use crate::cap::data::DataCap;
+    use crate::cap::page::PageSlot;
+    let dc = DataCap::from_bytes_sized(content, target_size);
+    let size = dc.content_len();
+    let mut pages = Vec::new();
+    for p in 0..dc.backing.page_count() {
+        if let PageSlot::Loaded(pb) = dc.backing.page(p) {
+            // A Loaded page is non-zero: store only its prefix up to the last
+            // non-zero byte (trailing zeros within the page zero-pad back
+            // identically at decode), packed tightly. Dedup identical pages by
+            // their full-page content hash → shared (arena_off, len).
+            let (arena_off, len) = *dedup.entry(pb.hash).or_insert_with(|| {
+                let len = pb.bytes.iter().rposition(|&b| b != 0).map_or(1, |i| i + 1);
+                let off = arena.len() as u32;
+                arena.extend_from_slice(&pb.bytes[..len]);
+                (off, len as u32)
+            });
+            pages.push(ArenaPageRef {
+                page_index: p as u32,
+                arena_off,
+                len,
+            });
+        }
+    }
+    DataDesc { size, pages }
+}
+
+/// Canonical Image assembler. Callers supply logical content (code +
+/// per-slot contiguous bytes + size, exactly as before the arena
+/// redesign); [`build`](ImageBuilder::build) packs a single page-granular
+/// `arena` deterministically: code laid contiguously at offset 0, then
+/// each data cap (pinned then initial, in `Key` order) page-split with
+/// all-zero pages elided and byte-identical pages deduplicated. The packing
+/// is a pure function of the logical content, so equal logical Images
+/// produce equal arenas and equal `image_content_hash`es regardless of
+/// builder call order.
+#[derive(Default)]
+pub struct ImageBuilder {
+    code: Vec<u8>,
+    endpoints: BTreeMap<Key, EndpointDef>,
+    memory_mappings: Vec<MemoryMapping>,
+    pinned: BTreeMap<Key, PinnedSpec>,
+    initial: BTreeMap<Key, (Vec<u8>, u64)>,
+    yield_receiver_slot: Option<Key>,
+    gas_slots: Vec<Key>,
+    quota_slots: Vec<Key>,
+}
+
+enum PinnedSpec {
+    Data { content: Vec<u8>, size: u64 },
+    Image { content_hash: [u8; 32] },
+}
+
+impl ImageBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn code(mut self, code: Vec<u8>) -> Self {
+        self.code = code;
+        self
+    }
+    pub fn endpoint(mut self, key: Key, ep: EndpointDef) -> Self {
+        self.endpoints.insert(key, ep);
+        self
+    }
+    pub fn mapping(mut self, m: MemoryMapping) -> Self {
+        self.memory_mappings.push(m);
+        self
+    }
+    pub fn pinned_data(mut self, key: Key, content: Vec<u8>, size: u64) -> Self {
+        self.pinned.insert(key, PinnedSpec::Data { content, size });
+        self
+    }
+    pub fn pinned_image(mut self, key: Key, content_hash: [u8; 32]) -> Self {
+        self.pinned.insert(key, PinnedSpec::Image { content_hash });
+        self
+    }
+    pub fn initial_data(mut self, key: Key, content: Vec<u8>, size: u64) -> Self {
+        self.initial.insert(key, (content, size));
+        self
+    }
+    pub fn yield_receiver_slot(mut self, slot: Option<Key>) -> Self {
+        self.yield_receiver_slot = slot;
+        self
+    }
+    pub fn gas_slots(mut self, slots: Vec<Key>) -> Self {
+        self.gas_slots = slots;
+        self
+    }
+    pub fn quota_slots(mut self, slots: Vec<Key>) -> Self {
+        self.quota_slots = slots;
+        self
+    }
+
+    pub fn build(self) -> Image {
+        let mut arena: Vec<u8> = Vec::new();
+        let mut dedup: BTreeMap<[u8; 32], (u32, u32)> = BTreeMap::new();
+
+        // Data caps first, in deterministic Key order (pinned, then
+        // initial). Each non-zero page is appended as its non-zero prefix
+        // (trailing-zero-trimmed, packed tightly), with identical pages
+        // deduplicated by content hash.
+        let mut pinned_slots: BTreeMap<Key, PinnedCap> = BTreeMap::new();
+        for (key, spec) in self.pinned {
+            let pc = match spec {
+                PinnedSpec::Data { content, size } => PinnedCap::Data {
+                    desc: pack_data(&mut arena, &mut dedup, &content, size),
+                },
+                PinnedSpec::Image { content_hash } => PinnedCap::Image { content_hash },
+            };
+            pinned_slots.insert(key, pc);
+        }
+        let mut initial_slots: BTreeMap<Key, DataDesc> = BTreeMap::new();
+        for (key, (content, size)) in self.initial {
+            initial_slots.insert(key, pack_data(&mut arena, &mut dedup, &content, size));
+        }
+
+        // Code last: contiguous, stored at its EXACT length. The deblob
+        // re-copies code into a fresh aligned slab, so its arena offset
+        // needs no alignment.
+        let code = if self.code.is_empty() {
+            CodeRef::default()
+        } else {
+            let arena_off = arena.len() as u32;
+            let len = self.code.len() as u32;
+            arena.extend_from_slice(&self.code);
+            CodeRef { arena_off, len }
+        };
+
+        Image {
+            code,
+            endpoints: self.endpoints,
+            memory_mappings: self.memory_mappings,
+            pinned_slots,
+            initial_slots,
+            yield_receiver_slot: self.yield_receiver_slot,
+            gas_slots: self.gas_slots,
+            quota_slots: self.quota_slots,
+            arena,
+        }
     }
 }
 

--- a/rust/javm-cap/src/lib.rs
+++ b/rust/javm-cap/src/lib.rs
@@ -47,7 +47,8 @@ pub use cap::{Cap, CapHash, MAX_SOURCE_DEPTH, NUM_REGS};
 pub use error::{CapError, OpError};
 pub use hash::{Blake2b256, Hash, Hasher};
 pub use image::{
-    Image, InitialDataCap, PinnedCap, chain_extend, chain_genesis, image_content_hash,
+    ArenaPageRef, CodeRef, DataDesc, DataDescError, Image, ImageBuilder, InitialDataCap, PinnedCap,
+    chain_extend, chain_genesis, image_content_hash,
 };
 pub use kernel_image::{ALL_KERNEL_IMAGES, KernelImage, kernel_image_hash, recognize_kernel_image};
 pub use slot::{Key, MAX_KEY_LEN, SlotPath, key_from_regs, key_to_regs};

--- a/rust/javm-cap/tests/cap_view.rs
+++ b/rust/javm-cap/tests/cap_view.rs
@@ -6,7 +6,7 @@
 //! [`DataCap::flush`] folds the overlay into a fresh backing.
 
 use javm_cap::cap::data::PageResolution;
-use javm_cap::{Cap, DataCap, PAGE_SIZE};
+use javm_cap::{Cap, DataCap, PAGE_SIZE, PageSlot};
 
 /// Build a 2-page cap whose page 0 is nonzero (`marker`) and page 1 zero.
 fn cap_2pages(marker: &[u8]) -> DataCap {
@@ -184,4 +184,83 @@ fn place_shared_clamps_to_extent() {
     assert_eq!(page_at(&mem, 0)[0], 0); // page 0 untouched
     assert_eq!(page_at(&mem, 1)[0], 0x55); // page 1 placed
     assert_eq!(mem.page_count(), 2); // extent unchanged
+}
+
+/// `DataCap::from_sparse_pages` (the Image-arena wire-decode constructor) must
+/// produce a cap byte- and hash-identical to the contiguous `from_bytes_sized`
+/// for the same logical content. This is the load-bearing invariant of the
+/// arena format: a sparse blob (zero pages elided) decodes to the *same*
+/// `DataCap` — and thus the same cap hash — the old inline form produced, so
+/// the conformance oracle and both engines never fork. Pinned here (incl.
+/// `size == 0`, a partial last page, and interior/trailing zero pages) so a
+/// future change to either constructor cannot silently diverge.
+#[test]
+fn from_sparse_pages_matches_from_bytes_sized() {
+    let p = PAGE_SIZE;
+    // page0 nonzero, page1 ALL-ZERO (must be elided), page2 nonzero.
+    let mut interior = vec![0x11u8; p];
+    interior.extend(core::iter::repeat_n(0u8, p));
+    interior.extend(core::iter::repeat_n(0x22u8, p));
+
+    let cases: &[(Vec<u8>, u64)] = &[
+        (vec![], 0),                        // degenerate: floors to one empty page
+        (vec![], p as u64),                 // pure zero page
+        (vec![0x7u8; 10], p as u64),        // content < size (partial page)
+        (vec![0x7u8; p], p as u64),         // exactly one page
+        (vec![0x9u8; 5000], 2 * p as u64),  // spans two pages, partial last
+        (vec![0x3u8; 3 * p], 3 * p as u64), // three full pages
+        (interior.clone(), 3 * p as u64),   // interior zero page (elided)
+        (vec![0x4u8; p], 4 * p as u64),     // one page + trailing zero pages
+    ];
+
+    for (content, target_size) in cases {
+        let inline = DataCap::from_bytes_sized(content, *target_size);
+        // Reconstruct sparsely from inline's NON-ZERO pages only — exactly
+        // what the wire decode does (omitted pages are the canonical zero).
+        let pages: Vec<(u32, Vec<u8>)> = (0..inline.backing.page_count())
+            .filter_map(|i| match inline.backing.page(i) {
+                PageSlot::Loaded(pb) => Some((i as u32, pb.bytes.clone())),
+                _ => None,
+            })
+            .collect();
+        let inline_clen = inline.content_len();
+        let sparse =
+            DataCap::from_sparse_pages(inline_clen, pages.iter().map(|(i, b)| (*i, b.as_slice())));
+        let sparse_clen = sparse.content_len();
+        assert_eq!(
+            Cap::Data(inline).cap_hash(),
+            Cap::Data(sparse).cap_hash(),
+            "sparse vs inline cap hash mismatch (content.len()={}, size={target_size})",
+            content.len(),
+        );
+        assert_eq!(inline_clen, sparse_clen, "content_len mismatch");
+    }
+
+    // `size == 0` specifically: both floor to a single canonical empty page.
+    assert_eq!(
+        Cap::Data(DataCap::from_sparse_pages(
+            0,
+            core::iter::empty::<(u32, &[u8])>()
+        ))
+        .cap_hash(),
+        Cap::Data(DataCap::from_bytes_sized(&[], 0)).cap_hash(),
+    );
+
+    // A `len`-trimmed page (trailing zeros within the page dropped) zero-pads
+    // back to the identical page — so the wire trim is hash-invisible.
+    let mut full_page = vec![0u8; p];
+    full_page[..3].copy_from_slice(&[1, 2, 3]);
+    assert_eq!(
+        Cap::Data(DataCap::from_sparse_pages(
+            p as u64,
+            [(0u32, &full_page[..3])]
+        ))
+        .cap_hash(),
+        Cap::Data(DataCap::from_sparse_pages(
+            p as u64,
+            [(0u32, full_page.as_slice())]
+        ))
+        .cap_hash(),
+        "trimmed page must zero-pad to the same cap as the full page",
+    );
 }

--- a/rust/javm-cap/tests/image.rs
+++ b/rust/javm-cap/tests/image.rs
@@ -1,7 +1,7 @@
 use javm_cap::image::{EndpointDef, MemoryMapping};
 use javm_cap::{
-    Blake2b256, Image, InitialDataCap, Key, PinnedCap, SlotPath, chain_extend, chain_genesis,
-    image_cap, image_content_hash,
+    ArenaPageRef, Blake2b256, DataDesc, Image, ImageBuilder, Key, PAGE_SIZE, PinnedCap, SlotPath,
+    chain_extend, chain_genesis, image_cap, image_content_hash,
 };
 use ssz::Decode as _;
 use std::collections::BTreeMap;
@@ -18,53 +18,42 @@ fn empty_image_hashes_deterministically() {
 
 #[test]
 fn image_ssz_roundtrip() {
-    let mut img = Image::empty();
-    img.code = b"sample code".to_vec();
-    img.endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            entry_pc: 0x100,
-            arg_registers: 1,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
     let mut initial_regs = BTreeMap::new();
     initial_regs.insert(1u8, 0x4000);
-    img.endpoints.insert(
-        Key::from(255u8),
-        EndpointDef {
-            entry_pc: 0xDEADBEEF,
-            arg_registers: 4,
-            arg_cnode_size: 8,
-            initial_regs,
-        },
-    );
-    img.memory_mappings.push(MemoryMapping {
-        start: 0x1000,
-        size: 0x4000,
-        source: SlotPath::root(Key::from(65u8)),
-    });
-    img.memory_mappings.push(MemoryMapping {
-        start: 0x5000,
-        size: 0x2000,
-        source: SlotPath::root(Key::from(3u8)),
-    });
-    img.pinned_slots.insert(
-        Key::from(11u8),
-        PinnedCap::Data {
-            content: vec![0xAB; 1024],
-            size: 4096,
-        },
-    );
-    img.initial_slots.insert(
-        Key::from(65u8),
-        InitialDataCap {
-            content: Vec::new(),
+    let img = ImageBuilder::new()
+        .code(b"sample code".to_vec())
+        .endpoint(
+            Key::from(0u8),
+            EndpointDef {
+                entry_pc: 0x100,
+                arg_registers: 1,
+                arg_cnode_size: 0,
+                initial_regs: BTreeMap::new(),
+            },
+        )
+        .endpoint(
+            Key::from(255u8),
+            EndpointDef {
+                entry_pc: 0xDEADBEEF,
+                arg_registers: 4,
+                arg_cnode_size: 8,
+                initial_regs,
+            },
+        )
+        .mapping(MemoryMapping {
+            start: 0x1000,
             size: 0x4000,
-        },
-    );
-    img.yield_receiver_slot = Some(Key::from(9u8));
+            source: SlotPath::root(Key::from(65u8)),
+        })
+        .mapping(MemoryMapping {
+            start: 0x5000,
+            size: 0x2000,
+            source: SlotPath::root(Key::from(3u8)),
+        })
+        .pinned_data(Key::from(11u8), vec![0xAB; 1024], 4096)
+        .initial_data(Key::from(65u8), Vec::new(), 0x4000)
+        .yield_receiver_slot(Some(Key::from(9u8)))
+        .build();
 
     let bytes = ssz::Encode::as_ssz_bytes(&img);
     let decoded = Image::from_ssz_bytes(&bytes).expect("decode");
@@ -73,10 +62,8 @@ fn image_ssz_roundtrip() {
 
 #[test]
 fn different_code_different_hash() {
-    let mut a = Image::empty();
-    a.code = b"AAAA".to_vec();
-    let mut b = Image::empty();
-    b.code = b"BBBB".to_vec();
+    let a = Image::with_code(b"AAAA".to_vec());
+    let b = Image::with_code(b"BBBB".to_vec());
     assert_ne!(image_content_hash(&a), image_content_hash(&b));
 }
 
@@ -98,40 +85,18 @@ fn endpoints_affect_hash() {
 
 #[test]
 fn pinned_slots_order_independent() {
-    // BTreeMap iteration is deterministic; insertion order
+    // BTreeMap iteration is deterministic; builder call order
     // shouldn't matter for the resulting hash.
-    let mut a = Image::empty();
-    a.pinned_slots.insert(
-        Key::from(3u8),
-        PinnedCap::Data {
-            content: vec![0xAA; 100],
-            size: 100,
-        },
-    );
-    a.pinned_slots.insert(
-        Key::from(7u8),
-        PinnedCap::Data {
-            content: vec![0xBB; 200],
-            size: 200,
-        },
-    );
+    let a = ImageBuilder::new()
+        .pinned_data(Key::from(3u8), vec![0xAA; 100], 100)
+        .pinned_data(Key::from(7u8), vec![0xBB; 200], 200)
+        .build();
 
-    let mut b = Image::empty();
-    // Different insertion order.
-    b.pinned_slots.insert(
-        Key::from(7u8),
-        PinnedCap::Data {
-            content: vec![0xBB; 200],
-            size: 200,
-        },
-    );
-    b.pinned_slots.insert(
-        Key::from(3u8),
-        PinnedCap::Data {
-            content: vec![0xAA; 100],
-            size: 100,
-        },
-    );
+    // Different builder call order.
+    let b = ImageBuilder::new()
+        .pinned_data(Key::from(7u8), vec![0xBB; 200], 200)
+        .pinned_data(Key::from(3u8), vec![0xAA; 100], 100)
+        .build();
 
     assert_eq!(image_content_hash(&a), image_content_hash(&b));
 }
@@ -145,12 +110,10 @@ fn chain_genesis_equals_content_hash() {
 #[test]
 fn chain_extend_changes_with_new_image() {
     let img_a = Image::empty();
-    let mut img_b = Image::empty();
-    img_b.code = b"B".to_vec();
+    let img_b = Image::with_code(b"B".to_vec());
     let prev = chain_genesis::<H>(&img_a);
     let extended_b = chain_extend::<H>(&prev, &img_b);
-    let mut img_c = Image::empty();
-    img_c.code = b"C".to_vec();
+    let img_c = Image::with_code(b"C".to_vec());
     let extended_c = chain_extend::<H>(&prev, &img_c);
     assert_ne!(extended_b, extended_c);
 }
@@ -161,10 +124,8 @@ fn chain_extend_is_associative_under_sequence() {
     // chain hash. Calling chain_extend twice in different orders
     // gives different chains (as expected — chain order matters).
     let img_a = Image::empty();
-    let mut img_b = Image::empty();
-    img_b.code = b"B".to_vec();
-    let mut img_c = Image::empty();
-    img_c.code = b"C".to_vec();
+    let img_b = Image::with_code(b"B".to_vec());
+    let img_c = Image::with_code(b"C".to_vec());
 
     let chain_abc = {
         let g = chain_genesis::<H>(&img_a);
@@ -195,31 +156,20 @@ fn mapping_is_pinned_classifies_by_source_slot() {
     // the shared classifier the interpreter drivers (`javm` `build_entry`,
     // `nub-arch-local`) use so they agree with the recompiler's
     // pinned-vs-initial slot classification.
-    let mut img = Image::empty();
-    img.memory_mappings.push(MemoryMapping {
-        start: 0x1000_0000,
-        size: 0x1000,
-        source: SlotPath::root(Key::from(5u8)),
-    });
-    img.memory_mappings.push(MemoryMapping {
-        start: 0x1000_1000,
-        size: 0x1000,
-        source: SlotPath::root(Key::from(6u8)),
-    });
-    img.pinned_slots.insert(
-        Key::from(5u8),
-        PinnedCap::Data {
-            content: vec![1, 2, 3],
+    let img = ImageBuilder::new()
+        .mapping(MemoryMapping {
+            start: 0x1000_0000,
             size: 0x1000,
-        },
-    );
-    img.initial_slots.insert(
-        Key::from(6u8),
-        InitialDataCap {
-            content: vec![4, 5, 6],
+            source: SlotPath::root(Key::from(5u8)),
+        })
+        .mapping(MemoryMapping {
+            start: 0x1000_1000,
             size: 0x1000,
-        },
-    );
+            source: SlotPath::root(Key::from(6u8)),
+        })
+        .pinned_data(Key::from(5u8), vec![1, 2, 3], 0x1000)
+        .initial_data(Key::from(6u8), vec![4, 5, 6], 0x1000)
+        .build();
 
     let dummy = [0u8; 32];
     let cap = image_cap(&img, &[(Key::from(5u8), dummy)], &[(Key::from(6u8), dummy)]).unwrap();
@@ -238,4 +188,112 @@ fn mgmt_copy_preserves_chain_hash() {
     let chain = chain_genesis::<H>(&img);
     let copy = chain;
     assert_eq!(chain, copy);
+}
+
+#[test]
+fn sparse_data_slot_encodes_smaller_than_inlined() {
+    // A data slot whose logical content is mostly zeros: one non-zero
+    // page followed by many all-zero pages. The builder elides the
+    // zero pages, so the arena (and the whole Image SSZ) is far smaller
+    // than the same logical content stored densely (every page inlined).
+    const LOGICAL_PAGES: usize = 16;
+    let size = (LOGICAL_PAGES * PAGE_SIZE) as u64;
+
+    // Only the first page is non-zero; the rest are .bss-style zeros.
+    let mut content = vec![0u8; LOGICAL_PAGES * PAGE_SIZE];
+    content[..PAGE_SIZE].fill(0xCD);
+
+    // Sparse: builder elides the 15 all-zero pages.
+    let sparse = ImageBuilder::new()
+        .pinned_data(Key::from(1u8), content, size)
+        .build();
+    // The arena holds exactly the one named page.
+    assert_eq!(
+        sparse.arena.len(),
+        PAGE_SIZE,
+        "only the non-zero page stored"
+    );
+    match sparse.pinned_slots.get(&Key::from(1u8)) {
+        Some(PinnedCap::Data { desc }) => {
+            assert_eq!(desc.size, size);
+            assert_eq!(desc.pages.len(), 1, "15 zero pages elided");
+            assert_eq!(desc.page_count(), LOGICAL_PAGES as u64);
+        }
+        other => panic!("expected pinned Data, got {other:?}"),
+    }
+
+    // Dense: hand-build the same logical content with every page named
+    // and inlined into the arena (the pre-elision wire form).
+    let mut arena = vec![0u8; LOGICAL_PAGES * PAGE_SIZE];
+    arena[..PAGE_SIZE].fill(0xCD);
+    let pages: Vec<ArenaPageRef> = (0..LOGICAL_PAGES)
+        .map(|p| ArenaPageRef {
+            page_index: p as u32,
+            arena_off: (p * PAGE_SIZE) as u32,
+            len: PAGE_SIZE as u32,
+        })
+        .collect();
+    let mut dense = Image::empty();
+    dense.pinned_slots.insert(
+        Key::from(1u8),
+        PinnedCap::Data {
+            desc: DataDesc { size, pages },
+        },
+    );
+    dense.arena = arena;
+
+    // Same logical content (byte-identical materialized memory) ...
+    let sparse_desc = match sparse.pinned_slots.get(&Key::from(1u8)) {
+        Some(PinnedCap::Data { desc }) => desc,
+        _ => unreachable!(),
+    };
+    let dense_desc = match dense.pinned_slots.get(&Key::from(1u8)) {
+        Some(PinnedCap::Data { desc }) => desc,
+        _ => unreachable!(),
+    };
+    assert_eq!(
+        ssz::hash_tree_root(&sparse_desc.to_data_cap(&sparse.arena)),
+        ssz::hash_tree_root(&dense_desc.to_data_cap(&dense.arena)),
+        "sparse and dense materialize identical data caps",
+    );
+
+    // ... yet the sparse SSZ is far smaller.
+    let sparse_len = ssz::Encode::as_ssz_bytes(&sparse).len();
+    let dense_len = ssz::Encode::as_ssz_bytes(&dense).len();
+    assert!(
+        sparse_len < dense_len,
+        "sparse SSZ ({sparse_len} B) should be smaller than inlined dense ({dense_len} B)",
+    );
+}
+
+#[test]
+fn equal_logical_image_two_builds_same_hash() {
+    // Building the same logical Image two ways — here a data slot whose
+    // content has a duplicated page (which the builder dedups in the
+    // arena) plus a different builder call order — yields the SAME
+    // image_content_hash. Cap identity is over logical {size, pages},
+    // independent of arena layout / dedup / call order.
+    let mut dup_content = vec![0u8; 3 * PAGE_SIZE];
+    dup_content[..PAGE_SIZE].fill(0x11);
+    dup_content[2 * PAGE_SIZE..].fill(0x11); // page 0 and page 2 identical
+    let size = (3 * PAGE_SIZE) as u64;
+
+    let a = ImageBuilder::new()
+        .code(b"shared".to_vec())
+        .pinned_data(Key::from(2u8), dup_content.clone(), size)
+        .initial_data(Key::from(9u8), vec![0x22; PAGE_SIZE], PAGE_SIZE as u64)
+        .build();
+
+    // Different builder call order; identical logical content.
+    let b = ImageBuilder::new()
+        .initial_data(Key::from(9u8), vec![0x22; PAGE_SIZE], PAGE_SIZE as u64)
+        .pinned_data(Key::from(2u8), dup_content, size)
+        .code(b"shared".to_vec())
+        .build();
+
+    assert_eq!(
+        image_content_hash(&a),
+        image_content_hash(&b),
+        "logical-equal images hash equal regardless of build order / dedup",
+    );
 }

--- a/rust/javm-cap/tests/rkyv_roundtrip.rs
+++ b/rust/javm-cap/tests/rkyv_roundtrip.rs
@@ -46,8 +46,7 @@ fn rkyv_archive_roundtrip_data_cap() {
 
 #[test]
 fn image_cap_roundtrip_preserves_hash() {
-    let mut img = Image::empty();
-    img.code = vec![0u8, 10u8, 42];
+    let mut img = Image::with_code(vec![0u8, 10u8, 42]);
     let mut endpoints = BTreeMap::new();
     endpoints.insert(
         Key::from(0u8),

--- a/rust/javm-fuzz/src/replay.rs
+++ b/rust/javm-fuzz/src/replay.rs
@@ -9,7 +9,7 @@
 use crate::{Program, SIG_BASE, encode};
 use javm_bench::{BuiltCaps, RawRun, run_interpreter_raw, run_recompiler_raw};
 use javm_cap::abi::SCRATCHPAD_SLOT;
-use javm_cap::image::{EndpointDef, Image, InitialDataCap, MemoryMapping, PinnedCap};
+use javm_cap::image::{EndpointDef, Image, ImageBuilder, MemoryMapping};
 use javm_cap::slot::{Key, SlotPath};
 use std::collections::BTreeMap;
 
@@ -20,24 +20,18 @@ const WINDOW_SLOT: u32 = 1;
 /// signature epilogue stores the `SIG_BYTES`-byte register file into its head).
 const SIG_REGION_BYTES: u64 = 4096;
 
-/// Map the scratchpad (`slot[0]`) signature region at [`SIG_BASE`] into `img`: an
-/// empty-content `InitialDataCap` of one page. The guest's signature epilogue
-/// CoWs this region during the run; both engines surface its effective bytes as
-/// the run's register signature.
-fn add_signature_region(img: &mut Image) {
+/// Map the scratchpad (`slot[0]`) signature region at [`SIG_BASE`] into the
+/// builder: an empty-content initial data slot of one page. The guest's
+/// signature epilogue CoWs this region during the run; both engines surface its
+/// effective bytes as the run's register signature.
+fn add_signature_region(b: ImageBuilder) -> ImageBuilder {
     let slot = Key::from(SCRATCHPAD_SLOT);
-    img.memory_mappings.push(MemoryMapping {
+    b.mapping(MemoryMapping {
         start: SIG_BASE as u64,
         size: SIG_REGION_BYTES,
         source: SlotPath::root(slot.clone()),
-    });
-    img.initial_slots.insert(
-        slot,
-        InitialDataCap {
-            content: Vec::new(),
-            size: SIG_REGION_BYTES,
-        },
-    );
+    })
+    .initial_data(slot, Vec::new(), SIG_REGION_BYTES)
 }
 
 /// Build an `Image` from raw instruction `words` (+ `ecalli 0` terminator)
@@ -48,31 +42,25 @@ fn add_signature_region(img: &mut Image) {
 pub fn image_with_ro(words: &[u32], ro_start: u32, ro_bytes: &[u8]) -> Image {
     let mut code = encode::enc(words);
     code.extend_from_slice(&encode::enc(&[encode::HALT]));
-    let mut img = Image::empty();
-    img.code = code;
-    img.endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            entry_pc: 0,
-            arg_registers: 0,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
     let slot = Key::from((WINDOW_SLOT + 1) as u8);
-    img.memory_mappings.push(MemoryMapping {
-        start: ro_start as u64,
-        size: ro_bytes.len() as u64,
-        source: SlotPath::root(slot.clone()),
-    });
-    img.pinned_slots.insert(
-        slot,
-        PinnedCap::Data {
-            content: ro_bytes.to_vec(),
+    ImageBuilder::new()
+        .code(code)
+        .endpoint(
+            Key::from(0u8),
+            EndpointDef {
+                entry_pc: 0,
+                arg_registers: 0,
+                arg_cnode_size: 0,
+                initial_regs: BTreeMap::new(),
+            },
+        )
+        .mapping(MemoryMapping {
+            start: ro_start as u64,
             size: ro_bytes.len() as u64,
-        },
-    );
-    img
+            source: SlotPath::root(slot.clone()),
+        })
+        .pinned_data(slot, ro_bytes.to_vec(), ro_bytes.len() as u64)
+        .build()
 }
 
 /// Build an `Image` from raw `words` with **several** pinned read-only data
@@ -83,9 +71,7 @@ pub fn image_with_ro(words: &[u32], ro_start: u32, ro_bytes: &[u8]) -> Image {
 pub fn image_with_ro_caps(words: &[u32], caps: &[(u32, &[u8])]) -> Image {
     let mut code = encode::enc(words);
     code.extend_from_slice(&encode::enc(&[encode::HALT]));
-    let mut img = Image::empty();
-    img.code = code;
-    img.endpoints.insert(
+    let mut b = ImageBuilder::new().code(code).endpoint(
         Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
@@ -96,20 +82,15 @@ pub fn image_with_ro_caps(words: &[u32], caps: &[(u32, &[u8])]) -> Image {
     );
     for (i, (start, bytes)) in caps.iter().enumerate() {
         let slot = Key::from((WINDOW_SLOT + 1 + i as u32) as u8);
-        img.memory_mappings.push(MemoryMapping {
-            start: *start as u64,
-            size: bytes.len() as u64,
-            source: SlotPath::root(slot.clone()),
-        });
-        img.pinned_slots.insert(
-            slot,
-            PinnedCap::Data {
-                content: bytes.to_vec(),
+        b = b
+            .mapping(MemoryMapping {
+                start: *start as u64,
                 size: bytes.len() as u64,
-            },
-        );
+                source: SlotPath::root(slot.clone()),
+            })
+            .pinned_data(slot, bytes.to_vec(), bytes.len() as u64);
     }
-    img
+    b.build()
 }
 
 /// Run a pre-built `Image` through both engines and compare.
@@ -140,9 +121,7 @@ pub fn image_for(prog: &Program) -> Image {
     let mut code = prog.code_bytes();
     code.extend_from_slice(&encode::enc(&[encode::HALT]));
 
-    let mut img = Image::empty();
-    img.code = code;
-    img.endpoints.insert(
+    let mut b = ImageBuilder::new().code(code).endpoint(
         Key::from(0u8),
         EndpointDef {
             entry_pc: 0,
@@ -151,25 +130,20 @@ pub fn image_for(prog: &Program) -> Image {
             initial_regs: prog.init_regs.clone(),
         },
     );
-    add_signature_region(&mut img);
+    b = add_signature_region(b);
     if let Some(mem) = &prog.init_mem {
         let slot = Key::from((WINDOW_SLOT) as u8);
-        img.memory_mappings.push(MemoryMapping {
-            start: mem.start as u64,
-            size: mem.bytes.len() as u64,
-            source: SlotPath::root(slot.clone()),
-        });
         // Empty content → no overlay; the mapping only sizes the data extent,
         // and the window materializes as ephemeral zero pages on both engines.
-        img.initial_slots.insert(
-            slot,
-            InitialDataCap {
-                content: Vec::new(),
+        b = b
+            .mapping(MemoryMapping {
+                start: mem.start as u64,
                 size: mem.bytes.len() as u64,
-            },
-        );
+                source: SlotPath::root(slot.clone()),
+            })
+            .initial_data(slot, Vec::new(), mem.bytes.len() as u64);
     }
-    img
+    b.build()
 }
 
 /// Interpreter outcome for `prog`.

--- a/rust/javm-guest-tests/tests/call_status.rs
+++ b/rust/javm-guest-tests/tests/call_status.rs
@@ -56,16 +56,10 @@ fn endpoints(extra1: bool) -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, eps: BTreeMap<Key, EndpointDef>, recv: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: eps,
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: recv,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = eps;
+    img.yield_receiver_slot = recv;
+    img
 }
 
 fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {

--- a/rust/javm-guest-tests/tests/conformance.rs
+++ b/rust/javm-guest-tests/tests/conformance.rs
@@ -82,8 +82,8 @@ mod backend {
         let mut pinned_hashes = Vec::new();
         for (slot, pinned) in &image.pinned_slots {
             let h = match pinned {
-                PinnedCap::Data { content, size } => {
-                    let cap = Cap::data_inline_with_size(content, *size);
+                PinnedCap::Data { desc } => {
+                    let cap = Cap::data_from_desc(&image.arena, desc);
                     nub.put_cap(&cap)
                         .unwrap_or_else(|e| panic!("endpoint {ep}: put_cap pinned data: {e}"))
                 }
@@ -92,8 +92,8 @@ mod backend {
             pinned_hashes.push((slot.clone(), h));
         }
         let mut initial_hashes = Vec::new();
-        for (slot, init) in &image.initial_slots {
-            let cap = Cap::data_inline_with_size(&init.content, init.size);
+        for (slot, desc) in &image.initial_slots {
+            let cap = Cap::data_from_desc(&image.arena, desc);
             let h = nub
                 .put_cap(&cap)
                 .unwrap_or_else(|e| panic!("endpoint {ep}: put_cap initial data: {e}"));

--- a/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
+++ b/rust/javm-guest-tests/tests/derive_spawn_pinned.rs
@@ -19,7 +19,7 @@
 //! register-setup code is needed.
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use javm_cap::image::{EndpointDef, Image, PinnedCap};
+use javm_cap::image::{EndpointDef, Image, ImageBuilder};
 use javm_cap::{Cap, CapHash, Key, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
@@ -47,42 +47,22 @@ fn child_image() -> Image {
 /// Parent image: one `ecalli OP_DERIVE_SPAWN`. `image_slot` (slot 3) is a
 /// pinned `Cap::Image`; the dst (slot 66) is a pinned `Cap::Data`.
 fn parent_image(child_hash: CapHash) -> Image {
-    let mut endpoints = BTreeMap::new();
-    endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            // Code-region byte offset (the runtime adds CODE_BASE); the
-            // single instruction sits at offset 0.
-            entry_pc: 0,
-            arg_registers: 0,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
-    let mut pinned_slots = BTreeMap::new();
-    pinned_slots.insert(
-        Key::from(IMAGE_SLOT),
-        PinnedCap::Image {
-            content_hash: child_hash,
-        },
-    );
-    pinned_slots.insert(
-        Key::from(PINNED_DST),
-        PinnedCap::Data {
-            content: vec![0xAB; 16],
-            size: 4096,
-        },
-    );
-    Image {
-        code: ecalli(OP_DERIVE_SPAWN).to_le_bytes().to_vec(),
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots,
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    ImageBuilder::new()
+        .code(ecalli(OP_DERIVE_SPAWN).to_le_bytes().to_vec())
+        .endpoint(
+            Key::from(0u8),
+            EndpointDef {
+                // Code-region byte offset (the runtime adds CODE_BASE); the
+                // single instruction sits at offset 0.
+                entry_pc: 0,
+                arg_registers: 0,
+                arg_cnode_size: 0,
+                initial_regs: BTreeMap::new(),
+            },
+        )
+        .pinned_image(Key::from(IMAGE_SLOT), child_hash)
+        .pinned_data(Key::from(PINNED_DST), vec![0xAB; 16], 4096)
+        .build()
 }
 
 /// φ[7]=image_slot, φ[8]=cnode_slot(unused), φ[9]=dst — matching the 3-arg

--- a/rust/javm-guest-tests/tests/gas_slots.rs
+++ b/rust/javm-guest-tests/tests/gas_slots.rs
@@ -51,16 +51,11 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots,
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img.gas_slots = gas_slots;
+    img
 }
 
 fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {

--- a/rust/javm-guest-tests/tests/host_image_hash_chain.rs
+++ b/rust/javm-guest-tests/tests/host_image_hash_chain.rs
@@ -14,7 +14,7 @@
 //! Gated to the nub Hyperlight host (linux-x86_64), like the other guest tests.
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use javm_cap::image::{EndpointDef, Image, PinnedCap};
+use javm_cap::image::{EndpointDef, Image, ImageBuilder};
 use javm_cap::{Cap, CapHash, Key, NUM_REGS};
 use nub::Nub;
 use std::collections::BTreeMap;
@@ -45,43 +45,23 @@ fn child_image() -> Image {
 /// halt). `IMAGE_SLOT` is a pinned `Cap::Image` (the src); `PINNED_DST` is a
 /// pinned `Cap::Data`. Endpoint args φ[7]=src, φ[8]=dst.
 fn parent_image(child_hash: CapHash) -> Image {
-    let mut endpoints = BTreeMap::new();
-    endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            entry_pc: 0,
-            arg_registers: 0,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
-    let mut pinned_slots = BTreeMap::new();
-    pinned_slots.insert(
-        Key::from(IMAGE_SLOT),
-        PinnedCap::Image {
-            content_hash: child_hash,
-        },
-    );
-    pinned_slots.insert(
-        Key::from(PINNED_DST),
-        PinnedCap::Data {
-            content: vec![0xAB; 16],
-            size: 4096,
-        },
-    );
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_IMAGE_HASH_CHAIN).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
-    Image {
-        code,
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots,
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    ImageBuilder::new()
+        .code(code)
+        .endpoint(
+            Key::from(0u8),
+            EndpointDef {
+                entry_pc: 0,
+                arg_registers: 0,
+                arg_cnode_size: 0,
+                initial_regs: BTreeMap::new(),
+            },
+        )
+        .pinned_image(Key::from(IMAGE_SLOT), child_hash)
+        .pinned_data(Key::from(PINNED_DST), vec![0xAB; 16], 4096)
+        .build()
 }
 
 /// Publish the parent instance and invoke endpoint 0 with the given

--- a/rust/javm-guest-tests/tests/host_yield_mint.rs
+++ b/rust/javm-guest-tests/tests/host_yield_mint.rs
@@ -51,16 +51,9 @@ fn prog_image() -> Image {
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
-    Image {
-        code,
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoints;
+    img
 }
 
 /// Invoke the program with the given sender slot; return (exit_reason,

--- a/rust/javm-guest-tests/tests/jit_cache.rs
+++ b/rust/javm-guest-tests/tests/jit_cache.rs
@@ -26,16 +26,9 @@ fn reply_image() -> Image {
             initial_regs: BTreeMap::new(),
         },
     );
-    Image {
-        code: ecalli(OP_REPLY).to_le_bytes().to_vec(),
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(ecalli(OP_REPLY).to_le_bytes().to_vec());
+    img.endpoints = endpoints;
+    img
 }
 
 #[test]

--- a/rust/javm-guest-tests/tests/mint_gas.rs
+++ b/rust/javm-guest-tests/tests/mint_gas.rs
@@ -14,7 +14,7 @@
 //! nub Hyperlight host (linux-x86_64).
 #![cfg(all(target_os = "linux", target_arch = "x86_64"))]
 
-use javm_cap::image::{EndpointDef, Image, PinnedCap};
+use javm_cap::image::{EndpointDef, Image, ImageBuilder};
 use javm_cap::yield_cap::{YK_MINT_GAS, YK_MINT_QUOTA};
 use javm_cap::{yield_sender, CNodeCap, Cap, CapHashOrRef, Key, NUM_REGS};
 use nub::Nub;
@@ -39,37 +39,22 @@ fn ecalli(imm: u32) -> u32 {
 /// Image: `host_yield(φ7=sender, φ8=key, φ9=dst); reply`, with a pinned
 /// `Cap::Data` at PINNED_DST so the negative run targets a read-only slot.
 fn prog_image() -> Image {
-    let mut endpoints = BTreeMap::new();
-    endpoints.insert(
-        Key::from(0u8),
-        EndpointDef {
-            entry_pc: 0,
-            arg_registers: 0,
-            arg_cnode_size: 0,
-            initial_regs: BTreeMap::new(),
-        },
-    );
-    let mut pinned_slots = BTreeMap::new();
-    pinned_slots.insert(
-        Key::from(PINNED_DST),
-        PinnedCap::Data {
-            content: vec![0xAB; 16],
-            size: 4096,
-        },
-    );
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
-    Image {
-        code,
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots,
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    ImageBuilder::new()
+        .code(code)
+        .endpoint(
+            Key::from(0u8),
+            EndpointDef {
+                entry_pc: 0,
+                arg_registers: 0,
+                arg_cnode_size: 0,
+                initial_regs: BTreeMap::new(),
+            },
+        )
+        .pinned_data(Key::from(PINNED_DST), vec![0xAB; 16], 4096)
+        .build()
 }
 
 /// Invoke the program: `mint_key` selects mint_gas vs mint_quota; `dst` is the

--- a/rust/javm-guest-tests/tests/oog_yield.rs
+++ b/rust/javm-guest-tests/tests/oog_yield.rs
@@ -61,16 +61,11 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots,
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img.gas_slots = gas_slots;
+    img
 }
 
 /// Run the OOG-catch scenario. `catch_oog` controls whether the chain's

--- a/rust/javm-guest-tests/tests/pending_origin.rs
+++ b/rust/javm-guest-tests/tests/pending_origin.rs
@@ -48,16 +48,10 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img
 }
 
 fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {

--- a/rust/javm-guest-tests/tests/root_cnode_seeding.rs
+++ b/rust/javm-guest-tests/tests/root_cnode_seeding.rs
@@ -45,16 +45,9 @@ fn prog_image() -> Image {
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_IMAGE_HASH_CHAIN).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
-    Image {
-        code,
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoints;
+    img
 }
 
 /// Invoke the program with the given src slot; return (exit_reason, exit_arg).

--- a/rust/javm-guest-tests/tests/root_meter.rs
+++ b/rust/javm-guest-tests/tests/root_meter.rs
@@ -67,16 +67,9 @@ fn root_meter_self_harvest_via_set_gas_meter() {
     let mut code = Vec::new();
     code.extend_from_slice(&ecalli(OP_HOST_YIELD).to_le_bytes());
     code.extend_from_slice(&ecalli(OP_REPLY).to_le_bytes());
-    let img = Image {
-        code,
-        endpoints,
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots: vec![Key::from(GAS_SLOT)],
-        quota_slots: Vec::new(),
-    };
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoints;
+    img.gas_slots = vec![Key::from(GAS_SLOT)];
     let image_h = nub
         .put_cap(&Cap::image_with_slots(&img, &[], &[]).expect("image"))
         .expect("put image");

--- a/rust/javm-guest-tests/tests/set_gas_meter.rs
+++ b/rust/javm-guest-tests/tests/set_gas_meter.rs
@@ -59,16 +59,10 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, gas_slots: Vec<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots,
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.gas_slots = gas_slots;
+    img
 }
 
 /// Invoke a standalone image and return its `(exit_reason, return_value)`.

--- a/rust/javm-guest-tests/tests/unfunded_meter.rs
+++ b/rust/javm-guest-tests/tests/unfunded_meter.rs
@@ -41,16 +41,10 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, gas_slots: Vec<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot: None,
-        gas_slots,
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.gas_slots = gas_slots;
+    img
 }
 
 /// Run a chain (top frame, host-budgeted) that CALLs a `reply` child. If

--- a/rust/javm-guest-tests/tests/yield_owner_edge.rs
+++ b/rust/javm-guest-tests/tests/yield_owner_edge.rs
@@ -59,16 +59,11 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, gas_slots: Vec<Key>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots,
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img.gas_slots = gas_slots;
+    img
 }
 
 fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {

--- a/rust/javm-guest-tests/tests/yield_routing.rs
+++ b/rust/javm-guest-tests/tests/yield_routing.rs
@@ -58,16 +58,10 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img
 }
 
 /// A: `host_call(φ7=B slot, φ8=endpoint); [mid_op;] reply`. The slot/endpoint

--- a/rust/javm-guest-tests/tests/yield_walk_past.rs
+++ b/rust/javm-guest-tests/tests/yield_walk_past.rs
@@ -58,16 +58,10 @@ fn endpoint0() -> BTreeMap<Key, EndpointDef> {
 }
 
 fn image(code: Vec<u8>, yield_receiver_slot: Option<Key>) -> Image {
-    Image {
-        code,
-        endpoints: endpoint0(),
-        memory_mappings: Vec::new(),
-        pinned_slots: BTreeMap::new(),
-        initial_slots: BTreeMap::new(),
-        yield_receiver_slot,
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    }
+    let mut img = Image::with_code(code);
+    img.endpoints = endpoint0();
+    img.yield_receiver_slot = yield_receiver_slot;
+    img
 }
 
 fn put_instance(nub: &mut Nub, img: &Image, cnode_h: [u8; 32]) -> nub::AbiCapHash {

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -39,7 +39,7 @@ use crate::layout::{
 };
 use javm_cap::Key;
 use javm_cap::abi::BARE_YIELD_RECEIVER_SLOT;
-use javm_cap::image::{EndpointDef, Image, InitialDataCap, MemoryMapping, PinnedCap};
+use javm_cap::image::{EndpointDef, Image, ImageBuilder, MemoryMapping};
 use javm_cap::slot::SlotPath;
 use std::collections::BTreeMap;
 
@@ -438,10 +438,17 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         def.initial_regs.insert(SP_REG, stack_top);
     }
 
+    // The data regions are handed to `ImageBuilder` as the same contiguous
+    // `ro_data`/`rw_data` buffers as before; `build()` page-splits them,
+    // elides all-zero pages (the leading rw gap and trailing `.bss` stop
+    // being serialized), and deduplicates identical pages into one shared
+    // page-granular `arena`. `MemoryMapping`s and geometry are unchanged —
+    // each region's `size` is still `page_count * PAGE_SIZE`, so the
+    // resulting `DataCap`s are byte- and hash-identical to the old inline
+    // form; only the wire encoding shrinks.
     let mut memory_mappings: Vec<MemoryMapping> = Vec::new();
-    let mut pinned_slots: BTreeMap<Key, PinnedCap> = BTreeMap::new();
-    let mut initial_slots: BTreeMap<Key, InitialDataCap> = BTreeMap::new();
     let page_bytes = u64::from(PVM_PAGE_SIZE);
+    let mut builder = ImageBuilder::new();
 
     let stack_slot = Key::from(STACK_CAP_INDEX);
     let stack_size = u64::from(layout.stack.page_count) * page_bytes;
@@ -450,13 +457,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
         size: stack_size,
         source: SlotPath::root(stack_slot.clone()),
     });
-    initial_slots.insert(
-        stack_slot,
-        InitialDataCap {
-            content: Vec::new(),
-            size: stack_size,
-        },
-    );
+    builder = builder.initial_data(stack_slot, Vec::new(), stack_size);
 
     if let Some(ro) = &layout.ro {
         let ro_slot = Key::from(RO_CAP_INDEX);
@@ -466,13 +467,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
             size,
             source: SlotPath::root(ro_slot.clone()),
         });
-        pinned_slots.insert(
-            ro_slot,
-            PinnedCap::Data {
-                content: ro_data,
-                size,
-            },
-        );
+        builder = builder.pinned_data(ro_slot, ro_data, size);
     }
 
     if let Some(rw) = &layout.rw {
@@ -483,13 +478,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
             size,
             source: SlotPath::root(rw_slot.clone()),
         });
-        initial_slots.insert(
-            rw_slot,
-            InitialDataCap {
-                content: rw_data,
-                size,
-            },
-        );
+        builder = builder.initial_data(rw_slot, rw_data, size);
     }
 
     if let Some(heap) = &layout.heap {
@@ -500,13 +489,7 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
             size,
             source: SlotPath::root(heap_slot.clone()),
         });
-        initial_slots.insert(
-            heap_slot,
-            InitialDataCap {
-                content: Vec::new(),
-                size,
-            },
-        );
+        builder = builder.initial_data(heap_slot, Vec::new(), size);
     }
 
     // Layout geometry: code occupies `[CODE_BASE, CODE_BASE +
@@ -531,16 +514,16 @@ pub fn link_elf(elf_data: &[u8]) -> Result<Image, TranspileError> {
     // via a declarative mapping, so an untrusted Image cannot relocate
     // it. `memory_mappings` describes data/slot regions only.
 
-    Ok(Image {
-        code,
-        endpoints,
-        memory_mappings,
-        pinned_slots,
-        initial_slots,
-        yield_receiver_slot: Some(Key::from(BARE_YIELD_RECEIVER_SLOT)),
-        gas_slots: Vec::new(),
-        quota_slots: Vec::new(),
-    })
+    builder = builder.code(code);
+    for (key, ep) in endpoints {
+        builder = builder.endpoint(key, ep);
+    }
+    for mapping in memory_mappings {
+        builder = builder.mapping(mapping);
+    }
+    Ok(builder
+        .yield_receiver_slot(Some(Key::from(BARE_YIELD_RECEIVER_SLOT)))
+        .build())
 }
 
 /// Verify the 4 bytes at `off` decode to an `auipc`; error otherwise.

--- a/rust/nub/tests/meter.rs
+++ b/rust/nub/tests/meter.rs
@@ -16,8 +16,7 @@ const GAS_SLOT: u8 = 5;
 /// `ecalli 42` at PC 0 (exits `HostCall(42)` after consuming a fixed amount of
 /// gas). `gas_slots[0]` optionally names the slot holding the `Gas` handle.
 fn ecalli_42_image(with_gas_slot: bool) -> Image {
-    let mut img = Image::empty();
-    img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
+    let mut img = Image::with_code(0x02A0_200Bu32.to_le_bytes().to_vec());
     let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     endpoints.insert(
         Key::from(0u8),

--- a/rust/nub/tests/parallel_api.rs
+++ b/rust/nub/tests/parallel_api.rs
@@ -7,9 +7,8 @@ use std::collections::BTreeMap;
 use std::thread;
 
 fn ecalli_imm_image(imm: u32) -> Image {
-    let mut img = Image::empty();
     let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
-    img.code = instr.to_le_bytes().to_vec();
+    let mut img = Image::with_code(instr.to_le_bytes().to_vec());
     img.endpoints.insert(
         Key::from(0u8),
         EndpointDef {

--- a/rust/nub/tests/parallel_kvm.rs
+++ b/rust/nub/tests/parallel_kvm.rs
@@ -7,9 +7,8 @@ use std::collections::BTreeMap;
 use std::thread;
 
 fn ecalli_imm_image(imm: u32) -> Image {
-    let mut img = Image::empty();
     let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
-    img.code = instr.to_le_bytes().to_vec();
+    let mut img = Image::with_code(instr.to_le_bytes().to_vec());
     img.endpoints.insert(
         Key::from(0u8),
         EndpointDef {

--- a/rust/nub/tests/smoke.rs
+++ b/rust/nub/tests/smoke.rs
@@ -10,11 +10,10 @@ use std::collections::BTreeMap;
 
 /// Build a minimal PVM2 Image whose endpoint 0 runs `ecalli 42` at PC 0.
 fn ecalli_42_image() -> Image {
-    let mut img = Image::empty();
     // PVM2 `ecalli 42` — custom-0 (opcode bits[6:2] = 0b00010), funct3 =
     // 0b010, rd = 0, rs1 = 0, imm = 42. As an I-type 32-bit word:
     //   (42 << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11 = 0x02A0_200B
-    img.code = 0x02A0_200Bu32.to_le_bytes().to_vec();
+    let mut img = Image::with_code(0x02A0_200Bu32.to_le_bytes().to_vec());
     // Code is mapped at the fixed CODE_BASE; no data mappings.
 
     let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();

--- a/rust/nub/tests/test_bin_smoke.rs
+++ b/rust/nub/tests/test_bin_smoke.rs
@@ -47,9 +47,8 @@ fn test_bin_smoke_returns_42_on_second_vcpu() {
 }
 
 fn ecalli_image(imm: u32) -> Image {
-    let mut img = Image::empty();
     let instr = (imm << 20) | (0b010 << 12) | (0b00010 << 2) | 0b11;
-    img.code = instr.to_le_bytes().to_vec();
+    let mut img = Image::with_code(instr.to_le_bytes().to_vec());
     let mut endpoints: BTreeMap<Key, EndpointDef> = BTreeMap::new();
     endpoints.insert(
         Key::from(0u8),


### PR DESCRIPTION
## Page-granular arena `Image` wire format

Moves all `Image` payload bytes into a single trailing `arena: Vec<u8>` indexed by small descriptors, so the wire form stops serializing the zero pages it never needed to carry.

### Motivation
The old wire form stored each data region as one contiguous `content: Vec<u8>`, baking in two kinds of zeros: the **leading `rw` gap** (the transpiler's `rw_base` padding from the PVM data base up to the guest's data vaddr — e.g. 57.8 KB of zeros for `sub_vm_recurse`'s 16 bytes of real data) and **trailing `.bss`** (e.g. 262 KB for `fri_fold_tree`). The runtime `DataCap` already elides zeros (`PageSlot::Empty`); only the wire form paid for them.

### Format
- `code: Vec<u8>` → `CodeRef { arena_off, len }`
- pinned/initial data slots → `DataDesc { size, pages: Vec<ArenaPageRef> }` — page-granular sparse: only **non-zero** pages are named, each storing its non-zero prefix (`ArenaPageRef { page_index, arena_off, len }`). Omitted pages, and within-page trailing zeros, decode to the canonical zero page.
- identical pages dedup to one arena window; the arena is packed tightly.

`ImageBuilder` is the single canonical packer; the transpiler emits through it. `DataDesc::to_data_cap` / `DataCap::from_sparse_pages` is the single materialization point, **proven byte- and hash-identical** to the old contiguous `from_bytes_sized` — so the runtime `DataCap`, cap identity, gas, and both engines are unchanged; only the wire encoding shrinks. `image_cap` validates arena/descriptor bounds eagerly.

### Results — blob size across the 12 bench Images: **993,842 → 212,199 B (−79%)**

| workload | before | after | Δ |
|---|--:|--:|--:|
| sub_vm_recurse | 58,118 | 781 | −99% |
| fri_fold_tree | 276,989 | 6,668 | −98% |
| poly_eval | 72,301 | 2,684 | −96% |
| prime_sieve | 158,346 | 11,198 | −93% |
| sub_vm_data_recurse | 75,069 | 13,856 | −82% |
| goldilocks_mul | 5,485 | 1,412 | −74% |
| poseidon2_perm | 13,287 | 5,118 | −61% |
| mini_verifier | 15,517 | 7,348 | −53% |
| ecrecover | 198,631 | 100,311 | −49% |
| ed25519 | 91,621 | 46,587 | −49% |
| keccak | 9,255 | 5,182 | −44% |
| blake2b | 19,223 | 11,054 | −43% |

Every workload shrinks. `ecrecover`/`ed25519` are now bounded by their irreducible **code** (96 KB / 41 KB), not data zeros.

### Trade-off
Per-page `len` + tight packing drops the page-aligned arena, which forecloses a *future* zero-copy mmap of the arena. There is **no current loss** — the deblob already copies every page into a fresh aligned slab (`PageBytes::from_content`), so zero-copy wasn't happening regardless.

### Verification
- **502 workspace tests pass**, including the conformance interp-vs-recompiler differential and a new `from_sparse_pages == from_bytes_sized` regression test (covering `size == 0`, partial last page, interior/trailing zero pages, and the `len`-trim zero-pad).
- `clippy --workspace --all-targets -- -D warnings` and `cargo fmt` clean.
- Rust-kernel-local: no Lean spec / Genesis coupling, no JSON vectors, no golden blobs (bench blobs are regenerated by `build.rs`).
- Reviewed by a multi-agent adversarial pass; the one real finding (a degenerate `DataDesc{size:0}` decode) is fixed (`from_sparse_pages` floors like `from_bytes_sized`). Remaining notes are low-severity untrusted-input hardening (one pre-existing `mem_extent` `u32` overflow), captured as follow-ups in the doc.

Format documented in `grey-docs` `pvm-isa/10-image-arena-format.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
