### PR TITLE
bench-compare: blob size comparison, wasm vs polkavm vs nub

### DIFF
--- a/nub/bench-compare/BENCHMARKS.md
+++ b/nub/bench-compare/BENCHMARKS.md
@@ -12,16 +12,16 @@ A cell carries a `±` only when its confidence interval is wider than 2% of the 
 
 | Program | `nub_jit` | `polkavm64_recompiler_sync_gas_full` | `polkavm64_recompiler_async_gas_full` | `wasmtime_cranelift_fuel` |
 |---|--:|--:|--:|--:|
-| blake2b | **63.38 µs** (1.00x) | 116.46 µs (1.84x) | 117.56 µs (1.85x) | 3.45 ms (54.47x) |
-| ecrecover | **1.17 ms** (1.00x) | 1.84 ms (1.57x) | 1.83 ms (1.57x) | 43.99 ms (37.73x) |
-| prime-sieve | **224.81 µs** (1.00x) | 233.22 µs (1.04x) | 229.32 µs (1.02x) | 1.03 ms (4.58x) |
-| mini-verifier | **533.84 µs** (1.00x) | 653.05 µs (1.22x) | 653.06 µs (1.22x) | 3.80 ms (7.11x) |
-| keccak | **42.88 µs** (1.00x) | 58.92 µs (1.37x) | 58.52 µs (1.36x) | 2.90 ms (67.62x) |
-| fri-fold-tree | **536.58 µs** (1.00x) | 635.05 µs (1.18x) | 640.51 µs (1.19x) | 12.22 ms (22.78x) |
-| ed25519 | **496.08 µs** (1.00x) | 651.24 µs (1.31x) | 657.46 µs (1.33x) | 29.85 ms (60.17x) |
-| goldilocks-mul | **354.72 µs** (1.00x) | 396.51 µs (1.12x) | 376.00 µs (1.06x) | 1.02 ms (2.87x) |
-| poly-eval | **1.13 ms** (1.00x) | 1.22 ms (1.08x) | 1.28 ms (1.13x) | 10.03 ms (8.84x) |
-| poseidon2-perm | **1.22 ms** (1.00x) | 1.41 ms (1.16x) | 1.45 ms (1.19x) | 4.31 ms (3.54x) |
+| fri-fold-tree | **532.82 µs** (1.00x) | 628.51 µs (1.18x) | 612.55 µs (1.15x) | 12.24 ms (22.97x) |
+| ecrecover | **1.19 ms** (1.00x) | 1.85 ms (1.55x) | 1.83 ms (1.54x) | 44.56 ms (37.39x) |
+| ed25519 | **500.20 µs** (1.00x) | 650.68 µs (1.30x) | 650.67 µs (1.30x) | 30.01 ms (59.99x) |
+| blake2b | **64.79 µs** (1.00x) | 115.93 µs (1.79x) | 116.60 µs (1.80x) | 3.49 ms (53.91x) |
+| prime-sieve | 228.91 µs (1.03x) | 234.41 µs (1.05x) | **222.35 µs** (1.00x) | 1.02 ms (4.59x) |
+| mini-verifier | **542.58 µs** (1.00x) | 653.22 µs (1.20x) | 652.81 µs (1.20x) | 3.85 ms (7.09x) |
+| poly-eval | **1.13 ms** (1.00x) | 1.26 ms (1.12x) | 1.31 ms (1.16x) | 9.97 ms (8.83x) |
+| poseidon2-perm | **1.18 ms** (1.00x) | 1.43 ms (1.21x) | 1.43 ms (1.21x) | 4.40 ms (3.73x) |
+| keccak | **43.22 µs** (1.00x) | 58.55 µs (1.35x) | 58.94 µs (1.36x) | 2.90 ms (66.99x) |
+| goldilocks-mul | **353.01 µs** (1.00x) | 389.67 µs (1.10x) | 389.41 µs ±3% (1.10x) | 1.02 ms (2.88x) |
 
 Bold = fastest for that program; the multiple is versus it.
 
@@ -33,17 +33,114 @@ The bracketed figure is the difference against the table above: what the recompi
 
 | Program | `nub_jit` | `polkavm64_recompiler_sync_gas_full` | `polkavm64_recompiler_async_gas_full` | `wasmtime_cranelift_fuel` |
 |---|--:|--:|--:|--:|
-| blake2b | 4.55 µs (+58.83 µs recompile) | 9.41 µs (+107.05 µs recompile) | 9.37 µs (+108.19 µs recompile) | 5.50 µs (+3.45 ms recompile) |
-| ecrecover | 366.67 µs (+799.26 µs recompile) | 333.25 µs (+1.50 ms recompile) | 333.71 µs (+1.50 ms recompile) | 270.97 µs (+43.72 ms recompile) |
-| prime-sieve | 178.70 µs (+46.11 µs recompile) | 200.87 µs (+32.35 µs recompile) | 199.84 µs (+29.48 µs recompile) | 166.44 µs (+863.01 µs recompile) |
-| mini-verifier | 465.80 µs (+68.04 µs recompile) | 513.86 µs (+139.19 µs recompile) | 512.66 µs (+140.39 µs recompile) | 799.75 µs (+3.00 ms recompile) |
-| keccak | 6.45 µs (+36.43 µs recompile) | 12.28 µs (+46.64 µs recompile) | 12.60 µs (+45.92 µs recompile) | 7.66 µs (+2.89 ms recompile) |
-| fri-fold-tree | 451.60 µs (+84.98 µs recompile) | 498.60 µs (+136.45 µs recompile) | 500.64 µs (+139.86 µs recompile) | 771.91 µs (+11.45 ms recompile) |
-| ed25519 | 89.99 µs (+406.09 µs recompile) | 100.86 µs (+550.38 µs recompile) | 81.87 µs (+575.59 µs recompile) | 240.79 µs (+29.61 ms recompile) |
-| goldilocks-mul | 306.85 µs (+47.87 µs recompile) | 348.86 µs (+47.64 µs recompile) | 365.56 µs (+10.44 µs recompile) | 512.93 µs (+506.37 µs recompile) |
-| poly-eval | 1.08 ms (+51.00 µs recompile) | 1.19 ms (+33.79 µs recompile) | 1.27 ms (+11.04 µs recompile) | 1.49 ms (+8.53 ms recompile) |
-| poseidon2-perm | 1.15 ms (+63.06 µs recompile) | 1.26 ms (+157.41 µs recompile) | 1.24 ms (+201.23 µs recompile) | 1.94 ms (+2.37 ms recompile) |
+| fri-fold-tree | 452.27 µs (+80.55 µs recompile) | 500.71 µs (+127.80 µs recompile) | 498.88 µs (+113.68 µs recompile) | 773.91 µs (+11.47 ms recompile) |
+| ecrecover | 370.80 µs (+820.84 µs recompile) | 333.74 µs (+1.52 ms recompile) | 334.04 µs (+1.50 ms recompile) | 270.38 µs (+44.29 ms recompile) |
+| ed25519 | 91.63 µs (+408.57 µs recompile) | 82.77 µs (+567.91 µs recompile) | 81.99 µs (+568.68 µs recompile) | 242.71 µs (+29.77 ms recompile) |
+| blake2b | 4.65 µs (+60.14 µs recompile) | 8.91 µs (+107.03 µs recompile) | 9.69 µs (+106.90 µs recompile) | 5.57 µs (+3.49 ms recompile) |
+| prime-sieve | 180.14 µs (+48.77 µs recompile) | 216.61 µs (+17.80 µs recompile) | 199.67 µs (+22.68 µs recompile) | 166.04 µs (+854.32 µs recompile) |
+| mini-verifier | 475.52 µs (+67.06 µs recompile) | 513.60 µs (+139.62 µs recompile) | 512.98 µs (+139.83 µs recompile) | 785.81 µs (+3.06 ms recompile) |
+| poly-eval | 1.10 ms (+27.69 µs recompile) | 1.21 ms (+47.98 µs recompile) | 1.20 ms (+109.16 µs recompile) | 1.48 ms (+8.49 ms recompile) |
+| poseidon2-perm | 1.15 ms (+27.83 µs recompile) | 1.25 ms (+173.39 µs recompile) | 1.25 ms (+180.76 µs recompile) | 1.94 ms (+2.46 ms recompile) |
+| keccak | 6.50 µs (+36.72 µs recompile) | 12.08 µs (+46.47 µs recompile) | 12.64 µs (+46.31 µs recompile) | 7.81 µs (+2.89 ms recompile) |
+| goldilocks-mul | 309.79 µs (+43.22 µs recompile) | 349.68 µs (+39.99 µs recompile) | 366.12 µs (+23.29 µs recompile) | 505.44 µs (+511.61 µs recompile) |
 
+
+## Artifact size
+
+How big the program is, which for a chain VM is the other half of the story — it is what gets gossiped, stored and paid for.
+
+**Raw code excludes the data regions**, and that is the figure to read. Several kernels carry large initialized data that swamps everything else: `prime-sieve` is 214 bytes of nub code inside a 158,338-byte blob, 0.1% of it. Comparing whole blobs there compares static lookup tables, not code generators.
+
+The code figure is `code` for nub, `code + jump table + bitmask` for PolkaVM, and `Code + Type + Function + Table + Element + Global` for wasm. PolkaVM's two extras and wasm's aux sections are code information held *outside* the instruction stream — instruction boundaries, indirect-branch targets, function signatures — all of which RV64EMC encodes inline. The breakdown tables below show every component so the definition can be checked rather than taken on trust; note it is deliberately broader than upstream PolkaVM's own disassembler, which labels only `code` as "code size".
+
+`native` is absent: a host `.so` is a different kind of object — ELF program headers, relocations, a dynamic symbol table, and whatever of `std` got linked in — not a bigger or smaller one.
+
+**The whole-blob table is not built from identical sources**, and the raw-code table is the fairer one for that reason too. pvm2 builds the kernel crate's own binary, so it carries nub's guest runtime — the entry trampoline, the endpoint table, the bump arena. The other three build the thin wrapper in `guests/`, which calls into the same kernel as a library. That is each format's honest artifact, since the nub-rt endpoint binary *is* the PVM2 ABI, but it means the data regions are not measuring the same thing and nub is carrying runtime the others are not.
+
+**No compression is involved anywhere.** Trailing-zero trimming in nub and PolkaVM is BSS elision, exactly what ELF does with `p_filesz < p_memsz`, and wasm data segments carry no trailing zeros either. The varint/LEB128 encoding in PolkaVM and wasm is instruction encoding, not a container compressor: it cannot be disabled, and it is precisely the axis these formats trade on.
+
+### Raw code
+
+| Program | `pvm2` | `polkavm64` | `wasm32` |
+|---|--:|--:|--:|
+| prime-sieve | 214 (1.27x) | **168** (1.00x) | 318 (1.89x) |
+| ed25519 | **41,442** (1.00x) | 53,632 (1.29x) | 60,116 (1.45x) |
+| keccak | **1,884** (1.00x) | 4,551 (2.42x) | 2,760 (1.46x) |
+| blake2b | 6,980 (1.07x) | 12,453 (1.90x) | **6,552** (1.00x) |
+| ecrecover | 96,170 (1.16x) | 130,599 (1.57x) | **83,023** (1.00x) |
+| goldilocks-mul | 162 (1.17x) | **138** (1.00x) | 346 (2.51x) |
+| poseidon2-perm | **3,404** (1.00x) | 4,625 (1.36x) | 5,183 (1.52x) |
+| mini-verifier | **4,282** (1.00x) | 6,276 (1.47x) | 6,659 (1.56x) |
+| poly-eval | **824** (1.00x) | 996 (1.21x) | 10,885 (13.21x) |
+| fri-fold-tree | **4,192** (1.00x) | 6,252 (1.49x) | 17,178 (4.10x) |
+
+Bold = smallest for that program; the multiple is versus it.
+
+### Whole blob
+
+| Program | `pvm2` | `polkavm64` | `wasm32` |
+|---|--:|--:|--:|
+| prime-sieve | 158,338 (1.58x) | **100,210** (1.00x) | 100,402 (1.00x) |
+| ed25519 | 91,558 (1.65x) | **55,427** (1.00x) | 62,833 (1.13x) |
+| keccak | 9,193 (2.87x) | 4,783 (1.49x) | **3,204** (1.00x) |
+| blake2b | 19,153 (2.89x) | 12,489 (1.89x) | **6,621** (1.00x) |
+| ecrecover | 198,576 (2.32x) | 131,074 (1.53x) | **85,416** (1.00x) |
+| goldilocks-mul | 5,415 (31.30x) | **173** (1.00x) | 415 (2.40x) |
+| poseidon2-perm | 13,225 (2.47x) | **5,353** (1.00x) | 5,953 (1.11x) |
+| mini-verifier | 15,447 (2.10x) | **7,364** (1.00x) | 7,429 (1.01x) |
+| poly-eval | 6,733 (6.51x) | **1,034** (1.00x) | 11,257 (10.89x) |
+| fri-fold-tree | 14,821 (2.12x) | **6,982** (1.00x) | 18,559 (2.66x) |
+
+Bold = smallest for that program; the multiple is versus it.
+
+### Breakdown
+
+Every row sums to the file size.
+
+#### `pvm2`
+
+| Program | header | endpoints | code | ro | rw | = code | file |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| prime-sieve | 40 | 84 | 214 | 0 | 158,000 | **214** | 158,338 |
+| ed25519 | 40 | 84 | 41,442 | 2,279 | 47,713 | **41,442** | 91,558 |
+| keccak | 40 | 84 | 1,884 | 592 | 6,593 | **1,884** | 9,193 |
+| blake2b | 40 | 84 | 6,980 | 472 | 11,577 | **6,980** | 19,153 |
+| ecrecover | 40 | 84 | 96,170 | 993 | 101,289 | **96,170** | 198,576 |
+| goldilocks-mul | 40 | 84 | 162 | 416 | 4,713 | **162** | 5,415 |
+| poseidon2-perm | 40 | 84 | 3,404 | 1,088 | 8,609 | **3,404** | 13,225 |
+| mini-verifier | 40 | 84 | 4,282 | 1,328 | 9,713 | **4,282** | 15,447 |
+| poly-eval | 40 | 84 | 824 | 424 | 5,361 | **824** | 6,733 |
+| fri-fold-tree | 40 | 84 | 4,192 | 1,104 | 9,401 | **4,192** | 14,821 |
+
+#### `polkavm64`
+
+| Program | code | jump table | bitmask | §6 framing | ro | rw | exports | memory cfg | other | container | = code | file |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| prime-sieve | 148 | 1 | 19 | 4 | 0 | 100,000 | 6 | 7 | 0 | 25 | **168** | 100,210 |
+| ed25519 | 47,383 | 326 | 5,923 | 6 | 1,752 | 0 | 6 | 6 | 0 | 25 | **53,632** | 55,427 |
+| keccak | 4,029 | 18 | 504 | 4 | 192 | 0 | 6 | 6 | 0 | 24 | **4,551** | 4,783 |
+| blake2b | 11,048 | 24 | 1,381 | 4 | 0 | 0 | 6 | 5 | 0 | 21 | **12,453** | 12,489 |
+| ecrecover | 114,413 | 1,884 | 14,302 | 6 | 432 | 0 | 6 | 6 | 0 | 25 | **130,599** | 131,074 |
+| goldilocks-mul | 122 | 0 | 16 | 3 | 0 | 0 | 6 | 5 | 0 | 21 | **138** | 173 |
+| poseidon2-perm | 4,110 | 1 | 514 | 4 | 688 | 0 | 6 | 6 | 0 | 24 | **4,625** | 5,353 |
+| mini-verifier | 5,546 | 36 | 694 | 4 | 1,048 | 0 | 6 | 6 | 0 | 24 | **6,276** | 7,364 |
+| poly-eval | 874 | 12 | 110 | 4 | 0 | 0 | 6 | 7 | 0 | 21 | **996** | 1,034 |
+| fri-fold-tree | 5,539 | 20 | 693 | 4 | 688 | 0 | 6 | 8 | 0 | 24 | **6,252** | 6,982 |
+
+#### `wasm32`
+
+| Program | code(10) | type(1) | function(3) | table(4) | element(9) | global(6) | data(11) | custom(0) | other | container | = code | file |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| prime-sieve | 281 | 5 | 2 | 5 | 0 | 25 | 100,011 | 0 | 46 | 27 | **318** | 100,402 |
+| ed25519 | 59,988 | 64 | 25 | 5 | 9 | 25 | 2,642 | 0 | 46 | 29 | **60,116** | 62,833 |
+| keccak | 2,680 | 30 | 12 | 5 | 8 | 25 | 370 | 0 | 46 | 28 | **2,760** | 3,204 |
+| blake2b | 6,508 | 11 | 3 | 5 | 0 | 25 | 0 | 0 | 46 | 23 | **6,552** | 6,621 |
+| ecrecover | 82,819 | 73 | 69 | 5 | 32 | 25 | 2,318 | 0 | 46 | 29 | **83,023** | 85,416 |
+| goldilocks-mul | 300 | 13 | 3 | 5 | 0 | 25 | 0 | 0 | 46 | 23 | **346** | 415 |
+| poseidon2-perm | 5,137 | 13 | 3 | 5 | 0 | 25 | 698 | 0 | 46 | 26 | **5,183** | 5,953 |
+| mini-verifier | 6,608 | 17 | 4 | 5 | 0 | 25 | 698 | 0 | 46 | 26 | **6,659** | 7,429 |
+| poly-eval | 10,769 | 51 | 27 | 5 | 8 | 25 | 298 | 0 | 46 | 28 | **10,885** | 11,257 |
+| fri-fold-tree | 17,044 | 64 | 31 | 5 | 9 | 25 | 1,306 | 0 | 46 | 29 | **17,178** | 18,559 |
 ## Provenance
 
 - Guest toolchain: `rustc 1.95.0 (59807616e 2026-04-14)`
