### PR TITLE
javm: fix stale c.jr/c.jalr forbidden doc-comments

### DIFF
--- a/rust/javm-recompiler-x86/src/codegen.rs
+++ b/rust/javm-recompiler-x86/src/codegen.rs
@@ -956,8 +956,9 @@ fn decode_cb_imm(h: u16) -> i32 {
 }
 
 /// Expand a 2-byte RVC encoding to its 4-byte equivalent. Returns
-/// `None` for PVM2-forbidden RVC encodings (c.jr, c.jalr, c.ebreak,
-/// c.illegal) and for malformed encodings (reserved sub-cases).
+/// `None` for the forbidden RVC encodings (c.ebreak, c.illegal) and
+/// for malformed encodings (reserved sub-cases). c.jr/c.jalr expand
+/// to standard `jalr x0/x1, rs1, 0` and are not forbidden.
 ///
 /// The caller (`compile_rvc`) feeds the result through `compile_rv4`,
 /// so any shape `compile_rv4` understands is acceptable here. RVC
@@ -1537,8 +1538,9 @@ impl Compiler {
     /// 4-byte equivalent via `expand_rvc` and reuses `compile_rv4` —
     /// all the funct3/funct7 dispatch + fusion logic stays in one
     /// place, and the only RVC-specific code is the bit-shuffling of
-    /// the expansion. Forbidden RVC encodings (c.jr, c.jalr, c.ebreak,
-    /// c.illegal) return `None` from `expand_rvc` and emit a panic.
+    /// the expansion. The forbidden RVC encodings (c.ebreak, c.illegal)
+    /// return `None` from `expand_rvc` and emit a panic; c.jr/c.jalr are
+    /// standard jalr and compile normally.
     ///
     /// One contract: RVC expansion never produces a JAL with rd != 0
     /// (c.jal is RV32-only and doesn't exist in our target), so

--- a/rust/javm-transpiler/src/linker.rs
+++ b/rust/javm-transpiler/src/linker.rs
@@ -1096,7 +1096,7 @@ fn align_branch_targets(
                 //   (0, r, 0) r!=0  → c.jr     (= retf, terminator)
                 //   (0, r, s) both!=0 → c.mv  (NOT a terminator)
                 //   (1, 0, 0)        → c.ebreak (Reserved, terminator)
-                //   (1, r, 0) r!=0   → c.jalr (Reserved, terminator)
+                //   (1, r, 0) r!=0   → c.jalr (= callf, terminator)
                 //   (1, r, s) both!=0 → c.add (NOT a terminator)
                 let bit12 = (lo >> 12) & 1;
                 let rdrs1 = (lo >> 7) & 0x1F;


### PR DESCRIPTION
Fixes stale doc-comments that still described `c.jr`/`c.jalr` as PVM2-forbidden RVC encodings.

In current PVM2 (standard RV64E + C, native-`jalr` control flow), `c.jr` decompresses to `jalr x0, rs1, 0` and `c.jalr` to `jalr x1, rs1, 0`; both are handled normally by the decoder, recompiler, and linker. Only `c.ebreak` and the all-zero `c.illegal` are forbidden RVC encodings. The stale wording was left over from the retired PVM2-Base / `br_table` static-dispatch draft.

**Changes (comment-only, no behavior change):**
- `codegen.rs` — `expand_rvc` / `compile_rvc` doc-comments no longer list `c.jr`/`c.jalr` as forbidden.
- `linker.rs` — `align_branch_targets` dispatch table: `c.jalr` is a call, not `Reserved`.

The decode/recompile/link logic already treats `c.jr`/`c.jalr` as standard `jalr` (tests `decompress_c_jr_ra_is_jalr` / `..._jalr_link` pass); `cargo fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