@@ -70,181 +167,181 @@ Storage is excluded. An eager engine compiles inside the clock; nub compiles laz
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 15.42 µs | ±2.3% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 39.42 µs | ±1.6% | 2.56x | 2.6x |
-| `polkavm64_recompiler_async_gas` | yes | 40.54 µs | ±0.8% | 2.63x | 2.6x |
-| `polkavm64_recompiler_sync_gas` | yes | 40.55 µs | ±1.2% | 2.63x | 2.6x |
-| `nub_jit` | yes | 63.38 µs | ±0.2% | 4.11x | 4.1x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 116.46 µs | ±1.5% | 7.55x | 7.6x |
-| `polkavm64_recompiler_async_gas_full` | yes | 117.56 µs | ±0.8% | 7.63x | 7.6x |
-| `polkavm64_interpreter` | no | 127.04 µs | ±0.3% | 8.24x | 8.2x |
-| `nub_interp` | yes | 231.88 µs | ±0.9% | 15.04x | 15.0x |
-| `wasmtime_winch` | no | 438.54 µs | ±0.6% | 28.45x | 28.4x |
-| `wasmer_singlepass` | no | 2.19 ms | ±1.1% | 142.28x | 142.3x |
-| `wasmtime_cranelift` | no | 3.26 ms | ±0.4% | 211.41x | 211.4x |
-| `wasmtime_cranelift_fuel` | yes | 3.45 ms | ±0.6% | 223.95x | 224.0x |
+| `native` | no | 15.05 µs | ±0.5% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 39.44 µs | ±0.8% | 2.62x | 2.6x |
+| `polkavm64_recompiler_async_gas` | yes | 40.42 µs | ±0.6% | 2.69x | 2.7x |
+| `polkavm64_recompiler_sync_gas` | yes | 40.57 µs | ±0.7% | 2.70x | 2.7x |
+| `nub_jit` | yes | 64.79 µs | ±0.4% | 4.31x | 4.3x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 115.93 µs | ±0.5% | 7.70x | 7.7x |
+| `polkavm64_recompiler_async_gas_full` | yes | 116.60 µs | ±0.5% | 7.75x | 7.7x |
+| `polkavm64_interpreter` | no | 122.79 µs | ±0.7% | 8.16x | 8.2x |
+| `nub_interp` | yes | 234.50 µs | ±0.9% | 15.58x | 15.6x |
+| `wasmtime_winch` | no | 434.04 µs | ±0.5% | 28.84x | 28.8x |
+| `wasmer_singlepass` | no | 1.97 ms | ±1.5% | 130.98x | 131.0x |
+| `wasmtime_cranelift` | no | 3.32 ms | ±0.4% | 220.36x | 220.4x |
+| `wasmtime_cranelift_fuel` | yes | 3.49 ms | ±0.4% | 232.15x | 232.1x |
 
 ### ecrecover
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 110.02 µs | ±0.7% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 672.41 µs | ±0.4% | 6.11x | 6.1x |
-| `polkavm64_recompiler_async_gas` | yes | 705.13 µs | ±1.1% | 6.41x | 6.4x |
-| `polkavm64_recompiler_sync_gas` | yes | 734.25 µs | ±0.4% | 6.67x | 6.7x |
-| `nub_jit` | yes | 1.17 ms | ±0.4% | 10.60x | 10.6x |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.83 ms | ±0.2% | 16.67x | 16.7x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.84 ms | ±0.6% | 16.68x | 16.7x |
-| `wasmtime_winch` | no | 5.37 ms | ±0.5% | 48.81x | 48.8x |
-| `wasmer_singlepass` | no | 7.57 ms | ±1.6% | 68.83x | 68.8x |
-| `polkavm64_interpreter` | no | 12.35 ms | ±0.7% | 112.26x | 112.3x |
-| `nub_interp` | yes | 27.39 ms | ±0.8% | 248.98x | 249.0x |
-| `wasmtime_cranelift` | no | 36.16 ms | ±0.5% | 328.65x | 328.7x |
-| `wasmtime_cranelift_fuel` | yes | 43.99 ms | ±0.6% | 399.80x | 399.8x |
+| `native` | no | 110.09 µs | ±0.3% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 674.37 µs | ±0.5% | 6.13x | 6.1x |
+| `polkavm64_recompiler_async_gas` | yes | 709.74 µs | ±0.4% | 6.45x | 6.4x |
+| `polkavm64_recompiler_sync_gas` | yes | 720.27 µs | ±0.5% | 6.54x | 6.5x |
+| `nub_jit` | yes | 1.19 ms | ±0.5% | 10.82x | 10.8x |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.83 ms | ±0.3% | 16.63x | 16.6x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.85 ms | ±0.3% | 16.80x | 16.8x |
+| `wasmtime_winch` | no | 5.35 ms | ±0.2% | 48.56x | 48.6x |
+| `wasmer_singlepass` | no | 7.38 ms | ±2.0% | 67.00x | 67.0x |
+| `polkavm64_interpreter` | no | 12.46 ms | ±0.5% | 113.21x | 113.2x |
+| `nub_interp` | yes | 27.34 ms | ±0.5% | 248.37x | 248.4x |
+| `wasmtime_cranelift` | no | 35.29 ms | ±0.3% | 320.54x | 320.5x |
+| `wasmtime_cranelift_fuel` | yes | 44.56 ms | ±0.6% | 404.73x | 404.7x |
 
 ### ed25519
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 46.20 µs | ±0.4% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 209.50 µs | ±0.5% | 4.54x | 4.5x |
-| `polkavm64_recompiler_async_gas` | yes | 220.75 µs | ±0.5% | 4.78x | 4.8x |
-| `polkavm64_recompiler_sync_gas` | yes | 222.28 µs | ±0.6% | 4.81x | 4.8x |
-| `nub_jit` | yes | 496.08 µs | ±0.4% | 10.74x | 10.7x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 651.24 µs | ±0.3% | 14.10x | 14.1x |
-| `polkavm64_recompiler_async_gas_full` | yes | 657.46 µs | ±0.3% | 14.23x | 14.2x |
-| `polkavm64_interpreter` | no | 1.81 ms | ±0.9% | 39.23x | 39.2x |
-| `wasmtime_winch` | no | 3.12 ms | ±0.4% | 67.59x | 67.6x |
-| `nub_interp` | yes | 5.25 ms | ±0.6% | 113.66x | 113.7x |
-| `wasmer_singlepass` | no | 9.36 ms | ±1.7% | 202.53x | 202.5x |
-| `wasmtime_cranelift` | no | 23.93 ms | ±1.0% | 518.02x | 518.0x |
-| `wasmtime_cranelift_fuel` | yes | 29.85 ms | ±0.4% | 646.10x | 646.1x |
+| `native` | no | 46.08 µs | ±0.4% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 210.92 µs | ±0.2% | 4.58x | 4.6x |
+| `polkavm64_recompiler_sync_gas` | yes | 221.62 µs | ±0.7% | 4.81x | 4.8x |
+| `polkavm64_recompiler_async_gas` | yes | 223.77 µs | ±0.3% | 4.86x | 4.9x |
+| `nub_jit` | yes | 500.20 µs | ±0.3% | 10.86x | 10.9x |
+| `polkavm64_recompiler_async_gas_full` | yes | 650.67 µs | ±1.1% | 14.12x | 14.1x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 650.68 µs | ±0.7% | 14.12x | 14.1x |
+| `polkavm64_interpreter` | no | 1.83 ms | ±0.7% | 39.66x | 39.7x |
+| `wasmtime_winch` | no | 3.15 ms | ±0.6% | 68.46x | 68.5x |
+| `nub_interp` | yes | 5.35 ms | ±0.2% | 116.08x | 116.1x |
+| `wasmer_singlepass` | no | 7.74 ms | ±1.6% | 167.94x | 167.9x |
+| `wasmtime_cranelift` | no | 23.88 ms | ±0.6% | 518.29x | 518.3x |
+| `wasmtime_cranelift_fuel` | yes | 30.01 ms | ±0.4% | 651.28x | 651.3x |
 
 ### fri-fold-tree
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 233.89 µs | ±0.9% | 1.00x | 1.0x |
-| `nub_jit` | yes | 536.58 µs | ±0.3% | 2.29x | 2.3x |
-| `polkavm64_recompiler_async_gas` | yes | 594.55 µs | ±0.2% | 2.54x | 2.5x |
-| `polkavm64_recompiler_no_gas` | no | 598.25 µs | ±0.1% | 2.56x | 2.6x |
-| `polkavm64_recompiler_sync_gas` | yes | 598.67 µs | ±0.3% | 2.56x | 2.6x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 635.05 µs | ±0.5% | 2.72x | 2.7x |
-| `polkavm64_recompiler_async_gas_full` | yes | 640.51 µs | ±0.1% | 2.74x | 2.7x |
-| `wasmtime_winch` | no | 2.94 ms | ±0.6% | 12.55x | 12.6x |
-| `wasmer_singlepass` | no | 7.79 ms | ±1.1% | 33.29x | 33.3x |
-| `wasmtime_cranelift` | no | 8.68 ms | ±0.2% | 37.13x | 37.1x |
-| `polkavm64_interpreter` | no | 9.02 ms | ±0.5% | 38.56x | 38.6x |
-| `wasmtime_cranelift_fuel` | yes | 12.22 ms | ±0.7% | 52.26x | 52.3x |
-| `nub_interp` | yes | 13.59 ms | ±0.8% | 58.09x | 58.1x |
+| `native` | no | 234.60 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` | yes | 532.82 µs | ±0.3% | 2.27x | 2.3x |
+| `polkavm64_recompiler_sync_gas` | yes | 592.62 µs | ±0.4% | 2.53x | 2.5x |
+| `polkavm64_recompiler_async_gas` | yes | 597.00 µs | ±0.4% | 2.54x | 2.5x |
+| `polkavm64_recompiler_no_gas` | no | 598.61 µs | ±0.0% | 2.55x | 2.6x |
+| `polkavm64_recompiler_async_gas_full` | yes | 612.55 µs | ±0.2% | 2.61x | 2.6x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 628.51 µs | ±1.4% | 2.68x | 2.7x |
+| `wasmtime_winch` | no | 2.90 ms | ±0.4% | 12.38x | 12.4x |
+| `wasmer_singlepass` | no | 7.46 ms | ±1.5% | 31.82x | 31.8x |
+| `wasmtime_cranelift` | no | 8.73 ms | ±0.5% | 37.19x | 37.2x |
+| `polkavm64_interpreter` | no | 9.07 ms | ±0.6% | 38.67x | 38.7x |
+| `wasmtime_cranelift_fuel` | yes | 12.24 ms | ±0.6% | 52.17x | 52.2x |
+| `nub_interp` | yes | 13.12 ms | ±0.6% | 55.95x | 55.9x |
 
 ### goldilocks-mul
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 210.41 µs | ±0.6% | 1.00x | 1.0x |
-| `nub_jit` | yes | 354.72 µs | ±0.4% | 1.69x | 1.7x |
-| `polkavm64_recompiler_no_gas` | no | 358.15 µs | ±0.0% | 1.70x | 1.7x |
-| `polkavm64_recompiler_async_gas` | yes | 374.20 µs | ±0.1% | 1.78x | 1.8x |
-| `polkavm64_recompiler_async_gas_full` | yes | 376.00 µs | ±0.3% | 1.79x | 1.8x |
-| `polkavm64_recompiler_sync_gas` | yes | 394.53 µs | ±0.0% | 1.88x | 1.9x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 396.51 µs | ±0.1% | 1.88x | 1.9x |
-| `wasmtime_winch` | no | 771.14 µs | ±0.5% | 3.66x | 3.7x |
-| `wasmtime_cranelift` | no | 907.49 µs | ±0.4% | 4.31x | 4.3x |
-| `wasmtime_cranelift_fuel` | yes | 1.02 ms | ±0.3% | 4.84x | 4.8x |
-| `polkavm64_interpreter` | no | 2.07 ms | ±0.5% | 9.84x | 9.8x |
-| `wasmer_singlepass` | no | 2.94 ms | ±1.3% | 13.98x | 14.0x |
-| `nub_interp` | yes | 3.98 ms | ±0.3% | 18.90x | 18.9x |
+| `native` | no | 214.47 µs | ±0.4% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 340.10 µs | ±0.2% | 1.59x | 1.6x |
+| `nub_jit` | yes | 353.01 µs | ±0.3% | 1.65x | 1.6x |
+| `polkavm64_recompiler_async_gas` | yes | 370.92 µs | ±0.1% | 1.73x | 1.7x |
+| `polkavm64_recompiler_sync_gas` | yes | 384.91 µs | ±1.0% | 1.79x | 1.8x |
+| `polkavm64_recompiler_async_gas_full` | yes | 389.41 µs | ±2.7% | 1.82x | 1.8x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 389.67 µs | ±0.5% | 1.82x | 1.8x |
+| `wasmtime_winch` | no | 770.10 µs | ±0.9% | 3.59x | 3.6x |
+| `wasmtime_cranelift` | no | 897.49 µs | ±0.6% | 4.18x | 4.2x |
+| `wasmtime_cranelift_fuel` | yes | 1.02 ms | ±0.5% | 4.74x | 4.7x |
+| `polkavm64_interpreter` | no | 2.07 ms | ±0.7% | 9.65x | 9.7x |
+| `wasmer_singlepass` | no | 2.90 ms | ±1.4% | 13.53x | 13.5x |
+| `nub_interp` | yes | 3.92 ms | ±0.6% | 18.26x | 18.3x |
 
 ### keccak
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 15.94 µs | ±0.6% | 1.00x | 1.0x |
-| `polkavm64_recompiler_sync_gas` | yes | 32.35 µs | ±0.5% | 2.03x | 2.0x |
-| `polkavm64_recompiler_no_gas` | no | 32.56 µs | ±1.3% | 2.04x | 2.0x |
-| `polkavm64_recompiler_async_gas` | yes | 33.73 µs | ±1.0% | 2.12x | 2.1x |
-| `nub_jit` | yes | 42.88 µs | ±0.2% | 2.69x | 2.7x |
-| `polkavm64_recompiler_async_gas_full` | yes | 58.52 µs | ±0.8% | 3.67x | 3.7x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 58.92 µs | ±0.6% | 3.70x | 3.7x |
-| `polkavm64_interpreter` | no | 99.71 µs | ±0.4% | 6.25x | 6.3x |
-| `nub_interp` | yes | 277.46 µs | ±0.7% | 17.40x | 17.4x |
-| `wasmtime_winch` | no | 797.19 µs | ±0.5% | 50.01x | 50.0x |
-| `wasmer_singlepass` | no | 1.72 ms | ±0.9% | 108.07x | 108.1x |
-| `wasmtime_cranelift` | no | 2.14 ms | ±0.3% | 134.36x | 134.4x |
-| `wasmtime_cranelift_fuel` | yes | 2.90 ms | ±0.7% | 181.88x | 181.9x |
+| `native` | no | 16.31 µs | ±0.7% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 32.97 µs | ±1.1% | 2.02x | 2.0x |
+| `polkavm64_recompiler_async_gas` | yes | 34.03 µs | ±1.2% | 2.09x | 2.1x |
+| `polkavm64_recompiler_sync_gas` | yes | 34.32 µs | ±0.8% | 2.10x | 2.1x |
+| `nub_jit` | yes | 43.22 µs | ±0.5% | 2.65x | 2.7x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 58.55 µs | ±0.9% | 3.59x | 3.6x |
+| `polkavm64_recompiler_async_gas_full` | yes | 58.94 µs | ±1.1% | 3.61x | 3.6x |
+| `polkavm64_interpreter` | no | 100.07 µs | ±1.0% | 6.14x | 6.1x |
+| `nub_interp` | yes | 277.97 µs | ±0.6% | 17.04x | 17.0x |
+| `wasmtime_winch` | no | 814.13 µs | ±0.5% | 49.92x | 49.9x |
+| `wasmer_singlepass` | no | 1.65 ms | ±1.0% | 100.92x | 100.9x |
+| `wasmtime_cranelift` | no | 2.19 ms | ±0.5% | 134.54x | 134.5x |
+| `wasmtime_cranelift_fuel` | yes | 2.90 ms | ±0.5% | 177.52x | 177.5x |
 
 ### mini-verifier
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 243.17 µs | ±0.7% | 1.00x | 1.0x |
-| `nub_jit` | yes | 533.84 µs | ±0.2% | 2.20x | 2.2x |
-| `polkavm64_recompiler_async_gas` | yes | 601.23 µs | ±0.3% | 2.47x | 2.5x |
-| `polkavm64_recompiler_no_gas` | no | 606.04 µs | ±0.2% | 2.49x | 2.5x |
-| `polkavm64_recompiler_sync_gas` | yes | 609.31 µs | ±0.3% | 2.51x | 2.5x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 653.05 µs | ±0.1% | 2.69x | 2.7x |
-| `polkavm64_recompiler_async_gas_full` | yes | 653.06 µs | ±0.1% | 2.69x | 2.7x |
-| `wasmtime_winch` | no | 1.91 ms | ±0.4% | 7.87x | 7.9x |
-| `wasmtime_cranelift` | no | 3.21 ms | ±0.3% | 13.18x | 13.2x |
-| `wasmtime_cranelift_fuel` | yes | 3.80 ms | ±0.5% | 15.61x | 15.6x |
-| `wasmer_singlepass` | no | 6.46 ms | ±2.9% | 26.55x | 26.6x |
-| `polkavm64_interpreter` | no | 9.81 ms | ±1.4% | 40.36x | 40.4x |
-| `nub_interp` | yes | 14.06 ms | ±1.4% | 57.80x | 57.8x |
+| `native` | no | 244.06 µs | ±0.5% | 1.00x | 1.0x |
+| `nub_jit` | yes | 542.58 µs | ±0.6% | 2.22x | 2.2x |
+| `polkavm64_recompiler_no_gas` | no | 603.23 µs | ±0.1% | 2.47x | 2.5x |
+| `polkavm64_recompiler_sync_gas` | yes | 606.33 µs | ±1.0% | 2.48x | 2.5x |
+| `polkavm64_recompiler_async_gas` | yes | 612.13 µs | ±0.0% | 2.51x | 2.5x |
+| `polkavm64_recompiler_async_gas_full` | yes | 652.81 µs | ±0.1% | 2.67x | 2.7x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 653.22 µs | ±0.0% | 2.68x | 2.7x |
+| `wasmtime_winch` | no | 1.86 ms | ±0.6% | 7.60x | 7.6x |
+| `wasmtime_cranelift` | no | 3.27 ms | ±0.6% | 13.39x | 13.4x |
+| `wasmtime_cranelift_fuel` | yes | 3.85 ms | ±0.4% | 15.77x | 15.8x |
+| `wasmer_singlepass` | no | 6.26 ms | ±0.9% | 25.66x | 25.7x |
+| `polkavm64_interpreter` | no | 9.64 ms | ±0.8% | 39.49x | 39.5x |
+| `nub_interp` | yes | 13.61 ms | ±1.1% | 55.78x | 55.8x |
 
 ### poly-eval
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 682.54 µs | ±0.8% | 1.00x | 1.0x |
-| `nub_jit` | yes | 1.13 ms | ±0.3% | 1.66x | 1.7x |
-| `polkavm64_recompiler_sync_gas` | yes | 1.15 ms | ±0.1% | 1.69x | 1.7x |
-| `polkavm64_recompiler_async_gas` | yes | 1.21 ms | ±0.5% | 1.78x | 1.8x |
-| `polkavm64_recompiler_no_gas` | no | 1.22 ms | ±0.0% | 1.79x | 1.8x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.22 ms | ±1.1% | 1.79x | 1.8x |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.28 ms | ±0.5% | 1.87x | 1.9x |
-| `wasmtime_winch` | no | 3.03 ms | ±0.6% | 4.45x | 4.4x |
-| `wasmtime_cranelift` | no | 6.90 ms | ±0.2% | 10.11x | 10.1x |
-| `polkavm64_interpreter` | no | 8.06 ms | ±0.6% | 11.81x | 11.8x |
-| `wasmer_singlepass` | no | 8.72 ms | ±1.4% | 12.77x | 12.8x |
-| `wasmtime_cranelift_fuel` | yes | 10.03 ms | ±0.5% | 14.69x | 14.7x |
-| `nub_interp` | yes | 17.58 ms | ±0.4% | 25.76x | 25.8x |
+| `native` | no | 679.29 µs | ±0.5% | 1.00x | 1.0x |
+| `nub_jit` | yes | 1.13 ms | ±0.4% | 1.66x | 1.7x |
+| `polkavm64_recompiler_async_gas` | yes | 1.21 ms | ±0.4% | 1.78x | 1.8x |
+| `polkavm64_recompiler_sync_gas` | yes | 1.22 ms | ±0.7% | 1.80x | 1.8x |
+| `polkavm64_recompiler_no_gas` | no | 1.23 ms | ±0.2% | 1.81x | 1.8x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.26 ms | ±0.0% | 1.85x | 1.9x |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.31 ms | ±0.0% | 1.92x | 1.9x |
+| `wasmtime_winch` | no | 3.02 ms | ±0.5% | 4.45x | 4.5x |
+| `wasmtime_cranelift` | no | 7.03 ms | ±0.5% | 10.35x | 10.4x |
+| `polkavm64_interpreter` | no | 8.13 ms | ±0.7% | 11.96x | 12.0x |
+| `wasmer_singlepass` | no | 8.64 ms | ±1.5% | 12.71x | 12.7x |
+| `wasmtime_cranelift_fuel` | yes | 9.97 ms | ±0.5% | 14.68x | 14.7x |
+| `nub_interp` | yes | 17.35 ms | ±0.6% | 25.55x | 25.5x |
 
 ### poseidon2-perm
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 563.68 µs | ±0.6% | 1.00x | 1.0x |
-| `nub_jit` | yes | 1.22 ms | ±1.5% | 2.16x | 2.2x |
-| `polkavm64_recompiler_no_gas` | no | 1.36 ms | ±0.4% | 2.42x | 2.4x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.41 ms | ±0.8% | 2.51x | 2.5x |
-| `polkavm64_recompiler_sync_gas` | yes | 1.44 ms | ±0.0% | 2.55x | 2.6x |
-| `polkavm64_recompiler_async_gas` | yes | 1.44 ms | ±0.0% | 2.56x | 2.6x |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.45 ms | ±0.3% | 2.57x | 2.6x |
-| `wasmtime_winch` | no | 3.58 ms | ±0.6% | 6.35x | 6.3x |
-| `wasmtime_cranelift` | no | 3.92 ms | ±0.5% | 6.95x | 6.9x |
-| `wasmtime_cranelift_fuel` | yes | 4.31 ms | ±0.5% | 7.64x | 7.6x |
-| `wasmer_singlepass` | no | 12.76 ms | ±1.3% | 22.64x | 22.6x |
-| `polkavm64_interpreter` | no | 21.91 ms | ±0.8% | 38.87x | 38.9x |
-| `nub_interp` | yes | 35.91 ms | ±0.8% | 63.71x | 63.7x |
+| `native` | no | 574.05 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` | yes | 1.18 ms | ±0.3% | 2.06x | 2.1x |
+| `polkavm64_recompiler_no_gas` | no | 1.40 ms | ±0.5% | 2.44x | 2.4x |
+| `polkavm64_recompiler_async_gas` | yes | 1.40 ms | ±0.6% | 2.44x | 2.4x |
+| `polkavm64_recompiler_sync_gas` | yes | 1.40 ms | ±0.7% | 2.44x | 2.4x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.43 ms | ±0.4% | 2.48x | 2.5x |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.43 ms | ±0.4% | 2.48x | 2.5x |
+| `wasmtime_winch` | no | 3.59 ms | ±0.2% | 6.25x | 6.2x |
+| `wasmtime_cranelift` | no | 3.93 ms | ±0.4% | 6.85x | 6.9x |
+| `wasmtime_cranelift_fuel` | yes | 4.40 ms | ±0.5% | 7.67x | 7.7x |
+| `wasmer_singlepass` | no | 12.44 ms | ±0.4% | 21.67x | 21.7x |
+| `polkavm64_interpreter` | no | 22.28 ms | ±1.3% | 38.82x | 38.8x |
+| `nub_interp` | yes | 35.07 ms | ±0.9% | 61.10x | 61.1x |
 
 ### prime-sieve
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 88.97 µs | ±0.5% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 126.75 µs | ±0.2% | 1.42x | 1.4x |
-| `polkavm64_recompiler_async_gas` | yes | 220.70 µs | ±0.5% | 2.48x | 2.5x |
-| `nub_jit` | yes | 224.81 µs | ±0.5% | 2.53x | 2.5x |
-| `polkavm64_recompiler_sync_gas` | yes | 227.80 µs | ±1.9% | 2.56x | 2.6x |
-| `polkavm64_recompiler_async_gas_full` | yes | 229.32 µs | ±1.4% | 2.58x | 2.6x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 233.22 µs | ±0.7% | 2.62x | 2.6x |
-| `wasmtime_winch` | no | 538.75 µs | ±0.4% | 6.06x | 6.1x |
-| `wasmtime_cranelift` | no | 647.74 µs | ±0.7% | 7.28x | 7.3x |
-| `wasmtime_cranelift_fuel` | yes | 1.03 ms | ±0.7% | 11.57x | 11.6x |
-| `wasmer_singlepass` | no | 1.55 ms | ±1.7% | 17.41x | 17.4x |
-| `polkavm64_interpreter` | no | 2.08 ms | ±0.7% | 23.33x | 23.3x |
-| `nub_interp` | yes | 7.33 ms | ±0.9% | 82.42x | 82.4x |
+| `native` | no | 90.05 µs | ±0.3% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 126.49 µs | ±0.1% | 1.40x | 1.4x |
+| `polkavm64_recompiler_async_gas` | yes | 222.23 µs | ±0.5% | 2.47x | 2.5x |
+| `polkavm64_recompiler_async_gas_full` | yes | 222.35 µs | ±0.8% | 2.47x | 2.5x |
+| `nub_jit` | yes | 228.91 µs | ±0.7% | 2.54x | 2.5x |
+| `polkavm64_recompiler_sync_gas` | yes | 228.98 µs | ±0.1% | 2.54x | 2.5x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 234.41 µs | ±0.1% | 2.60x | 2.6x |
+| `wasmtime_winch` | no | 550.11 µs | ±0.6% | 6.11x | 6.1x |
+| `wasmtime_cranelift` | no | 641.84 µs | ±0.3% | 7.13x | 7.1x |
+| `wasmtime_cranelift_fuel` | yes | 1.02 ms | ±0.4% | 11.33x | 11.3x |
+| `wasmer_singlepass` | no | 1.55 ms | ±2.0% | 17.24x | 17.2x |
+| `polkavm64_interpreter` | no | 2.12 ms | ±0.4% | 23.59x | 23.6x |
+| `nub_interp` | yes | 8.17 ms | ±0.7% | 90.75x | 90.7x |
 
 ## compilation
 
@@ -256,171 +353,171 @@ Turning the program into executable form. Engine construction and file loading a
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 17.73 µs | ±0.7% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 18.69 µs | ±0.5% | 1.05x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 18.72 µs | ±0.5% | 1.06x | - |
-| `polkavm64_recompiler_async_gas` | yes | 18.77 µs | ±0.7% | 1.06x | - |
-| `nub_jit_compile` | yes | 42.99 µs | ±0.4% | 2.43x | - |
-| `nub_jit` | yes | 64.23 µs | ±0.4% | 3.62x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 97.37 µs | ±0.4% | 5.49x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 98.13 µs | ±0.4% | 5.54x | - |
-| `wasmtime_winch` | no | 423.57 µs | ±0.7% | 23.90x | - |
-| `wasmer_singlepass` | no | 1.07 ms | ±1.0% | 60.24x | - |
-| `wasmtime_cranelift` | no | 3.26 ms | ±0.5% | 183.76x | - |
-| `wasmtime_cranelift_fuel` | yes | 3.45 ms | ±0.4% | 194.53x | - |
+| `polkavm64_interpreter` | no | 17.91 µs | ±0.6% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 18.99 µs | ±0.7% | 1.06x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 19.03 µs | ±0.6% | 1.06x | - |
+| `polkavm64_recompiler_async_gas` | yes | 19.08 µs | ±0.7% | 1.07x | - |
+| `nub_jit_compile` | yes | 45.45 µs | ±0.4% | 2.54x | - |
+| `nub_jit` | yes | 64.76 µs | ±0.4% | 3.62x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 98.13 µs | ±0.5% | 5.48x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 98.61 µs | ±0.4% | 5.51x | - |
+| `wasmtime_winch` | no | 424.11 µs | ±0.4% | 23.68x | - |
+| `wasmer_singlepass` | no | 917.18 µs | ±1.8% | 51.21x | - |
+| `wasmtime_cranelift` | no | 3.24 ms | ±0.5% | 180.86x | - |
+| `wasmtime_cranelift_fuel` | yes | 3.46 ms | ±0.4% | 193.29x | - |
 
 ### ecrecover
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 194.37 µs | ±0.4% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 251.95 µs | ±0.3% | 1.30x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 263.15 µs | ±0.7% | 1.35x | - |
-| `polkavm64_recompiler_async_gas` | yes | 264.58 µs | ±0.5% | 1.36x | - |
-| `nub_jit` | yes | 612.95 µs | ±0.7% | 3.15x | - |
-| `nub_jit_compile` | yes | 863.23 µs | ±0.4% | 4.44x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.34 ms | ±0.5% | 6.89x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.35 ms | ±0.6% | 6.96x | - |
-| `wasmer_singlepass` | no | 3.62 ms | ±1.1% | 18.63x | - |
-| `wasmtime_winch` | no | 4.89 ms | ±0.6% | 25.17x | - |
-| `wasmtime_cranelift` | no | 35.17 ms | ±0.7% | 180.96x | - |
-| `wasmtime_cranelift_fuel` | yes | 43.73 ms | ±0.3% | 224.97x | - |
+| `polkavm64_interpreter` | no | 194.97 µs | ±0.6% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 251.82 µs | ±0.4% | 1.29x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 259.04 µs | ±0.6% | 1.33x | - |
+| `polkavm64_recompiler_async_gas` | yes | 262.52 µs | ±0.4% | 1.35x | - |
+| `nub_jit` | yes | 615.64 µs | ±0.5% | 3.16x | - |
+| `nub_jit_compile` | yes | 778.72 µs | ±0.6% | 3.99x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.35 ms | ±0.4% | 6.93x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.36 ms | ±0.5% | 6.99x | - |
+| `wasmer_singlepass` | no | 3.16 ms | ±1.2% | 16.23x | - |
+| `wasmtime_winch` | no | 4.86 ms | ±0.6% | 24.91x | - |
+| `wasmtime_cranelift` | no | 35.73 ms | ±0.4% | 183.25x | - |
+| `wasmtime_cranelift_fuel` | yes | 44.19 ms | ±0.3% | 226.65x | - |
 
 ### ed25519
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 82.30 µs | ±0.5% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 110.74 µs | ±0.4% | 1.35x | - |
-| `polkavm64_recompiler_async_gas` | yes | 111.68 µs | ±0.4% | 1.36x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 112.85 µs | ±0.8% | 1.37x | - |
-| `nub_jit` | yes | 277.45 µs | ±0.2% | 3.37x | - |
-| `nub_jit_compile` | yes | 355.71 µs | ±0.2% | 4.32x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 522.36 µs | ±0.4% | 6.35x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 529.25 µs | ±0.5% | 6.43x | - |
-| `wasmtime_winch` | no | 2.81 ms | ±0.4% | 34.11x | - |
-| `wasmer_singlepass` | no | 4.84 ms | ±0.9% | 58.80x | - |
-| `wasmtime_cranelift` | no | 23.75 ms | ±0.4% | 288.62x | - |
-| `wasmtime_cranelift_fuel` | yes | 29.86 ms | ±0.3% | 362.87x | - |
+| `polkavm64_interpreter` | no | 82.71 µs | ±0.7% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 112.82 µs | ±0.4% | 1.36x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 113.74 µs | ±0.4% | 1.38x | - |
+| `polkavm64_recompiler_async_gas` | yes | 115.01 µs | ±0.3% | 1.39x | - |
+| `nub_jit` | yes | 286.36 µs | ±0.8% | 3.46x | - |
+| `nub_jit_compile` | yes | 361.35 µs | ±0.6% | 4.37x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 523.97 µs | ±0.5% | 6.34x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 529.98 µs | ±0.7% | 6.41x | - |
+| `wasmtime_winch` | no | 2.73 ms | ±0.8% | 32.99x | - |
+| `wasmer_singlepass` | no | 3.29 ms | ±1.0% | 39.73x | - |
+| `wasmtime_cranelift` | no | 23.98 ms | ±0.5% | 289.89x | - |
+| `wasmtime_cranelift_fuel` | yes | 29.50 ms | ±0.4% | 356.68x | - |
 
 ### fri-fold-tree
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 9.90 µs | ±0.4% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 11.09 µs | ±0.8% | 1.12x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 11.36 µs | ±0.9% | 1.15x | - |
-| `polkavm64_recompiler_async_gas` | yes | 11.68 µs | ±0.4% | 1.18x | - |
-| `nub_jit_compile` | yes | 26.64 µs | ±0.7% | 2.69x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 53.83 µs | ±0.3% | 5.44x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 54.34 µs | ±0.3% | 5.49x | - |
-| `nub_jit` | yes | 70.18 µs | ±0.6% | 7.09x | - |
-| `wasmer_singlepass` | no | 1.49 ms | ±0.9% | 150.09x | - |
-| `wasmtime_winch` | no | 1.65 ms | ±0.3% | 167.14x | - |
-| `wasmtime_cranelift` | no | 8.10 ms | ±0.4% | 818.37x | - |
-| `wasmtime_cranelift_fuel` | yes | 11.50 ms | ±0.3% | 1161.45x | - |
+| `polkavm64_interpreter` | no | 9.73 µs | ±0.8% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 10.65 µs | ±0.5% | 1.09x | - |
+| `polkavm64_recompiler_async_gas` | yes | 10.73 µs | ±0.6% | 1.10x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 10.77 µs | ±0.6% | 1.11x | - |
+| `nub_jit_compile` | yes | 26.49 µs | ±0.9% | 2.72x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 53.84 µs | ±0.3% | 5.53x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 53.94 µs | ±0.2% | 5.54x | - |
+| `nub_jit` | yes | 72.89 µs | ±0.6% | 7.49x | - |
+| `wasmer_singlepass` | no | 1.40 ms | ±0.9% | 144.34x | - |
+| `wasmtime_winch` | no | 1.62 ms | ±0.7% | 166.89x | - |
+| `wasmtime_cranelift` | no | 8.13 ms | ±0.2% | 835.21x | - |
+| `wasmtime_cranelift_fuel` | yes | 11.57 ms | ±0.5% | 1189.17x | - |
 
 ### goldilocks-mul
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 350.2 ns | ±0.7% | 1.00x | - |
-| `nub_jit_compile` | yes | 1.06 µs | ±0.2% | 3.01x | - |
-| `polkavm64_recompiler_no_gas` | no | 1.52 µs | ±0.6% | 4.33x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 1.55 µs | ±0.3% | 4.41x | - |
-| `polkavm64_recompiler_async_gas` | yes | 1.58 µs | ±0.5% | 4.50x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 3.19 µs | ±0.5% | 9.11x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 3.20 µs | ±0.5% | 9.12x | - |
-| `nub_jit` | yes | 23.90 µs | ±0.6% | 68.23x | - |
-| `wasmtime_winch` | no | 205.22 µs | ±0.7% | 586.01x | - |
-| `wasmtime_cranelift` | no | 367.33 µs | ±0.8% | 1048.90x | - |
-| `wasmtime_cranelift_fuel` | yes | 490.23 µs | ±0.7% | 1399.86x | - |
-| `wasmer_singlepass` | no | 651.59 µs | ±2.5% | 1860.63x | - |
+| `polkavm64_interpreter` | no | 354.3 ns | ±0.5% | 1.00x | - |
+| `nub_jit_compile` | yes | 1.28 µs | ±0.5% | 3.61x | - |
+| `polkavm64_recompiler_no_gas` | no | 1.54 µs | ±0.6% | 4.35x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 1.57 µs | ±0.4% | 4.44x | - |
+| `polkavm64_recompiler_async_gas` | yes | 1.58 µs | ±0.5% | 4.47x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 3.18 µs | ±0.4% | 8.98x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 3.20 µs | ±0.4% | 9.02x | - |
+| `nub_jit` | yes | 24.44 µs | ±0.5% | 68.99x | - |
+| `wasmtime_winch` | no | 207.67 µs | ±0.2% | 586.18x | - |
+| `wasmtime_cranelift` | no | 369.10 µs | ±0.6% | 1041.83x | - |
+| `wasmtime_cranelift_fuel` | yes | 496.00 µs | ±0.4% | 1400.03x | - |
+| `wasmer_singlepass` | no | 642.29 µs | ±1.5% | 1812.96x | - |
 
 ### keccak
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 6.65 µs | ±0.6% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 7.37 µs | ±0.6% | 1.11x | - |
-| `polkavm64_recompiler_async_gas` | yes | 7.52 µs | ±0.4% | 1.13x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 7.52 µs | ±0.2% | 1.13x | - |
-| `nub_jit_compile` | yes | 9.28 µs | ±0.5% | 1.40x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 33.29 µs | ±0.1% | 5.00x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 33.46 µs | ±0.5% | 5.03x | - |
-| `nub_jit` | yes | 34.55 µs | ±0.2% | 5.20x | - |
-| `wasmtime_winch` | no | 764.93 µs | ±0.6% | 115.02x | - |
-| `wasmer_singlepass` | no | 828.53 µs | ±1.3% | 124.58x | - |
-| `wasmtime_cranelift` | no | 2.13 ms | ±0.6% | 320.06x | - |
-| `wasmtime_cranelift_fuel` | yes | 2.83 ms | ±0.5% | 426.09x | - |
+| `polkavm64_interpreter` | no | 6.76 µs | ±0.3% | 1.00x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 7.61 µs | ±0.5% | 1.13x | - |
+| `polkavm64_recompiler_no_gas` | no | 7.69 µs | ±0.6% | 1.14x | - |
+| `polkavm64_recompiler_async_gas` | yes | 7.75 µs | ±0.3% | 1.15x | - |
+| `nub_jit_compile` | yes | 9.52 µs | ±0.4% | 1.41x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 33.48 µs | ±0.6% | 4.95x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 34.11 µs | ±0.5% | 5.05x | - |
+| `nub_jit` | yes | 35.84 µs | ±0.5% | 5.30x | - |
+| `wasmtime_winch` | no | 760.40 µs | ±0.4% | 112.50x | - |
+| `wasmer_singlepass` | no | 804.30 µs | ±1.4% | 118.99x | - |
+| `wasmtime_cranelift` | no | 2.15 ms | ±0.2% | 318.76x | - |
+| `wasmtime_cranelift_fuel` | yes | 2.86 ms | ±0.6% | 423.04x | - |
 
 ### mini-verifier
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 9.39 µs | ±0.5% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 10.08 µs | ±0.5% | 1.07x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 10.32 µs | ±0.4% | 1.10x | - |
-| `polkavm64_recompiler_async_gas` | yes | 10.40 µs | ±0.6% | 1.11x | - |
-| `nub_jit_compile` | yes | 26.72 µs | ±0.4% | 2.84x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 50.50 µs | ±0.4% | 5.38x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 51.02 µs | ±0.4% | 5.43x | - |
-| `nub_jit` | yes | 53.40 µs | ±0.3% | 5.68x | - |
-| `wasmtime_winch` | no | 561.95 µs | ±0.6% | 59.82x | - |
-| `wasmer_singlepass` | no | 926.06 µs | ±1.3% | 98.57x | - |
-| `wasmtime_cranelift` | no | 2.44 ms | ±0.7% | 259.75x | - |
-| `wasmtime_cranelift_fuel` | yes | 3.00 ms | ±0.5% | 319.55x | - |
+| `polkavm64_interpreter` | no | 9.56 µs | ±0.6% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 9.75 µs | ±0.4% | 1.02x | - |
+| `polkavm64_recompiler_async_gas` | yes | 9.81 µs | ±0.5% | 1.03x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 10.51 µs | ±0.8% | 1.10x | - |
+| `nub_jit_compile` | yes | 26.72 µs | ±0.6% | 2.79x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 51.25 µs | ±0.4% | 5.36x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 51.34 µs | ±0.4% | 5.37x | - |
+| `nub_jit` | yes | 54.76 µs | ±0.6% | 5.73x | - |
+| `wasmtime_winch` | no | 563.08 µs | ±0.4% | 58.88x | - |
+| `wasmer_singlepass` | no | 899.45 µs | ±1.5% | 94.06x | - |
+| `wasmtime_cranelift` | no | 2.48 ms | ±0.5% | 259.79x | - |
+| `wasmtime_cranelift_fuel` | yes | 3.02 ms | ±0.3% | 315.56x | - |
 
 ### poly-eval
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
 | `polkavm64_interpreter` | no | 1.72 µs | ±0.6% | 1.00x | - |
-| `polkavm64_recompiler_no_gas` | no | 3.00 µs | ±0.9% | 1.75x | - |
-| `polkavm64_recompiler_async_gas` | yes | 3.06 µs | ±0.3% | 1.79x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 3.10 µs | ±0.3% | 1.81x | - |
-| `nub_jit_compile` | yes | 8.34 µs | ±0.5% | 4.86x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 11.01 µs | ±0.5% | 6.42x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 11.11 µs | ±0.7% | 6.48x | - |
-| `nub_jit` | yes | 31.60 µs | ±0.4% | 18.43x | - |
-| `wasmtime_winch` | no | 1.29 ms | ±0.5% | 749.39x | - |
-| `wasmer_singlepass` | no | 1.40 ms | ±1.0% | 814.00x | - |
-| `wasmtime_cranelift` | no | 5.34 ms | ±0.3% | 3112.50x | - |
-| `wasmtime_cranelift_fuel` | yes | 8.37 ms | ±0.4% | 4879.57x | - |
+| `polkavm64_recompiler_no_gas` | no | 3.06 µs | ±0.5% | 1.78x | - |
+| `polkavm64_recompiler_async_gas` | yes | 3.17 µs | ±0.5% | 1.85x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 3.23 µs | ±0.7% | 1.88x | - |
+| `nub_jit_compile` | yes | 9.53 µs | ±0.3% | 5.55x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 11.18 µs | ±0.8% | 6.51x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 11.28 µs | ±0.3% | 6.57x | - |
+| `nub_jit` | yes | 32.73 µs | ±0.8% | 19.07x | - |
+| `wasmtime_winch` | no | 1.30 ms | ±0.2% | 758.40x | - |
+| `wasmer_singlepass` | no | 1.33 ms | ±0.8% | 777.80x | - |
+| `wasmtime_cranelift` | no | 5.47 ms | ±0.4% | 3189.79x | - |
+| `wasmtime_cranelift_fuel` | yes | 8.54 ms | ±0.2% | 4976.08x | - |
 
 ### poseidon2-perm
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 7.49 µs | ±0.9% | 1.00x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 8.04 µs | ±0.3% | 1.07x | - |
-| `polkavm64_recompiler_no_gas` | no | 8.10 µs | ±0.6% | 1.08x | - |
-| `polkavm64_recompiler_async_gas` | yes | 8.29 µs | ±0.6% | 1.11x | - |
-| `nub_jit_compile` | yes | 22.21 µs | ±0.3% | 2.97x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 37.24 µs | ±0.5% | 4.97x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 37.47 µs | ±0.5% | 5.00x | - |
-| `nub_jit` | yes | 47.49 µs | ±0.3% | 6.34x | - |
-| `wasmtime_winch` | no | 468.52 µs | ±0.6% | 62.55x | - |
-| `wasmer_singlepass` | no | 914.23 µs | ±2.4% | 122.06x | - |
-| `wasmtime_cranelift` | no | 1.98 ms | ±0.5% | 265.01x | - |
-| `wasmtime_cranelift_fuel` | yes | 2.44 ms | ±0.4% | 325.81x | - |
+| `polkavm64_interpreter` | no | 7.56 µs | ±0.3% | 1.00x | - |
+| `polkavm64_recompiler_no_gas` | no | 7.77 µs | ±0.5% | 1.03x | - |
+| `polkavm64_recompiler_async_gas` | yes | 7.79 µs | ±0.3% | 1.03x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 7.91 µs | ±0.5% | 1.05x | - |
+| `nub_jit_compile` | yes | 22.91 µs | ±0.3% | 3.03x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 37.41 µs | ±0.5% | 4.95x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 37.49 µs | ±0.4% | 4.96x | - |
+| `nub_jit` | yes | 47.68 µs | ±0.8% | 6.30x | - |
+| `wasmtime_winch` | no | 469.90 µs | ±0.9% | 62.12x | - |
+| `wasmer_singlepass` | no | 869.38 µs | ±1.1% | 114.94x | - |
+| `wasmtime_cranelift` | no | 2.00 ms | ±0.4% | 264.56x | - |
+| `wasmtime_cranelift_fuel` | yes | 2.43 ms | ±0.5% | 321.61x | - |
 
 ### prime-sieve
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `polkavm64_interpreter` | no | 1.81 µs | ±0.6% | 1.00x | - |
-| `nub_jit_compile` | yes | 3.43 µs | ±0.5% | 1.90x | - |
-| `polkavm64_recompiler_no_gas` | no | 4.72 µs | ±0.5% | 2.61x | - |
-| `polkavm64_recompiler_sync_gas` | yes | 4.80 µs | ±1.0% | 2.65x | - |
-| `polkavm64_recompiler_async_gas` | yes | 4.81 µs | ±0.8% | 2.66x | - |
-| `polkavm64_recompiler_async_gas_full` | yes | 6.96 µs | ±0.5% | 3.85x | - |
-| `polkavm64_recompiler_sync_gas_full` | yes | 7.03 µs | ±0.8% | 3.89x | - |
-| `wasmtime_winch` | no | 323.19 µs | ±0.6% | 178.91x | - |
-| `wasmtime_cranelift` | no | 484.64 µs | ±0.8% | 268.28x | - |
-| `nub_jit` | yes | 485.97 µs | ±0.4% | 269.02x | - |
-| `wasmer_singlepass` | no | 725.79 µs | ±1.9% | 401.78x | - |
-| `wasmtime_cranelift_fuel` | yes | 800.52 µs | ±0.5% | 443.14x | - |
+| `polkavm64_interpreter` | no | 1.84 µs | ±0.4% | 1.00x | - |
+| `nub_jit_compile` | yes | 3.70 µs | ±0.6% | 2.02x | - |
+| `polkavm64_recompiler_no_gas` | no | 4.69 µs | ±0.3% | 2.56x | - |
+| `polkavm64_recompiler_sync_gas` | yes | 4.79 µs | ±0.4% | 2.61x | - |
+| `polkavm64_recompiler_async_gas` | yes | 4.80 µs | ±0.4% | 2.61x | - |
+| `polkavm64_recompiler_async_gas_full` | yes | 6.94 µs | ±0.6% | 3.78x | - |
+| `polkavm64_recompiler_sync_gas_full` | yes | 7.07 µs | ±0.6% | 3.85x | - |
+| `wasmtime_winch` | no | 327.84 µs | ±0.6% | 178.58x | - |
+| `nub_jit` | yes | 489.48 µs | ±0.7% | 266.63x | - |
+| `wasmtime_cranelift` | no | 489.57 µs | ±0.4% | 266.68x | - |
+| `wasmer_singlepass` | no | 697.57 µs | ±1.6% | 379.99x | - |
+| `wasmtime_cranelift_fuel` | yes | 818.07 µs | ±0.5% | 445.63x | - |
 
 ## invoke
 
@@ -430,181 +527,181 @@ Cold invocation with compilation excluded: a fresh instance every sample. Where 
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 632.8 ns | ±0.3% | 1.00x | 1.0x |
-| `nub_jit` | yes | 4.55 µs | ±0.3% | 7.20x | 7.2x |
-| `wasmtime_cranelift` | no | 5.46 µs | ±0.7% | 8.64x | 8.6x |
-| `wasmtime_cranelift_fuel` | yes | 5.50 µs | ±1.0% | 8.70x | 8.7x |
-| `wasmtime_winch` | no | 6.02 µs | ±0.5% | 9.51x | 9.5x |
-| `polkavm64_recompiler_no_gas` | no | 8.83 µs | ±0.5% | 13.95x | 13.9x |
-| `polkavm64_recompiler_async_gas_full` | yes | 9.37 µs | ±1.0% | 14.81x | 14.8x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 9.41 µs | ±0.9% | 14.87x | 14.9x |
-| `polkavm64_recompiler_async_gas` | yes | 9.65 µs | ±1.3% | 15.25x | 15.2x |
-| `polkavm64_recompiler_sync_gas` | yes | 9.79 µs | ±1.0% | 15.47x | 15.5x |
-| `wasmer_singlepass` | no | 45.08 µs | ±4.2% | 71.24x | 71.2x |
-| `polkavm64_interpreter` | no | 103.17 µs | ±1.1% | 163.04x | 163.0x |
-| `nub_interp` | yes | 152.07 µs | ±1.2% | 240.31x | 240.3x |
+| `native` | no | 640.2 ns | ±0.3% | 1.00x | 1.0x |
+| `nub_jit` | yes | 4.65 µs | ±0.4% | 7.26x | 7.3x |
+| `wasmtime_cranelift_fuel` | yes | 5.57 µs | ±1.0% | 8.71x | 8.7x |
+| `wasmtime_cranelift` | no | 5.62 µs | ±1.0% | 8.77x | 8.8x |
+| `wasmtime_winch` | no | 6.17 µs | ±0.8% | 9.65x | 9.6x |
+| `polkavm64_recompiler_sync_gas` | yes | 8.63 µs | ±1.7% | 13.49x | 13.5x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 8.91 µs | ±1.2% | 13.91x | 13.9x |
+| `polkavm64_recompiler_no_gas` | no | 8.95 µs | ±1.0% | 13.98x | 14.0x |
+| `polkavm64_recompiler_async_gas` | yes | 9.65 µs | ±1.1% | 15.07x | 15.1x |
+| `polkavm64_recompiler_async_gas_full` | yes | 9.69 µs | ±1.5% | 15.14x | 15.1x |
+| `wasmer_singlepass` | no | 45.42 µs | ±3.6% | 70.95x | 70.9x |
+| `polkavm64_interpreter` | no | 98.42 µs | ±0.7% | 153.75x | 153.7x |
+| `nub_interp` | yes | 152.54 µs | ±1.1% | 238.28x | 238.3x |
 
 ### ecrecover
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 91.28 µs | ±0.1% | 1.00x | 1.0x |
-| `wasmtime_cranelift` | no | 258.28 µs | ±0.5% | 2.83x | 2.8x |
-| `wasmtime_cranelift_fuel` | yes | 270.97 µs | ±0.5% | 2.97x | 3.0x |
-| `polkavm64_recompiler_no_gas` | no | 319.06 µs | ±0.1% | 3.50x | 3.5x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 333.25 µs | ±0.1% | 3.65x | 3.7x |
-| `polkavm64_recompiler_async_gas` | yes | 333.40 µs | ±0.1% | 3.65x | 3.7x |
-| `polkavm64_recompiler_async_gas_full` | yes | 333.71 µs | ±0.1% | 3.66x | 3.7x |
-| `polkavm64_recompiler_sync_gas` | yes | 333.86 µs | ±0.1% | 3.66x | 3.7x |
-| `nub_jit` | yes | 366.67 µs | ±0.2% | 4.02x | 4.0x |
-| `wasmtime_winch` | no | 386.51 µs | ±0.5% | 4.23x | 4.2x |
-| `wasmer_singlepass` | no | 1.14 ms | ±2.8% | 12.52x | 12.5x |
-| `polkavm64_interpreter` | no | 12.14 ms | ±0.6% | 132.95x | 132.9x |
-| `nub_interp` | yes | 26.51 ms | ±0.9% | 290.48x | 290.5x |
+| `native` | no | 92.65 µs | ±0.7% | 1.00x | 1.0x |
+| `wasmtime_cranelift` | no | 260.07 µs | ±0.3% | 2.81x | 2.8x |
+| `wasmtime_cranelift_fuel` | yes | 270.38 µs | ±0.5% | 2.92x | 2.9x |
+| `polkavm64_recompiler_no_gas` | no | 319.48 µs | ±0.1% | 3.45x | 3.4x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 333.74 µs | ±0.1% | 3.60x | 3.6x |
+| `polkavm64_recompiler_async_gas_full` | yes | 334.04 µs | ±0.2% | 3.61x | 3.6x |
+| `polkavm64_recompiler_sync_gas` | yes | 334.41 µs | ±0.2% | 3.61x | 3.6x |
+| `nub_jit` | yes | 370.80 µs | ±0.4% | 4.00x | 4.0x |
+| `wasmtime_winch` | no | 416.98 µs | ±0.4% | 4.50x | 4.5x |
+| `polkavm64_recompiler_async_gas` | yes | 451.73 µs | ±0.1% | 4.88x | 4.9x |
+| `wasmer_singlepass` | no | 1.18 ms | ±3.2% | 12.74x | 12.7x |
+| `polkavm64_interpreter` | no | 12.18 ms | ±0.3% | 131.41x | 131.4x |
+| `nub_interp` | yes | 26.59 ms | ±0.5% | 287.00x | 287.0x |
 
 ### ed25519
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 29.35 µs | ±0.6% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 74.26 µs | ±0.2% | 2.53x | 2.5x |
-| `polkavm64_recompiler_async_gas_full` | yes | 81.87 µs | ±0.1% | 2.79x | 2.8x |
-| `polkavm64_recompiler_async_gas` | yes | 81.96 µs | ±0.2% | 2.79x | 2.8x |
-| `polkavm64_recompiler_sync_gas` | yes | 82.37 µs | ±0.1% | 2.81x | 2.8x |
-| `nub_jit` | yes | 89.99 µs | ±0.2% | 3.07x | 3.1x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 100.86 µs | ±0.1% | 3.44x | 3.4x |
-| `wasmtime_cranelift` | no | 196.13 µs | ±0.9% | 6.68x | 6.7x |
-| `wasmtime_cranelift_fuel` | yes | 240.79 µs | ±0.4% | 8.20x | 8.2x |
-| `wasmtime_winch` | no | 348.38 µs | ±0.5% | 11.87x | 11.9x |
-| `wasmer_singlepass` | no | 1.29 ms | ±1.5% | 43.90x | 43.9x |
-| `polkavm64_interpreter` | no | 1.76 ms | ±0.3% | 60.03x | 60.0x |
-| `nub_interp` | yes | 4.91 ms | ±0.7% | 167.20x | 167.2x |
+| `native` | no | 29.54 µs | ±0.6% | 1.00x | 1.0x |
+| `polkavm64_recompiler_async_gas_full` | yes | 81.99 µs | ±0.3% | 2.78x | 2.8x |
+| `polkavm64_recompiler_async_gas` | yes | 82.05 µs | ±0.2% | 2.78x | 2.8x |
+| `polkavm64_recompiler_sync_gas` | yes | 82.38 µs | ±0.3% | 2.79x | 2.8x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 82.77 µs | ±0.3% | 2.80x | 2.8x |
+| `polkavm64_recompiler_no_gas` | no | 90.54 µs | ±8.9% | 3.06x | 3.1x |
+| `nub_jit` | yes | 91.63 µs | ±0.7% | 3.10x | 3.1x |
+| `wasmtime_cranelift` | no | 199.08 µs | ±0.5% | 6.74x | 6.7x |
+| `wasmtime_cranelift_fuel` | yes | 242.71 µs | ±0.3% | 8.22x | 8.2x |
+| `wasmtime_winch` | no | 351.42 µs | ±0.9% | 11.90x | 11.9x |
+| `wasmer_singlepass` | no | 1.29 ms | ±1.7% | 43.57x | 43.6x |
+| `polkavm64_interpreter` | no | 1.77 ms | ±0.8% | 59.86x | 59.9x |
+| `nub_interp` | yes | 4.87 ms | ±0.3% | 164.86x | 164.9x |
 
 ### fri-fold-tree
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 220.96 µs | ±0.3% | 1.00x | 1.0x |
-| `nub_jit` | yes | 451.60 µs | ±0.4% | 2.04x | 2.0x |
-| `polkavm64_recompiler_async_gas` | yes | 498.03 µs | ±0.1% | 2.25x | 2.3x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 498.60 µs | ±0.1% | 2.26x | 2.3x |
-| `polkavm64_recompiler_no_gas` | no | 498.91 µs | ±0.1% | 2.26x | 2.3x |
-| `polkavm64_recompiler_async_gas_full` | yes | 500.64 µs | ±0.1% | 2.27x | 2.3x |
-| `polkavm64_recompiler_sync_gas` | yes | 500.75 µs | ±0.3% | 2.27x | 2.3x |
-| `wasmtime_cranelift` | no | 751.15 µs | ±0.6% | 3.40x | 3.4x |
-| `wasmtime_cranelift_fuel` | yes | 771.91 µs | ±0.3% | 3.49x | 3.5x |
-| `wasmtime_winch` | no | 1.26 ms | ±0.5% | 5.69x | 5.7x |
-| `wasmer_singlepass` | no | 4.62 ms | ±1.2% | 20.90x | 20.9x |
-| `polkavm64_interpreter` | no | 8.90 ms | ±0.8% | 40.26x | 40.3x |
-| `nub_interp` | yes | 13.48 ms | ±1.1% | 60.99x | 61.0x |
+| `native` | no | 221.62 µs | ±0.5% | 1.00x | 1.0x |
+| `nub_jit` | yes | 452.27 µs | ±0.5% | 2.04x | 2.0x |
+| `polkavm64_recompiler_no_gas` | no | 498.08 µs | ±0.1% | 2.25x | 2.2x |
+| `polkavm64_recompiler_async_gas` | yes | 498.30 µs | ±0.1% | 2.25x | 2.2x |
+| `polkavm64_recompiler_sync_gas` | yes | 498.78 µs | ±0.1% | 2.25x | 2.3x |
+| `polkavm64_recompiler_async_gas_full` | yes | 498.88 µs | ±0.1% | 2.25x | 2.3x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 500.71 µs | ±0.2% | 2.26x | 2.3x |
+| `wasmtime_cranelift` | no | 736.81 µs | ±0.8% | 3.32x | 3.3x |
+| `wasmtime_cranelift_fuel` | yes | 773.91 µs | ±0.5% | 3.49x | 3.5x |
+| `wasmtime_winch` | no | 1.26 ms | ±0.5% | 5.67x | 5.7x |
+| `wasmer_singlepass` | no | 4.63 ms | ±1.8% | 20.88x | 20.9x |
+| `polkavm64_interpreter` | no | 8.88 ms | ±0.6% | 40.05x | 40.1x |
+| `nub_interp` | yes | 13.02 ms | ±0.6% | 58.76x | 58.8x |
 
 ### goldilocks-mul
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 197.02 µs | ±0.7% | 1.00x | 1.0x |
-| `nub_jit` | yes | 306.85 µs | ±0.3% | 1.56x | 1.6x |
-| `polkavm64_recompiler_no_gas` | no | 331.72 µs | ±0.1% | 1.68x | 1.7x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 348.86 µs | ±0.0% | 1.77x | 1.8x |
-| `polkavm64_recompiler_sync_gas` | yes | 349.02 µs | ±0.1% | 1.77x | 1.8x |
-| `polkavm64_recompiler_async_gas_full` | yes | 365.56 µs | ±0.1% | 1.86x | 1.9x |
-| `polkavm64_recompiler_async_gas` | yes | 365.66 µs | ±0.1% | 1.86x | 1.9x |
-| `wasmtime_cranelift_fuel` | yes | 512.93 µs | ±0.8% | 2.60x | 2.6x |
-| `wasmtime_cranelift` | no | 519.76 µs | ±0.5% | 2.64x | 2.6x |
-| `wasmtime_winch` | no | 548.89 µs | ±0.7% | 2.79x | 2.8x |
-| `wasmer_singlepass` | no | 1.64 ms | ±1.1% | 8.32x | 8.3x |
-| `polkavm64_interpreter` | no | 2.07 ms | ±0.8% | 10.49x | 10.5x |
-| `nub_interp` | yes | 3.92 ms | ±0.9% | 19.90x | 19.9x |
+| `native` | no | 194.13 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` | yes | 309.79 µs | ±0.3% | 1.60x | 1.6x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 349.68 µs | ±0.2% | 1.80x | 1.8x |
+| `polkavm64_recompiler_no_gas` | no | 350.66 µs | ±0.0% | 1.81x | 1.8x |
+| `polkavm64_recompiler_async_gas` | yes | 365.41 µs | ±0.1% | 1.88x | 1.9x |
+| `polkavm64_recompiler_async_gas_full` | yes | 366.12 µs | ±0.2% | 1.89x | 1.9x |
+| `polkavm64_recompiler_sync_gas` | yes | 373.54 µs | ±0.8% | 1.92x | 1.9x |
+| `wasmtime_cranelift_fuel` | yes | 505.44 µs | ±0.6% | 2.60x | 2.6x |
+| `wasmtime_cranelift` | no | 522.30 µs | ±0.5% | 2.69x | 2.7x |
+| `wasmtime_winch` | no | 538.98 µs | ±0.7% | 2.78x | 2.8x |
+| `wasmer_singlepass` | no | 1.62 ms | ±1.1% | 8.35x | 8.4x |
+| `polkavm64_interpreter` | no | 2.09 ms | ±0.6% | 10.75x | 10.7x |
+| `nub_interp` | yes | 3.95 ms | ±0.6% | 20.36x | 20.4x |
 
 ### keccak
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 1.63 µs | ±0.5% | 1.00x | 1.0x |
-| `nub_jit` | yes | 6.45 µs | ±0.2% | 3.96x | 4.0x |
-| `wasmtime_cranelift` | no | 7.52 µs | ±1.0% | 4.62x | 4.6x |
-| `wasmtime_cranelift_fuel` | yes | 7.66 µs | ±0.8% | 4.71x | 4.7x |
-| `wasmtime_winch` | no | 8.20 µs | ±0.7% | 5.03x | 5.0x |
-| `polkavm64_recompiler_no_gas` | no | 10.16 µs | ±8.1% | 6.24x | 6.2x |
-| `polkavm64_recompiler_async_gas` | yes | 10.49 µs | ±2.9% | 6.45x | 6.4x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 12.28 µs | ±1.0% | 7.54x | 7.5x |
-| `polkavm64_recompiler_sync_gas` | yes | 12.41 µs | ±1.7% | 7.62x | 7.6x |
-| `polkavm64_recompiler_async_gas_full` | yes | 12.60 µs | ±1.1% | 7.74x | 7.7x |
-| `wasmer_singlepass` | no | 27.91 µs | ±2.8% | 17.14x | 17.1x |
-| `polkavm64_interpreter` | no | 91.09 µs | ±0.8% | 55.94x | 55.9x |
-| `nub_interp` | yes | 236.59 µs | ±0.8% | 145.31x | 145.3x |
+| `native` | no | 1.63 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` | yes | 6.50 µs | ±0.4% | 3.99x | 4.0x |
+| `wasmtime_cranelift` | no | 7.60 µs | ±1.2% | 4.67x | 4.7x |
+| `wasmtime_cranelift_fuel` | yes | 7.81 µs | ±0.7% | 4.80x | 4.8x |
+| `wasmtime_winch` | no | 8.43 µs | ±0.8% | 5.18x | 5.2x |
+| `polkavm64_recompiler_sync_gas` | yes | 10.98 µs | ±1.2% | 6.74x | 6.7x |
+| `polkavm64_recompiler_no_gas` | no | 11.60 µs | ±1.5% | 7.12x | 7.1x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 12.08 µs | ±2.4% | 7.42x | 7.4x |
+| `polkavm64_recompiler_async_gas` | yes | 12.63 µs | ±1.1% | 7.76x | 7.8x |
+| `polkavm64_recompiler_async_gas_full` | yes | 12.64 µs | ±1.0% | 7.76x | 7.8x |
+| `wasmer_singlepass` | no | 27.65 µs | ±2.0% | 16.98x | 17.0x |
+| `polkavm64_interpreter` | no | 90.40 µs | ±1.2% | 55.53x | 55.5x |
+| `nub_interp` | yes | 235.81 µs | ±0.6% | 144.85x | 144.8x |
 
 ### mini-verifier
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 224.18 µs | ±0.4% | 1.00x | 1.0x |
-| `nub_jit` | yes | 465.80 µs | ±0.4% | 2.08x | 2.1x |
-| `polkavm64_recompiler_no_gas` | no | 512.13 µs | ±0.1% | 2.28x | 2.3x |
-| `polkavm64_recompiler_async_gas_full` | yes | 512.66 µs | ±0.1% | 2.29x | 2.3x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 513.86 µs | ±0.1% | 2.29x | 2.3x |
-| `polkavm64_recompiler_sync_gas` | yes | 584.37 µs | ±0.0% | 2.61x | 2.6x |
-| `polkavm64_recompiler_async_gas` | yes | 584.55 µs | ±0.0% | 2.61x | 2.6x |
-| `wasmtime_cranelift` | no | 767.06 µs | ±0.6% | 3.42x | 3.4x |
-| `wasmtime_cranelift_fuel` | yes | 799.75 µs | ±0.6% | 3.57x | 3.6x |
-| `wasmtime_winch` | no | 1.27 ms | ±0.3% | 5.67x | 5.7x |
-| `wasmer_singlepass` | no | 4.38 ms | ±1.3% | 19.56x | 19.6x |
-| `polkavm64_interpreter` | no | 9.65 ms | ±0.6% | 43.03x | 43.0x |
-| `nub_interp` | yes | 14.07 ms | ±0.6% | 62.77x | 62.8x |
+| `native` | no | 225.82 µs | ±0.7% | 1.00x | 1.0x |
+| `nub_jit` | yes | 475.52 µs | ±0.5% | 2.11x | 2.1x |
+| `polkavm64_recompiler_sync_gas` | yes | 512.33 µs | ±0.1% | 2.27x | 2.3x |
+| `polkavm64_recompiler_async_gas_full` | yes | 512.98 µs | ±0.1% | 2.27x | 2.3x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 513.60 µs | ±0.2% | 2.27x | 2.3x |
+| `polkavm64_recompiler_async_gas` | yes | 517.48 µs | ±0.5% | 2.29x | 2.3x |
+| `polkavm64_recompiler_no_gas` | no | 582.47 µs | ±0.0% | 2.58x | 2.6x |
+| `wasmtime_cranelift` | no | 766.30 µs | ±0.5% | 3.39x | 3.4x |
+| `wasmtime_cranelift_fuel` | yes | 785.81 µs | ±0.5% | 3.48x | 3.5x |
+| `wasmtime_winch` | no | 1.30 ms | ±0.4% | 5.77x | 5.8x |
+| `wasmer_singlepass` | no | 4.38 ms | ±0.6% | 19.38x | 19.4x |
+| `polkavm64_interpreter` | no | 9.55 ms | ±0.7% | 42.28x | 42.3x |
+| `nub_interp` | yes | 13.52 ms | ±0.6% | 59.89x | 59.9x |
 
 ### poly-eval
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 652.51 µs | ±0.3% | 1.00x | 1.0x |
-| `nub_jit` | yes | 1.08 ms | ±0.2% | 1.66x | 1.7x |
-| `polkavm64_recompiler_no_gas` | no | 1.18 ms | ±0.5% | 1.82x | 1.8x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.19 ms | ±0.8% | 1.82x | 1.8x |
-| `polkavm64_recompiler_async_gas` | yes | 1.21 ms | ±1.4% | 1.86x | 1.9x |
-| `polkavm64_recompiler_sync_gas` | yes | 1.22 ms | ±0.4% | 1.87x | 1.9x |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.27 ms | ±0.2% | 1.94x | 1.9x |
-| `wasmtime_cranelift_fuel` | yes | 1.49 ms | ±0.4% | 2.29x | 2.3x |
-| `wasmtime_cranelift` | no | 1.54 ms | ±0.3% | 2.35x | 2.4x |
-| `wasmtime_winch` | no | 1.70 ms | ±0.5% | 2.61x | 2.6x |
-| `wasmer_singlepass` | no | 5.70 ms | ±1.0% | 8.74x | 8.7x |
-| `polkavm64_interpreter` | no | 8.03 ms | ±0.8% | 12.30x | 12.3x |
-| `nub_interp` | yes | 17.41 ms | ±0.6% | 26.69x | 26.7x |
+| `native` | no | 652.67 µs | ±0.3% | 1.00x | 1.0x |
+| `nub_jit` | yes | 1.10 ms | ±0.6% | 1.69x | 1.7x |
+| `polkavm64_recompiler_no_gas` | no | 1.19 ms | ±0.6% | 1.82x | 1.8x |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.20 ms | ±0.2% | 1.83x | 1.8x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.21 ms | ±0.4% | 1.86x | 1.9x |
+| `polkavm64_recompiler_sync_gas` | yes | 1.22 ms | ±0.3% | 1.87x | 1.9x |
+| `polkavm64_recompiler_async_gas` | yes | 1.24 ms | ±0.6% | 1.91x | 1.9x |
+| `wasmtime_cranelift_fuel` | yes | 1.48 ms | ±1.0% | 2.27x | 2.3x |
+| `wasmtime_cranelift` | no | 1.50 ms | ±0.5% | 2.30x | 2.3x |
+| `wasmtime_winch` | no | 1.73 ms | ±0.6% | 2.65x | 2.6x |
+| `wasmer_singlepass` | no | 6.08 ms | ±1.1% | 9.31x | 9.3x |
+| `polkavm64_interpreter` | no | 8.09 ms | ±0.9% | 12.40x | 12.4x |
+| `nub_interp` | yes | 17.40 ms | ±0.9% | 26.65x | 26.7x |
 
 ### poseidon2-perm
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 547.82 µs | ±0.5% | 1.00x | 1.0x |
-| `nub_jit` | yes | 1.15 ms | ±0.2% | 2.10x | 2.1x |
-| `polkavm64_recompiler_no_gas` | no | 1.24 ms | ±0.1% | 2.27x | 2.3x |
-| `polkavm64_recompiler_async_gas_full` | yes | 1.24 ms | ±0.1% | 2.27x | 2.3x |
-| `polkavm64_recompiler_async_gas` | yes | 1.25 ms | ±0.2% | 2.27x | 2.3x |
-| `polkavm64_recompiler_sync_gas` | yes | 1.25 ms | ±0.0% | 2.29x | 2.3x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 1.26 ms | ±0.2% | 2.29x | 2.3x |
-| `wasmtime_cranelift` | no | 1.87 ms | ±0.5% | 3.42x | 3.4x |
-| `wasmtime_cranelift_fuel` | yes | 1.94 ms | ±0.3% | 3.53x | 3.5x |
-| `wasmtime_winch` | no | 3.26 ms | ±0.4% | 5.95x | 6.0x |
-| `wasmer_singlepass` | no | 10.62 ms | ±0.2% | 19.38x | 19.4x |
-| `polkavm64_interpreter` | no | 22.19 ms | ±0.9% | 40.50x | 40.5x |
-| `nub_interp` | yes | 36.16 ms | ±0.2% | 66.00x | 66.0x |
+| `native` | no | 548.84 µs | ±0.2% | 1.00x | 1.0x |
+| `nub_jit` | yes | 1.15 ms | ±0.4% | 2.10x | 2.1x |
+| `polkavm64_recompiler_async_gas_full` | yes | 1.25 ms | ±0.1% | 2.27x | 2.3x |
+| `polkavm64_recompiler_async_gas` | yes | 1.25 ms | ±0.1% | 2.27x | 2.3x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 1.25 ms | ±0.1% | 2.28x | 2.3x |
+| `polkavm64_recompiler_sync_gas` | yes | 1.25 ms | ±0.1% | 2.28x | 2.3x |
+| `polkavm64_recompiler_no_gas` | no | 1.26 ms | ±0.4% | 2.29x | 2.3x |
+| `wasmtime_cranelift` | no | 1.88 ms | ±0.8% | 3.42x | 3.4x |
+| `wasmtime_cranelift_fuel` | yes | 1.94 ms | ±0.4% | 3.54x | 3.5x |
+| `wasmtime_winch` | no | 3.09 ms | ±0.6% | 5.63x | 5.6x |
+| `wasmer_singlepass` | no | 10.62 ms | ±0.3% | 19.35x | 19.3x |
+| `polkavm64_interpreter` | no | 22.19 ms | ±0.7% | 40.44x | 40.4x |
+| `nub_interp` | yes | 34.80 ms | ±0.8% | 63.40x | 63.4x |
 
 ### prime-sieve
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 54.77 µs | ±0.3% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 112.84 µs | ±0.2% | 2.06x | 2.1x |
-| `wasmtime_cranelift` | no | 115.48 µs | ±0.8% | 2.11x | 2.1x |
-| `wasmer_singlepass` | no | 159.18 µs | ±2.1% | 2.91x | 2.9x |
-| `wasmtime_cranelift_fuel` | yes | 166.44 µs | ±0.3% | 3.04x | 3.0x |
-| `wasmtime_winch` | no | 171.25 µs | ±0.5% | 3.13x | 3.1x |
-| `nub_jit` | yes | 178.70 µs | ±0.6% | 3.26x | 3.3x |
-| `polkavm64_recompiler_async_gas_full` | yes | 199.84 µs | ±0.1% | 3.65x | 3.6x |
-| `polkavm64_recompiler_async_gas` | yes | 200.15 µs | ±0.1% | 3.65x | 3.7x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 200.87 µs | ±0.1% | 3.67x | 3.7x |
-| `polkavm64_recompiler_sync_gas` | yes | 216.14 µs | ±0.0% | 3.95x | 3.9x |
-| `polkavm64_interpreter` | no | 2.07 ms | ±0.7% | 37.75x | 37.7x |
-| `nub_interp` | yes | 7.31 ms | ±1.0% | 133.46x | 133.5x |
+| `native` | no | 55.60 µs | ±0.6% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 114.02 µs | ±0.1% | 2.05x | 2.1x |
+| `wasmtime_cranelift` | no | 115.06 µs | ±0.6% | 2.07x | 2.1x |
+| `wasmer_singlepass` | no | 159.06 µs | ±2.7% | 2.86x | 2.9x |
+| `wasmtime_cranelift_fuel` | yes | 166.04 µs | ±0.6% | 2.99x | 3.0x |
+| `wasmtime_winch` | no | 169.32 µs | ±0.5% | 3.05x | 3.0x |
+| `nub_jit` | yes | 180.14 µs | ±0.5% | 3.24x | 3.2x |
+| `polkavm64_recompiler_async_gas_full` | yes | 199.67 µs | ±0.1% | 3.59x | 3.6x |
+| `polkavm64_recompiler_async_gas` | yes | 199.73 µs | ±0.1% | 3.59x | 3.6x |
+| `polkavm64_recompiler_sync_gas` | yes | 201.11 µs | ±0.1% | 3.62x | 3.6x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 216.61 µs | ±0.1% | 3.90x | 3.9x |
+| `polkavm64_interpreter` | no | 2.09 ms | ±0.4% | 37.58x | 37.6x |
+| `nub_interp` | yes | 8.02 ms | ±0.7% | 144.27x | 144.3x |
 
 ## runtime
 
@@ -618,164 +715,164 @@ Rows are absent where a program cannot be re-run in one instance (the three gues
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 624.3 ns | ±0.5% | 1.00x | 1.0x |
-| `wasmtime_cranelift` | no | 751.1 ns | ±0.3% | 1.20x | 1.2x |
-| `wasmtime_cranelift_fuel` | yes | 781.1 ns | ±0.5% | 1.25x | 1.3x |
-| `wasmtime_winch` | no | 1.21 µs | ±0.5% | 1.94x | 1.9x |
-| `polkavm64_recompiler_no_gas` | no | 1.41 µs | ±0.2% | 2.25x | 2.3x |
-| `polkavm64_recompiler_async_gas_full` | yes | 2.13 µs | ±0.3% | 3.41x | 3.4x |
-| `polkavm64_recompiler_async_gas` | yes | 2.20 µs | ±0.3% | 3.53x | 3.5x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 2.43 µs | ±0.3% | 3.89x | 3.9x |
-| `polkavm64_recompiler_sync_gas` | yes | 2.50 µs | ±0.0% | 4.01x | 4.0x |
-| `nub_jit` † | yes | 4.54 µs | ±0.3% | 7.28x | 7.3x |
-| `wasmer_singlepass` | no | 4.68 µs | ±0.9% | 7.50x | 7.5x |
-| `polkavm64_interpreter` | no | 40.07 µs | ±0.7% | 64.18x | 64.2x |
-| `nub_interp` | yes | 138.84 µs | ±0.7% | 222.39x | 222.4x |
+| `native` | no | 628.9 ns | ±0.9% | 1.00x | 1.0x |
+| `wasmtime_cranelift` | no | 764.4 ns | ±0.5% | 1.22x | 1.2x |
+| `wasmtime_cranelift_fuel` | yes | 790.2 ns | ±0.6% | 1.26x | 1.3x |
+| `wasmtime_winch` | no | 1.22 µs | ±0.7% | 1.94x | 1.9x |
+| `polkavm64_recompiler_no_gas` | no | 1.41 µs | ±0.4% | 2.24x | 2.2x |
+| `polkavm64_recompiler_async_gas_full` | yes | 2.11 µs | ±0.3% | 3.35x | 3.3x |
+| `polkavm64_recompiler_sync_gas` | yes | 2.20 µs | ±0.4% | 3.50x | 3.5x |
+| `polkavm64_recompiler_async_gas` | yes | 2.34 µs | ±0.5% | 3.73x | 3.7x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 2.37 µs | ±0.3% | 3.77x | 3.8x |
+| `nub_jit` † | yes | 4.56 µs | ±0.5% | 7.26x | 7.3x |
+| `wasmer_singlepass` | no | 4.69 µs | ±0.3% | 7.45x | 7.5x |
+| `polkavm64_interpreter` | no | 40.43 µs | ±0.7% | 64.29x | 64.3x |
+| `nub_interp` | yes | 140.80 µs | ±0.7% | 223.90x | 223.9x |
 
 ### ecrecover
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 93.15 µs | ±0.5% | 1.00x | 1.0x |
-| `wasmtime_cranelift` | no | 248.56 µs | ±0.3% | 2.67x | 2.7x |
-| `wasmtime_cranelift_fuel` | yes | 261.53 µs | ±0.4% | 2.81x | 2.8x |
-| `polkavm64_recompiler_no_gas` | no | 308.29 µs | ±0.1% | 3.31x | 3.3x |
-| `polkavm64_recompiler_sync_gas` | yes | 320.54 µs | ±0.1% | 3.44x | 3.4x |
-| `polkavm64_recompiler_async_gas_full` | yes | 323.33 µs | ±0.1% | 3.47x | 3.5x |
-| `polkavm64_recompiler_async_gas` | yes | 323.45 µs | ±0.1% | 3.47x | 3.5x |
-| `nub_jit` † | yes | 369.12 µs | ±0.4% | 3.96x | 4.0x |
-| `wasmtime_winch` | no | 379.85 µs | ±0.6% | 4.08x | 4.1x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 461.33 µs | ±0.0% | 4.95x | 5.0x |
-| `wasmer_singlepass` | no | 748.07 µs | ±0.4% | 8.03x | 8.0x |
-| `polkavm64_interpreter` | no | 11.41 ms | ±0.7% | 122.49x | 122.5x |
-| `nub_interp` | yes | 26.65 ms | ±1.2% | 286.14x | 286.1x |
+| `native` | no | 91.67 µs | ±0.3% | 1.00x | 1.0x |
+| `wasmtime_cranelift` | no | 252.03 µs | ±0.4% | 2.75x | 2.7x |
+| `wasmtime_cranelift_fuel` | yes | 259.77 µs | ±0.4% | 2.83x | 2.8x |
+| `polkavm64_recompiler_no_gas` | no | 308.40 µs | ±0.1% | 3.36x | 3.4x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 320.02 µs | ±0.1% | 3.49x | 3.5x |
+| `polkavm64_recompiler_sync_gas` | yes | 320.29 µs | ±0.2% | 3.49x | 3.5x |
+| `polkavm64_recompiler_async_gas_full` | yes | 323.06 µs | ±0.1% | 3.52x | 3.5x |
+| `polkavm64_recompiler_async_gas` | yes | 323.45 µs | ±0.2% | 3.53x | 3.5x |
+| `nub_jit` † | yes | 368.45 µs | ±0.6% | 4.02x | 4.0x |
+| `wasmtime_winch` | no | 394.13 µs | ±0.4% | 4.30x | 4.3x |
+| `wasmer_singlepass` | no | 762.30 µs | ±0.7% | 8.32x | 8.3x |
+| `polkavm64_interpreter` | no | 11.40 ms | ±1.6% | 124.35x | 124.3x |
+| `nub_interp` | yes | 26.32 ms | ±0.7% | 287.10x | 287.1x |
 
 ### ed25519
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 29.50 µs | ±0.5% | 1.00x | 1.0x |
-| `polkavm64_recompiler_no_gas` | no | 65.65 µs | ±0.1% | 2.23x | 2.2x |
-| `polkavm64_recompiler_async_gas_full` | yes | 73.48 µs | ±0.1% | 2.49x | 2.5x |
-| `polkavm64_recompiler_async_gas` | yes | 73.66 µs | ±0.2% | 2.50x | 2.5x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 73.83 µs | ±0.1% | 2.50x | 2.5x |
-| `polkavm64_recompiler_sync_gas` | yes | 73.91 µs | ±0.2% | 2.51x | 2.5x |
-| `nub_jit` † | yes | 89.37 µs | ±0.3% | 3.03x | 3.0x |
-| `wasmtime_cranelift` | no | 189.07 µs | ±0.3% | 6.41x | 6.4x |
-| `wasmtime_cranelift_fuel` | yes | 232.99 µs | ±0.4% | 7.90x | 7.9x |
-| `wasmtime_winch` | no | 341.09 µs | ±0.6% | 11.56x | 11.6x |
-| `wasmer_singlepass` | no | 893.54 µs | ±0.3% | 30.29x | 30.3x |
-| `polkavm64_interpreter` | no | 1.46 ms | ±1.0% | 49.47x | 49.5x |
-| `nub_interp` | yes | 4.82 ms | ±0.7% | 163.25x | 163.3x |
+| `native` | no | 29.75 µs | ±0.8% | 1.00x | 1.0x |
+| `polkavm64_recompiler_no_gas` | no | 65.67 µs | ±0.1% | 2.21x | 2.2x |
+| `polkavm64_recompiler_async_gas_full` | yes | 73.76 µs | ±0.1% | 2.48x | 2.5x |
+| `polkavm64_recompiler_sync_gas` | yes | 73.88 µs | ±0.1% | 2.48x | 2.5x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 73.91 µs | ±0.2% | 2.48x | 2.5x |
+| `nub_jit` † | yes | 90.61 µs | ±0.7% | 3.05x | 3.0x |
+| `polkavm64_recompiler_async_gas` | yes | 91.59 µs | ±0.0% | 3.08x | 3.1x |
+| `wasmtime_cranelift` | no | 192.16 µs | ±0.5% | 6.46x | 6.5x |
+| `wasmtime_cranelift_fuel` | yes | 232.29 µs | ±0.3% | 7.81x | 7.8x |
+| `wasmtime_winch` | no | 340.82 µs | ±0.4% | 11.46x | 11.5x |
+| `wasmer_singlepass` | no | 906.42 µs | ±0.3% | 30.47x | 30.5x |
+| `polkavm64_interpreter` | no | 1.43 ms | ±0.9% | 48.18x | 48.2x |
+| `nub_interp` | yes | 4.80 ms | ±0.8% | 161.38x | 161.4x |
 
 ### fri-fold-tree
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 219.38 µs | ±0.5% | 1.00x | 1.0x |
-| `nub_jit` † | yes | 454.22 µs | ±0.5% | 2.07x | 2.1x |
-| `wasmtime_cranelift` | no | 722.91 µs | ±0.4% | 3.30x | 3.3x |
-| `wasmtime_cranelift_fuel` | yes | 752.82 µs | ±0.4% | 3.43x | 3.4x |
-| `wasmtime_winch` | no | 1.19 ms | ±0.7% | 5.44x | 5.4x |
-| `wasmer_singlepass` | no | 3.58 ms | ±0.6% | 16.30x | 16.3x |
+| `native` | no | 222.21 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` † | yes | 456.30 µs | ±0.4% | 2.05x | 2.1x |
+| `wasmtime_cranelift` | no | 721.32 µs | ±0.5% | 3.25x | 3.2x |
+| `wasmtime_cranelift_fuel` | yes | 748.69 µs | ±0.4% | 3.37x | 3.4x |
+| `wasmtime_winch` | no | 1.25 ms | ±0.5% | 5.64x | 5.6x |
+| `wasmer_singlepass` | no | 3.61 ms | ±0.3% | 16.26x | 16.3x |
 
 ### goldilocks-mul
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 196.35 µs | ±0.6% | 1.00x | 1.0x |
-| `nub_jit` † | yes | 312.95 µs | ±0.3% | 1.59x | 1.6x |
-| `polkavm64_recompiler_no_gas` | no | 330.54 µs | ±0.2% | 1.68x | 1.7x |
-| `polkavm64_recompiler_sync_gas` | yes | 346.15 µs | ±0.1% | 1.76x | 1.8x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 346.50 µs | ±0.1% | 1.76x | 1.8x |
-| `polkavm64_recompiler_async_gas` | yes | 358.19 µs | ±0.2% | 1.82x | 1.8x |
-| `polkavm64_recompiler_async_gas_full` | yes | 358.92 µs | ±0.1% | 1.83x | 1.8x |
-| `wasmtime_cranelift_fuel` | yes | 509.51 µs | ±0.7% | 2.59x | 2.6x |
-| `wasmtime_cranelift` | no | 512.78 µs | ±0.6% | 2.61x | 2.6x |
-| `wasmtime_winch` | no | 528.81 µs | ±0.5% | 2.69x | 2.7x |
-| `wasmer_singlepass` | no | 1.43 ms | ±0.5% | 7.27x | 7.3x |
-| `polkavm64_interpreter` | no | 2.08 ms | ±0.8% | 10.58x | 10.6x |
-| `nub_interp` | yes | 3.99 ms | ±0.8% | 20.30x | 20.3x |
+| `native` | no | 194.84 µs | ±0.5% | 1.00x | 1.0x |
+| `nub_jit` † | yes | 307.84 µs | ±0.4% | 1.58x | 1.6x |
+| `polkavm64_recompiler_no_gas` | no | 329.01 µs | ±0.1% | 1.69x | 1.7x |
+| `polkavm64_recompiler_sync_gas` | yes | 346.00 µs | ±0.1% | 1.78x | 1.8x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 346.13 µs | ±0.1% | 1.78x | 1.8x |
+| `polkavm64_recompiler_async_gas` | yes | 358.34 µs | ±0.1% | 1.84x | 1.8x |
+| `polkavm64_recompiler_async_gas_full` | yes | 360.58 µs | ±0.1% | 1.85x | 1.9x |
+| `wasmtime_cranelift` | no | 510.14 µs | ±0.5% | 2.62x | 2.6x |
+| `wasmtime_cranelift_fuel` | yes | 512.45 µs | ±0.4% | 2.63x | 2.6x |
+| `wasmtime_winch` | no | 529.88 µs | ±0.7% | 2.72x | 2.7x |
+| `wasmer_singlepass` | no | 1.42 ms | ±0.6% | 7.30x | 7.3x |
+| `polkavm64_interpreter` | no | 2.08 ms | ±0.8% | 10.66x | 10.7x |
+| `nub_interp` | yes | 3.91 ms | ±0.5% | 20.05x | 20.0x |
 
 ### keccak
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 1.62 µs | ±0.4% | 1.00x | 1.0x |
-| `wasmtime_cranelift` | no | 2.16 µs | ±0.3% | 1.33x | 1.3x |
-| `wasmtime_cranelift_fuel` | yes | 2.24 µs | ±0.3% | 1.38x | 1.4x |
-| `polkavm64_recompiler_no_gas` | no | 2.38 µs | ±0.3% | 1.47x | 1.5x |
-| `wasmtime_winch` | no | 2.62 µs | ±0.7% | 1.62x | 1.6x |
-| `wasmer_singlepass` | no | 3.41 µs | ±0.5% | 2.11x | 2.1x |
-| `polkavm64_recompiler_sync_gas` | yes | 3.49 µs | ±0.2% | 2.16x | 2.2x |
-| `polkavm64_recompiler_async_gas_full` | yes | 3.51 µs | ±0.3% | 2.17x | 2.2x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 3.54 µs | ±0.3% | 2.19x | 2.2x |
-| `polkavm64_recompiler_async_gas` | yes | 3.55 µs | ±0.2% | 2.19x | 2.2x |
-| `nub_jit` † | yes | 6.55 µs | ±0.4% | 4.05x | 4.0x |
-| `polkavm64_interpreter` | no | 71.64 µs | ±0.5% | 44.25x | 44.2x |
-| `nub_interp` | yes | 230.32 µs | ±1.2% | 142.25x | 142.3x |
+| `native` | no | 1.61 µs | ±0.6% | 1.00x | 1.0x |
+| `wasmtime_cranelift` | no | 2.19 µs | ±0.5% | 1.36x | 1.4x |
+| `wasmtime_cranelift_fuel` | yes | 2.28 µs | ±0.5% | 1.42x | 1.4x |
+| `polkavm64_recompiler_no_gas` | no | 2.37 µs | ±0.2% | 1.48x | 1.5x |
+| `wasmtime_winch` | no | 2.70 µs | ±0.4% | 1.68x | 1.7x |
+| `polkavm64_recompiler_async_gas_full` | yes | 3.36 µs | ±0.2% | 2.09x | 2.1x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 3.39 µs | ±0.3% | 2.10x | 2.1x |
+| `wasmer_singlepass` | no | 3.45 µs | ±0.4% | 2.14x | 2.1x |
+| `polkavm64_recompiler_sync_gas` | yes | 3.52 µs | ±0.2% | 2.18x | 2.2x |
+| `polkavm64_recompiler_async_gas` | yes | 3.53 µs | ±0.2% | 2.19x | 2.2x |
+| `nub_jit` † | yes | 6.66 µs | ±0.4% | 4.14x | 4.1x |
+| `polkavm64_interpreter` | no | 70.68 µs | ±1.3% | 43.91x | 43.9x |
+| `nub_interp` | yes | 230.67 µs | ±0.8% | 143.32x | 143.3x |
 
 ### mini-verifier
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 228.68 µs | ±0.5% | 1.00x | 1.0x |
-| `nub_jit` † | yes | 470.01 µs | ±0.6% | 2.06x | 2.1x |
-| `polkavm64_recompiler_async_gas_full` | yes | 507.32 µs | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 507.52 µs | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_no_gas` | no | 507.53 µs | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_async_gas` | yes | 507.58 µs | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_sync_gas` | yes | 578.45 µs | ±0.0% | 2.53x | 2.5x |
-| `wasmtime_cranelift` | no | 767.20 µs | ±0.4% | 3.35x | 3.4x |
-| `wasmtime_cranelift_fuel` | yes | 789.91 µs | ±0.4% | 3.45x | 3.5x |
-| `wasmtime_winch` | no | 1.23 ms | ±0.5% | 5.36x | 5.4x |
-| `wasmer_singlepass` | no | 3.95 ms | ±0.5% | 17.27x | 17.3x |
-| `polkavm64_interpreter` | no | 9.65 ms | ±0.4% | 42.19x | 42.2x |
-| `nub_interp` | yes | 14.03 ms | ±1.0% | 61.35x | 61.3x |
+| `native` | no | 230.80 µs | ±0.3% | 1.00x | 1.0x |
+| `nub_jit` † | yes | 467.07 µs | ±0.6% | 2.02x | 2.0x |
+| `polkavm64_recompiler_async_gas_full` | yes | 507.94 µs | ±0.2% | 2.20x | 2.2x |
+| `polkavm64_recompiler_async_gas` | yes | 508.43 µs | ±0.2% | 2.20x | 2.2x |
+| `polkavm64_recompiler_sync_gas` | yes | 509.12 µs | ±0.3% | 2.21x | 2.2x |
+| `polkavm64_recompiler_no_gas` | no | 509.14 µs | ±0.3% | 2.21x | 2.2x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 509.55 µs | ±0.3% | 2.21x | 2.2x |
+| `wasmtime_cranelift` | no | 764.94 µs | ±0.6% | 3.31x | 3.3x |
+| `wasmtime_cranelift_fuel` | yes | 794.11 µs | ±0.4% | 3.44x | 3.4x |
+| `wasmtime_winch` | no | 1.32 ms | ±0.5% | 5.72x | 5.7x |
+| `wasmer_singlepass` | no | 3.95 ms | ±0.5% | 17.11x | 17.1x |
+| `polkavm64_interpreter` | no | 9.62 ms | ±0.7% | 41.67x | 41.7x |
+| `nub_interp` | yes | 13.66 ms | ±0.4% | 59.18x | 59.2x |
 
 ### poly-eval
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 664.86 µs | ±0.6% | 1.00x | 1.0x |
-| `nub_jit` † | yes | 1.09 ms | ±0.7% | 1.64x | 1.6x |
-| `wasmtime_cranelift_fuel` | yes | 1.47 ms | ±0.4% | 2.21x | 2.2x |
-| `wasmtime_cranelift` | no | 1.51 ms | ±0.5% | 2.28x | 2.3x |
-| `wasmtime_winch` | no | 1.66 ms | ±0.6% | 2.50x | 2.5x |
-| `wasmer_singlepass` | no | 4.89 ms | ±0.6% | 7.36x | 7.4x |
+| `native` | no | 659.94 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` † | yes | 1.10 ms | ±0.4% | 1.66x | 1.7x |
+| `wasmtime_cranelift_fuel` | yes | 1.47 ms | ±0.4% | 2.23x | 2.2x |
+| `wasmtime_cranelift` | no | 1.52 ms | ±0.4% | 2.30x | 2.3x |
+| `wasmtime_winch` | no | 1.68 ms | ±0.7% | 2.55x | 2.6x |
+| `wasmer_singlepass` | no | 4.93 ms | ±0.4% | 7.48x | 7.5x |
 
 ### poseidon2-perm
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 560.49 µs | ±0.4% | 1.00x | 1.0x |
-| `nub_jit` † | yes | 1.18 ms | ±0.4% | 2.10x | 2.1x |
-| `polkavm64_recompiler_no_gas` | no | 1.24 ms | ±0.1% | 2.22x | 2.2x |
+| `native` | no | 559.16 µs | ±0.4% | 1.00x | 1.0x |
+| `nub_jit` † | yes | 1.18 ms | ±0.4% | 2.11x | 2.1x |
+| `polkavm64_recompiler_no_gas` | no | 1.24 ms | ±0.2% | 2.22x | 2.2x |
 | `polkavm64_recompiler_async_gas_full` | yes | 1.24 ms | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_async_gas` | yes | 1.25 ms | ±0.1% | 2.22x | 2.2x |
-| `polkavm64_recompiler_sync_gas` | yes | 1.25 ms | ±0.1% | 2.23x | 2.2x |
+| `polkavm64_recompiler_async_gas` | yes | 1.24 ms | ±0.2% | 2.22x | 2.2x |
 | `polkavm64_recompiler_sync_gas_full` | yes | 1.25 ms | ±0.1% | 2.23x | 2.2x |
-| `wasmtime_cranelift` | no | 1.86 ms | ±0.3% | 3.32x | 3.3x |
-| `wasmtime_cranelift_fuel` | yes | 1.92 ms | ±0.4% | 3.43x | 3.4x |
-| `wasmtime_winch` | no | 3.27 ms | ±0.6% | 5.83x | 5.8x |
-| `wasmer_singlepass` | no | 9.79 ms | ±0.4% | 17.47x | 17.5x |
-| `polkavm64_interpreter` | no | 22.16 ms | ±0.5% | 39.54x | 39.5x |
-| `nub_interp` | yes | 36.34 ms | ±1.1% | 64.83x | 64.8x |
+| `polkavm64_recompiler_sync_gas` | yes | 1.40 ms | ±0.0% | 2.51x | 2.5x |
+| `wasmtime_cranelift` | no | 1.88 ms | ±0.7% | 3.36x | 3.4x |
+| `wasmtime_cranelift_fuel` | yes | 1.93 ms | ±0.4% | 3.45x | 3.5x |
+| `wasmtime_winch` | no | 3.23 ms | ±0.8% | 5.78x | 5.8x |
+| `wasmer_singlepass` | no | 9.91 ms | ±0.3% | 17.73x | 17.7x |
+| `polkavm64_interpreter` | no | 22.23 ms | ±0.8% | 39.76x | 39.8x |
+| `nub_interp` | yes | 34.58 ms | ±0.9% | 61.85x | 61.8x |
 
 ### prime-sieve
 
 | Engine | Metered | Time | ± | vs fastest | vs native |
 |---|---|--:|--:|--:|--:|
-| `native` | no | 54.60 µs | ±0.2% | 1.00x | 1.0x |
-| `wasmtime_cranelift` | no | 76.20 µs | ±1.0% | 1.40x | 1.4x |
-| `polkavm64_recompiler_no_gas` | no | 85.06 µs | ±3.1% | 1.56x | 1.6x |
-| `wasmer_singlepass` | no | 118.11 µs | ±0.4% | 2.16x | 2.2x |
-| `wasmtime_cranelift_fuel` | yes | 142.21 µs | ±0.5% | 2.60x | 2.6x |
-| `wasmtime_winch` | no | 146.64 µs | ±0.6% | 2.69x | 2.7x |
-| `nub_jit` † | yes | 176.48 µs | ±0.4% | 3.23x | 3.2x |
-| `polkavm64_recompiler_async_gas` | yes | 184.22 µs | ±0.1% | 3.37x | 3.4x |
-| `polkavm64_recompiler_sync_gas_full` | yes | 184.55 µs | ±0.1% | 3.38x | 3.4x |
-| `polkavm64_recompiler_async_gas_full` | yes | 184.58 µs | ±0.1% | 3.38x | 3.4x |
-| `polkavm64_recompiler_sync_gas` | yes | 185.14 µs | ±0.3% | 3.39x | 3.4x |
-| `polkavm64_interpreter` | no | 2.07 ms | ±0.7% | 37.89x | 37.9x |
-| `nub_interp` | yes | 7.20 ms | ±0.4% | 131.88x | 131.9x |
+| `native` | no | 55.25 µs | ±0.6% | 1.00x | 1.0x |
+| `wasmtime_cranelift` | no | 75.66 µs | ±0.6% | 1.37x | 1.4x |
+| `polkavm64_recompiler_no_gas` | no | 88.63 µs | ±4.1% | 1.60x | 1.6x |
+| `wasmer_singlepass` | no | 118.26 µs | ±0.7% | 2.14x | 2.1x |
+| `wasmtime_cranelift_fuel` | yes | 140.50 µs | ±0.3% | 2.54x | 2.5x |
+| `wasmtime_winch` | no | 147.46 µs | ±0.6% | 2.67x | 2.7x |
+| `nub_jit` † | yes | 183.77 µs | ±0.9% | 3.33x | 3.3x |
+| `polkavm64_recompiler_sync_gas_full` | yes | 184.79 µs | ±0.1% | 3.34x | 3.3x |
+| `polkavm64_recompiler_async_gas` | yes | 184.86 µs | ±0.2% | 3.35x | 3.3x |
+| `polkavm64_recompiler_async_gas_full` | yes | 185.11 µs | ±0.2% | 3.35x | 3.4x |
+| `polkavm64_recompiler_sync_gas` | yes | 185.17 µs | ±0.1% | 3.35x | 3.4x |
+| `polkavm64_interpreter` | no | 2.09 ms | ±0.6% | 37.85x | 37.9x |
+| `nub_interp` | yes | 7.91 ms | ±0.7% | 143.21x | 143.2x |

--- a/nub/bench-compare/README.md
+++ b/nub/bench-compare/README.md
@@ -31,6 +31,7 @@ cargo run --release -p bench-build     # fan every kernel out to 4 targets
 cargo run --release -- list            # what is available
 cargo run --release -- validate        # do all engines agree?
 cargo run --release -- run             # measure
+cargo run --release -- size            # artifact size (no measurement needed)
 cargo run --release -- report --write  # -> BENCHMARKS.md
 ```
 
@@ -205,6 +206,69 @@ failing every measurement.
 `nub_jit_compile` remains alongside it, measuring emission alone with
 no sandbox. The two answer different questions: how fast the
 recompiler *emits*, versus what a full cold invocation costs.
+
+## Artifact size
+
+Speed is half the story; for a chain VM the other half is how big the
+program is, because the blob is what gets gossiped, stored and paid for.
+`report` emits two size tables, and `bench-compare size` prints the same
+ones without needing any measurement.
+
+**Whole blob** is the file on disk. **Raw code** excludes the data
+regions, and it is the figure to read — several kernels carry large
+initialized data that swamps everything else. `prime-sieve` is 214 bytes
+of nub code inside a 158,338-byte blob, 0.1% of it; comparing whole
+blobs there compares static lookup tables, not code generators.
+
+| family | code figure |
+|---|---|
+| `pvm2` | `code` |
+| `polkavm64` | `code` + jump table + bitmask |
+| `wasm32` | `Code`(10) + `Type`(1) + `Function`(3) + `Table`(4) + `Element`(9) + `Global`(6) |
+
+PolkaVM's two extras are code information held *outside* the instruction
+stream. Its instructions are variable-length, so the bitmask — one bit
+per code byte, marking instruction starts — is what makes the stream
+decodable at all; RV64EMC encodes that in the low two bits of each word.
+The jump table lists legal indirect-branch targets, which `jalr rd, rs1,
+imm` takes straight from a register. wasm's aux sections are the same
+argument: `Type`/`Function` hold signatures the register machines encode
+implicitly in their calling convention, and `Table`/`Element` are the
+direct analogue of PolkaVM's jump table.
+
+This is deliberately **broader than upstream PolkaVM's own
+disassembler**, which labels only `code` as "code size". That is why the
+breakdown tables exist: they show every component and every row
+reconciles to the file size, so the definition can be checked rather
+than taken on trust.
+
+`native` is excluded from both tables. A host `.so` is a different kind
+of object — ELF program headers, relocations, a dynamic symbol table,
+and whatever of `std` the linker pulled in — not a bigger or smaller
+one; it is ~1.9 MB even for the workload whose entire PVM2 code is 126
+bytes. Same reason `compilation` omits it.
+
+**No compression is involved in any of the three, and there is nothing
+to disable.** nub trims trailing zeros off `ro`/`rw` and PolkaVM stores
+only the initial non-zero prefix of its data sections; both are BSS
+elision, exactly what ELF does with `p_filesz < p_memsz`, and wasm data
+segments are explicitly offset so they carry no trailing zeros either.
+No entropy coder, dictionary or transform exists in any of these
+containers, and `polkavm_linker::Config` has no compression knob at all.
+
+The varint/LEB128 encoding in PolkaVM and wasm is **instruction
+encoding, not a container compressor.** It cannot be turned off — there
+is no alternative encoding — and would not be worth turning off if it
+could: it is precisely the axis these formats trade on. PolkaVM buys
+cheap small immediates with variable-length instructions and pays a
+12.5% bitmask; RISC-V pays fixed width and needs no side table. Both are
+raw code, and comparing them is the point.
+
+Guest wasm is built with debug info off and symbols stripped, so the
+whole-blob column is a like-for-like comparison. Without that it is not:
+PolkaVM strips at link (`Config::set_strip(true)`) and nub's linker
+never copies DWARF, so an unstripped wasm would be compared against two
+stripped formats — and DWARF was 86–98% of every `.wasm`.
 
 ## Engines deliberately excluded
 

--- a/nub/bench-compare/bench-build/src/main.rs
+++ b/nub/bench-compare/bench-build/src/main.rs
@@ -194,12 +194,38 @@ fn build_pvm2(root: &Path, artifacts: &Path, program: &str) -> Result<Artifact> 
 /// that cost.
 fn build_cdylib(root: &Path, artifacts: &Path, program: &str, family: Family) -> Result<Artifact> {
     let target_dir = root.join("target/guests");
-    let status = cargo(root)
-        .args(["build", "--release", "-p"])
+    let mut cmd = cargo(root);
+    cmd.args(["build", "--release", "-p"])
         .arg(format!("guest-{program}"))
         .args(["--target", family.triple()])
-        .env("CARGO_TARGET_DIR", &target_dir)
-        .status()?;
+        .env("CARGO_TARGET_DIR", &target_dir);
+
+    // Strip the wasm guests, so the size comparison is like-for-like.
+    //
+    // The workspace root sets `[profile.release] debug = true` for the
+    // *harness* — it is what makes the measuring process profilable —
+    // but `members` includes `guests/*`, so without this every guest
+    // inherits it. That put full DWARF in every `.wasm`: 86-98% of each
+    // artifact, and 1.33 MB of ed25519's 1.39 MB. PolkaVM strips at
+    // link (`Config::set_strip(true)`) and nub's linker never copies
+    // debug info, so leaving wasm unstripped would compare one
+    // unstripped format against two stripped ones.
+    //
+    // Env vars rather than `[profile.release.package.*]` overrides
+    // because a per-package override would only reach the thin
+    // `guest-*` wrapper crates. Nearly all of that DWARF comes from the
+    // kernel crate under `nub/programs/` and its transitive crypto
+    // dependencies, which the env var covers and a package override
+    // does not.
+    //
+    // Debug info cannot affect code generation, so this changes only
+    // the artifact's size — not what any engine executes.
+    if matches!(family, Family::Wasm32) {
+        cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "false")
+            .env("CARGO_PROFILE_RELEASE_STRIP", "symbols");
+    }
+
+    let status = cmd.status()?;
     if !status.success() {
         bail!("{} build failed for {program}", family.dir());
     }
@@ -225,7 +251,11 @@ fn build_cdylib(root: &Path, artifacts: &Path, program: &str, family: Family) ->
         family: family.dir().into(),
         path: rel(root, &dest),
         target: family.triple().into(),
-        rustflags: "(default)".into(),
+        rustflags: match family {
+            Family::Wasm32 => "(default) + CARGO_PROFILE_RELEASE_{DEBUG=false,STRIP=symbols}",
+            Family::Native => "(default)",
+        }
+        .into(),
     })
 }
 

--- a/nub/bench-compare/guests/bench-abi.rs
+++ b/nub/bench-compare/guests/bench-abi.rs
@@ -13,6 +13,62 @@
 // `#[nub_rt::endpoint(0)]` binary *is* the ABI, so `bench-build`
 // builds that directly.
 
+// A global allocator for the polkavm build.
+//
+// Three kernels (`ecrecover`, `poly-eval`, `fri-fold-tree`) use `alloc`
+// internally, so on a freestanding target something has to provide
+// `#[global_allocator]`. The native and wasm families link `std` and
+// get one for free; the PVM2 family gets one from the kernel binary's
+// own `nub_rt::bump_allocator!`. polkavm is the only build that has
+// neither — it is `no_std` with `-Zbuild-std=core,alloc` — and without
+// this it fails to link with "no global memory allocator found".
+//
+// Deliberately not `nub_rt::bump_allocator!`: `nub-rt` is the PVM2
+// guest runtime, and its `_start` trampoline and `.nub.endpoints`
+// section are gated on `target_os = "none"` + `riscv64`, which the
+// polkavm target also matches. Depending on it here would inject the
+// PVM2 entry ABI into a polkavm blob.
+//
+// A bump arena because these kernels run once and exit: allocation is a
+// pointer bump and nothing is ever freed. The arena lives in `.bss`, so
+// it costs nothing in the blob.
+#[cfg(target_env = "polkavm")]
+const GUEST_HEAP_BYTES: usize = 256 * 1024;
+
+#[cfg(target_env = "polkavm")]
+struct BumpAlloc {
+    heap: core::cell::UnsafeCell<[u8; GUEST_HEAP_BYTES]>,
+    pos: core::cell::UnsafeCell<usize>,
+}
+
+// SAFETY: guests are single-threaded — polkavm runs one instruction
+// stream and a guest has no way to create a thread.
+#[cfg(target_env = "polkavm")]
+unsafe impl Sync for BumpAlloc {}
+
+#[cfg(target_env = "polkavm")]
+unsafe impl core::alloc::GlobalAlloc for BumpAlloc {
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        let pos = unsafe { &mut *self.pos.get() };
+        let aligned = (*pos + layout.align() - 1) & !(layout.align() - 1);
+        let next = aligned + layout.size();
+        if next > GUEST_HEAP_BYTES {
+            return core::ptr::null_mut();
+        }
+        *pos = next;
+        unsafe { (*self.heap.get()).as_mut_ptr().add(aligned) }
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: core::alloc::Layout) {}
+}
+
+#[cfg(target_env = "polkavm")]
+#[global_allocator]
+static GUEST_HEAP: BumpAlloc = BumpAlloc {
+    heap: core::cell::UnsafeCell::new([0; GUEST_HEAP_BYTES]),
+    pos: core::cell::UnsafeCell::new(0),
+};
+
 /// Define the `run` export for whichever target we are building.
 macro_rules! bench_entry {
     ($kernel:path) => {

--- a/nub/bench-compare/src/backend.rs
+++ b/nub/bench-compare/src/backend.rs
@@ -97,7 +97,30 @@ impl Family {
             Family::Polkavm64 => "polkavm",
         }
     }
+
+    /// Where `bench-build` puts this family's artifact for `program`.
+    pub fn artifact_path(self, root: &Path, program: &str) -> PathBuf {
+        root.join("artifacts")
+            .join(self.dir())
+            .join(format!("{program}.{}", self.ext()))
+    }
 }
+
+/// The families whose artifact size is comparable, in report order.
+///
+/// `Native` is absent, and that is not an oversight. A host `.so` is a
+/// different *kind* of object rather than a bigger or smaller one: ELF
+/// program headers, relocations, a dynamic symbol table, and whatever
+/// of `std` the linker pulled in. It is ~1.9 MB even for the workload
+/// whose entire PVM2 code is 126 bytes. Sizing it against three
+/// bytecode containers would produce a number with no meaning, the same
+/// reason `compilation` omits it.
+///
+/// An explicit array rather than [`Family`]'s derived `Ord`, so column
+/// order is a decision rather than a side effect of declaration order.
+/// nub first, matching the timing headline, which also puts the subject
+/// first.
+pub const SIZE_FAMILIES: [Family; 3] = [Family::Pvm2, Family::Polkavm64, Family::Wasm32];
 
 /// What a row can do, and what it costs to do it.
 #[derive(Debug, Clone, Copy)]

--- a/nub/bench-compare/src/main.rs
+++ b/nub/bench-compare/src/main.rs
@@ -7,6 +7,7 @@
 
 mod backend;
 mod report;
+mod size;
 mod utils;
 
 use std::collections::BTreeMap;
@@ -94,6 +95,9 @@ enum Command {
         #[arg(long)]
         exact: bool,
     },
+    /// Artifact size across engines. Reads `artifacts/`; needs no
+    /// measurements and writes nothing.
+    Size,
     /// Render the measurements as markdown.
     Report {
         /// Overwrite `BENCHMARKS.md`.
@@ -103,11 +107,20 @@ enum Command {
 }
 
 fn main() -> Result<()> {
-    // Must happen before anything allocates a mapping we care about.
-    utils::disable_aslr_and_restart();
-    refuse_debug_build()?;
-
     let cli = Cli::parse();
+
+    // Timing hygiene, and only the measuring commands need it.
+    // Re-exec'ing the process and refusing a debug build to print a
+    // table of byte counts would be wrong — and `refuse_debug_build`
+    // would block `cargo run -- size` during development. Parsing args
+    // first is safe: `exec` replaces the whole image, and no engine has
+    // been constructed yet.
+    if matches!(cli.command, Command::Run { .. } | Command::Validate { .. }) {
+        // Must happen before anything allocates a mapping we care about.
+        utils::disable_aslr_and_restart();
+        refuse_debug_build()?;
+    }
+
     let root = workspace_root()?;
 
     match cli.command {
@@ -118,6 +131,10 @@ fn main() -> Result<()> {
             kinds,
             exact,
         } => run(&root, filter.as_deref(), &kinds, exact),
+        Command::Size => {
+            print!("{}", size::render(&root, PROGRAMS));
+            Ok(())
+        }
         Command::Report { write } => report::render(&root, write),
     }
 }
@@ -139,12 +156,6 @@ fn refuse_debug_build() -> Result<()> {
 
 fn workspace_root() -> Result<PathBuf> {
     Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
-}
-
-fn artifact_path(root: &Path, program: &str, family: Family) -> PathBuf {
-    root.join("artifacts")
-        .join(family.dir())
-        .join(format!("{program}.{}", family.ext()))
 }
 
 fn list(root: &Path) -> Result<()> {
@@ -171,7 +182,7 @@ fn list(root: &Path) -> Result<()> {
             Family::Polkavm64,
         ]
         .into_iter()
-        .filter(|f| artifact_path(root, p, *f).exists())
+        .filter(|f| f.artifact_path(root, p).exists())
         .map(|f| f.dir())
         .collect();
         if have.len() < 4 {
@@ -204,7 +215,7 @@ fn validate(root: &Path, write: bool) -> Result<()> {
     for program in PROGRAMS {
         let mut values: BTreeMap<u32, Vec<&str>> = BTreeMap::new();
         for engine in &engines {
-            let path = artifact_path(root, program, engine.family());
+            let path = engine.family().artifact_path(root, program);
             if !path.exists() {
                 continue;
             }
@@ -452,7 +463,7 @@ fn run(root: &Path, filter: Option<&str>, kinds: &[String], exact: bool) -> Resu
                         continue;
                     }
                 }
-                let path = artifact_path(root, program, engine.family());
+                let path = engine.family().artifact_path(root, program);
                 if !path.exists() {
                     continue;
                 }

--- a/nub/bench-compare/src/report.rs
+++ b/nub/bench-compare/src/report.rs
@@ -172,6 +172,10 @@ pub fn render(root: &Path, write: bool) -> Result<()> {
     let mut out = String::new();
     out.push_str("# nub benchmark comparison\n\n");
     out.push_str(&headline(&records));
+    // Size is the second headline claim, and it is a property of the
+    // artifacts — so it sits directly above the section describing how
+    // those artifacts were built.
+    out.push_str(&crate::size::render(root, crate::PROGRAMS));
     out.push_str(&provenance(root)?);
     out.push_str(
         "\n## How to read this\n\n\
@@ -454,6 +458,29 @@ fn headline(records: &[Record]) -> String {
     out
 }
 
+/// Whether `artifacts/` has been rebuilt since the last measurement.
+///
+/// Compares the artifact manifest against the newest result file. False
+/// when either is missing — an absent answer is not evidence of
+/// staleness.
+fn artifacts_newer_than_results(root: &Path) -> bool {
+    let built =
+        match std::fs::metadata(root.join("artifacts/manifest.json")).and_then(|m| m.modified()) {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+    let newest_result = std::fs::read_dir(root.join("target/results"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| e.metadata().and_then(|m| m.modified()).ok())
+        .max();
+    match newest_result {
+        Some(measured) => built > measured,
+        None => false,
+    }
+}
+
 fn provenance(root: &Path) -> Result<String> {
     let mut s = String::from("## Provenance\n\n");
     let manifest = root.join("artifacts/manifest.json");
@@ -463,6 +490,18 @@ fn provenance(root: &Path) -> Result<String> {
                 s.push_str(&format!("- Guest toolchain: `{rustc}`\n"));
             }
         }
+    }
+    if artifacts_newer_than_results(root) {
+        // The size tables are always current — they are read straight
+        // off disk. The timings are whatever the last sweep produced.
+        // When the artifacts have been rebuilt since, the two halves of
+        // this report describe different binaries, which is exactly the
+        // mistake worth catching automatically rather than remembering.
+        s.push_str(
+            "- **The artifacts are newer than the measurements.** The size tables \
+             below describe the current artifacts; the timings do not. Re-run \
+             `scripts/run.sh`.\n",
+        );
     }
     if let Ok(cpu) = std::fs::read_to_string("/proc/cpuinfo") {
         if let Some(model) = cpu

--- a/nub/bench-compare/src/size.rs
+++ b/nub/bench-compare/src/size.rs
@@ -7,8 +7,8 @@
 //!
 //! **Raw code** excludes the data regions. It exists because several
 //! kernels carry large initialized data that swamps the signal
-//! completely: `prime-sieve` is 178 bytes of nub code inside a
-//! 158,182-byte blob — 0.1%. A whole-blob comparison of that row
+//! completely: `prime-sieve` is 214 bytes of nub code inside a
+//! 158,338-byte blob — 0.1%. A whole-blob comparison of that row
 //! compares static lookup tables, not code generators.
 //!
 //! # What counts as code, per format
@@ -72,16 +72,16 @@
 //!
 //! | program | pvm2 | polkavm64 | wasm32 |
 //! |---|--:|--:|--:|
-//! | goldilocks-mul | 126 | 138 | 346 |
-//! | keccak | 1848 | 4551 | 2760 |
-//! | blake2b | 6944 | 12453 | 6552 |
-//! | ed25519 | 41406 | 53632 | 60116 |
-//! | ecrecover | 96112 | 130599 | 82977 |
-//! | prime-sieve | 178 | 168 | 318 |
-//! | poly-eval | 766 | 1000 | 10885 |
-//! | poseidon2-perm | 3368 | 4625 | 5183 |
-//! | fri-fold-tree | 4134 | 6256 | 17178 |
-//! | mini-verifier | 4246 | 6276 | 6659 |
+//! | goldilocks-mul | 162 | 138 | 346 |
+//! | keccak | 1884 | 4551 | 2760 |
+//! | blake2b | 6980 | 12453 | 6552 |
+//! | ed25519 | 41442 | 53632 | 60116 |
+//! | ecrecover | 96170 | 130599 | 83023 |
+//! | prime-sieve | 214 | 168 | 318 |
+//! | poly-eval | 824 | 996 | 10885 |
+//! | poseidon2-perm | 3404 | 4625 | 5183 |
+//! | fri-fold-tree | 4192 | 6252 | 17178 |
+//! | mini-verifier | 4282 | 6276 | 6659 |
 
 use std::path::Path;
 
@@ -476,7 +476,7 @@ pub fn render(root: &Path, programs: &[&str]) -> String {
          story — it is what gets gossiped, stored and paid for.\n\n\
          **Raw code excludes the data regions**, and that is the figure to read. \
          Several kernels carry large initialized data that swamps everything \
-         else: `prime-sieve` is 178 bytes of nub code inside a 158,182-byte \
+         else: `prime-sieve` is 214 bytes of nub code inside a 158,338-byte \
          blob, 0.1% of it. Comparing whole blobs there compares static lookup \
          tables, not code generators.\n\n\
          The code figure is `code` for nub, `code + jump table + bitmask` for \

--- a/nub/bench-compare/src/size.rs
+++ b/nub/bench-compare/src/size.rs
@@ -1,0 +1,687 @@
+//! Artifact size: how big the program is, as opposed to how fast it runs.
+//!
+//! Two figures per artifact, because one would hide things.
+//!
+//! **Whole blob** is the file on disk — what actually gets gossiped,
+//! stored and paid for.
+//!
+//! **Raw code** excludes the data regions. It exists because several
+//! kernels carry large initialized data that swamps the signal
+//! completely: `prime-sieve` is 178 bytes of nub code inside a
+//! 158,182-byte blob — 0.1%. A whole-blob comparison of that row
+//! compares static lookup tables, not code generators.
+//!
+//! # What counts as code, per format
+//!
+//! | format | code figure |
+//! |---|---|
+//! | pvm2 | `code` |
+//! | polkavm64 | `code` + jump table + bitmask |
+//! | wasm32 | `Code`(10) + `Type`(1) + `Function`(3) + `Table`(4) + `Element`(9) + `Global`(6) |
+//!
+//! nub's is the whole story on its side: PVM2 is standard RV64EMC, and
+//! a fixed-width self-delimiting encoding needs no side tables.
+//!
+//! PolkaVM's two extras are code information relocated *out* of the
+//! instruction stream, so leaving them out would not be measuring the
+//! same thing. Its instructions are variable-length, so the bitmask —
+//! one bit per code byte, marking instruction starts — is what makes
+//! the stream decodable at all; RISC-V encodes that inline in the low
+//! two bits of each word. The jump table lists legal indirect-branch
+//! targets, which `jalr rd, rs1, imm` simply takes from a register.
+//! Note this is *broader* than upstream's own disassembler, which
+//! labels only `code` as "code size" — hence the breakdown table, so
+//! the definition is checkable rather than asserted.
+//!
+//! wasm's aux sections are the same argument: `Type`/`Function` hold
+//! per-function signatures that the register machines encode implicitly
+//! in their calling convention, and `Table`/`Element` are the direct
+//! analogue of PolkaVM's jump table.
+//!
+//! All three figures are **payload bytes, excluding container framing**.
+//! The breakdown tables' framing columns absorb the difference, and
+//! every breakdown row sums to the file size.
+//!
+//! # No compression is involved, in any of the three
+//!
+//! There is nothing to disable. nub trims trailing zeros off `ro`/`rw`
+//! (`nub_program::codec`) and PolkaVM stores only the initial non-zero
+//! prefix of its data sections; both are BSS elision — exactly what ELF
+//! does with `p_filesz < p_memsz` — and wasm data segments are
+//! explicitly offset so they carry no trailing zeros either. No entropy
+//! coder, dictionary or transform exists in any of these containers,
+//! and `polkavm_linker::Config` has no compression knob at all.
+//!
+//! The varint/LEB128 encoding in PolkaVM and wasm is **instruction
+//! encoding, not container compression**. It cannot be turned off —
+//! there is no alternative encoding — and turning it off is not what
+//! anyone would want anyway: it is precisely the axis these formats
+//! trade on. PolkaVM buys small immediates with variable-length
+//! instructions and pays a 12.5% bitmask; RISC-V pays fixed width and
+//! needs no side table. Both are raw code.
+//!
+//! # Golden values
+//!
+//! Recorded rather than asserted: `artifacts/` is gitignored, so a
+//! golden test could never run in CI, and these legitimately move with
+//! the kernel sources, the inline threshold and the linkers. They are
+//! here so a surprising diff is recognizable as one. Regenerate with
+//! `cargo run --release -- size`.
+//!
+//! As of 2026-07-28, rustc 1.95.0:
+//!
+//! | program | pvm2 | polkavm64 | wasm32 |
+//! |---|--:|--:|--:|
+//! | goldilocks-mul | 126 | 138 | 346 |
+//! | keccak | 1848 | 4551 | 2760 |
+//! | blake2b | 6944 | 12453 | 6552 |
+//! | ed25519 | 41406 | 53632 | 60116 |
+//! | ecrecover | 96112 | 130599 | 82977 |
+//! | prime-sieve | 178 | 168 | 318 |
+//! | poly-eval | 766 | 1000 | 10885 |
+//! | poseidon2-perm | 3368 | 4625 | 5183 |
+//! | fri-fold-tree | 4134 | 6256 | 17178 |
+//! | mini-verifier | 4246 | 6276 | 6659 |
+
+use std::path::Path;
+
+use anyhow::{bail, Result};
+
+use crate::backend::{Family, SIZE_FAMILIES};
+
+/// Byte counts for one artifact.
+pub struct Sizes {
+    /// The file on disk.
+    pub file: u64,
+    /// The raw-code figure for this family — see the module docs.
+    pub code: u64,
+    /// Every component, in table order. Sums to `file`.
+    pub parts: Vec<(&'static str, u64)>,
+}
+
+impl Sizes {
+    fn part(&self, name: &str) -> u64 {
+        self.parts
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, v)| *v)
+            .unwrap_or(0)
+    }
+
+    /// Every container must account for every byte. A walk that ends
+    /// anywhere but the end of the file means the parser is wrong, and
+    /// a wrong parser that still prints a plausible number is the
+    /// failure mode worth engineering against.
+    fn check(self, what: &str) -> Result<Self> {
+        let sum: u64 = self.parts.iter().map(|(_, v)| *v).sum();
+        if sum != self.file {
+            bail!(
+                "{what}: components sum to {sum} but the file is {} bytes",
+                self.file
+            );
+        }
+        Ok(self)
+    }
+}
+
+/// Parse one artifact's container. Never decodes instructions.
+pub fn measure(bytes: &[u8], family: Family) -> Result<Sizes> {
+    match family {
+        Family::Pvm2 => nub(bytes),
+        Family::Polkavm64 => polkavm(bytes),
+        Family::Wasm32 => wasm(bytes),
+        Family::Native => bail!("native artifacts have no comparable size figure"),
+    }
+}
+
+// ---- pvm2 -------------------------------------------------------------
+
+/// `magic|version|flags|stack|ro|rw|heap|code_len|ro_len|rw_len|n_endpoints`
+const NUB_HEADER: usize = 40;
+
+fn u32_at(bytes: &[u8], off: usize) -> Result<u64> {
+    let raw = bytes
+        .get(off..off + 4)
+        .ok_or_else(|| anyhow::anyhow!("truncated at offset {off}"))?;
+    Ok(u32::from_le_bytes(raw.try_into().unwrap()) as u64)
+}
+
+fn nub(bytes: &[u8]) -> Result<Sizes> {
+    if bytes.get(..4) != Some(b"NUBP") {
+        bail!("not a nub program blob (bad magic)");
+    }
+    // The on-disk lengths come from the header, NOT from the decoded
+    // blob. `from_bytes` zero-extends `ro`/`rw` back to
+    // `pages * PAGE_SIZE`, so `blob.ro_data.len()` is the in-memory
+    // size and will not reconcile against the file.
+    let code_len = u32_at(bytes, 24)?;
+    let ro_len = u32_at(bytes, 28)?;
+    let rw_len = u32_at(bytes, 32)?;
+    let endpoint_count = u32_at(bytes, 36)?;
+
+    // Endpoint records are variable-length: 12 bytes plus 16 per
+    // seeded register.
+    let mut off = NUB_HEADER;
+    for _ in 0..endpoint_count {
+        let reg_count = *bytes
+            .get(off + 3)
+            .ok_or_else(|| anyhow::anyhow!("truncated endpoint record"))?
+            as usize;
+        off += 12 + reg_count * 16;
+    }
+    let endpoints = (off - NUB_HEADER) as u64;
+
+    Sizes {
+        file: bytes.len() as u64,
+        code: code_len,
+        parts: vec![
+            ("header", NUB_HEADER as u64),
+            ("endpoints", endpoints),
+            ("code", code_len),
+            ("ro", ro_len),
+            ("rw", rw_len),
+        ],
+    }
+    .check("pvm2")
+}
+
+// ---- polkavm64 --------------------------------------------------------
+
+const PVM_HEADER: usize = 13;
+const SECTION_MEMORY_CONFIG: u8 = 1;
+const SECTION_RO_DATA: u8 = 2;
+const SECTION_RW_DATA: u8 = 3;
+const SECTION_EXPORTS: u8 = 5;
+const SECTION_CODE_AND_JUMP_TABLE: u8 = 6;
+const SECTION_END: u8 = 0;
+
+/// PolkaVM's varint — **not LEB128**.
+///
+/// The count of leading one-bits in the first byte gives how many extra
+/// little-endian bytes follow; the first byte's remaining low bits are
+/// the value's *high* bits. Decoding it as LEB128 silently yields wrong
+/// answers for every value >= 128, i.e. for every real artifact, while
+/// still producing plausible-looking numbers — so this has its own
+/// test.
+fn pvm_varint(bytes: &[u8], i: usize) -> Result<(u64, usize)> {
+    let first = *bytes
+        .get(i)
+        .ok_or_else(|| anyhow::anyhow!("truncated varint"))?;
+    let extra = first.leading_ones().min(4) as usize;
+    let upper = if extra >= 4 {
+        0
+    } else {
+        u64::from(first) & ((1u64 << (8 - extra - 1)) - 1)
+    };
+    let mut value = 0u64;
+    for k in 0..extra {
+        let b = *bytes
+            .get(i + 1 + k)
+            .ok_or_else(|| anyhow::anyhow!("truncated varint"))?;
+        value |= u64::from(b) << (8 * k);
+    }
+    value |= upper << (8 * extra);
+    Ok((value, i + 1 + extra))
+}
+
+fn polkavm(bytes: &[u8]) -> Result<Sizes> {
+    if bytes.get(..4) != Some(b"PVM\0") {
+        bail!("not a polkavm blob (bad magic)");
+    }
+    let declared = u64::from_le_bytes(
+        bytes
+            .get(5..13)
+            .ok_or_else(|| anyhow::anyhow!("truncated header"))?
+            .try_into()
+            .unwrap(),
+    );
+    if declared != bytes.len() as u64 {
+        bail!("header says {declared} bytes, file is {}", bytes.len());
+    }
+
+    let (mut code, mut jump_table, mut bitmask, mut framing) = (0u64, 0u64, 0u64, 0u64);
+    let (mut ro, mut rw, mut exports, mut memcfg, mut other) = (0u64, 0u64, 0u64, 0u64, 0u64);
+
+    let mut i = PVM_HEADER;
+    loop {
+        let id = *bytes
+            .get(i)
+            .ok_or_else(|| anyhow::anyhow!("truncated section id"))?;
+        i += 1;
+        if id == SECTION_END {
+            break;
+        }
+        let (len, next) = pvm_varint(bytes, i)?;
+        i = next;
+        let payload = bytes
+            .get(i..i + len as usize)
+            .ok_or_else(|| anyhow::anyhow!("truncated section {id}"))?;
+
+        match id {
+            SECTION_CODE_AND_JUMP_TABLE => {
+                // varint entry_count | u8 entry_size | varint code_len
+                let (entry_count, j) = pvm_varint(payload, 0)?;
+                let entry_size = *payload
+                    .get(j)
+                    .ok_or_else(|| anyhow::anyhow!("truncated jump-table header"))?
+                    as u64;
+                let (code_len, j) = pvm_varint(payload, j + 1)?;
+                framing = j as u64;
+                jump_table = entry_count
+                    .checked_mul(entry_size)
+                    .ok_or_else(|| anyhow::anyhow!("jump table size overflow"))?;
+                code = code_len;
+                bitmask = len
+                    .checked_sub(framing + jump_table + code)
+                    .ok_or_else(|| anyhow::anyhow!("section 6 shorter than its parts"))?;
+                // Independent cross-check: the bitmask is exactly one
+                // bit per code byte. Misread `entry_size` and this
+                // fires immediately, which is the whole point of
+                // checking it rather than trusting the subtraction.
+                let expect = code.div_ceil(8);
+                if bitmask != expect {
+                    bail!("bitmask is {bitmask} bytes, expected {expect} for {code} bytes of code");
+                }
+            }
+            SECTION_RO_DATA => ro += len,
+            SECTION_RW_DATA => rw += len,
+            SECTION_EXPORTS => exports += len,
+            SECTION_MEMORY_CONFIG => memcfg += len,
+            // `SECTION_IMPORTS`, the optional debug/metadata sections
+            // (ids >= 128, absent because the linker strips), and
+            // anything a future version adds. Never an error:
+            // surfacing an unexpected section as a number is more
+            // useful than refusing to measure.
+            _ => other += len,
+        }
+        i += len as usize;
+    }
+    if i != bytes.len() {
+        bail!("walk ended at {i}, file is {} bytes", bytes.len());
+    }
+
+    // Framing: the fixed header, each section's (id, varint len), and
+    // the one-byte terminator. Whatever the components do not account
+    // for is exactly that.
+    let accounted = code + jump_table + bitmask + framing + ro + rw + exports + memcfg + other;
+    let container = bytes.len() as u64 - accounted;
+
+    Sizes {
+        file: bytes.len() as u64,
+        code: code + jump_table + bitmask,
+        parts: vec![
+            ("code", code),
+            ("jump table", jump_table),
+            ("bitmask", bitmask),
+            ("§6 framing", framing),
+            ("ro", ro),
+            ("rw", rw),
+            ("exports", exports),
+            ("memory cfg", memcfg),
+            ("other", other),
+            ("container", container),
+        ],
+    }
+    .check("polkavm64")
+}
+
+// ---- wasm32 -----------------------------------------------------------
+
+const WASM_HEADER: usize = 8;
+const WASM_CUSTOM: u8 = 0;
+const WASM_DATA: u8 = 11;
+
+/// Sections counted as code, each with its breakdown-column label.
+///
+/// Listed individually rather than summed into one bucket so the
+/// breakdown table shows every contributor — the code figure here is a
+/// sum of six sections, and a reader should be able to check it rather
+/// than take it on trust.
+const WASM_CODE_SECTIONS: [(u8, &str); 6] = [
+    (10, "code(10)"),
+    (1, "type(1)"),
+    (3, "function(3)"),
+    (4, "table(4)"),
+    (9, "element(9)"),
+    (6, "global(6)"),
+];
+
+fn leb128(bytes: &[u8], mut i: usize) -> Result<(u64, usize)> {
+    let (mut value, mut shift) = (0u64, 0u32);
+    loop {
+        let b = *bytes
+            .get(i)
+            .ok_or_else(|| anyhow::anyhow!("truncated LEB128"))?;
+        i += 1;
+        value |= u64::from(b & 0x7f) << shift;
+        if b & 0x80 == 0 {
+            return Ok((value, i));
+        }
+        shift += 7;
+        if shift > 63 {
+            bail!("LEB128 too long");
+        }
+    }
+}
+
+fn wasm(bytes: &[u8]) -> Result<Sizes> {
+    if bytes.get(..4) != Some(b"\0asm") {
+        bail!("not a wasm module (bad magic)");
+    }
+    let mut per_code = [0u64; WASM_CODE_SECTIONS.len()];
+    let (mut data, mut custom, mut other) = (0u64, 0u64, 0u64);
+    let mut framing = 0u64;
+
+    let mut i = WASM_HEADER;
+    while i < bytes.len() {
+        let start = i;
+        let id = bytes[i];
+        i += 1;
+        let (len, next) = leb128(bytes, i)?;
+        i = next;
+        framing += (i - start) as u64;
+        if bytes.len() < i + len as usize {
+            bail!("truncated section {id}");
+        }
+        match WASM_CODE_SECTIONS.iter().position(|(s, _)| *s == id) {
+            Some(k) => per_code[k] += len,
+            None if id == WASM_DATA => data += len,
+            None if id == WASM_CUSTOM => custom += len,
+            // Memory, Export, Import, Start, DataCount, Tag, and
+            // whatever a future proposal adds.
+            None => other += len,
+        }
+        i += len as usize;
+    }
+    if i != bytes.len() {
+        bail!("walk ended at {i}, file is {} bytes", bytes.len());
+    }
+
+    let mut parts: Vec<(&'static str, u64)> = WASM_CODE_SECTIONS
+        .iter()
+        .zip(per_code)
+        .map(|((_, label), n)| (*label, n))
+        .collect();
+    parts.push(("data(11)", data));
+    parts.push(("custom(0)", custom));
+    parts.push(("other", other));
+    parts.push(("container", WASM_HEADER as u64 + framing));
+
+    Sizes {
+        file: bytes.len() as u64,
+        code: per_code.iter().sum(),
+        parts,
+    }
+    .check("wasm32")
+}
+
+// ---- rendering --------------------------------------------------------
+
+/// Thousands separators. Exact bytes throughout, never KiB: the
+/// breakdown tables exist so a reader can check that a row sums, and
+/// rounded units would break that.
+fn commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// One row of the size section: the three families' figures for one
+/// program, or the reason a family is missing.
+struct Row {
+    program: String,
+    sizes: Vec<(Family, Result<Sizes>)>,
+}
+
+/// The whole `## Artifact size` section.
+///
+/// Infallible by construction: a missing or unparseable artifact
+/// becomes a `-` cell, never an error, so adding this to `report`
+/// cannot make `report` fail. Returns `""` when no artifact exists at
+/// all.
+pub fn render(root: &Path, programs: &[&str]) -> String {
+    let mut rows: Vec<Row> = Vec::new();
+    for program in programs {
+        let mut sizes = Vec::new();
+        for family in SIZE_FAMILIES {
+            let path = family.artifact_path(root, program);
+            if !path.exists() {
+                continue;
+            }
+            let measured = std::fs::read(&path)
+                .map_err(Into::into)
+                .and_then(|bytes| measure(&bytes, family));
+            sizes.push((family, measured));
+        }
+        if !sizes.is_empty() {
+            rows.push(Row {
+                program: (*program).to_string(),
+                sizes,
+            });
+        }
+    }
+    if rows.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from("\n## Artifact size\n\n");
+    out.push_str(
+        "How big the program is, which for a chain VM is the other half of the \
+         story — it is what gets gossiped, stored and paid for.\n\n\
+         **Raw code excludes the data regions**, and that is the figure to read. \
+         Several kernels carry large initialized data that swamps everything \
+         else: `prime-sieve` is 178 bytes of nub code inside a 158,182-byte \
+         blob, 0.1% of it. Comparing whole blobs there compares static lookup \
+         tables, not code generators.\n\n\
+         The code figure is `code` for nub, `code + jump table + bitmask` for \
+         PolkaVM, and `Code + Type + Function + Table + Element + Global` for \
+         wasm. PolkaVM's two extras and wasm's aux sections are code \
+         information held *outside* the instruction stream — instruction \
+         boundaries, indirect-branch targets, function signatures — all of \
+         which RV64EMC encodes inline. The breakdown tables below show every \
+         component so the definition can be checked rather than taken on \
+         trust; note it is deliberately broader than upstream PolkaVM's own \
+         disassembler, which labels only `code` as \"code size\".\n\n\
+         `native` is absent: a host `.so` is a different kind of object — ELF \
+         program headers, relocations, a dynamic symbol table, and whatever of \
+         `std` got linked in — not a bigger or smaller one.\n\n\
+         **No compression is involved anywhere.** Trailing-zero trimming in \
+         nub and PolkaVM is BSS elision, exactly what ELF does with \
+         `p_filesz < p_memsz`, and wasm data segments carry no trailing zeros \
+         either. The varint/LEB128 encoding in PolkaVM and wasm is instruction \
+         encoding, not a container compressor: it cannot be disabled, and it \
+         is precisely the axis these formats trade on.\n\n",
+    );
+
+    out.push_str("### Raw code\n\n");
+    out.push_str(&matrix(&rows, |s| s.code));
+    out.push_str("\n### Whole blob\n\n");
+    out.push_str(&matrix(&rows, |s| s.file));
+
+    out.push_str("\n### Breakdown\n\n");
+    out.push_str("Every row sums to the file size.\n");
+    for family in SIZE_FAMILIES {
+        out.push_str(&breakdown(&rows, family));
+    }
+
+    let failures: Vec<String> = rows
+        .iter()
+        .flat_map(|r| {
+            r.sizes.iter().filter_map(move |(f, s)| {
+                s.as_ref()
+                    .err()
+                    .map(|e| format!("- `{}` / `{}`: {e:#}\n", r.program, f.dir()))
+            })
+        })
+        .collect();
+    if !failures.is_empty() {
+        out.push_str("\nUnparseable artifacts (shown as `-` above):\n\n");
+        for f in &failures {
+            out.push_str(f);
+        }
+    }
+    out
+}
+
+/// A program × family matrix, cells `{bytes} ({ratio}x)`, smallest bold.
+fn matrix(rows: &[Row], pick: impl Fn(&Sizes) -> u64) -> String {
+    let mut out = String::from("| Program |");
+    for f in SIZE_FAMILIES {
+        out.push_str(&format!(" `{}` |", f.dir()));
+    }
+    out.push_str("\n|---|");
+    for _ in SIZE_FAMILIES {
+        out.push_str("--:|");
+    }
+    out.push('\n');
+
+    for row in rows {
+        out.push_str(&format!("| {} |", row.program));
+        let best = row
+            .sizes
+            .iter()
+            .filter_map(|(_, s)| s.as_ref().ok().map(&pick))
+            .min()
+            .unwrap_or(0);
+        for family in SIZE_FAMILIES {
+            match row.sizes.iter().find(|(f, _)| *f == family) {
+                Some((_, Ok(s))) => {
+                    let v = pick(s);
+                    let mark = if v == best { "**" } else { "" };
+                    let ratio = if best > 0 {
+                        format!(" ({:.2}x)", v as f64 / best as f64)
+                    } else {
+                        String::new()
+                    };
+                    out.push_str(&format!(" {mark}{}{mark}{ratio} |", commas(v)));
+                }
+                _ => out.push_str(" - |"),
+            }
+        }
+        out.push('\n');
+    }
+    out.push_str("\nBold = smallest for that program; the multiple is versus it.\n");
+    out
+}
+
+/// One family's per-component table.
+fn breakdown(rows: &[Row], family: Family) -> String {
+    let cols: Vec<&'static str> = match rows
+        .iter()
+        .filter_map(|r| r.sizes.iter().find(|(f, _)| *f == family))
+        .find_map(|(_, s)| s.as_ref().ok())
+    {
+        Some(s) => s.parts.iter().map(|(n, _)| *n).collect(),
+        None => return String::new(),
+    };
+
+    let mut out = format!("\n#### `{}`\n\n| Program |", family.dir());
+    for c in &cols {
+        out.push_str(&format!(" {c} |"));
+    }
+    // The code figure is a sum of components for two of the three
+    // families, so name it explicitly rather than leaving the reader to
+    // add up columns.
+    out.push_str(" = code | file |\n|---|");
+    for _ in &cols {
+        out.push_str("--:|");
+    }
+    out.push_str("--:|--:|\n");
+
+    for row in rows {
+        let Some((_, Ok(s))) = row.sizes.iter().find(|(f, _)| *f == family) else {
+            continue;
+        };
+        out.push_str(&format!("| {} |", row.program));
+        for c in &cols {
+            out.push_str(&format!(" {} |", commas(s.part(c))));
+        }
+        out.push_str(&format!(" **{}** | {} |\n", commas(s.code), commas(s.file)));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// PolkaVM's varint is not LEB128 — the leading-ones count gives
+    /// the extra byte count and the first byte's low bits are the
+    /// value's *high* bits. A LEB128 implementation passes for values
+    /// under 128 and silently diverges above, so test both sides.
+    #[test]
+    fn polkavm_varint_is_not_leb128() {
+        // Single byte: no leading ones, value in the low 7 bits.
+        assert_eq!(pvm_varint(&[0x00], 0).unwrap(), (0, 1));
+        assert_eq!(pvm_varint(&[0x7f], 0).unwrap(), (127, 1));
+        // One leading one => one extra byte; low 6 bits of the first
+        // byte are the high bits.
+        assert_eq!(pvm_varint(&[0x80, 0x80], 0).unwrap(), (128, 2));
+        assert_eq!(pvm_varint(&[0x80, 0xff], 0).unwrap(), (255, 2));
+        assert_eq!(pvm_varint(&[0x81, 0x00], 0).unwrap(), (256, 2));
+        // Four leading ones => four extra bytes, first byte carries no
+        // value bits.
+        assert_eq!(
+            pvm_varint(&[0xf0, 0x78, 0x56, 0x34, 0x12], 0).unwrap(),
+            (0x1234_5678, 5)
+        );
+    }
+
+    #[test]
+    fn leb128_matches_spec() {
+        assert_eq!(leb128(&[0x00], 0).unwrap(), (0, 1));
+        assert_eq!(leb128(&[0x7f], 0).unwrap(), (127, 1));
+        assert_eq!(leb128(&[0x80, 0x01], 0).unwrap(), (128, 2));
+        assert_eq!(leb128(&[0xe5, 0x8e, 0x26], 0).unwrap(), (624_485, 3));
+    }
+
+    #[test]
+    fn rejects_foreign_containers() {
+        assert!(nub(b"PVM\0nope").is_err());
+        assert!(polkavm(b"NUBPnope").is_err());
+        assert!(wasm(b"NUBPnope").is_err());
+    }
+
+    /// Every artifact present must reconcile: the components have to
+    /// account for every byte of the file.
+    ///
+    /// `artifacts/` is gitignored and nothing in it is tracked, so this
+    /// skips rather than fails on a clean checkout or in CI.
+    #[test]
+    fn artifacts_reconcile() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut checked = 0;
+        for family in SIZE_FAMILIES {
+            let dir = root.join("artifacts").join(family.dir());
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some(family.ext()) {
+                    continue;
+                }
+                let bytes = std::fs::read(&path).expect("read artifact");
+                let sizes =
+                    measure(&bytes, family).unwrap_or_else(|e| panic!("{}: {e:#}", path.display()));
+                assert!(
+                    sizes.code <= sizes.file,
+                    "{}: code {} exceeds file {}",
+                    path.display(),
+                    sizes.code,
+                    sizes.file
+                );
+                checked += 1;
+            }
+        }
+        if checked == 0 {
+            eprintln!("skipped: no artifacts built (run `cargo run -p bench-build --release`)");
+        }
+    }
+}

--- a/nub/bench-compare/src/size.rs
+++ b/nub/bench-compare/src/size.rs
@@ -491,6 +491,15 @@ pub fn render(root: &Path, programs: &[&str]) -> String {
          `native` is absent: a host `.so` is a different kind of object — ELF \
          program headers, relocations, a dynamic symbol table, and whatever of \
          `std` got linked in — not a bigger or smaller one.\n\n\
+         **The whole-blob table is not built from identical sources**, and the \
+         raw-code table is the fairer one for that reason too. pvm2 builds the \
+         kernel crate's own binary, so it carries nub's guest runtime — the \
+         entry trampoline, the endpoint table, the bump arena. The other three \
+         build the thin wrapper in `guests/`, which calls into the same kernel \
+         as a library. That is each format's honest artifact, since the nub-rt \
+         endpoint binary *is* the PVM2 ABI, but it means the data regions are \
+         not measuring the same thing and nub is carrying runtime the others \
+         are not.\n\n\
          **No compression is involved anywhere.** Trailing-zero trimming in \
          nub and PolkaVM is BSS elision, exactly what ELF does with \
          `p_filesz < p_memsz`, and wasm data segments carry no trailing zeros \

--- a/nub/programs/blake2b/Cargo.toml
+++ b/nub/programs/blake2b/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 # Pinned exactly. The `(return_value, gas)` vectors in nub-bench and

--- a/nub/programs/ecrecover/Cargo.toml
+++ b/nub/programs/ecrecover/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 # Pinned exactly. The `(return_value, gas)` vectors in nub-bench and

--- a/nub/programs/ed25519/Cargo.toml
+++ b/nub/programs/ed25519/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 # Pinned exactly. The `(return_value, gas)` vectors in nub-bench and

--- a/nub/programs/fri-fold-tree/Cargo.toml
+++ b/nub/programs/fri-fold-tree/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 gp = { package = "bench-goldilocks-poseidon2", path = "../goldilocks-poseidon2" }

--- a/nub/programs/goldilocks-mul/Cargo.toml
+++ b/nub/programs/goldilocks-mul/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 gp = { package = "bench-goldilocks-poseidon2", path = "../goldilocks-poseidon2" }

--- a/nub/programs/keccak/Cargo.toml
+++ b/nub/programs/keccak/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 # Pinned exactly. The `(return_value, gas)` vectors in nub-bench and

--- a/nub/programs/mini-verifier/Cargo.toml
+++ b/nub/programs/mini-verifier/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 gp = { package = "bench-goldilocks-poseidon2", path = "../goldilocks-poseidon2" }

--- a/nub/programs/poly-eval/Cargo.toml
+++ b/nub/programs/poly-eval/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 gp = { package = "bench-goldilocks-poseidon2", path = "../goldilocks-poseidon2" }

--- a/nub/programs/poseidon2-perm/Cargo.toml
+++ b/nub/programs/poseidon2-perm/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 gp = { package = "bench-goldilocks-poseidon2", path = "../goldilocks-poseidon2" }

--- a/nub/programs/prime-sieve/Cargo.toml
+++ b/nub/programs/prime-sieve/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+# A plain rlib. The kernel is a *library* consumed by the engine
+# wrappers in `bench-compare/guests/*`, which are themselves the
+# cdylibs. Listing `cdylib` here made the kernel a final artifact in its
+# own right, and under the polkavm target (whose spec sets
+# `only-cdylib`) that meant it had to supply a `#[global_allocator]` it
+# has no business owning — which is exactly how it broke.
+crate-type = ["lib"]
 
 [dependencies]
 nub-rt = { path = "../../nub-rt" }


### PR DESCRIPTION
Adds a blob size comparison to `bench-compare` — whole blob and raw code, across wasm32, polkavm64 and pvm2 — and fixes two pre-existing problems found while building it.

## Why raw code, not just whole blob

Speed is half the story; for a chain VM the other half is how big the program is, because the blob is what gets gossiped, stored and paid for.

A whole-blob comparison alone would be misleading, because several kernels carry large initialized data that swamps everything else. `prime-sieve` is **214 bytes of nub code inside a 158,338-byte blob — 0.1% of it**. That row would be comparing static lookup tables, not code generators. `goldilocks-mul` is 3% code, `poly-eval` 12%.

## What counts as code

| family | code figure |
|---|---|
| `pvm2` | `code` |
| `polkavm64` | `code` + jump table + bitmask |
| `wasm32` | `Code`(10) + `Type`(1) + `Function`(3) + `Table`(4) + `Element`(9) + `Global`(6) |

PolkaVM's two extras are code information held *outside* the instruction stream. Its instructions are variable-length, so the bitmask — one bit per code byte, marking instruction starts — is what makes the stream decodable at all; RV64EMC encodes that in the low two bits of each word. The jump table lists legal indirect-branch targets, which `jalr rd, rs1, imm` takes straight from a register. wasm's aux sections are the same argument: `Type`/`Function` hold signatures the register machines encode implicitly in their calling convention, and `Table`/`Element` are the direct analogue of PolkaVM's jump table.

This is deliberately **broader than upstream PolkaVM's own disassembler**, which labels only `code` as "code size". That is why every table has a breakdown showing each component, with every row reconciling to the file size — the definition is checkable rather than asserted.

`native` is excluded from both tables: a host `.so` is a different kind of object, ~1.9 MB even for the workload whose entire PVM2 code is 162 bytes.

## Compression

There is none in any of the three formats, and nothing to disable. Trailing-zero trimming in nub and PolkaVM is BSS elision — exactly what ELF does with `p_filesz < p_memsz` — and wasm data segments carry no trailing zeros either. `polkavm_linker::Config` has no compression knob at all.

The varint/LEB128 encoding in PolkaVM and wasm is **instruction encoding, not a container compressor**. It cannot be turned off and would not be worth turning off: it is precisely the axis these formats trade on. PolkaVM buys cheap small immediates with variable-length instructions and pays a 12.5% bitmask; RISC-V pays fixed width and needs no side table. Both are raw code.

## Results

On **raw code** nub is smallest for 6 of 10 — wasm takes blake2b and ecrecover, polkavm takes prime-sieve and goldilocks-mul.

On **whole blobs** nub is last almost everywhere, 2× to 31× PolkaVM, because it stores markedly more initialized data for the same kernel. Part of that is an asymmetry now stated in the report: pvm2 builds the kernel crate's own binary and therefore carries nub's guest runtime, while the other three build the thin wrapper in `guests/` calling the same kernel as a library. That is each format's honest artifact — the nub-rt endpoint binary *is* the PVM2 ABI — but the data regions are not measuring the same thing.

## Two pre-existing bugs fixed

**`bench-build` could not rebuild the polkavm artifacts.** It fails with "no global memory allocator found" on ecrecover; the blobs on disk had only survived because a warm cache meant the broken unit was never recompiled. Touching a kernel source reproduces it on unmodified master. Every kernel crate declared `crate-type = ["lib", "cdylib"]` and the polkavm target spec sets `"only-cdylib": true`, so the *kernel* was built as a final cdylib rather than an rlib dependency of its wrapper — and a final artifact on a freestanding target needs a `#[global_allocator]` the kernel has no business owning. The kernels are now plain libraries, and the polkavm wrapper carries its own bump arena in `.bss`.

**The checked-in pvm2 artifacts were stale.** They carried code sizes from older sources — prime-sieve 178 bytes — while `javm-bench` and `nub-bench`, building from the same crates, produce 214. The regenerated artifacts agree with the rest of the tree, which is why the whole timing sweep was redone rather than only the wasm rows.

## The wasm strip

The workspace root sets `[profile.release] debug = true` for the *harness*, but `members` includes `guests/*`, so every guest inherited it — putting full DWARF in every `.wasm`, 86–98% of each artifact and 1.33 MB of ed25519's 1.39 MB. PolkaVM strips at link and nub's linker never copies debug info, so the whole-blob table was pitting one unstripped format against two stripped ones. Guest wasm is now built with debug off and symbols stripped: `ed25519.wasm` goes 1,389,275 → 62,833 bytes, with code figures unchanged, as they must be.

`native` is deliberately left unstripped — `vs native` anchors every ratio in the report and `dlopen` never maps `.debug_*`, so there was nothing to gain against a real if small risk.

## Verification

- All 30 code figures were **cross-checked against an independent implementation** before being recorded, and the parsers assert reconciliation invariants at runtime: the components must account for every byte of the file, and polkavm additionally checks `bitmask == ceil(code/8)`, which fires immediately on a misread `entry_size`. A failure demotes the row to `-` with a footnote; it never panics or aborts the report.
- Parsers are hand-rolled for all three containers, so the size table is not gated behind any engine feature. PolkaVM's varint is **not** LEB128 (leading-ones length prefix, first byte carries the value's high bits); decoding it as LEB128 gives wrong answers for every value ≥ 128 while still looking plausible, so it has its own test.
- Full 496-row sweep against the rebuilt artifacts: no confidence interval reaches 10%, 8 of ~500 cells exceed 2%, every recompile delta is positive. One cell came out inverted (`cold` faster than `invoke`, which is impossible); re-measuring twice gave cold 366/390 µs against invoke 351/350 µs, so the sweep's sample was the outlier and those two rows were replaced.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc -D warnings`, `cargo test --workspace` (539 passed) all clean, plus the same set inside the excluded `bench-compare` workspace and `bench-compare validate`.
